### PR TITLE
docs: 添加 Cursor Cloud 开发环境说明至 AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,3 +175,32 @@
    - 范围 (scope)：可选（如 ux, actions, wiki）。
    示例：`fix(actions): 修复 CLAW 页面格式缺失主要技术路线的问题`
    示例：`chore: 更新主页统计数据与图谱 (172 nodes, 955 edges)`
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+This is a **pure content + tooling** repo — no backend services, databases, or Docker required. The stack is:
+- **Python 3.12** (scripts, linting, tests) with deps in `requirements-dev.txt`
+- **Node.js 22 + npm** (ESLint for `docs/main.js` only) with deps in `package.json`
+- **GNU Make** as the task runner (see `Makefile` for all targets)
+
+### Gotchas
+
+- `pip-audit` (used in `make ci-test`) requires `python3-venv` to be installed at the system level (`apt install python3-venv`). The update script handles `pip install` but system packages must be pre-installed.
+- Python tools (`ruff`, `mypy`, `pytest`, `pip-audit`, etc.) install to `~/.local/bin`. Ensure `PATH` includes `$HOME/.local/bin` before running Make targets.
+- `PYTHONPATH=scripts` is required for `mypy` and `pytest` (already set in the Makefile targets).
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Full CI gate (mirrors GH Actions) | `make ci-test` |
+| Wiki health check | `make lint` |
+| Pre-commit preflight (syncs all derived files + checks) | `make ci-preflight` |
+| Unit tests only | `make test` |
+| Serve static site locally | `cd docs && python3 -m http.server 8080` |
+
+### Before committing wiki changes
+
+Always run `make ci-preflight` — it regenerates derived files (`index.md`, `exports/`, `docs/exports/`, search index, sitemap, README stats, `docs/index.html`) and then runs lint + export checks. Committing without this causes CI failures from stale derived data.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious development environment caveats discovered during initial Cloud Agent setup.

### What's included

- Environment overview (Python 3.12 + Node.js 22 + Make)
- Gotchas: `python3-venv` requirement for `pip-audit`, `~/.local/bin` PATH, `PYTHONPATH` for mypy/pytest
- Quick-reference command table for common Make targets
- Reminder to run `make ci-preflight` before committing wiki changes

### Environment verification

All checks pass on the Cloud Agent VM:

| Check | Command | Result |
|-------|---------|--------|
| Python lint | `make lint-py` | All checks passed, 36 files formatted |
| Type checking | `make typecheck` | Success: 26 source files |
| JS lint | `make lint-js` | Clean |
| Tests | `make test` | 55 passed, 57% coverage |
| Full CI | `make ci-test` | All green |
| Wiki lint | `make lint` | 37/37 search quality, 0 issues |

### Demo

[knowledge_graph_demo.mp4](https://cursor.com/agents/bc-b72e594f-08f1-4fd9-81ce-97f7021ff876/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fknowledge_graph_demo.mp4)

Interactive knowledge graph with 251 nodes and 1569 edges serving locally on the static site.

[Homepage](https://cursor.com/agents/bc-b72e594f-08f1-4fd9-81ce-97f7021ff876/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Knowledge graph visualization](https://cursor.com/agents/bc-b72e594f-08f1-4fd9-81ce-97f7021ff876/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fknowledge_graph.webp)
[Search filtering to RL node](https://cursor.com/agents/bc-b72e594f-08f1-4fd9-81ce-97f7021ff876/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_rl_node.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b72e594f-08f1-4fd9-81ce-97f7021ff876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b72e594f-08f1-4fd9-81ce-97f7021ff876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

