### PR TITLE
feat(ci): make ci-test、Actions 缓存与 search_wiki_core 单测（覆盖率≥52%）

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
 
       - name: Install dev dependencies
         run: pip install -r requirements-dev.txt
@@ -39,6 +41,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
 
       - name: npm ci (ESLint)
         run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,10 @@
 
 1. Fork / 分支开发（推荐前缀 `cursor/` 之类由维护者约定）。
 2. 安装开发依赖：`pip install -r requirements-dev.txt`，若参与前端脚本检查则 `npm ci`。
-3. 修改 `wiki/` 或 `scripts/` 后运行 `make ci-preflight`，并提交其生成的导出与统计文件（若脚本有变更）。
-4. 运行 `make test`（含 Ruff + pytest 覆盖率门禁）。
-5. 发起 Pull Request，按模板填写摘要与验证方式。
+3. 修改维护脚本或测试后，建议运行 **`make ci-test`**（与 `tests.yml` 对齐：Ruff、Mypy、pip-audit、ESLint、pytest）。
+4. 修改 `wiki/` 或导出/索引链时运行 **`make ci-preflight`**，并提交其生成的导出与统计文件。
+5. 日常也可用 `make test` 仅跑 pytest（含覆盖率阈值）。
+6. 发起 Pull Request，按模板填写摘要与验证方式。
 
 ## 代码风格
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: lint test format lint-py lint-js typecheck complexity audit-dev catalog export export-check search ingest log coverage graph anki slides fetch badge vectors eval-search ci-preflight ci-check
+.PHONY: lint test ci-test format lint-py lint-js typecheck complexity audit-dev catalog export export-check search ingest log coverage graph anki slides fetch badge vectors eval-search ci-preflight ci-check
+
+# 与 .github/workflows/tests.yml 步骤顺序一致（不含 Wiki lint）
+ci-test:
+	ruff check scripts tests
+	ruff format --check scripts tests
+	PYTHONPATH=scripts mypy scripts
+	python3 -m pip_audit -r requirements-dev.txt
+	npm ci
+	npm run lint:js
+	PYTHONPATH=scripts python3 -m pytest
 
 lint:
 	python3 scripts/eval_search_quality.py

--- a/docs/contributing-ci.md
+++ b/docs/contributing-ci.md
@@ -2,15 +2,27 @@
 
 提交前尽量跑齐与 GitHub Actions 相同的检查，避免 PR 反复红。
 
+## 一键对齐 Tests 工作流
+
+与 [`.github/workflows/tests.yml`](../.github/workflows/tests.yml) 中 **Ruff / Mypy / pip-audit / ESLint / Pytest** 顺序一致（不含 Wiki 专项 lint）：
+
+```bash
+pip install -r requirements-dev.txt
+make ci-test
+```
+
+说明：变更 `wiki/` 或导出/索引链时，仍需执行 `make ci-preflight`（见下表）。
+
 ## 对照表
 
 | 检查项 | 本地命令 | CI Workflow |
 |--------|----------|----------------|
+| **Tests 工作流一键** | `make ci-test` | `tests.yml` |
 | Wiki lint + 搜索/导出质量 | `make ci-preflight`（或拆：`make lint`、`scripts/ci_preflight.py`） | `search-regression.yml`、`export.yml`（main 自动导出） |
 | Ruff（含 import 排序） | `ruff check scripts tests` | `tests.yml` |
 | Ruff 格式 | `ruff format scripts tests`（检查：`ruff format --check scripts tests`） | `tests.yml` |
 | 静态类型（scripts） | `PYTHONPATH=scripts mypy scripts` | `tests.yml` |
-| 单元测试 + 覆盖率阈值 | `make test` 或 `PYTHONPATH=scripts python3 -m pytest` | `tests.yml` |
+| 单元测试 + 覆盖率阈值（监测模块合计 ≥ **52%**） | `make test` 或 `PYTHONPATH=scripts python3 -m pytest` | `tests.yml` |
 | 依赖漏洞审计 | `python3 -m pip_audit -r requirements-dev.txt` | `tests.yml` |
 | 圈复杂度参考 | `make complexity`（仅输出，非硬性门禁） | — |
 | Wiki lint（轻量依赖） | `python3 scripts/lint_wiki.py` | `lint.yml` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ addopts = [
     "--cov=search_wiki",
     "--cov=utils",
     "--cov-report=term-missing",
-    "--cov-fail-under=37",
+    "--cov-fail-under=52",
 ]
 
 [tool.coverage.run]

