### PR TITLE
P0 工程基础修复：CI 接入 pytest + 修复 .gitignore 与测试副作用

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pytest pyyaml numpy
+
+      - name: Run pytest
+        run: python3 -m pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,5 @@ playwright-report/
 # Local vector artifacts
 exports/vector-index.npz
 
-# Local search cache
+# Local search cache (CLI use only — docs/search-index.json is a Pages artifact and must be tracked)
 exports/search-cache.json
-docs/search-index.json

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: lint catalog export export-check search ingest log coverage graph anki slides fetch badge vectors eval-search ci-preflight ci-check
+.PHONY: lint test catalog export export-check search ingest log coverage graph anki slides fetch badge vectors eval-search ci-preflight ci-check
 
 lint:
 	python3 scripts/eval_search_quality.py
 	python3 scripts/lint_wiki.py
+
+test:
+	python3 -m pytest tests/ -q
 
 catalog:
 	python3 scripts/generate_page_catalog.py

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -1,6 +1,7 @@
-from pathlib import Path
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -11,7 +12,14 @@ from build_search_index import generate_search_index  # noqa: E402
 
 class SearchIndexTests(unittest.TestCase):
     def test_search_index_includes_tech_map_nodes(self):
-        payload = generate_search_index(ROOT / "docs" / "search-index.json")
+        # Write to a temp path so running the test does not mutate the
+        # real docs/search-index.json artifact in the working tree.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = Path(tmp) / "search-index.json"
+            payload = generate_search_index(output_path)
+
+            self.assertTrue(output_path.exists(), "generate_search_index should write to the provided path")
+
         docs = payload["docs"]
         tech_docs = [doc for doc in docs if doc["path"].startswith("tech-map/")]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

针对前一轮代码质量评估中识别出的 **P0** 三条工程基础问题做最小集合修复：

1. CI 完全没跑 pytest——`tests/` 目录里 39 个 unittest 用例只能本地手跑，任何 PR 把它们打挂 CI 都不会失败。
2. `docs/search-index.json` 同时被 `.gitignore` 列入并且被 git 跟踪，本地一跑 `make ci-preflight` 就会让 `git status` 出现 `MM` 噪声。
3. `tests/test_search_index.py` 直接写到 `docs/search-index.json`（与上一条配合放大副作用）。

## 改动

四个独立 commit，每条对应一个最小修复：

| Commit | 内容 |
|---|---|
| `chore(gitignore): ...` | `.gitignore` 移除 `docs/search-index.json`，注释说明这是 Pages 必须入库的产物；保留 `exports/search-cache.json` 的忽略 |
| `fix(tests): ...` | `tests/test_search_index.py` 改写到 `tempfile.TemporaryDirectory()`，断言文件被写出但不污染工作区 |
| `chore(makefile): ...` | 新增 `make test` target（与现有 `make lint` / `make ci-preflight` 风格一致） |
| `ci(tests): ...` | 新建 `.github/workflows/tests.yml`，触发条件与 `lint.yml` 一致，安装 pytest 后跑 `python3 -m pytest tests/ -q` |

## 验证

```
$ make test
python3 -m pytest tests/ -q
.......................................                                  [100%]
39 passed in 0.52s

$ make ci-preflight
...
✅ 所有检查通过！
✅ 所有导出质量检查通过。
通过：12/12

$ git status docs/search-index.json
nothing to commit, working tree clean    # 测试不再污染该文件
```

## 范围与影响

- 不动任何 wiki 内容、不动派生的 `exports/` / `docs/exports/`。
- 不引入新依赖（`pytest` 只在 CI 与本地 dev 装，不进入 wiki / Pages 运行时）。
- 与 P1（`pyproject.toml` + ruff、`lint_wiki.py` 重构、Dependabot）正交，可以独立 review、独立合并。

## 后续建议（不在本 PR）

- **P1**：加 `pyproject.toml` + `ruff` 静态检查，把 `CANONICAL_FACTS` 抽出 `lint_wiki.py`，修复 "Impedance 柔顺性" 同页自我矛盾误报。
- **P2**：补 `extract_internal_links`、`compute_health_score`、`connected_components/modularity` 的单测；加 Dependabot；CSP + DOMPurify。
- **P3**：拆 `docs/main.js` ES module；Playwright 替代 `tests/test_content_sync.py` 的字符串断言。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93b5cfe7-2271-47b1-8a10-1d2b1c93fe0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93b5cfe7-2271-47b1-8a10-1d2b1c93fe0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

