### PR TITLE
docs(entity): 补充 atom01-train 输入/输出、Reward 与训练/Sim2Sim 指令细节

### DIFF
--- a/docs/exports/index-v1.json
+++ b/docs/exports/index-v1.json
@@ -27,7 +27,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-centroidal-dynamics",
@@ -94,7 +94,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/gentlehumanoid_upper_body_compliance.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-estimation",
@@ -125,7 +125,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-rich-manipulation",
@@ -218,7 +218,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-concepts-dexterous-kinematics",
@@ -271,7 +271,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/sim2real.md"
+      "ingest_source": "sources/papers/simulation_tools.md"
     },
     {
       "id": "wiki-concepts-embodied-data-cleaning",
@@ -366,7 +366,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-footstep-planning",
@@ -398,7 +398,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/contact_planning.md"
     },
     {
       "id": "wiki-concepts-force-control-basics",
@@ -487,7 +487,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/reward_design.md"
     },
     {
       "id": "wiki-concepts-hqp",
@@ -638,7 +638,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-motion-retargeting",
@@ -698,7 +698,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-optimal-control",
@@ -730,7 +730,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/mpc.md"
     },
     {
       "id": "wiki-concepts-privileged-training",
@@ -792,7 +792,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-concepts-ros2-basics",
@@ -910,7 +910,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-state-estimation",
@@ -943,7 +943,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/humanoid_motion_control_know_how.md"
     },
     {
       "id": "wiki-concepts-system-identification",
@@ -1068,7 +1068,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-video-as-simulation",
@@ -1132,7 +1132,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-whole-body-coordination",
@@ -1391,7 +1391,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/diffusion_and_gen.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-methods-dmp",
@@ -1541,7 +1541,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/diffusion_and_gen.md"
+      "ingest_source": "sources/papers/locomotion_rl.md"
     },
     {
       "id": "wiki-methods-in-hand-reorientation",
@@ -1645,7 +1645,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/mpc.md"
     },
     {
       "id": "wiki-methods-model-predictive-control",
@@ -1779,7 +1779,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/humanoid_motion_control_know_how.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-methods-safe-rl",
@@ -1857,7 +1857,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/optimal_control.md"
     },
     {
       "id": "wiki-methods-unified-multimodal-tokens",
@@ -1989,7 +1989,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-tasks-bimanual-manipulation",
@@ -2060,7 +2060,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/gentlehumanoid_upper_body_compliance.md"
     },
     {
       "id": "wiki-tasks-locomotion",
@@ -2097,7 +2097,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-tasks-manipulation",
@@ -2135,7 +2135,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-tasks-teleoperation",
@@ -4435,14 +4435,14 @@
       "title": "Atom01 Train",
       "path": "wiki/entities/atom01-train.md",
       "summary": "type: entity。",
-      "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
+      "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-27\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n\n## 训练任务的输入与输出（面向 IsaacLab / PPO）\n\n> 这一节用于回答「detail 子网页里 atom01_train 的输入输出到底是什么」。\n\n### 输入（Observation / Command）\n\n在 Atom01 这类人形 locomotion 训练里，策略网络通常接收以下输入块（按功能分组）：\n\n- **本体状态（proprioception）**：\n  - IMU 重力投影 / 角速度\n  - 关节位置（相对默认姿态）\n  - 关节速度\n  - 上一时刻动作（action history）\n- **高层命令（command）**：\n  - 目标前进速度 `vx`\n  - 侧向速度 `vy`\n  - 偏航角速度 `yaw_rate`\n- **可选历史堆叠（history stack）**：\n  - 过去 `N` 帧观测，用于改善延迟与状态估计鲁棒性\n- **可选特权信息（仅 teacher / 仿真）**：\n  - 接触状态、地形信息、扰动参数等\n\n### 输出（Action）\n\n- 主流输出是 **每个可控关节的目标增量或目标角**（再经 PD 转力矩），例如：\n  - `target_joint_pos = default_pos + action_scale * policy_output`\n- 在部署链路里，动作会进一步经过：\n  - 限幅（joint/action clipping）\n  - 滤波（anti-jitter）\n  - 与控制频率对齐（如 50Hz/100Hz）\n\n## Reward 设计（建议从“稳定+跟踪+代价”三层开始）\n\n为了便于在 detail 页快速查阅，这里把 reward 设计收敛成可执行模板：\n\n1. **任务主目标（必须项）**\n   - 线速度跟踪：`r_lin_vel`\n   - 角速度跟踪：`r_ang_vel`\n2. **稳定性项（人形关键）**\n   - 躯干直立：`r_upright`\n   - 基座高度：`r_base_height`\n   - 脚接触节律/防滑：`r_contact` / `r_no_slip`\n3. **代价与约束项（防止“钻奖励漏洞”）**\n   - 能耗/力矩惩罚：`r_torque_penalty`\n   - 动作变化率惩罚：`r_action_rate`\n   - 关节越界惩罚：`r_joint_limit`\n\n建议流程：\n\n- **先训出不摔（简化 reward）**，再逐步加入平滑、能耗与步态细节。\n- 若出现“原地抖动但不走”，优先检查：\n  - 跟踪奖励是否过小\n  - `action_rate` / `torque` 惩罚是否过重\n\n## 训练代码配置细节（你应该优先看的参数）\n\n围绕 `atom01_train`，可把训练配置分成 5 组：\n\n1. **环境与任务**：任务名、episode 长度、并行环境数 `num_envs`\n2. **观测与动作**：obs 归一化、history 长度、动作缩放与 clipping\n3. **奖励与终止**：reward 权重表、跌倒阈值、姿态越界终止条件\n4. **PPO 超参数**：learning rate、clip range、entropy coef、horizon、mini-batch\n5. **域随机化（Sim2Real 前置）**：摩擦、质量、延迟、传感器噪声、推扰动\n\n实操建议：\n\n- 每次只改一组参数，避免多变量耦合导致无法归因。\n- 训练日志至少跟踪：总 reward、各 reward 分量、跌倒率、速度跟踪误差。\n\n## 开始训练与 Sim2Sim 指令（可直接放到 detail 页）\n\n> 说明：本仓库当前已收录 `atom01_train` 的来源与定位，但没有把上游 README 的完整命令原文入库。为保证页面可用性，先给出 IsaacLab 生态常用命令模板（按实际脚本名替换）。\n\n### 1) 开始训练（Train）\n\n```bash\n# 进入训练仓库后\npython scripts/train.py --task atom01_walk --headless\n```\n\n常见可选参数：\n\n```bash\npython scripts/train.py   --task atom01_walk   --num_envs 4096   --max_iterations 5000   --seed 42   --headless\n```\n\n### 2) Sim2Sim（例如 Isaac → MuJoCo）\n\n```bash\n# 使用训练好的 checkpoint 在第二仿真器回放/评测\npython scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n常见可选参数：\n\n```bash\npython scripts/sim2sim.py   --task atom01_walk   --checkpoint logs/atom01_walk/model_XXXX.pt   --sim mujoco\n```\n\n如果上游仓库采用 `isaaclab.sh` 启动方式，可等价写成：\n\n```bash\n./isaaclab.sh -p scripts/train.py --task atom01_walk --headless\n./isaaclab.sh -p scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n> 建议在后续 ingest 中补全 `atom01_train` README 的原始命令段落，再把本节模板替换成“仓库实参版”。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
       "tags": [
         "entities",
         "entity",
         "humanoid",
-        "rl",
-        "sim2real",
-        "tooling"
+        "locomotion",
+        "control",
+        "dynamics"
       ],
       "related": [
         "entity-roboto-origin",
@@ -4515,7 +4515,7 @@
       "type": "entity_page",
       "entity_kind": "library",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "entity-drake",
@@ -4609,7 +4609,7 @@
       "type": "entity_page",
       "entity_kind": "simulator",
       "has_ingest": true,
-      "ingest_source": "sources/papers/locomotion_rl.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-legged-gym",
@@ -4641,7 +4641,7 @@
       "type": "entity_page",
       "entity_kind": "framework",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-mujoco",

--- a/docs/exports/site-data-v1.json
+++ b/docs/exports/site-data-v1.json
@@ -52,14 +52,14 @@
           "wiki-methods-action-chunking",
           "wiki-methods-actuator-network",
           "entity-atom01-firmware",
+          "entity-atom01-train",
           "wiki-tasks-balance-recovery",
           "wiki-tasks-bimanual-manipulation",
           "entity-boston-dynamics",
           "wiki-comparisons-clf-vs-cbf",
           "wiki-concepts-capture-point-dcm",
           "wiki-concepts-centroidal-dynamics",
-          "wiki-formalizations-cmdp",
-          "wiki-formalizations-contact-complementarity"
+          "wiki-formalizations-cmdp"
         ],
         "references": [
           "reference-papers-latent-skill-prior",
@@ -91,7 +91,6 @@
         "entry_items": [
           "entity-anymal",
           "wiki-methods-actuator-network",
-          "entity-atom01-train",
           "wiki-methods-auto-labeling-pipelines",
           "wiki-methods-behavior-cloning",
           "wiki-formalizations-bellman-equation",
@@ -100,7 +99,8 @@
           "wiki-concepts-contact-dynamics",
           "wiki-concepts-contact-estimation",
           "wiki-concepts-curriculum-learning",
-          "wiki-methods-dagger"
+          "wiki-methods-dagger",
+          "wiki-concepts-domain-randomization"
         ],
         "references": [
           "reference-papers-imitation-learning",
@@ -172,7 +172,6 @@
           "wiki-methods-actuator-network",
           "entity-atom01-deploy",
           "entity-atom01-description",
-          "entity-atom01-train",
           "wiki-concepts-contact-estimation",
           "wiki-concepts-curriculum-learning",
           "wiki-methods-diffusion-policy",
@@ -180,7 +179,8 @@
           "wiki-concepts-embodied-scaling-laws",
           "wiki-queries-ethercat-master-optimization",
           "wiki-concepts-ethercat-protocol",
-          "wiki-methods-generative-world-models"
+          "wiki-methods-generative-world-models",
+          "wiki-methods-imitation-learning"
         ],
         "references": [
           "reference-papers-locomotion-rl",
@@ -204,6 +204,7 @@
         "entry_items": [
           "entity-anymal",
           "wiki-methods-actuator-network",
+          "entity-atom01-train",
           "wiki-tasks-balance-recovery",
           "wiki-methods-behavior-cloning",
           "entity-boston-dynamics",
@@ -212,8 +213,7 @@
           "entity-crocoddyl",
           "wiki-concepts-curriculum-learning",
           "wiki-methods-dagger",
-          "entity-drake",
-          "wiki-formalizations-ekf"
+          "entity-drake"
         ],
         "references": [
           "reference-papers-latent-skill-prior",
@@ -244,7 +244,6 @@
         "entry_items": [
           "wiki-methods-actuator-network",
           "entity-allegro-hand",
-          "entity-atom01-train",
           "wiki-methods-claw",
           "wiki-formalizations-contact-complementarity",
           "wiki-concepts-domain-randomization",
@@ -253,7 +252,8 @@
           "wiki-methods-generative-data-augmentation",
           "wiki-methods-generative-world-models",
           "wiki-formalizations-hjb",
-          "entity-isaac-gym-isaac-lab"
+          "entity-isaac-gym-isaac-lab",
+          "wiki-formalizations-lqr"
         ],
         "references": [
           "reference-papers-locomotion-rl",
@@ -4844,14 +4844,14 @@
         "type": "entity_page",
         "path": "wiki/entities/atom01-train.md",
         "summary": "type: entity。",
-        "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
+        "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-27\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n\n## 训练任务的输入与输出（面向 IsaacLab / PPO）\n\n> 这一节用于回答「detail 子网页里 atom01_train 的输入输出到底是什么」。\n\n### 输入（Observation / Command）\n\n在 Atom01 这类人形 locomotion 训练里，策略网络通常接收以下输入块（按功能分组）：\n\n- **本体状态（proprioception）**：\n  - IMU 重力投影 / 角速度\n  - 关节位置（相对默认姿态）\n  - 关节速度\n  - 上一时刻动作（action history）\n- **高层命令（command）**：\n  - 目标前进速度 `vx`\n  - 侧向速度 `vy`\n  - 偏航角速度 `yaw_rate`\n- **可选历史堆叠（history stack）**：\n  - 过去 `N` 帧观测，用于改善延迟与状态估计鲁棒性\n- **可选特权信息（仅 teacher / 仿真）**：\n  - 接触状态、地形信息、扰动参数等\n\n### 输出（Action）\n\n- 主流输出是 **每个可控关节的目标增量或目标角**（再经 PD 转力矩），例如：\n  - `target_joint_pos = default_pos + action_scale * policy_output`\n- 在部署链路里，动作会进一步经过：\n  - 限幅（joint/action clipping）\n  - 滤波（anti-jitter）\n  - 与控制频率对齐（如 50Hz/100Hz）\n\n## Reward 设计（建议从“稳定+跟踪+代价”三层开始）\n\n为了便于在 detail 页快速查阅，这里把 reward 设计收敛成可执行模板：\n\n1. **任务主目标（必须项）**\n   - 线速度跟踪：`r_lin_vel`\n   - 角速度跟踪：`r_ang_vel`\n2. **稳定性项（人形关键）**\n   - 躯干直立：`r_upright`\n   - 基座高度：`r_base_height`\n   - 脚接触节律/防滑：`r_contact` / `r_no_slip`\n3. **代价与约束项（防止“钻奖励漏洞”）**\n   - 能耗/力矩惩罚：`r_torque_penalty`\n   - 动作变化率惩罚：`r_action_rate`\n   - 关节越界惩罚：`r_joint_limit`\n\n建议流程：\n\n- **先训出不摔（简化 reward）**，再逐步加入平滑、能耗与步态细节。\n- 若出现“原地抖动但不走”，优先检查：\n  - 跟踪奖励是否过小\n  - `action_rate` / `torque` 惩罚是否过重\n\n## 训练代码配置细节（你应该优先看的参数）\n\n围绕 `atom01_train`，可把训练配置分成 5 组：\n\n1. **环境与任务**：任务名、episode 长度、并行环境数 `num_envs`\n2. **观测与动作**：obs 归一化、history 长度、动作缩放与 clipping\n3. **奖励与终止**：reward 权重表、跌倒阈值、姿态越界终止条件\n4. **PPO 超参数**：learning rate、clip range、entropy coef、horizon、mini-batch\n5. **域随机化（Sim2Real 前置）**：摩擦、质量、延迟、传感器噪声、推扰动\n\n实操建议：\n\n- 每次只改一组参数，避免多变量耦合导致无法归因。\n- 训练日志至少跟踪：总 reward、各 reward 分量、跌倒率、速度跟踪误差。\n\n## 开始训练与 Sim2Sim 指令（可直接放到 detail 页）\n\n> 说明：本仓库当前已收录 `atom01_train` 的来源与定位，但没有把上游 README 的完整命令原文入库。为保证页面可用性，先给出 IsaacLab 生态常用命令模板（按实际脚本名替换）。\n\n### 1) 开始训练（Train）\n\n```bash\n# 进入训练仓库后\npython scripts/train.py --task atom01_walk --headless\n```\n\n常见可选参数：\n\n```bash\npython scripts/train.py   --task atom01_walk   --num_envs 4096   --max_iterations 5000   --seed 42   --headless\n```\n\n### 2) Sim2Sim（例如 Isaac → MuJoCo）\n\n```bash\n# 使用训练好的 checkpoint 在第二仿真器回放/评测\npython scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n常见可选参数：\n\n```bash\npython scripts/sim2sim.py   --task atom01_walk   --checkpoint logs/atom01_walk/model_XXXX.pt   --sim mujoco\n```\n\n如果上游仓库采用 `isaaclab.sh` 启动方式，可等价写成：\n\n```bash\n./isaaclab.sh -p scripts/train.py --task atom01_walk --headless\n./isaaclab.sh -p scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n> 建议在后续 ingest 中补全 `atom01_train` README 的原始命令段落，再把本节模板替换成“仓库实参版”。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
         "tags": [
           "entities",
           "entity",
           "humanoid",
-          "rl",
-          "sim2real",
-          "tooling"
+          "locomotion",
+          "control",
+          "dynamics"
         ],
         "related": [
           "entity-roboto-origin",

--- a/exports/index-v1.json
+++ b/exports/index-v1.json
@@ -27,7 +27,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-centroidal-dynamics",
@@ -94,7 +94,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/gentlehumanoid_upper_body_compliance.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-estimation",
@@ -125,7 +125,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-contact-rich-manipulation",
@@ -218,7 +218,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-concepts-dexterous-kinematics",
@@ -271,7 +271,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/sim2real.md"
+      "ingest_source": "sources/papers/simulation_tools.md"
     },
     {
       "id": "wiki-concepts-embodied-data-cleaning",
@@ -366,7 +366,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-footstep-planning",
@@ -398,7 +398,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/contact_planning.md"
     },
     {
       "id": "wiki-concepts-force-control-basics",
@@ -487,7 +487,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/reward_design.md"
     },
     {
       "id": "wiki-concepts-hqp",
@@ -638,7 +638,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-motion-retargeting",
@@ -698,7 +698,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-optimal-control",
@@ -730,7 +730,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/mpc.md"
     },
     {
       "id": "wiki-concepts-privileged-training",
@@ -792,7 +792,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-concepts-ros2-basics",
@@ -910,7 +910,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-state-estimation",
@@ -943,7 +943,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/humanoid_motion_control_know_how.md"
     },
     {
       "id": "wiki-concepts-system-identification",
@@ -1068,7 +1068,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-concepts-video-as-simulation",
@@ -1132,7 +1132,7 @@
       "type": "wiki_page",
       "page_type": "concept",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/contact_dynamics.md"
     },
     {
       "id": "wiki-concepts-whole-body-coordination",
@@ -1391,7 +1391,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/diffusion_and_gen.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-methods-dmp",
@@ -1541,7 +1541,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/diffusion_and_gen.md"
+      "ingest_source": "sources/papers/locomotion_rl.md"
     },
     {
       "id": "wiki-methods-in-hand-reorientation",
@@ -1645,7 +1645,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/mpc.md"
     },
     {
       "id": "wiki-methods-model-predictive-control",
@@ -1779,7 +1779,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/humanoid_motion_control_know_how.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-methods-safe-rl",
@@ -1857,7 +1857,7 @@
       "type": "wiki_page",
       "page_type": "method",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/optimal_control.md"
     },
     {
       "id": "wiki-methods-unified-multimodal-tokens",
@@ -1989,7 +1989,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/footstep_and_balance.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "wiki-tasks-bimanual-manipulation",
@@ -2060,7 +2060,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/mpc.md"
+      "ingest_source": "sources/papers/gentlehumanoid_upper_body_compliance.md"
     },
     {
       "id": "wiki-tasks-locomotion",
@@ -2097,7 +2097,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/privileged_training.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "wiki-tasks-manipulation",
@@ -2135,7 +2135,7 @@
       "type": "wiki_page",
       "page_type": "task",
       "has_ingest": true,
-      "ingest_source": "sources/papers/motion_control_projects.md"
+      "ingest_source": "sources/papers/imitation_learning.md"
     },
     {
       "id": "wiki-tasks-teleoperation",
@@ -4435,14 +4435,14 @@
       "title": "Atom01 Train",
       "path": "wiki/entities/atom01-train.md",
       "summary": "type: entity。",
-      "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
+      "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-27\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n\n## 训练任务的输入与输出（面向 IsaacLab / PPO）\n\n> 这一节用于回答「detail 子网页里 atom01_train 的输入输出到底是什么」。\n\n### 输入（Observation / Command）\n\n在 Atom01 这类人形 locomotion 训练里，策略网络通常接收以下输入块（按功能分组）：\n\n- **本体状态（proprioception）**：\n  - IMU 重力投影 / 角速度\n  - 关节位置（相对默认姿态）\n  - 关节速度\n  - 上一时刻动作（action history）\n- **高层命令（command）**：\n  - 目标前进速度 `vx`\n  - 侧向速度 `vy`\n  - 偏航角速度 `yaw_rate`\n- **可选历史堆叠（history stack）**：\n  - 过去 `N` 帧观测，用于改善延迟与状态估计鲁棒性\n- **可选特权信息（仅 teacher / 仿真）**：\n  - 接触状态、地形信息、扰动参数等\n\n### 输出（Action）\n\n- 主流输出是 **每个可控关节的目标增量或目标角**（再经 PD 转力矩），例如：\n  - `target_joint_pos = default_pos + action_scale * policy_output`\n- 在部署链路里，动作会进一步经过：\n  - 限幅（joint/action clipping）\n  - 滤波（anti-jitter）\n  - 与控制频率对齐（如 50Hz/100Hz）\n\n## Reward 设计（建议从“稳定+跟踪+代价”三层开始）\n\n为了便于在 detail 页快速查阅，这里把 reward 设计收敛成可执行模板：\n\n1. **任务主目标（必须项）**\n   - 线速度跟踪：`r_lin_vel`\n   - 角速度跟踪：`r_ang_vel`\n2. **稳定性项（人形关键）**\n   - 躯干直立：`r_upright`\n   - 基座高度：`r_base_height`\n   - 脚接触节律/防滑：`r_contact` / `r_no_slip`\n3. **代价与约束项（防止“钻奖励漏洞”）**\n   - 能耗/力矩惩罚：`r_torque_penalty`\n   - 动作变化率惩罚：`r_action_rate`\n   - 关节越界惩罚：`r_joint_limit`\n\n建议流程：\n\n- **先训出不摔（简化 reward）**，再逐步加入平滑、能耗与步态细节。\n- 若出现“原地抖动但不走”，优先检查：\n  - 跟踪奖励是否过小\n  - `action_rate` / `torque` 惩罚是否过重\n\n## 训练代码配置细节（你应该优先看的参数）\n\n围绕 `atom01_train`，可把训练配置分成 5 组：\n\n1. **环境与任务**：任务名、episode 长度、并行环境数 `num_envs`\n2. **观测与动作**：obs 归一化、history 长度、动作缩放与 clipping\n3. **奖励与终止**：reward 权重表、跌倒阈值、姿态越界终止条件\n4. **PPO 超参数**：learning rate、clip range、entropy coef、horizon、mini-batch\n5. **域随机化（Sim2Real 前置）**：摩擦、质量、延迟、传感器噪声、推扰动\n\n实操建议：\n\n- 每次只改一组参数，避免多变量耦合导致无法归因。\n- 训练日志至少跟踪：总 reward、各 reward 分量、跌倒率、速度跟踪误差。\n\n## 开始训练与 Sim2Sim 指令（可直接放到 detail 页）\n\n> 说明：本仓库当前已收录 `atom01_train` 的来源与定位，但没有把上游 README 的完整命令原文入库。为保证页面可用性，先给出 IsaacLab 生态常用命令模板（按实际脚本名替换）。\n\n### 1) 开始训练（Train）\n\n```bash\n# 进入训练仓库后\npython scripts/train.py --task atom01_walk --headless\n```\n\n常见可选参数：\n\n```bash\npython scripts/train.py   --task atom01_walk   --num_envs 4096   --max_iterations 5000   --seed 42   --headless\n```\n\n### 2) Sim2Sim（例如 Isaac → MuJoCo）\n\n```bash\n# 使用训练好的 checkpoint 在第二仿真器回放/评测\npython scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n常见可选参数：\n\n```bash\npython scripts/sim2sim.py   --task atom01_walk   --checkpoint logs/atom01_walk/model_XXXX.pt   --sim mujoco\n```\n\n如果上游仓库采用 `isaaclab.sh` 启动方式，可等价写成：\n\n```bash\n./isaaclab.sh -p scripts/train.py --task atom01_walk --headless\n./isaaclab.sh -p scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n> 建议在后续 ingest 中补全 `atom01_train` README 的原始命令段落，再把本节模板替换成“仓库实参版”。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
       "tags": [
         "entities",
         "entity",
         "humanoid",
-        "rl",
-        "sim2real",
-        "tooling"
+        "locomotion",
+        "control",
+        "dynamics"
       ],
       "related": [
         "entity-roboto-origin",
@@ -4515,7 +4515,7 @@
       "type": "entity_page",
       "entity_kind": "library",
       "has_ingest": true,
-      "ingest_source": "sources/papers/robot_kinematics_tools.md"
+      "ingest_source": "sources/papers/whole_body_control.md"
     },
     {
       "id": "entity-drake",
@@ -4609,7 +4609,7 @@
       "type": "entity_page",
       "entity_kind": "simulator",
       "has_ingest": true,
-      "ingest_source": "sources/papers/locomotion_rl.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-legged-gym",
@@ -4641,7 +4641,7 @@
       "type": "entity_page",
       "entity_kind": "framework",
       "has_ingest": true,
-      "ingest_source": "sources/papers/reward_design.md"
+      "ingest_source": "sources/papers/policy_optimization.md"
     },
     {
       "id": "entity-mujoco",

--- a/exports/site-data-v1.json
+++ b/exports/site-data-v1.json
@@ -52,14 +52,14 @@
           "wiki-methods-action-chunking",
           "wiki-methods-actuator-network",
           "entity-atom01-firmware",
+          "entity-atom01-train",
           "wiki-tasks-balance-recovery",
           "wiki-tasks-bimanual-manipulation",
           "entity-boston-dynamics",
           "wiki-comparisons-clf-vs-cbf",
           "wiki-concepts-capture-point-dcm",
           "wiki-concepts-centroidal-dynamics",
-          "wiki-formalizations-cmdp",
-          "wiki-formalizations-contact-complementarity"
+          "wiki-formalizations-cmdp"
         ],
         "references": [
           "reference-papers-latent-skill-prior",
@@ -91,7 +91,6 @@
         "entry_items": [
           "entity-anymal",
           "wiki-methods-actuator-network",
-          "entity-atom01-train",
           "wiki-methods-auto-labeling-pipelines",
           "wiki-methods-behavior-cloning",
           "wiki-formalizations-bellman-equation",
@@ -100,7 +99,8 @@
           "wiki-concepts-contact-dynamics",
           "wiki-concepts-contact-estimation",
           "wiki-concepts-curriculum-learning",
-          "wiki-methods-dagger"
+          "wiki-methods-dagger",
+          "wiki-concepts-domain-randomization"
         ],
         "references": [
           "reference-papers-imitation-learning",
@@ -172,7 +172,6 @@
           "wiki-methods-actuator-network",
           "entity-atom01-deploy",
           "entity-atom01-description",
-          "entity-atom01-train",
           "wiki-concepts-contact-estimation",
           "wiki-concepts-curriculum-learning",
           "wiki-methods-diffusion-policy",
@@ -180,7 +179,8 @@
           "wiki-concepts-embodied-scaling-laws",
           "wiki-queries-ethercat-master-optimization",
           "wiki-concepts-ethercat-protocol",
-          "wiki-methods-generative-world-models"
+          "wiki-methods-generative-world-models",
+          "wiki-methods-imitation-learning"
         ],
         "references": [
           "reference-papers-locomotion-rl",
@@ -204,6 +204,7 @@
         "entry_items": [
           "entity-anymal",
           "wiki-methods-actuator-network",
+          "entity-atom01-train",
           "wiki-tasks-balance-recovery",
           "wiki-methods-behavior-cloning",
           "entity-boston-dynamics",
@@ -212,8 +213,7 @@
           "entity-crocoddyl",
           "wiki-concepts-curriculum-learning",
           "wiki-methods-dagger",
-          "entity-drake",
-          "wiki-formalizations-ekf"
+          "entity-drake"
         ],
         "references": [
           "reference-papers-latent-skill-prior",
@@ -244,7 +244,6 @@
         "entry_items": [
           "wiki-methods-actuator-network",
           "entity-allegro-hand",
-          "entity-atom01-train",
           "wiki-methods-claw",
           "wiki-formalizations-contact-complementarity",
           "wiki-concepts-domain-randomization",
@@ -253,7 +252,8 @@
           "wiki-methods-generative-data-augmentation",
           "wiki-methods-generative-world-models",
           "wiki-formalizations-hjb",
-          "entity-isaac-gym-isaac-lab"
+          "entity-isaac-gym-isaac-lab",
+          "wiki-formalizations-lqr"
         ],
         "references": [
           "reference-papers-locomotion-rl",
@@ -4844,14 +4844,14 @@
         "type": "entity_page",
         "path": "wiki/entities/atom01-train.md",
         "summary": "type: entity。",
-        "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-25\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
+        "content_markdown": "---\ntype: entity\ntags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]\nstatus: complete\nupdated: 2026-04-27\nrelated:\n  - ./roboto-origin.md\n  - ./robot-lab.md\n  - ./isaac-gym-isaac-lab.md\nsources:\n  - ../../sources/repos/atom01_train.md\nsummary: \"atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置、策略学习与仿真迁移流程构建。\"\n---\n\n# Atom01 Train\n\n**atom01_train** 是 Roboparty Atom01 项目的训练主仓库，聚焦 IsaacLab 场景下的策略学习、实验配置与迁移链路。\n\n## 为什么重要\n\n- 是 Atom01 从模型到策略的训练入口。\n- 将硬件平台约束映射到训练环境，帮助减少部署落差。\n- 与 `atom01_deploy` 联合构成训练→部署闭环。\n\n## 核心结构/机制\n\n- **训练配置**：任务参数、奖励项与训练超参数。\n- **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。\n- **工程接口**：与模型描述与部署链路对齐。\n\n\n## 训练任务的输入与输出（面向 IsaacLab / PPO）\n\n> 这一节用于回答「detail 子网页里 atom01_train 的输入输出到底是什么」。\n\n### 输入（Observation / Command）\n\n在 Atom01 这类人形 locomotion 训练里，策略网络通常接收以下输入块（按功能分组）：\n\n- **本体状态（proprioception）**：\n  - IMU 重力投影 / 角速度\n  - 关节位置（相对默认姿态）\n  - 关节速度\n  - 上一时刻动作（action history）\n- **高层命令（command）**：\n  - 目标前进速度 `vx`\n  - 侧向速度 `vy`\n  - 偏航角速度 `yaw_rate`\n- **可选历史堆叠（history stack）**：\n  - 过去 `N` 帧观测，用于改善延迟与状态估计鲁棒性\n- **可选特权信息（仅 teacher / 仿真）**：\n  - 接触状态、地形信息、扰动参数等\n\n### 输出（Action）\n\n- 主流输出是 **每个可控关节的目标增量或目标角**（再经 PD 转力矩），例如：\n  - `target_joint_pos = default_pos + action_scale * policy_output`\n- 在部署链路里，动作会进一步经过：\n  - 限幅（joint/action clipping）\n  - 滤波（anti-jitter）\n  - 与控制频率对齐（如 50Hz/100Hz）\n\n## Reward 设计（建议从“稳定+跟踪+代价”三层开始）\n\n为了便于在 detail 页快速查阅，这里把 reward 设计收敛成可执行模板：\n\n1. **任务主目标（必须项）**\n   - 线速度跟踪：`r_lin_vel`\n   - 角速度跟踪：`r_ang_vel`\n2. **稳定性项（人形关键）**\n   - 躯干直立：`r_upright`\n   - 基座高度：`r_base_height`\n   - 脚接触节律/防滑：`r_contact` / `r_no_slip`\n3. **代价与约束项（防止“钻奖励漏洞”）**\n   - 能耗/力矩惩罚：`r_torque_penalty`\n   - 动作变化率惩罚：`r_action_rate`\n   - 关节越界惩罚：`r_joint_limit`\n\n建议流程：\n\n- **先训出不摔（简化 reward）**，再逐步加入平滑、能耗与步态细节。\n- 若出现“原地抖动但不走”，优先检查：\n  - 跟踪奖励是否过小\n  - `action_rate` / `torque` 惩罚是否过重\n\n## 训练代码配置细节（你应该优先看的参数）\n\n围绕 `atom01_train`，可把训练配置分成 5 组：\n\n1. **环境与任务**：任务名、episode 长度、并行环境数 `num_envs`\n2. **观测与动作**：obs 归一化、history 长度、动作缩放与 clipping\n3. **奖励与终止**：reward 权重表、跌倒阈值、姿态越界终止条件\n4. **PPO 超参数**：learning rate、clip range、entropy coef、horizon、mini-batch\n5. **域随机化（Sim2Real 前置）**：摩擦、质量、延迟、传感器噪声、推扰动\n\n实操建议：\n\n- 每次只改一组参数，避免多变量耦合导致无法归因。\n- 训练日志至少跟踪：总 reward、各 reward 分量、跌倒率、速度跟踪误差。\n\n## 开始训练与 Sim2Sim 指令（可直接放到 detail 页）\n\n> 说明：本仓库当前已收录 `atom01_train` 的来源与定位，但没有把上游 README 的完整命令原文入库。为保证页面可用性，先给出 IsaacLab 生态常用命令模板（按实际脚本名替换）。\n\n### 1) 开始训练（Train）\n\n```bash\n# 进入训练仓库后\npython scripts/train.py --task atom01_walk --headless\n```\n\n常见可选参数：\n\n```bash\npython scripts/train.py   --task atom01_walk   --num_envs 4096   --max_iterations 5000   --seed 42   --headless\n```\n\n### 2) Sim2Sim（例如 Isaac → MuJoCo）\n\n```bash\n# 使用训练好的 checkpoint 在第二仿真器回放/评测\npython scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n常见可选参数：\n\n```bash\npython scripts/sim2sim.py   --task atom01_walk   --checkpoint logs/atom01_walk/model_XXXX.pt   --sim mujoco\n```\n\n如果上游仓库采用 `isaaclab.sh` 启动方式，可等价写成：\n\n```bash\n./isaaclab.sh -p scripts/train.py --task atom01_walk --headless\n./isaaclab.sh -p scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>\n```\n\n> 建议在后续 ingest 中补全 `atom01_train` README 的原始命令段落，再把本节模板替换成“仓库实参版”。\n\n## 常见误区或局限\n\n- 误区：只要训练收敛就能真机稳定。真机仍受通信、校准、硬件误差影响。\n- 局限：训练仓库往往强调算法迭代，部署鲁棒性要靠额外工程补齐。\n\n## 参考来源\n\n- [sources/repos/atom01_train.md](../../sources/repos/atom01_train.md)\n- [Roboparty/atom01_train](https://github.com/Roboparty/atom01_train)\n\n## 关联页面\n\n- [Roboto Origin（开源人形机器人基线）](./roboto-origin.md)\n- [robot_lab (IsaacLab 扩展框架)](./robot-lab.md)\n- [Isaac Gym / Isaac Lab](./isaac-gym-isaac-lab.md)\n\n## 推荐继续阅读\n\n- [Atom01 Deploy](./atom01-deploy.md)\n- [Reinforcement Learning](../methods/reinforcement-learning.md)",
         "tags": [
           "entities",
           "entity",
           "humanoid",
-          "rl",
-          "sim2real",
-          "tooling"
+          "locomotion",
+          "control",
+          "dynamics"
         ],
         "related": [
           "entity-roboto-origin",

--- a/wiki/entities/atom01-train.md
+++ b/wiki/entities/atom01-train.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [humanoid, isaac-lab, rl, sim2sim, sim2real, roboparty]
 status: complete
-updated: 2026-04-25
+updated: 2026-04-27
 related:
   - ./roboto-origin.md
   - ./robot-lab.md
@@ -27,6 +27,115 @@ summary: "atom01_train 是 Atom01 的训练仓库，围绕 IsaacLab 训练配置
 - **训练配置**：任务参数、奖励项与训练超参数。
 - **仿真迁移**：支持 Sim2Sim/Sim2Real 工作流。
 - **工程接口**：与模型描述与部署链路对齐。
+
+
+## 训练任务的输入与输出（面向 IsaacLab / PPO）
+
+> 这一节用于回答「detail 子网页里 atom01_train 的输入输出到底是什么」。
+
+### 输入（Observation / Command）
+
+在 Atom01 这类人形 locomotion 训练里，策略网络通常接收以下输入块（按功能分组）：
+
+- **本体状态（proprioception）**：
+  - IMU 重力投影 / 角速度
+  - 关节位置（相对默认姿态）
+  - 关节速度
+  - 上一时刻动作（action history）
+- **高层命令（command）**：
+  - 目标前进速度 `vx`
+  - 侧向速度 `vy`
+  - 偏航角速度 `yaw_rate`
+- **可选历史堆叠（history stack）**：
+  - 过去 `N` 帧观测，用于改善延迟与状态估计鲁棒性
+- **可选特权信息（仅 teacher / 仿真）**：
+  - 接触状态、地形信息、扰动参数等
+
+### 输出（Action）
+
+- 主流输出是 **每个可控关节的目标增量或目标角**（再经 PD 转力矩），例如：
+  - `target_joint_pos = default_pos + action_scale * policy_output`
+- 在部署链路里，动作会进一步经过：
+  - 限幅（joint/action clipping）
+  - 滤波（anti-jitter）
+  - 与控制频率对齐（如 50Hz/100Hz）
+
+## Reward 设计（建议从“稳定+跟踪+代价”三层开始）
+
+为了便于在 detail 页快速查阅，这里把 reward 设计收敛成可执行模板：
+
+1. **任务主目标（必须项）**
+   - 线速度跟踪：`r_lin_vel`
+   - 角速度跟踪：`r_ang_vel`
+2. **稳定性项（人形关键）**
+   - 躯干直立：`r_upright`
+   - 基座高度：`r_base_height`
+   - 脚接触节律/防滑：`r_contact` / `r_no_slip`
+3. **代价与约束项（防止“钻奖励漏洞”）**
+   - 能耗/力矩惩罚：`r_torque_penalty`
+   - 动作变化率惩罚：`r_action_rate`
+   - 关节越界惩罚：`r_joint_limit`
+
+建议流程：
+
+- **先训出不摔（简化 reward）**，再逐步加入平滑、能耗与步态细节。
+- 若出现“原地抖动但不走”，优先检查：
+  - 跟踪奖励是否过小
+  - `action_rate` / `torque` 惩罚是否过重
+
+## 训练代码配置细节（你应该优先看的参数）
+
+围绕 `atom01_train`，可把训练配置分成 5 组：
+
+1. **环境与任务**：任务名、episode 长度、并行环境数 `num_envs`
+2. **观测与动作**：obs 归一化、history 长度、动作缩放与 clipping
+3. **奖励与终止**：reward 权重表、跌倒阈值、姿态越界终止条件
+4. **PPO 超参数**：learning rate、clip range、entropy coef、horizon、mini-batch
+5. **域随机化（Sim2Real 前置）**：摩擦、质量、延迟、传感器噪声、推扰动
+
+实操建议：
+
+- 每次只改一组参数，避免多变量耦合导致无法归因。
+- 训练日志至少跟踪：总 reward、各 reward 分量、跌倒率、速度跟踪误差。
+
+## 开始训练与 Sim2Sim 指令（可直接放到 detail 页）
+
+> 说明：本仓库当前已收录 `atom01_train` 的来源与定位，但没有把上游 README 的完整命令原文入库。为保证页面可用性，先给出 IsaacLab 生态常用命令模板（按实际脚本名替换）。
+
+### 1) 开始训练（Train）
+
+```bash
+# 进入训练仓库后
+python scripts/train.py --task atom01_walk --headless
+```
+
+常见可选参数：
+
+```bash
+python scripts/train.py   --task atom01_walk   --num_envs 4096   --max_iterations 5000   --seed 42   --headless
+```
+
+### 2) Sim2Sim（例如 Isaac → MuJoCo）
+
+```bash
+# 使用训练好的 checkpoint 在第二仿真器回放/评测
+python scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>
+```
+
+常见可选参数：
+
+```bash
+python scripts/sim2sim.py   --task atom01_walk   --checkpoint logs/atom01_walk/model_XXXX.pt   --sim mujoco
+```
+
+如果上游仓库采用 `isaaclab.sh` 启动方式，可等价写成：
+
+```bash
+./isaaclab.sh -p scripts/train.py --task atom01_walk --headless
+./isaaclab.sh -p scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>
+```
+
+> 建议在后续 ingest 中补全 `atom01_train` README 的原始命令段落，再把本节模板替换成“仓库实参版”。
 
 ## 常见误区或局限
 


### PR DESCRIPTION
### Motivation
- 回答并在 `detail.html?id=entity-atom01-train` 子页中补全关于训练任务的输入/输出、Reward 设计与训练相关配置的查阅需求。  
- 提供 IsaacLab 生态下可直接复用的“开始训练 / Sim2Sim”命令模板以便用户快速上手。  
- 保证网页导出层（`exports/` 与 `docs/exports/`）同步包含新增正文，供前端 detail page 即时消费。  

### Description
- 在 `wiki/entities/atom01-train.md` 中新增节：`训练任务的输入与输出（面向 IsaacLab / PPO）`、`Reward 设计`、`训练代码配置细节` 以及 `开始训练与 Sim2Sim 指令`，并把页面 `updated` 时间更新为 `2026-04-27`。  
- 为输入/输出列出常见 observation / command / action 格式，为 Reward 给出“稳定+跟踪+代价”三层模板，并把训练配置拆为 5 组（环境、obs/action、reward/终止、PPO 超参、域随机化）。  
- 在页面中添加 IsaacLab 常用命令模板示例：`python scripts/train.py --task atom01_walk --headless` 与 `python scripts/sim2sim.py --task atom01_walk --checkpoint <ckpt_path>`（并给出常见 CLI 选项示例与说明）。  
- 运行导出脚本生成并同步更新导出数据文件：`exports/index-v1.json`、`exports/site-data-v1.json` 及 `docs/exports/` 下对应文件，同时更新 `docs/search-index.json`，并提交这些变更。  

### Testing
- Ran `python3 scripts/export_minimal.py` to regenerate site exports and mirror to `docs/exports/`; the command completed successfully and wrote updated `index-v1.json` and `site-data-v1.json`.  
- Ran `python3 scripts/check_export_quality.py` to validate export consistency; all automated checks passed (`Through: 12/12`, export quality OK).  
- Verified the modified `wiki/entities/atom01-train.md` appears in the mirrored `docs/exports/site-data-v1.json` and is searchable via the updated `docs/search-index.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeeb2be5ac8323b10d605cf04b894f)