### PR TITLE
feat: Add detail page mini knowledge map with 1-hop neighbors

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v21.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v21.md
@@ -39,7 +39,7 @@
 
 ## P2: 硬件通信与底层实时链路形式化 (Quantity)
 
-- [~] **发布通信层形式化定义 (+3)**:
+- [x] **发布通信层形式化定义 (+3)**:
     - [x] `wiki/formalizations/control-loop-latency-modeling.md` (控制环路延迟建模：总线、计算与内核调度延迟的数学求和)。
     - [x] `wiki/formalizations/udp-multicast-dynamics.md` (UDP 组播动力学：在 LCM 等中间件中的数据包丢失与一致性形式化)。
     - [x] `wiki/concepts/clock-synchronization-algorithms.md` (时钟同步算法：PTP/DC 协议在多板卡运控中的实现原理)。
@@ -48,8 +48,8 @@
 
 ## P3: 交互层“情境化”导航优化 (UX/UI)
 
-- [ ] **详情页“当前位置”微地图**：
-    - [ ] 修改 `docs/main.js`，在页面顶部显示一个微小的 D3 局部图谱，展示当前节点及其 1-hop 邻居，实现“一叶知秋”的导航体验。
+- [x] **详情页“当前位置”微地图**：
+    - [x] 修改 `docs/main.js`、`docs/detail.html`、`docs/style.css`，在 detail-hero 顶部新增 `#detailMiniMapWrap` D3 局部图谱，展示当前节点及其 1-hop 邻居（最多 12 个），点击邻居节点跳转对应详情页，实现“一叶知秋”的导航体验。
 - [x] **搜索结果按“置信度”分级**：
     - [x] 优化 UI，将搜索结果分为“精确匹配”与“潜在关联”两个区块。
 
@@ -60,8 +60,8 @@
 - [ ] `make lint`: 0 errors。
 - [ ] 知识图谱节点数 **≥ 190**。
 - [ ] 事实库扩展至 **140 条** 以上。
-- [ ] 详情页“微地图”组件上线并正常工作。
-- [ ] `log.md` 记录 V21 关键改动。
+- [x] 详情页“微地图”组件上线并正常工作。
+- [x] `log.md` 记录 V21 关键改动。
 
 ---
 

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -49,6 +49,13 @@
             </div>
           </aside>
         </div>
+        <aside id="detailMiniMapWrap" class="detail-mini-map" aria-label="知识地图局部视图" hidden>
+          <div class="detail-mini-map-head">
+            <h3>知识地图（1-hop 邻居）</h3>
+            <span id="detailMiniMapMeta" class="detail-mini-map-meta">正在读取邻居关系…</span>
+          </div>
+          <svg id="detailMiniMapSvg" class="detail-mini-map-svg" role="img" aria-label="当前节点 1-hop 邻居图"></svg>
+        </aside>
       </div>
     </section>
 
@@ -165,6 +172,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
   <script defer src="main.js"></script>
 </body>
 </html>

--- a/docs/main.js
+++ b/docs/main.js
@@ -885,6 +885,116 @@
     return null;
   }
 
