### PR TITLE
[2026-04-25] ingest | sources/repos/roboto_origin.md — 接入 Roboto Origin 原始资料并沉淀实体页

### DIFF
--- a/docs/exports/index-v1.json
+++ b/docs/exports/index-v1.json
@@ -1,7 +1,7 @@
 {
   "version": "v1",
   "generated_mode": "script",
-  "item_count": 217,
+  "item_count": 218,
   "items": [
     {
       "id": "wiki-concepts-capture-point-dcm",
@@ -27,7 +27,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/footstep_and_balance.md"
     },
     {
       "id": "wiki-concepts-centroidal-dynamics",
@@ -94,7 +94,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-estimation",
@@ -125,7 +125,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-rich-manipulation",
@@ -218,7 +218,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-dexterous-kinematics",
@@ -271,7 +271,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/simulation_tools.md"
+      "ingest_source": "sources/papers/sim2real.md"
     },
     {
       "id": "wiki-concepts-embodied-data-cleaning",
@@ -366,7 +366,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-footstep-planning",
@@ -487,7 +487,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-hqp",
@@ -638,7 +638,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/footstep_and_balance.md"
     },
     {
       "id": "wiki-concepts-motion-retargeting",
@@ -698,7 +698,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-optimal-control",
@@ -730,7 +730,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/robot_kinematics_tools.md"
     },
     {
       "id": "wiki-concepts-privileged-training",
@@ -792,7 +792,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-ros2-basics",
@@ -910,7 +910,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-state-estimation",
@@ -943,7 +943,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-system-identification",
@@ -1132,7 +1132,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_planning.md"
     },
     {
       "id": "wiki-concepts-whole-body-coordination",
@@ -1391,7 +1391,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/diffusion_and_gen.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-methods-dmp",
@@ -1541,7 +1541,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-methods-in-hand-reorientation",
@@ -1645,7 +1645,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-methods-model-predictive-control",
@@ -1680,7 +1680,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/system_identification.md"
     },
     {
       "id": "wiki-methods-mppi",
@@ -1779,7 +1779,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/sim2real.md"
     },
     {
       "id": "wiki-methods-safe-rl",
@@ -1857,7 +1857,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/optimal_control.md"
+      "ingest_source": "sources/papers/robot_kinematics_tools.md"
     },
     {
       "id": "wiki-methods-unified-multimodal-tokens",
@@ -1989,7 +1989,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/whole_body_control.md"
+      "ingest_source": "sources/papers/footstep_and_balance.md"
     },
     {
       "id": "wiki-tasks-bimanual-manipulation",
@@ -2097,7 +2097,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-tasks-manipulation",
@@ -2135,7 +2135,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-tasks-teleoperation",
@@ -4469,7 +4469,7 @@
       "type": "entity_page",
       "entity_kind": "simulator",
       "has_ingest": true,
-      "ingest_source": "sources/papers/simulation_tools.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-legged-gym",
@@ -4501,7 +4501,7 @@
       "type": "entity_page",
       "entity_kind": "framework",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-mujoco",
@@ -4611,7 +4611,7 @@
       "title": "开源人形机器人硬件方案对比",
       "path": "wiki/entities/open-source-humanoid-hardware.md",
       "summary": "type: entity。",
-      "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-21\nrelated:\n  - ./humanoid-robot.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
+      "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./humanoid-robot.md\n  - ./roboto-origin.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\n  - ../../sources/repos/roboto_origin.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- [roboto_origin.md](../../sources/repos/roboto_origin.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
       "tags": [
         "entities",
         "entity",
@@ -4622,9 +4622,11 @@
       ],
       "related": [
         "entity-humanoid-robot",
+        "entity-roboto-origin",
         "wiki-queries-humanoid-hardware-selection",
         "wiki-roadmaps-humanoid-control-roadmap",
-        "sources-papers-humanoid-hardware"
+        "sources-papers-humanoid-hardware",
+        "sources-repos-roboto-origin"
       ],
       "source_links": [],
       "status": "active",
@@ -4685,6 +4687,35 @@
       "status": "active",
       "type": "entity_page",
       "entity_kind": "simulator"
+    },
+    {
+      "id": "entity-roboto-origin",
+      "title": "Roboto Origin（开源人形机器人基线）",
+      "path": "wiki/entities/roboto-origin.md",
+      "summary": "type: entity。",
+      "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, ros2, isaac-lab]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./open-source-humanoid-hardware.md\n  - ./humanoid-robot.md\n  - ./robot-lab.md\n  - ./unitree.md\nsources:\n  - ../../sources/repos/roboto_origin.md\nsummary: \"Roboto Origin 是 Roboparty 发布的开源人形机器人基线项目，通过聚合 hardware/deploy/train/description/firmware 五个子仓库，提供可复现的 DIY 人形机器人研发路径。\"\n---\n\n# Roboto Origin（开源人形机器人基线）\n\n**Roboto Origin** 是 Roboparty 发布的“全链路开源”人形机器人项目入口页，目标不是只给一个仓库，而是提供从硬件到训练再到部署的可复现工程路径。\n\n## 为什么重要\n\n1. **低门槛复现路径**：将 DIY 人形机器人的关键模块显式拆分，降低单人/小团队上手门槛。\n2. **工程边界清晰**：官方明确聚合仓库用于导航，贡献回流到子仓库，避免 monorepo 混乱。\n3. **覆盖全栈闭环**：硬件设计、URDF 描述、RL 训练、ROS2 部署、固件链路全部公开。\n\n## 核心结构\n\nRoboto Origin 的仓库体系可理解为“五段流水线”：\n\n- **Atom01_hardware**：机械与电子设计（CAD/PCB/BOM）\n- **atom01_description**：机器人模型描述（URDF + 网格）\n- **atom01_train**：IsaacLab 训练与 Sim2Sim\n- **atom01_deploy**：ROS2 真机驱动与部署\n- **atom01_firmware**：底层固件与板端支持\n\n这种拆分方式适合把“研究迭代”和“工程落地”分离维护。\n\n## 常见误区 / 局限\n\n- **误区 1：把 `roboto_origin` 当成可直接开发主仓库。**\n  实际上它更像索引入口，真正开发需进入各模块仓库。\n- **误区 2：认为开源即开箱即用。**\n  项目仍需要较强的 Linux/ROS2/硬件调试能力。\n- **局限：** 当前公开资料更偏“原型复现与社区协作”，对工业级可靠性（长期运行、认证、安全冗余）覆盖有限。\n\n## 关联页面\n\n- [开源人形机器人硬件方案对比](./open-source-humanoid-hardware.md)\n- [人形机器人（Humanoid Robot）](./humanoid-robot.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Unitree](./unitree.md)\n\n## 推荐继续阅读\n\n- [Roboparty / roboto_origin](https://github.com/Roboparty/roboto_origin)\n- [Humanoid Robot Know-How Documentation](https://roboparty.com/roboto_origin/doc)\n\n## 参考来源\n\n- [sources/repos/roboto_origin.md](../../sources/repos/roboto_origin.md)\n- [Roboparty/roboto_origin README](https://github.com/Roboparty/roboto_origin)",
+      "tags": [
+        "entities",
+        "entity",
+        "humanoid",
+        "rl",
+        "tooling",
+        "hardware"
+      ],
+      "related": [
+        "entity-open-source-humanoid-hardware",
+        "entity-humanoid-robot",
+        "entity-robot-lab",
+        "entity-unitree",
+        "sources-repos-roboto-origin"
+      ],
+      "source_links": [
+        "https://github.com/Roboparty/roboto_origin",
+        "https://roboparty.com/roboto_origin/doc"
+      ],
+      "status": "active",
+      "type": "entity_page",
+      "entity_kind": "framework"
     },
     {
       "id": "entity-shadow-hand",

--- a/docs/exports/site-data-v1.json
+++ b/docs/exports/site-data-v1.json
@@ -4981,7 +4981,7 @@
         "type": "entity_page",
         "path": "wiki/entities/open-source-humanoid-hardware.md",
         "summary": "type: entity。",
-        "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-21\nrelated:\n  - ./humanoid-robot.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
+        "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./humanoid-robot.md\n  - ./roboto-origin.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\n  - ../../sources/repos/roboto_origin.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- [roboto_origin.md](../../sources/repos/roboto_origin.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
         "tags": [
           "entities",
           "entity",
@@ -4992,9 +4992,11 @@
         ],
         "related": [
           "entity-humanoid-robot",
+          "entity-roboto-origin",
           "wiki-queries-humanoid-hardware-selection",
           "wiki-roadmaps-humanoid-control-roadmap",
-          "sources-papers-humanoid-hardware"
+          "sources-papers-humanoid-hardware",
+          "sources-repos-roboto-origin"
         ],
         "source_links": [],
         "status": "active"
@@ -5047,6 +5049,34 @@
         ],
         "source_links": [
           "https://github.com/fan-ziqi/robot_lab"
+        ],
+        "status": "active"
+      },
+      "entity-roboto-origin": {
+        "id": "entity-roboto-origin",
+        "title": "Roboto Origin（开源人形机器人基线）",
+        "type": "entity_page",
+        "path": "wiki/entities/roboto-origin.md",
+        "summary": "type: entity。",
+        "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, ros2, isaac-lab]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./open-source-humanoid-hardware.md\n  - ./humanoid-robot.md\n  - ./robot-lab.md\n  - ./unitree.md\nsources:\n  - ../../sources/repos/roboto_origin.md\nsummary: \"Roboto Origin 是 Roboparty 发布的开源人形机器人基线项目，通过聚合 hardware/deploy/train/description/firmware 五个子仓库，提供可复现的 DIY 人形机器人研发路径。\"\n---\n\n# Roboto Origin（开源人形机器人基线）\n\n**Roboto Origin** 是 Roboparty 发布的“全链路开源”人形机器人项目入口页，目标不是只给一个仓库，而是提供从硬件到训练再到部署的可复现工程路径。\n\n## 为什么重要\n\n1. **低门槛复现路径**：将 DIY 人形机器人的关键模块显式拆分，降低单人/小团队上手门槛。\n2. **工程边界清晰**：官方明确聚合仓库用于导航，贡献回流到子仓库，避免 monorepo 混乱。\n3. **覆盖全栈闭环**：硬件设计、URDF 描述、RL 训练、ROS2 部署、固件链路全部公开。\n\n## 核心结构\n\nRoboto Origin 的仓库体系可理解为“五段流水线”：\n\n- **Atom01_hardware**：机械与电子设计（CAD/PCB/BOM）\n- **atom01_description**：机器人模型描述（URDF + 网格）\n- **atom01_train**：IsaacLab 训练与 Sim2Sim\n- **atom01_deploy**：ROS2 真机驱动与部署\n- **atom01_firmware**：底层固件与板端支持\n\n这种拆分方式适合把“研究迭代”和“工程落地”分离维护。\n\n## 常见误区 / 局限\n\n- **误区 1：把 `roboto_origin` 当成可直接开发主仓库。**\n  实际上它更像索引入口，真正开发需进入各模块仓库。\n- **误区 2：认为开源即开箱即用。**\n  项目仍需要较强的 Linux/ROS2/硬件调试能力。\n- **局限：** 当前公开资料更偏“原型复现与社区协作”，对工业级可靠性（长期运行、认证、安全冗余）覆盖有限。\n\n## 关联页面\n\n- [开源人形机器人硬件方案对比](./open-source-humanoid-hardware.md)\n- [人形机器人（Humanoid Robot）](./humanoid-robot.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Unitree](./unitree.md)\n\n## 推荐继续阅读\n\n- [Roboparty / roboto_origin](https://github.com/Roboparty/roboto_origin)\n- [Humanoid Robot Know-How Documentation](https://roboparty.com/roboto_origin/doc)\n\n## 参考来源\n\n- [sources/repos/roboto_origin.md](../../sources/repos/roboto_origin.md)\n- [Roboparty/roboto_origin README](https://github.com/Roboparty/roboto_origin)",
+        "tags": [
+          "entities",
+          "entity",
+          "humanoid",
+          "rl",
+          "tooling",
+          "hardware"
+        ],
+        "related": [
+          "entity-open-source-humanoid-hardware",
+          "entity-humanoid-robot",
+          "entity-robot-lab",
+          "entity-unitree",
+          "sources-repos-roboto-origin"
+        ],
+        "source_links": [
+          "https://github.com/Roboparty/roboto_origin",
+          "https://roboparty.com/roboto_origin/doc"
         ],
         "status": "active"
       },

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -173,6 +173,7 @@
   <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-open-source-humanoid-hardware</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-pinocchio</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-robot-lab</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-roboto-origin</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-shadow-hand</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-unitree-g1</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://imchong.github.io/Robotics_Notebooks/docs/detail.html?id=entity-unitree</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/exports/index-v1.json
+++ b/exports/index-v1.json
@@ -1,7 +1,7 @@
 {
   "version": "v1",
   "generated_mode": "script",
-  "item_count": 217,
+  "item_count": 218,
   "items": [
     {
       "id": "wiki-concepts-capture-point-dcm",
@@ -27,7 +27,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/footstep_and_balance.md"
     },
     {
       "id": "wiki-concepts-centroidal-dynamics",
@@ -94,7 +94,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-estimation",
@@ -125,7 +125,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-rich-manipulation",
@@ -218,7 +218,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-dexterous-kinematics",
@@ -271,7 +271,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/simulation_tools.md"
+      "ingest_source": "sources/papers/sim2real.md"
     },
     {
       "id": "wiki-concepts-embodied-data-cleaning",
@@ -366,7 +366,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-footstep-planning",
@@ -487,7 +487,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-hqp",
@@ -638,7 +638,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/footstep_and_balance.md"
     },
     {
       "id": "wiki-concepts-motion-retargeting",
@@ -698,7 +698,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-optimal-control",
@@ -730,7 +730,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/robot_kinematics_tools.md"
     },
     {
       "id": "wiki-concepts-privileged-training",
@@ -792,7 +792,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-ros2-basics",
@@ -910,7 +910,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-state-estimation",
@@ -943,7 +943,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-concepts-system-identification",
@@ -1132,7 +1132,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_planning.md"
     },
     {
       "id": "wiki-concepts-whole-body-coordination",
@@ -1391,7 +1391,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/diffusion_and_gen.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-methods-dmp",
@@ -1541,7 +1541,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-methods-in-hand-reorientation",
@@ -1645,7 +1645,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/privileged_training.md"
     },
     {
       "id": "wiki-methods-model-predictive-control",
@@ -1680,7 +1680,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/system_identification.md"
     },
     {
       "id": "wiki-methods-mppi",
@@ -1779,7 +1779,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/sim2real.md"
     },
     {
       "id": "wiki-methods-safe-rl",
@@ -1857,7 +1857,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/optimal_control.md"
+      "ingest_source": "sources/papers/robot_kinematics_tools.md"
     },
     {
       "id": "wiki-methods-unified-multimodal-tokens",
@@ -1989,7 +1989,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/whole_body_control.md"
+      "ingest_source": "sources/papers/footstep_and_balance.md"
     },
     {
       "id": "wiki-tasks-bimanual-manipulation",
@@ -2097,7 +2097,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-tasks-manipulation",
@@ -2135,7 +2135,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-tasks-teleoperation",
@@ -4469,7 +4469,7 @@
       "type": "entity_page",
       "entity_kind": "simulator",
       "has_ingest": true,
-      "ingest_source": "sources/papers/simulation_tools.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-legged-gym",
@@ -4501,7 +4501,7 @@
       "type": "entity_page",
       "entity_kind": "framework",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-mujoco",
@@ -4611,7 +4611,7 @@
       "title": "开源人形机器人硬件方案对比",
       "path": "wiki/entities/open-source-humanoid-hardware.md",
       "summary": "type: entity。",
-      "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-21\nrelated:\n  - ./humanoid-robot.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
+      "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./humanoid-robot.md\n  - ./roboto-origin.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\n  - ../../sources/repos/roboto_origin.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- [roboto_origin.md](../../sources/repos/roboto_origin.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
       "tags": [
         "entities",
         "entity",
@@ -4622,9 +4622,11 @@
       ],
       "related": [
         "entity-humanoid-robot",
+        "entity-roboto-origin",
         "wiki-queries-humanoid-hardware-selection",
         "wiki-roadmaps-humanoid-control-roadmap",
-        "sources-papers-humanoid-hardware"
+        "sources-papers-humanoid-hardware",
+        "sources-repos-roboto-origin"
       ],
       "source_links": [],
       "status": "active",
@@ -4685,6 +4687,35 @@
       "status": "active",
       "type": "entity_page",
       "entity_kind": "simulator"
+    },
+    {
+      "id": "entity-roboto-origin",
+      "title": "Roboto Origin（开源人形机器人基线）",
+      "path": "wiki/entities/roboto-origin.md",
+      "summary": "type: entity。",
+      "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, ros2, isaac-lab]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./open-source-humanoid-hardware.md\n  - ./humanoid-robot.md\n  - ./robot-lab.md\n  - ./unitree.md\nsources:\n  - ../../sources/repos/roboto_origin.md\nsummary: \"Roboto Origin 是 Roboparty 发布的开源人形机器人基线项目，通过聚合 hardware/deploy/train/description/firmware 五个子仓库，提供可复现的 DIY 人形机器人研发路径。\"\n---\n\n# Roboto Origin（开源人形机器人基线）\n\n**Roboto Origin** 是 Roboparty 发布的“全链路开源”人形机器人项目入口页，目标不是只给一个仓库，而是提供从硬件到训练再到部署的可复现工程路径。\n\n## 为什么重要\n\n1. **低门槛复现路径**：将 DIY 人形机器人的关键模块显式拆分，降低单人/小团队上手门槛。\n2. **工程边界清晰**：官方明确聚合仓库用于导航，贡献回流到子仓库，避免 monorepo 混乱。\n3. **覆盖全栈闭环**：硬件设计、URDF 描述、RL 训练、ROS2 部署、固件链路全部公开。\n\n## 核心结构\n\nRoboto Origin 的仓库体系可理解为“五段流水线”：\n\n- **Atom01_hardware**：机械与电子设计（CAD/PCB/BOM）\n- **atom01_description**：机器人模型描述（URDF + 网格）\n- **atom01_train**：IsaacLab 训练与 Sim2Sim\n- **atom01_deploy**：ROS2 真机驱动与部署\n- **atom01_firmware**：底层固件与板端支持\n\n这种拆分方式适合把“研究迭代”和“工程落地”分离维护。\n\n## 常见误区 / 局限\n\n- **误区 1：把 `roboto_origin` 当成可直接开发主仓库。**\n  实际上它更像索引入口，真正开发需进入各模块仓库。\n- **误区 2：认为开源即开箱即用。**\n  项目仍需要较强的 Linux/ROS2/硬件调试能力。\n- **局限：** 当前公开资料更偏“原型复现与社区协作”，对工业级可靠性（长期运行、认证、安全冗余）覆盖有限。\n\n## 关联页面\n\n- [开源人形机器人硬件方案对比](./open-source-humanoid-hardware.md)\n- [人形机器人（Humanoid Robot）](./humanoid-robot.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Unitree](./unitree.md)\n\n## 推荐继续阅读\n\n- [Roboparty / roboto_origin](https://github.com/Roboparty/roboto_origin)\n- [Humanoid Robot Know-How Documentation](https://roboparty.com/roboto_origin/doc)\n\n## 参考来源\n\n- [sources/repos/roboto_origin.md](../../sources/repos/roboto_origin.md)\n- [Roboparty/roboto_origin README](https://github.com/Roboparty/roboto_origin)",
+      "tags": [
+        "entities",
+        "entity",
+        "humanoid",
+        "rl",
+        "tooling",
+        "hardware"
+      ],
+      "related": [
+        "entity-open-source-humanoid-hardware",
+        "entity-humanoid-robot",
+        "entity-robot-lab",
+        "entity-unitree",
+        "sources-repos-roboto-origin"
+      ],
+      "source_links": [
+        "https://github.com/Roboparty/roboto_origin",
+        "https://roboparty.com/roboto_origin/doc"
+      ],
+      "status": "active",
+      "type": "entity_page",
+      "entity_kind": "framework"
     },
     {
       "id": "entity-shadow-hand",

--- a/exports/site-data-v1.json
+++ b/exports/site-data-v1.json
@@ -4981,7 +4981,7 @@
         "type": "entity_page",
         "path": "wiki/entities/open-source-humanoid-hardware.md",
         "summary": "type: entity。",
-        "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-21\nrelated:\n  - ./humanoid-robot.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
+        "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, robotics, research]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./humanoid-robot.md\n  - ./roboto-origin.md\n  - ../queries/humanoid-hardware-selection.md\n  - ../roadmaps/humanoid-control-roadmap.md\nsources:\n  - ../../sources/papers/humanoid_hardware.md\n  - ../../sources/repos/roboto_origin.md\nsummary: \"主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。\"\n---\n\n# 开源人形机器人硬件方案对比\n\n随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。\n\n## 核心方案对比\n\n| 方案名称 | 主导机构 | 自由度 (DOF) | 核心执行器 | 成本估算 | 软件生态 |\n|------|------|-----|-----------|---------|---------|\n| **Berkeley Humanoid** | UC Berkeley | 12-14 | 准直接驱动 (QDD) | < 5,000 USD | 基于 Python/C++ 的简易控制框架 |\n| **Roboto Origin** | Roboparty | 20+ | QDD + 舵机混合 | < 3,000 USD | ROS2 支持，兼容简单平衡算法 |\n| **ODRI (Bolt/Solo)** | Max Planck | 6-12 (双腿/四足) | 基于 T-Motor 改造 | 中等 | OCS2 / Pinocchio 深度支持 |\n| **Unitree H1 (SDK版)** | Unitree | 19 | 商业级 QDD | > 50,000 USD | Isaac Gym (legged_gym) 生态极强 |\n\n## 1. Berkeley Humanoid (准直接驱动派)\n- **特点**：极其强调低成本和维修便捷性。它证明了使用廉价的无刷电机和 3D 打印结构，也能完成稳定的动态行走。\n- **优点**：动力学透明度高，非常适合做强化学习的 Sim2Real 验证。\n\n## 2. Roboto Origin (科普与原型派)\n- **特点**：由国内开源社区驱动，旨在打造人人都能拥有的“第一台人形机器人”。\n- **优点**：文档详尽，组装门槛低。\n\n## 3. ODRI 架构 (学术严谨派)\n- **特点**：Open Dynamic Robot Initiative。虽然其人形版本较少，但其开源的执行器模块（Actuator Modules）被广泛借鉴。\n- **优点**：力控精度极高，代码质量达工业级。\n\n## 选型建议\n\n- **如果你想验证 RL 算法**：首选 **Berkeley Humanoid** 类方案，因为其 QDD 电机的动力学建模最为简单。\n- **如果你想研究全身协调 (WBC)**：建议寻找支持更高自由度的平台，或者在仿真中使用 **ODRI** 模型进行先行验证。\n\n## 关联页面\n- [人形机器人 (Humanoid Robot)](./humanoid-robot.md)\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)\n- [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)\n\n## 参考来源\n- [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)\n- [roboto_origin.md](../../sources/repos/roboto_origin.md)\n- 各开源项目 GitHub Readme 与 Wiki。",
         "tags": [
           "entities",
           "entity",
@@ -4992,9 +4992,11 @@
         ],
         "related": [
           "entity-humanoid-robot",
+          "entity-roboto-origin",
           "wiki-queries-humanoid-hardware-selection",
           "wiki-roadmaps-humanoid-control-roadmap",
-          "sources-papers-humanoid-hardware"
+          "sources-papers-humanoid-hardware",
+          "sources-repos-roboto-origin"
         ],
         "source_links": [],
         "status": "active"
@@ -5047,6 +5049,34 @@
         ],
         "source_links": [
           "https://github.com/fan-ziqi/robot_lab"
+        ],
+        "status": "active"
+      },
+      "entity-roboto-origin": {
+        "id": "entity-roboto-origin",
+        "title": "Roboto Origin（开源人形机器人基线）",
+        "type": "entity_page",
+        "path": "wiki/entities/roboto-origin.md",
+        "summary": "type: entity。",
+        "content_markdown": "---\ntype: entity\ntags: [humanoid, hardware, open-source, ros2, isaac-lab]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./open-source-humanoid-hardware.md\n  - ./humanoid-robot.md\n  - ./robot-lab.md\n  - ./unitree.md\nsources:\n  - ../../sources/repos/roboto_origin.md\nsummary: \"Roboto Origin 是 Roboparty 发布的开源人形机器人基线项目，通过聚合 hardware/deploy/train/description/firmware 五个子仓库，提供可复现的 DIY 人形机器人研发路径。\"\n---\n\n# Roboto Origin（开源人形机器人基线）\n\n**Roboto Origin** 是 Roboparty 发布的“全链路开源”人形机器人项目入口页，目标不是只给一个仓库，而是提供从硬件到训练再到部署的可复现工程路径。\n\n## 为什么重要\n\n1. **低门槛复现路径**：将 DIY 人形机器人的关键模块显式拆分，降低单人/小团队上手门槛。\n2. **工程边界清晰**：官方明确聚合仓库用于导航，贡献回流到子仓库，避免 monorepo 混乱。\n3. **覆盖全栈闭环**：硬件设计、URDF 描述、RL 训练、ROS2 部署、固件链路全部公开。\n\n## 核心结构\n\nRoboto Origin 的仓库体系可理解为“五段流水线”：\n\n- **Atom01_hardware**：机械与电子设计（CAD/PCB/BOM）\n- **atom01_description**：机器人模型描述（URDF + 网格）\n- **atom01_train**：IsaacLab 训练与 Sim2Sim\n- **atom01_deploy**：ROS2 真机驱动与部署\n- **atom01_firmware**：底层固件与板端支持\n\n这种拆分方式适合把“研究迭代”和“工程落地”分离维护。\n\n## 常见误区 / 局限\n\n- **误区 1：把 `roboto_origin` 当成可直接开发主仓库。**\n  实际上它更像索引入口，真正开发需进入各模块仓库。\n- **误区 2：认为开源即开箱即用。**\n  项目仍需要较强的 Linux/ROS2/硬件调试能力。\n- **局限：** 当前公开资料更偏“原型复现与社区协作”，对工业级可靠性（长期运行、认证、安全冗余）覆盖有限。\n\n## 关联页面\n\n- [开源人形机器人硬件方案对比](./open-source-humanoid-hardware.md)\n- [人形机器人（Humanoid Robot）](./humanoid-robot.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Unitree](./unitree.md)\n\n## 推荐继续阅读\n\n- [Roboparty / roboto_origin](https://github.com/Roboparty/roboto_origin)\n- [Humanoid Robot Know-How Documentation](https://roboparty.com/roboto_origin/doc)\n\n## 参考来源\n\n- [sources/repos/roboto_origin.md](../../sources/repos/roboto_origin.md)\n- [Roboparty/roboto_origin README](https://github.com/Roboparty/roboto_origin)",
+        "tags": [
+          "entities",
+          "entity",
+          "humanoid",
+          "rl",
+          "tooling",
+          "hardware"
+        ],
+        "related": [
+          "entity-open-source-humanoid-hardware",
+          "entity-humanoid-robot",
+          "entity-robot-lab",
+          "entity-unitree",
+          "sources-repos-roboto-origin"
+        ],
+        "source_links": [
+          "https://github.com/Roboparty/roboto_origin",
+          "https://roboparty.com/roboto_origin/doc"
         ],
         "status": "active"
       },

--- a/index.md
+++ b/index.md
@@ -160,6 +160,7 @@ SORT type ASC
 - [开源人形机器人硬件方案对比](entities/open-source-humanoid-hardware.md) — 随着具身智能的爆发，人形机器人的硬件门槛正在迅速降低。对于预算有限的实验室或个人研究者，**开源硬件方案 (Open-source Humanoid Hardware)** 是验证算法的首选。 `📅unknown` `[entity_page]`
 - [Pinocchio (刚体动力学库)](entities/pinocchio.md) — Pinocchio** 是一个由法国国家信息与自动化研究所（INRIA）开源的，专注于**高计算效率**和**分析导数 (Analytical Derivatives)** 的刚体动力学（Rigi `📅unknown` `[entity_page]`
 - [robot_lab (IsaacLab 扩展框架)](entities/robot-lab.md) — robot_lab** 是由开发者 `fan-ziqi` 维护的一个建立在 NVIDIA **IsaacLab** 之上的强化学习 (RL) 扩展库。它允许用户在隔离的仓库中开发机器人资产、环境和 `📅unknown` `[entity_page]`
+- [Roboto Origin（开源人形机器人基线）](entities/roboto-origin.md) — **Roboto Origin** 是 Roboparty 发布的“全链路开源”人形机器人项目入口，聚合 hardware/deploy/train/description/firmware 五个子仓库。 `📅2026-04-25` `[entity_page]`
 - [Shadow Hand (灵巧手)](entities/shadow-hand.md) — Shadow Hand** 由英国 Shadow Robot Company 开发，是目前世界上最接近人类手部功能的灵巧手平台之一。它拥有 5 根手指 and 20 个主动驱动关节（总计 24 个自由度 `📅unknown` `[entity_page]`
 - [Unitree G1 (人形机器人)](entities/unitree-g1.md) — Unitree G1** 是宇树科技 (Unitree) 在 H1 之后推出的一款量产型、高性价比的人形机器人平台。其设计初衷是降低人形机器人研究的门槛，使其能够大规模进入实验室、高校和家庭场景。 `📅unknown` `[entity_page]`
 - [Unitree](entities/unitree.md) — Unitree Robotics（宇树科技）** 是当前腿式机器人和人形机器人领域最有影响力的公司之一。 `📅unknown` `[entity_page]`

--- a/log.md
+++ b/log.md
@@ -414,3 +414,5 @@
 - V21 checklist 对应条目已勾选
 
 ## [2026-04-25] lint | 同步 sources/papers/policy_optimization.md 的最新进展（BRRL/BPO 2026）至全站 8 个相关 wiki 页面，消除陈旧预警并更新索引
+
+## [2026-04-25] ingest | sources/repos/roboto_origin.md — 新增 Roboto Origin 及其五个官方模块仓库与文档资料归档，并沉淀 wiki/entities/roboto-origin.md

--- a/sources/repos/roboto_origin.md
+++ b/sources/repos/roboto_origin.md
@@ -1,0 +1,54 @@
+# roboto_origin
+
+> 来源归档
+
+- **标题：** ROBOTO_ORIGIN - Fully Open-Source DIY Humanoid Robot
+- **类型：** repo（聚合仓库）
+- **来源：** Roboparty（GitHub 组织）
+- **链接：** https://github.com/Roboparty/roboto_origin
+- **入库日期：** 2026-04-25
+- **一句话说明：** Roboparty 发布的人形机器人开源基线仓库，聚合硬件、部署、训练、描述、固件五个子仓库，目标是可复现的 DIY 人形机器人研发链路。
+- **沉淀到 wiki：** 是（`wiki/entities/roboto-origin.md`）
+
+---
+
+## 核心定位
+
+`roboto_origin` 官方声明为 **snapshot aggregation only**：
+- 用于汇总项目整体说明与入口
+- 实际开发与贡献建议进入各子仓库
+- 覆盖结构、电子、训练、部署全栈流程
+
+该仓库强调：可通过公开供应链与开源代码复现一个可跑可跳的人形机器人原型。
+
+---
+
+## 关联仓库（官方模块）
+
+| 模块 | 主要职责 | 仓库链接 |
+|------|---------|---------|
+| Atom01_hardware | 机械结构、CAD、PCB、BOM | https://github.com/Roboparty/Atom01_hardware |
+| atom01_deploy | ROS2 驱动、中间件、部署配置、IMU/电机集成 | https://github.com/Roboparty/atom01_deploy |
+| atom01_train | IsaacLab 训练、仿真配置、Sim2Sim（含 MuJoCo） | https://github.com/Roboparty/atom01_train |
+| atom01_description | URDF 运动学/动力学模型与网格资源 | https://github.com/Roboparty/atom01_description |
+| atom01_firmware | 固件、USB2CAN、OrangePi 构建与守护进程 | https://github.com/Roboparty/atom01_firmware |
+
+---
+
+## 关联资料（文档与知识库）
+
+- 官方文档：<https://roboparty.com/roboto_origin/doc>
+- 中文 README：<https://github.com/Roboparty/roboto_origin/blob/main/README_cn.md>
+- 中文贡献指南：<https://github.com/Roboparty/roboto_origin/blob/main/CONTRIBUTING_CN.md>
+- 人形机器人运动控制 Know-How（飞书）：<https://roboparty.feishu.cn/wiki/GvUxwKVeNiGa7kku6vEcvqfKn87>
+
+---
+
+## 与本仓库现有资料的关系
+
+| 资料 | 关系 |
+|------|------|
+| [unitree.md](unitree.md) | 同属人形硬件与控制生态参考对象 |
+| [robot_lab.md](robot_lab.md) | 同样强调 IsaacLab 训练工作流，但定位不同（通用训练扩展 vs 原型机全栈） |
+| [isaac_gym_isaac_lab.md](isaac_gym_isaac_lab.md) | `atom01_train` 的上游训练基础设施 |
+| [sources/notes/know-how.md](../notes/know-how.md) | 早期条目已有 Roboto 文档入口，这里补齐结构化来源归档 |

--- a/wiki/entities/open-source-humanoid-hardware.md
+++ b/wiki/entities/open-source-humanoid-hardware.md
@@ -2,13 +2,15 @@
 type: entity
 tags: [humanoid, hardware, open-source, robotics, research]
 status: complete
-updated: 2026-04-21
+updated: 2026-04-25
 related:
   - ./humanoid-robot.md
+  - ./roboto-origin.md
   - ../queries/humanoid-hardware-selection.md
   - ../roadmaps/humanoid-control-roadmap.md
 sources:
   - ../../sources/papers/humanoid_hardware.md
+  - ../../sources/repos/roboto_origin.md
 summary: "主流开源人形机器人硬件方案对比：详细梳理了 Roboto Origin、Berkeley Humanoid (ODRI) 等平台的机械结构、执行器选型及开源生态，为研究者提供低成本入门指南。"
 ---
 
@@ -44,9 +46,11 @@ summary: "主流开源人形机器人硬件方案对比：详细梳理了 Roboto
 
 ## 关联页面
 - [人形机器人 (Humanoid Robot)](./humanoid-robot.md)
+- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)
 - [人形机器人硬件怎么选](../queries/humanoid-hardware-selection.md)
 - [Humanoid Control Roadmap](../roadmaps/humanoid-control-roadmap.md)
 
 ## 参考来源
 - [humanoid_hardware.md](../../sources/papers/humanoid_hardware.md)
+- [roboto_origin.md](../../sources/repos/roboto_origin.md)
 - 各开源项目 GitHub Readme 与 Wiki。

--- a/wiki/entities/roboto-origin.md
+++ b/wiki/entities/roboto-origin.md
@@ -1,0 +1,61 @@
+---
+type: entity
+tags: [humanoid, hardware, open-source, ros2, isaac-lab]
+status: complete
+updated: 2026-04-25
+related:
+  - ./open-source-humanoid-hardware.md
+  - ./humanoid-robot.md
+  - ./robot-lab.md
+  - ./unitree.md
+sources:
+  - ../../sources/repos/roboto_origin.md
+summary: "Roboto Origin 是 Roboparty 发布的开源人形机器人基线项目，通过聚合 hardware/deploy/train/description/firmware 五个子仓库，提供可复现的 DIY 人形机器人研发路径。"
+---
+
+# Roboto Origin（开源人形机器人基线）
+
+**Roboto Origin** 是 Roboparty 发布的“全链路开源”人形机器人项目入口页，目标不是只给一个仓库，而是提供从硬件到训练再到部署的可复现工程路径。
+
+## 为什么重要
+
+1. **低门槛复现路径**：将 DIY 人形机器人的关键模块显式拆分，降低单人/小团队上手门槛。
+2. **工程边界清晰**：官方明确聚合仓库用于导航，贡献回流到子仓库，避免 monorepo 混乱。
+3. **覆盖全栈闭环**：硬件设计、URDF 描述、RL 训练、ROS2 部署、固件链路全部公开。
+
+## 核心结构
+
+Roboto Origin 的仓库体系可理解为“五段流水线”：
+
+- **Atom01_hardware**：机械与电子设计（CAD/PCB/BOM）
+- **atom01_description**：机器人模型描述（URDF + 网格）
+- **atom01_train**：IsaacLab 训练与 Sim2Sim
+- **atom01_deploy**：ROS2 真机驱动与部署
+- **atom01_firmware**：底层固件与板端支持
+
+这种拆分方式适合把“研究迭代”和“工程落地”分离维护。
+
+## 常见误区 / 局限
+
+- **误区 1：把 `roboto_origin` 当成可直接开发主仓库。**
+  实际上它更像索引入口，真正开发需进入各模块仓库。
+- **误区 2：认为开源即开箱即用。**
+  项目仍需要较强的 Linux/ROS2/硬件调试能力。
+- **局限：** 当前公开资料更偏“原型复现与社区协作”，对工业级可靠性（长期运行、认证、安全冗余）覆盖有限。
+
+## 关联页面
+
+- [开源人形机器人硬件方案对比](./open-source-humanoid-hardware.md)
+- [人形机器人（Humanoid Robot）](./humanoid-robot.md)
+- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)
+- [Unitree](./unitree.md)
+
+## 推荐继续阅读
+
+- [Roboparty / roboto_origin](https://github.com/Roboparty/roboto_origin)
+- [Humanoid Robot Know-How Documentation](https://roboparty.com/roboto_origin/doc)
+
+## 参考来源
+
+- [sources/repos/roboto_origin.md](../../sources/repos/roboto_origin.md)
+- [Roboparty/roboto_origin README](https://github.com/Roboparty/roboto_origin)


### PR DESCRIPTION
### Motivation

- 将 Roboparty 的 `roboto_origin` 仓库及其官方模块作为原始资料归档到 `sources/`，便于后续在 wiki 中引用与溯源。
- 把该仓库提炼为一个结构化的实体页，填补本仓库关于开源人形硬件的实体覆盖并加强互链。

### Description

- 新增 `sources/repos/roboto_origin.md`，结构化记录 `roboto_origin` 及其五个官方子仓库（`Atom01_hardware` / `atom01_deploy` / `atom01_train` / `atom01_description` / `atom01_firmware`）和官方文档入口。
- 新增 `wiki/entities/roboto-origin.md`，按页面规范沉淀定位、重要性、核心结构、局限、关联页面与 `## 参考来源` 指向 `sources/`。
- 更新 `wiki/entities/open-source-humanoid-hardware.md`、`index.md` 与相关导出数据，使 `Roboto Origin` 在实体目录与互链中可见；并同步更新 `exports/` 与 `docs/exports/` 生成的数据文件。
- 追加 `log.md` 的 ingest 条目并运行导出脚本以刷新站点数据和搜索索引。

### Testing

- 运行 `python3 scripts/lint_wiki.py`，自动化检查通过（输出：0 issues）。
- 运行 `make export`（等同于 `python3 scripts/export_minimal.py`），导出成功并写入 `exports/index-v1.json` 与 `exports/site-data-v1.json`，同时镜像到 `docs/exports/` 并更新 `docs/search-index.json` 与 `docs/sitemap.xml`（均成功）。
- 运行 `make log OP=ingest ...` 完成并追加了相应 `log.md` 条目。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7b7591ec8323921be28e322071a2)