### PR TITLE
[2026-04-24] ingest | 补充 Bounded Ratio RL 资料并更新 Policy Optimization 页面

### DIFF
--- a/log.md
+++ b/log.md
@@ -390,3 +390,9 @@
 ## [2026-04-22] ingest | sources/repos/fusion2urdf.md, sources/repos/marathongo.md — 接入新仓库资料并更新全站索引
 
 ## [2026-04-23] ingest | robot_lab (Repo) & CLAW (Blog) — 接入 IsaacLab 扩展框架与 G1 合成数据管线并更新全站索引
+
+## [2026-04-24] ingest | sources/papers/policy_optimization.md — 补充 BRRL/BPO（Bounded Ratio RL）论文、项目页与代码仓库，并更新 Policy Optimization 方法页参考来源
+
+- 新增来源条目：`Bounded Ratio Reinforcement Learning (Ao et al., 2026)`（arXiv / project page / GitHub）
+- 更新 `wiki/methods/policy-optimization.md`：新增“BRRL / BPO（2026）”进展说明与参考来源
+- 关联强化：将 BRRL 映射到 policy-optimization / reinforcement-learning / ppo-vs-sac / locomotion

--- a/sources/papers/policy_optimization.md
+++ b/sources/papers/policy_optimization.md
@@ -6,7 +6,7 @@
 - **类型：** paper
 - **来源：** arXiv / NeurIPS / ICLR / ICML
 - **入库日期：** 2026-04-14
-- **最后更新：** 2026-04-14
+- **最后更新：** 2026-04-24
 - **一句话说明：** 覆盖 model-free 策略优化核心算法，支撑 policy-optimization.md、reinforcement-learning.md 和 locomotion RL 应用页面。
 
 ## 核心论文摘录（MVP）
@@ -51,7 +51,19 @@
   - [curriculum-learning](../../wiki/concepts/curriculum-learning.md)
   - [reward-design](../../wiki/concepts/reward-design.md)
 
+### 6) Bounded Ratio Reinforcement Learning (Ao et al., 2026)
+- **链接：** <https://arxiv.org/abs/2604.18578>
+- **项目页：** <https://bounded-ratio-rl.github.io/brrl/>
+- **代码：** <https://github.com/bounded-ratio-rl/bounded_ratio_rl>
+- **核心贡献：** 提出 BRRL（Bounded Ratio RL）框架，在有界 ratio 约束下给出解析最优策略，并据此构造 BPO（Bounded Policy Optimization）损失；论文给出单调改进理论保证，并在 MuJoCo / Atari / IsaacLab（含人形 locomotion）中报告了相对 PPO 的稳定性和性能优势。
+- **关键机制：** 将 PPO 中启发式 clip 目标重新解释为“朝向有界 ratio 最优解”的近似优化，并建立 BRRL 与 trust region 方法、CEM 的联系。
+- **对 wiki 的映射：**
+  - [Policy Optimization](../../wiki/methods/policy-optimization.md)
+  - [Reinforcement Learning](../../wiki/methods/reinforcement-learning.md)
+  - [PPO vs SAC](../../wiki/comparisons/ppo-vs-sac.md)
+  - [Locomotion](../../wiki/tasks/locomotion.md)
+
 ## 当前提炼状态
 
-- [x] PPO / SAC / TD3 / TRPO / Rudin et al. 五条核心摘要
+- [x] PPO / SAC / TD3 / TRPO / Rudin et al. / BRRL 六条核心摘要
 - [ ] 后续补：在不同机器人任务上三种算法的实测对比数据

--- a/wiki/methods/policy-optimization.md
+++ b/wiki/methods/policy-optimization.md
@@ -108,6 +108,19 @@ SAC 常用于：
 
 先用 BC / AWR 从演示数据初始化策略，再用 PPO / SAC 在线优化，兼顾样本效率和最终性能。
 
+## 新进展：BRRL / BPO（2026）
+
+**Bounded Ratio Reinforcement Learning (BRRL)** 给 PPO 的 clip 目标提供了一个更“可解释”的理论视角：  
+在有界重要性比约束下，先定义解析形式的最优策略，再通过 **BPO（Bounded Policy Optimization）** 损失逼近该最优策略。
+
+对工程实践的价值：
+- 为 “为什么 PPO 通常有效” 提供了更明确的解释框架（不仅是经验现象）
+- 在 MuJoCo / Atari / IsaacLab 报告了与 PPO 对比下更平滑或更高的收敛表现
+- 对机器人 RL 来说，尤其适合关注 **训练稳定性** 与 **可解释策略更新** 的场景
+
+当前可将其视为 PPO 家族的一个值得跟踪的新方向：  
+**默认 baseline 仍可用 PPO，但在不稳定任务上可以把 BPO 作为对照实验项。**
+
 ## 常见问题和调参技巧
 
 ### Reward Shaping
@@ -132,6 +145,7 @@ SAC 常用于：
 - Schulman et al., *Proximal Policy Optimization Algorithms* (2017) — PPO 原论文
 - Haarnoja et al., *Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning* (2018) — SAC 原论文
 - Rudin et al., *Learning to Walk in Minutes Using Massively Parallel Deep Reinforcement Learning* (2022) — locomotion + PPO 代表
+- Ao et al., *Bounded Ratio Reinforcement Learning* (2026) — BRRL/BPO，新近策略优化理论与算法
 - **ingest 档案：** [sources/papers/policy_optimization.md](../../sources/papers/policy_optimization.md)
 
 ## 关联页面
@@ -150,6 +164,7 @@ SAC 常用于：
 - Schulman et al., [*Proximal Policy Optimization Algorithms*](https://arxiv.org/abs/1707.06347) — PPO 原论文
 - Haarnoja et al., [*Soft Actor-Critic*](https://arxiv.org/abs/1801.01290) — SAC 原论文
 - Andrychowicz et al., [*Learning dexterous in-hand manipulation*](https://arxiv.org/abs/1808.00177) — 灵巧手操作 PPO 经典
+- Ao et al., [*Bounded Ratio Reinforcement Learning*](https://arxiv.org/abs/2604.18578) — BRRL / BPO 原论文
 
 ## 一句话记忆
 


### PR DESCRIPTION
### Motivation
- 将新提出的 Bounded Ratio Reinforcement Learning（BRRL / BPO）论文及其项目/代码纳入 sources 层以补全策略优化领域的最新进展并为 wiki 提供可溯源参考。
- 通过把 BRRL 与现有 PPO/SAC/TD3/TRPO 讨论关联，帮助在机器人 RL 场景中评估其对训练稳定性与策略更新可解释性的价值。

### Description
- 在 `sources/papers/policy_optimization.md` 中新增条目 `Bounded Ratio Reinforcement Learning (Ao et al., 2026)`，并加入 arXiv 链接、项目页、代码仓库、核心贡献与 wiki 映射等元信息，同时更新 `最后更新` 时间戳。 
- 在 `wiki/methods/policy-optimization.md` 中新增“小节：BRRL / BPO（2026）”，概述该方法的理论视角、工程意义与与 PPO 家族的关系，并把论文加入“参考来源/推荐继续阅读”。
- 在 `log.md` 中追加本次 ingest 记录以满足仓库的 append-only 操作日志规范。 

### Testing
- 运行 `python3 scripts/lint_wiki.py`，结果显示 `0` 个问题且所有检查通过（Sources 覆盖率报告：166/170 (98%)）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacbf34dec832380a252f4c05c6c02)