### PR TITLE
[2026-04-25] ingest | 接入 Roboparty Atom01 五个官方模块仓库原始资料

### DIFF
--- a/log.md
+++ b/log.md
@@ -416,3 +416,5 @@
 ## [2026-04-25] lint | 同步 sources/papers/policy_optimization.md 的最新进展（BRRL/BPO 2026）至全站 8 个相关 wiki 页面，消除陈旧预警并更新索引
 
 ## [2026-04-25] ingest | sources/repos/roboto_origin.md — 新增 Roboto Origin 及其五个官方模块仓库与文档资料归档，并沉淀 wiki/entities/roboto-origin.md
+
+## [2026-04-25] ingest | sources/repos/atom01_hardware.md, sources/repos/atom01_deploy.md, sources/repos/atom01_train.md, sources/repos/atom01_description.md, sources/repos/atom01_firmware.md — 接入 Roboparty Atom01 五个官方模块仓库原始资料

--- a/sources/README.md
+++ b/sources/README.md
@@ -29,6 +29,12 @@
 | [unitree.md](repos/unitree.md) | Unitree 硬件与 SDK |
 | [legged_gym.md](repos/legged_gym.md) | legged_gym 训练框架 |
 | [x] [robot_lab.md](repos/robot_lab.md) | robot_lab：基于 IsaacLab 的 RL 扩展框架，支持 26+ 机器人（四足 / 轮足 / 人形） |
+| [x] [roboto_origin.md](repos/roboto_origin.md) | Roboparty 人形机器人开源聚合入口（硬件/训练/部署/描述/固件） |
+| [x] [atom01_hardware.md](repos/atom01_hardware.md) | Atom01 硬件仓库（结构/CAD/PCB/BOM） |
+| [x] [atom01_deploy.md](repos/atom01_deploy.md) | Atom01 部署仓库（ROS2 驱动与上机流程） |
+| [x] [atom01_train.md](repos/atom01_train.md) | Atom01 训练仓库（IsaacLab 训练与迁移） |
+| [x] [atom01_description.md](repos/atom01_description.md) | Atom01 描述仓库（URDF/网格/模型） |
+| [x] [atom01_firmware.md](repos/atom01_firmware.md) | Atom01 固件仓库（板端构建与通信链路） |
 
 ### blogs/ — 博客来源归档
 | 文件 | 内容 |

--- a/sources/repos/atom01_deploy.md
+++ b/sources/repos/atom01_deploy.md
@@ -1,0 +1,24 @@
+# atom01_deploy
+
+> 来源归档
+
+- **标题：** atom01_deploy
+- **类型：** repo
+- **来源：** Roboparty（GitHub 组织）
+- **链接：** https://github.com/Roboparty/atom01_deploy
+- **入库日期：** 2026-04-25
+- **一句话说明：** Atom01 的部署与运行仓库，聚焦 ROS2 驱动、中间件、设备接入与上机部署流程。
+- **沉淀到 wiki：** 否（待后续补齐部署链路实践后再沉淀）
+
+---
+
+## 为什么值得保留
+
+- 承接训练策略到真实机器人执行的工程落地路径
+- 涵盖 IMU/电机/通信等部署关键环节
+- 对 Sim2Real 与可复现部署流程有直接参考价值
+
+## 与本仓库现有资料的关系
+
+- [roboto_origin.md](roboto_origin.md) 的部署子模块
+- 可与 [robot_lab.md](robot_lab.md) 对比“训练框架”与“部署执行”分层

--- a/sources/repos/atom01_description.md
+++ b/sources/repos/atom01_description.md
@@ -1,0 +1,24 @@
+# atom01_description
+
+> 来源归档
+
+- **标题：** atom01_description
+- **类型：** repo
+- **来源：** Roboparty（GitHub 组织）
+- **链接：** https://github.com/Roboparty/atom01_description
+- **入库日期：** 2026-04-25
+- **一句话说明：** Atom01 的机器人描述仓库，提供 URDF、网格与模型资源，是仿真/控制/可视化共享的模型基线。
+- **沉淀到 wiki：** 否（待与 URDF 相关条目合并后评估）
+
+---
+
+## 为什么值得保留
+
+- 连接机械实体与仿真系统的数据桥梁
+- 为动力学建模、碰撞体配置、可视化调试提供统一模型来源
+- 可支撑后续 model mismatch 与 system identification 分析
+
+## 与本仓库现有资料的关系
+
+- [roboto_origin.md](roboto_origin.md) 的描述子模块
+- 与 `sources/urdf.md`（URDF 资源入口）形成互补

