### PR TITLE
docs: 为 README 增加 CI 徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Live-brightgreen?logo=github)](https://imchong.github.io/Robotics_Notebooks/)
 [![Deploy GitHub Pages](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/pages.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/pages.yml)
+[![Wiki Lint](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml)
 [![License](https://img.shields.io/github/license/ImChong/Robotics_Notebooks)](./LICENSE)
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-217节点_1274边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
 [![Sources Coverage](https://img.shields.io/badge/sources覆盖率-99%25-green)](docs/checklists/tech-stack-next-phase-checklist-v21.md)


### PR DESCRIPTION
### Motivation
- 让仓库首页直接展示并便捷跳转到 Wiki Lint CI 状态，以便维护者快速查看 `lint.yml` 工作流运行结果。

### Description
- 在 `README.md` 顶部徽章区新增 `Wiki Lint` badge，链接指向 `.github/workflows/lint.yml` 的 workflow 页面。

### Testing
- 运行 `make lint`（包含 `python3 scripts/eval_search_quality.py` 与 `python3 scripts/lint_wiki.py`）进行回归与 lint 检查，所有自动化检查通过（0 issues，回归通过）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f05932608323ba19ed054da20994)