+  var TYPE_COLOR_DETAIL_MINI = {
+    concept: '#60a5fa', method: '#34d399', task: '#f472b6',
+    entity: '#fbbf24', comparison: '#c084fc', query: '#94a3b8',
+    formalization: '#fb923c', '': '#64748b'
+  };
+
+  function buildPathToDetailIdIndex(detailPages) {
+    var idx = {};
+    Object.keys(detailPages).forEach(function (id) {
+      var p = detailPages[id];
+      if (p && p.path) idx[p.path] = id;
+    });
+    return idx;
+  }
+
+  function renderDetailMiniMap(detailPage, detailPages) {
+    var wrap = document.getElementById('detailMiniMapWrap');
+    var svgEl = document.getElementById('detailMiniMapSvg');
+    var metaEl = document.getElementById('detailMiniMapMeta');
+    if (!wrap || !svgEl || typeof window.d3 === 'undefined') return;
+    var currentPath = (detailPage && detailPage.path) || '';
+    if (!currentPath) return;
+
+    fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
+      var nodeMap = {};
+      (gd.nodes || []).forEach(function (n) { nodeMap[n.id] = n; });
+      var current = nodeMap[currentPath];
+      if (!current) return; // 当前节点不在图谱里
+
+      var neighborSet = {};
+      (gd.edges || []).forEach(function (e) {
+        if (e.source === currentPath) neighborSet[e.target] = true;
+        else if (e.target === currentPath) neighborSet[e.source] = true;
+      });
+      var neighborIds = Object.keys(neighborSet).filter(function (id) { return nodeMap[id]; });
+      // 限制最多 12 个邻居，避免拥挤
+      var MAX_NEIGHBORS = 12;
+      if (neighborIds.length > MAX_NEIGHBORS) neighborIds = neighborIds.slice(0, MAX_NEIGHBORS);
+
+      var pathToId = buildPathToDetailIdIndex(detailPages);
+      var nodes = [{
+        id: currentPath, label: current.label || currentPath,
+        type: current.type || '', isCurrent: true
+      }].concat(neighborIds.map(function (id) {
+        var n = nodeMap[id];
+        return { id: id, label: n.label || id, type: n.type || '', isCurrent: false };
+      }));
+      var edges = neighborIds.map(function (id) { return { source: currentPath, target: id }; });
+
+      wrap.hidden = false;
+      var W = wrap.clientWidth || 700;
+      var H = 180;
+      svgEl.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+      svgEl.innerHTML = '';
+
+      var svg = window.d3.select(svgEl);
+      var g = svg.append('g');
+      var lineLayer = g.append('g');
+      var nodeLayer = g.append('g');
+
+      var sim = window.d3.forceSimulation(nodes)
+        .force('link', window.d3.forceLink(edges).id(function (d) { return d.id; }).distance(54).strength(0.5))
+        .force('charge', window.d3.forceManyBody().strength(-160).distanceMax(220))
+        .force('center', window.d3.forceCenter(W / 2, H / 2).strength(0.12))
+        .force('collision', window.d3.forceCollide().radius(14).strength(0.7))
+        .alphaDecay(0.05);
+
+      var line = lineLayer.selectAll('line').data(edges).join('line')
+        .style('stroke', 'var(--border-strong)')
+        .attr('stroke-width', 1);
+
+      var nodeG = nodeLayer.selectAll('g').data(nodes).join('g')
+        .attr('class', function (d) { return d.isCurrent ? 'mini-node-current' : 'mini-node'; })
+        .style('cursor', function (d) { return d.isCurrent ? 'default' : 'pointer'; })
+        .on('click', function (ev, d) {
+          if (d.isCurrent) return;
+          var pid = pathToId[d.id];
+          if (pid) window.location.href = detailHref(pid);
+        });
+
+      nodeG.append('title').text(function (d) { return d.label; });
+      nodeG.append('circle')
+        .attr('r', function (d) { return d.isCurrent ? 8 : 6; })
+        .attr('fill', function (d) { return TYPE_COLOR_DETAIL_MINI[d.type] || TYPE_COLOR_DETAIL_MINI['']; })
+        .attr('fill-opacity', 0.9);
+      nodeG.append('text')
+        .text(function (d) { return d.label.length > 10 ? d.label.slice(0, 10) + '…' : d.label; })
+        .attr('dy', function (d) { return (d.isCurrent ? 8 : 6) + 11; })
+        .attr('text-anchor', 'middle')
+        .attr('font-size', '10px')
+        .style('fill', 'var(--text-muted)')
+        .attr('pointer-events', 'none');
+
+      sim.on('tick', function () {
+        line
+          .attr('x1', function (d) { return d.source.x; }).attr('y1', function (d) { return d.source.y; })
+          .attr('x2', function (d) { return d.target.x; }).attr('y2', function (d) { return d.target.y; });
+        nodeG.attr('transform', function (d) { return 'translate(' + d.x + ',' + d.y + ')'; });
+      });
+
+      if (metaEl) {
+        var totalDeg = Object.keys(neighborSet).length;
+        var shown = neighborIds.length;
+        metaEl.textContent = shown + ' / ' + totalDeg + ' 个 1-hop 邻居 · 点击跳转';
+      }
+    }).catch(function () {
+      if (metaEl) metaEl.textContent = '邻居数据加载失败';
+    });
+  }
+
   function renderDetailPage(siteData) {
     if (!siteData || !siteData.pages) return;
 
@@ -1059,6 +1169,8 @@
     }
 
     renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。');
+
+    renderDetailMiniMap(detailPage, detailPages);
   }
 
   function renderModulePage(siteData) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -449,6 +449,40 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   max-width: 100%;
   padding: 14px 16px;
 }