--- a/tests/test_search_wiki_core.py
+++ b/tests/test_search_wiki_core.py
@@ -1,0 +1,138 @@
+"""Unit tests for scripts/search_wiki_core scoring helpers (raises coverage on pure logic)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from search_indexing import REPO_ROOT
+from search_wiki_core import (
+    collect_known_terms,
+    compute_avgdl,
+    compute_score,
+    extract_related_links,
+    levenshtein_distance,
+    normalize_scores,
+    suggest_terms,
+)
+
+
+class TestLevenshtein(unittest.TestCase):
+    def test_equal_and_empty(self):
+        self.assertEqual(levenshtein_distance("", ""), 0)
+        self.assertEqual(levenshtein_distance("abc", "abc"), 0)
+        self.assertEqual(levenshtein_distance("", "xy"), 2)
+        self.assertEqual(levenshtein_distance("a", ""), 1)
+
+    def test_edit_distance(self):
+        self.assertEqual(levenshtein_distance("kitten", "sitting"), 3)
+
+
+class TestNormalizeScores(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(normalize_scores([]), [])
+
+    def test_uniform_positive(self):
+        self.assertEqual(normalize_scores([3.0, 3.0, 3.0]), [1.0, 1.0, 1.0])
+
+    def test_uniform_non_positive(self):
+        self.assertEqual(normalize_scores([-1.0, -1.0]), [0.0, 0.0])
+
+    def test_range(self):
+        self.assertEqual(normalize_scores([0.0, 10.0]), [0.0, 1.0])
+
+
+class TestComputeScore(unittest.TestCase):
+    def test_no_query_tokens(self):
+        self.assertEqual(
+            compute_score({"a": 1}, [], title="t", avgdl=5.0, fm={}, page_type="concept"),
+            0.0,
+        )
+
+    def test_title_boost(self):
+        tc = {"mpc": 2}
+        s_title = compute_score(
+            tc, ["mpc"], title="MPC intro", avgdl=10.0, fm={}, page_type="method"
+        )
+        s_not = compute_score(tc, ["mpc"], title="other", avgdl=10.0, fm={}, page_type="method")
+        self.assertGreater(s_title, s_not)
+
+    def test_summary_boost(self):
+        tc = {"foo": 1}
+        fm = {"summary": "Contains foo term"}
+        with_summary = compute_score(
+            tc, ["foo"], title="none", avgdl=5.0, fm=fm, page_type="concept"
+        )
+        without = compute_score(tc, ["foo"], title="none", avgdl=5.0, fm={}, page_type="concept")
+        self.assertGreater(with_summary, without)
+
+    def test_page_type_multipliers(self):
+        tc = {"x": 1}
+        base = compute_score(tc, ["x"], title="", avgdl=5.0, fm={}, page_type="concept")
+        q = compute_score(tc, ["x"], title="", avgdl=5.0, fm={}, page_type="query")
+        c = compute_score(tc, ["x"], title="", avgdl=5.0, fm={}, page_type="comparison")
+        self.assertLess(q, base)
+        self.assertGreater(c, base)
+
+    def test_recent_updated_boost(self):
+        tc = {"z": 1}
+        today = date.today().isoformat()
+        recent = compute_score(
+            tc, ["z"], title="", avgdl=3.0, fm={"updated": today}, page_type="concept"
+        )
+        old = compute_score(
+            tc,
+            ["z"],
+            title="",
+            avgdl=3.0,
+            fm={"updated": "1990-01-01"},
+            page_type="concept",
+        )
+        self.assertGreater(recent, old)
+
+
+class TestComputeAvgdl(unittest.TestCase):
+    def test_basic(self):
+        docs = [
+            {"token_counts": {"a": 3}},
+            {"token_counts": {"b": 1}},
+        ]
+        self.assertAlmostEqual(compute_avgdl(docs), 2.0)
+
+
+class TestCollectKnownTerms(unittest.TestCase):
+    def test_merges_title_and_tags(self):
+        docs = [
+            {"title": "Hello", "tags": ["RL", "control"]},
+            {"title": "hello", "tags": ["RL"]},
+        ]
+        terms = collect_known_terms(docs)
+        self.assertEqual(terms["hello"], "Hello")
+        self.assertEqual(terms["rl"], "RL")
+
+
+class TestSuggestTerms(unittest.TestCase):
+    def test_typo_within_distance(self):
+        terms = {"locomotion": "locomotion"}
+        out = suggest_terms("lokomotion", terms, top_k=3)
+        self.assertTrue(any(t[0] == "locomotion" for t in out))
+
+    def test_empty_query(self):
+        self.assertEqual(suggest_terms("   ", {"a": "A"}, top_k=3), [])
+
+
+class TestExtractRelatedLinks(unittest.TestCase):
+    def test_resolves_relative_md(self):
+        src = REPO_ROOT / "wiki" / "concepts" / "armature-modeling.md"
+        content = "## 关联页面\n\n- [LIP ZMP](lip-zmp.md)\n"
+        links = extract_related_links(content, src)
+        self.assertTrue(any("lip-zmp.md" in entry for entry in links))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

落实先前讨论的增量改进：`make ci-test` 与 GitHub Actions **pip/npm 缓存**、为 `search_wiki_core` 纯逻辑补充单测并把覆盖率门禁从 **37% 提高到 52%**（当前全量约 **57%**）。

## 变更说明

- **`make ci-test`**：顺序与 `tests.yml` 一致（ruff check → format check → mypy → pip_audit → npm ci → eslint → pytest）。
- **`tests.yml`**：`setup-python` 启用 `cache: pip` + `cache-dependency-path: requirements-dev.txt`；`setup-node` 启用 `cache: npm`。
- **测试**：新增 [`tests/test_search_wiki_core.py`](tests/test_search_wiki_core.py)（Levenshtein、normalize_scores、compute_score、extract_related_links 等）。
- **`pyproject.toml`**：`--cov-fail-under=52`。
- **文档**：[`docs/contributing-ci.md`](docs/contributing-ci.md)、[`CONTRIBUTING.md`](CONTRIBUTING.md)。

## 验证

- `make ci-test`
- `PYTHONPATH=scripts python3 -m pytest`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c33ae117-845d-478d-95d0-c8a4b1e15ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c33ae117-845d-478d-95d0-c8a4b1e15ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