--- a/sources/repos/atom01_firmware.md
+++ b/sources/repos/atom01_firmware.md
@@ -1,0 +1,24 @@
+# atom01_firmware
+
+> 来源归档
+
+- **标题：** atom01_firmware
+- **类型：** repo
+- **来源：** Roboparty（GitHub 组织）
+- **链接：** https://github.com/Roboparty/atom01_firmware
+- **入库日期：** 2026-04-25
+- **一句话说明：** Atom01 的固件与板端运行仓库，覆盖通信（如 USB2CAN）、板级构建与运行守护等底层执行能力。
+- **沉淀到 wiki：** 否（待补齐通信与控制链条对照后再沉淀）
+
+---
+
+## 为什么值得保留
+
+- 直接关联真实机器人控制闭环中的实时与通信稳定性
+- 是上层策略在板端可执行性的关键依赖
+- 可与部署仓库共同构成“控制软件栈最底层”参考样例
+
+## 与本仓库现有资料的关系
+
+- [roboto_origin.md](roboto_origin.md) 的固件子模块
+- 与 `sources/sim2real.md` 的落地环节相关

--- a/sources/repos/atom01_hardware.md
+++ b/sources/repos/atom01_hardware.md
@@ -1,0 +1,24 @@
+# atom01_hardware
+
+> 来源归档
+
+- **标题：** Atom01_hardware
+- **类型：** repo
+- **来源：** Roboparty（GitHub 组织）
+- **链接：** https://github.com/Roboparty/Atom01_hardware
+- **入库日期：** 2026-04-25
+- **一句话说明：** Atom01 的硬件主仓库，覆盖结构件、CAD、PCB、BOM 与装配相关资源，是机器人实体落地的物理基础。
+- **沉淀到 wiki：** 否（待后续与硬件设计/供应链页面合并评估）
+
+---
+
+## 为什么值得保留
+
+- 作为 Atom01 项目的硬件单一事实来源（Single Source of Truth）
+- 对复现型研究（DIY 人形平台）至关重要
+- 可与 `atom01_description`（URDF）和 `atom01_firmware`（固件）形成三层映射
+
+## 与本仓库现有资料的关系
+
+- [roboto_origin.md](roboto_origin.md) 的硬件子模块
+- 可与 [unitree.md](unitree.md) 对比不同硬件开源策略

--- a/sources/repos/atom01_train.md
+++ b/sources/repos/atom01_train.md
@@ -1,0 +1,24 @@
+# atom01_train
+
+> 来源归档
+
+- **标题：** atom01_train
+- **类型：** repo
+- **来源：** Roboparty（GitHub 组织）
+- **链接：** https://github.com/Roboparty/atom01_train
+- **入库日期：** 2026-04-25
+- **一句话说明：** Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与 Sim2Sim/Sim2Real 迁移流程展开。
+- **沉淀到 wiki：** 否（待补充训练结果与方法对比后再升格）
+
+---
+
+## 为什么值得保留
+
+- 提供 Atom01 的策略训练入口与实验配置参考
+- 与 `atom01_deploy` 构成训练→部署闭环
+- 能补充本仓库在人形平台实战训练链路案例
+
+## 与本仓库现有资料的关系
+
+- [roboto_origin.md](roboto_origin.md) 的训练子模块
+- 与 [isaac_gym_isaac_lab.md](isaac_gym_isaac_lab.md)、[robot_lab.md](robot_lab.md) 同属 Isaac 生态


### PR DESCRIPTION
### Motivation

- 将用户指定的 Roboparty Atom01 相关子仓库作为原始资料接入 `sources/`，以保证知识库对该人形原型项目的可追溯性与引用入口。 

### Description

- 新增 5 个 `sources/repos/` 归档页面：`atom01_hardware.md`、`atom01_deploy.md`、`atom01_train.md`、`atom01_description.md`、`atom01_firmware.md`，每页包含来源、链接、入库日期与关系说明。 
- 更新 `sources/README.md` 的 `repos/` 列表以加入 `roboto_origin` 与上述 5 个 Atom01 子仓库入口。 
- 按 ingest 流程追加了 `log.md` 条目并将变更写入仓库工作区以便后续同步。 

### Testing

- 运行 `python3 scripts/append_log.py` 成功追加操作日志记录且返回成功信息。 
- 运行 `make lint`（含 `python3 scripts/eval_search_quality.py` 与 `python3 scripts/lint_wiki.py`）通过，搜索回归 36/37 (97%)，`lint_wiki.py` 报告 0 个问题 且 sources 覆盖率 100%。 
- 尝试推送远端失败因为当前仓库未配置远程（`git remote -v` 为空），因此尚未推送到远端仓库。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd8611cb88323aa19910c39f4d13a)