+.detail-mini-map {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 14px 6px;
+  box-shadow: var(--shadow-sm);
+}
+.detail-mini-map-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+.detail-mini-map-head h3 {
+  font-size: .95rem;
+  margin: 0;
+}
+.detail-mini-map-meta {
+  font-size: .78rem;
+  color: var(--text-muted);
+}
+.detail-mini-map-svg {
+  display: block;
+  width: 100%;
+  height: 180px;
+  border-radius: 8px;
+  background: var(--bg);
+}
+.detail-mini-map-svg text { font-family: var(--font-sans); }
+.detail-mini-map-svg .mini-node-current circle {
+  stroke: var(--accent);
+  stroke-width: 2.4px;
+}
 .detail-meta-list {
   display: grid;
   grid-template-columns: minmax(0, 1fr);

--- a/log.md
+++ b/log.md
@@ -190,3 +190,12 @@
 - 键盘导航沿用 `getResultCards()`（仅查 `article.card[data-result-url]`），新增的 `<h4>` 区块标题不会进入 ↑↓/Enter 选区
 - 验证：`python3 scripts/eval_search_quality.py` 通过率 **37/37 (100%)**；`node --check docs/main.js` 通过；`make lint` 仅余昨日 lwd ingest 留下的 1 条「陈旧页面」预警，与本次改动无关
 - V21 checklist 对应条目已勾选
+
+## [2026-05-07] feat | v21-execution | P3 详情页“知识地图”微地图（1-hop 邻居）
+
+- V21 P3 收口：在 `docs/detail.html` 的 detail-hero 顶部新增 `#detailMiniMapWrap` D3 局部图谱容器，并补齐 `<script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>`
+- `docs/main.js` 新增 `renderDetailMiniMap(detailPage, detailPages)`：基于 `exports/link-graph.json` 用 `detailPage.path` 定位当前节点，遍历 `edges` 收集 1-hop 邻居（最多 12 个，避免拥挤），D3 force simulation 绘制；点击邻居节点经 `path → detail page id` 反查后跳转 `detail.html?id=...`
+- 新增 `TYPE_COLOR_DETAIL_MINI` 与现有 `mini-graph.js` 的色板保持一致；当前节点用 `.mini-node-current` 描边强调；`<title>` 节点 hover 给出完整 label
+- `docs/style.css` 新增 `.detail-mini-map` / `.detail-mini-map-head` / `.detail-mini-map-svg` / `.mini-node-current` 样式（高度 180px，跟随 `--bg/--bg-alt/--border` 主题变量）
+- 验证：`make lint-js`（eslint）通过；`make test` 55 个测试全通过、覆盖率 57.16%（≥ 52% 阈值）；`make lint` 仅余昨日 lwd ingest 留下的 1 条「陈旧页面」预警，与本次改动无关
+- V21 checklist 对应条目已勾选；V21 DoD 中「微地图组件上线」「log.md 记录」两项亦同步勾选


### PR DESCRIPTION
## 摘要

在详情页顶部新增"知识地图"微地图组件，使用 D3 力导向图展示当前节点及其 1-hop 邻居（最多 12 个），支持点击邻居节点跳转对应详情页，实现"一叶知秋"的导航体验。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 核心功能
- **新增 `renderDetailMiniMap()` 函数**：从 `exports/link-graph.json` 加载知识图谱数据，定位当前节点，遍历边集合收集 1-hop 邻居，使用 D3 force simulation 绘制交互式局部图谱
- **邻居限制**：最多显示 12 个邻居，避免视图拥挤
- **交互设计**：
  - 当前节点用 `.mini-node-current` 样式描边强调
  - 邻居节点可点击，跳转至对应详情页
  - 节点 hover 显示完整标签（`<title>` 元素）
  - 标签超长自动截断（10 字符 + "…"）
- **色板一致性**：新增 `TYPE_COLOR_DETAIL_MINI` 对象，与现有 `mini-graph.js` 保持一致的节点类型配色

### 文件变更
- **`docs/detail.html`**：在 detail-hero 顶部新增 `#detailMiniMapWrap` 容器，包含标题、元数据显示区和 SVG 画布；引入 D3 v7 库
- **`docs/main.js`**：
  - 新增 `buildPathToDetailIdIndex()` 辅助函数，构建路径→详情页 ID 的反向索引
  - 新增 `renderDetailMiniMap()` 主函数，在 `renderDetailPage()` 中调用
- **`docs/style.css`**：新增 `.detail-mini-map*` 和 `.mini-node-current` 样式类，高度 180px，跟随主题变量（`--bg/--bg-alt/--border`）

### 错误处理
- 当前节点不在图谱中时静默返回
- 数据加载失败时在元数据区显示"邻居数据加载失败"提示

## 验证

- [x] `make lint-js`（eslint）通过
- [x] `make test` 55 个测试全通过、覆盖率 57.16%（≥ 52% 阈值）
- [x] `make lint` 仅余昨日 lwd ingest 留下的 1 条「陈旧页面」预警，与本次改动无关
- [x] V21 checklist P3 对应条目已勾选

## 相关 Issue

V21 P3 收口任务：详情页"当前位置"微地图

https://claude.ai/code/session_01Tx1RsJBHtDMrqW9U9fRrhh