### PR TITLE
feat(ux): 首页技术路线指南合并论文主线

### DIFF
--- a/docs/frontend-redesign-plan.md
+++ b/docs/frontend-redesign-plan.md
@@ -50,7 +50,7 @@ Phase 3（长期）：设计系统整体升级
 | `tech-map.html` | 技术栈节点，按 layer 卡片展示 | 静态卡片，不体现节点间依赖关系 |
 | `roadmap.html` | 学习路径页 | 功能完整，低优先级改动 |
 | `module.html` | 模块聚合页 | 功能完整，低优先级改动 |
-| `references.html` | 论文导航 | 功能完整，低优先级改动 |
+| `references.html` | 重定向到 `roadmap.html?id=roadmap-motion-control#paper-guide`（论文主线已并入路线页） |
 
 ### 1.2 核心问题
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
         <div>
           <p class="hero-kicker">Robotics Notebooks · 面向人形机器人运动控制的知识入口</p>
           <h1 class="hero-title">系统学习人形机器人运动控制</h1>
-          <p class="hero-subtitle">把 <strong>路线、图谱、模块、论文</strong> 串成一套极简导航系统。</p>
+          <p class="hero-subtitle">用 <strong>一条技术路线指南</strong> 串联学习阶段、相关入口与论文主线——适合从零入门，也方便有经验的运动控制工程师速查与备课。</p>
           
           <div class="hero-stat-row-mini" aria-label="知识库当前规模">
             <span id="heroNodeCount">252</span> Nodes ·
@@ -45,9 +45,8 @@
           </div>
 
           <div class="cta-row">
-            <a class="btn-primary" href="roadmap.html?id=roadmap-motion-control">🚀 开始路径</a>
+            <a class="btn-primary" href="roadmap.html?id=roadmap-motion-control">🧭 技术路线指南</a>
             <a class="btn-secondary" href="graph.html">🕸️ 知识图谱</a>
-            <a class="btn-secondary" href="references.html">📚 论文入口</a>
           </div>
         </div>
       </div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1268,6 +1268,15 @@
     });
   }
 
+  function setRoadmapPaperGuideVisible(show) {
+    const paperGuide = document.getElementById('paper-guide');
+    const paperSubnav = document.getElementById('roadmapSubnavPaper');
+    const paperToc = document.getElementById('roadmapTocPaperItem');
+    if (paperGuide) paperGuide.hidden = !show;
+    if (paperSubnav) paperSubnav.hidden = !show;
+    if (paperToc) paperToc.hidden = !show;
+  }
+
   function renderRoadmapPage(siteData) {
     if (!siteData || !siteData.pages) return;
 
@@ -1309,6 +1318,7 @@
       renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的相关项。' });
       renderSourceCards(sourceEl, [], '当前无可展示的来源链接。');
       if (breadcrumb) removeLoadingState(breadcrumb);
+      setRoadmapPaperGuideVisible(false);
       return;
     }
 
@@ -1368,6 +1378,7 @@
 
     renderInternalLinks(relatedEl, roadmapPage.related_items, detailPages, { emptyText: '当前路线暂无相关项。' });
     renderSourceCards(sourceEl, roadmapPage.source_links, '当前路线暂无来源链接。');
+    setRoadmapPaperGuideVisible(roadmapId === 'roadmap-motion-control');
   }
 
   function renderTechMapNodeCard(node, detailPages) {

--- a/docs/modules/imitation-learning.html
+++ b/docs/modules/imitation-learning.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/modules/motion-control.html
+++ b/docs/modules/motion-control.html
@@ -34,7 +34,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/modules/reinforcement-learning.html
+++ b/docs/modules/reinforcement-learning.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/references.html
+++ b/docs/references.html
@@ -3,145 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="机器人技术栈论文导航：按主线引导你高效阅读运动控制、RL、IL、Sim2Real 领域的代表作。" />
-  <title>论文导航 | Robotics Notebooks</title>
+  <meta name="description" content="论文导航已并入运动控制技术路线指南；正在为你跳转。" />
+  <title>论文导航已合并 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>" />
+  <meta http-equiv="refresh" content="0; url=roadmap.html?id=roadmap-motion-control#paper-guide" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header class="site-header">
-    <div class="header-inner">
-      <a class="site-title" href="index.html">🗺️ Robotics Notebooks | 机器人技术栈地图</a>
-      <div class="header-spacer"></div>
-      <div class="header-right">
-        <a class="github-link" href="https://github.com/ImChong/Robotics_Notebooks" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <button class="theme-toggle" id="themeToggle" aria-label="切换白天黑夜模式" title="切换白天黑夜模式">
-          <span class="icon-sun">☀️</span>
-          <span class="icon-moon">🌙</span>
-        </button>
-      </div>
-    </div>
-  </header>
-
-  <main>
-    <section class="page-hero">
-      <div class="container">
-        <p class="hero-kicker">CURATED RESEARCH PATHWAY</p>
-        <h1 class="hero-title">论文导航</h1>
-        <p class="hero-subtitle">这页不是“收藏夹”，而是按问题和主线串联的阅读系统，帮助你建立人形机器人的结构化理解。</p>
-        
-        <div class="hero-stat-row-mini">
-          <span>RL / IL 代表作</span> · 
-          <span>Sim2Real 专题</span> · 
-          <span>全站 200+ 节点关联</span>
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <h2 class="section-title">1. Motion Control：运动控制主线</h2>
-        <p class="section-subtitle">控制主线越稳，后面看学习方法（RL/IL）越不容易飘。</p>
-        <div class="card-grid">
-          <article class="card">
-            <h3>WBC / QP / TSID</h3>
-            <p>重点看任务优先级、接触力分配与全身协调。这是人形控制论文的基本语法。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-whole-body-control" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-          <article class="card">
-            <h3>Model Predictive Control</h3>
-            <p>看如何将动力学约束写成优化问题并在线实时求解。代表作：MIT Cheetah 系列、OCS2 工作。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-mpc" class="btn-secondary btn-inline">MPC 列表 →</a></div>
-          </article>
-          <article class="card">
-            <h3>Optimal Control Theory</h3>
-            <p>控制理论的数学基石。包括 DP、极大值原理与 DDP/iLQR 的推导。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-optimal-control" class="btn-secondary btn-inline">理论列表 →</a></div>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section section-alt">
-      <div class="container">
-        <h2 class="section-title">2. RL：机器人强化学习主线</h2>
-        <p class="section-subtitle">适合想真正理解 Humanoid Locomotion、鲁棒训练与策略部署的人。</p>
-        <div class="card-grid">
-          <article class="card">
-            <h3>Locomotion 代表作</h3>
-            <p>PPO 基线、RMA 快速自适应、AMP 对抗运动先验。不仅仅是“走”，更要看如何“稳”。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-locomotion-rl" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-          <article class="card">
-            <h3>Latent Skill Prior</h3>
-            <p>ASE, CALM, MimicKit。当你关心“既稳又自然”的行为时，这些技能嵌入工作是核心。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-latent-skill-prior" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <h2 class="section-title">3. Sim2Real：从仿真到真机</h2>
-        <p class="section-subtitle">最能体现工程含金量的部分，弥合仿真和现实的致命物理失配。</p>
-        <div class="card-grid">
-          <article class="card">
-            <h3>Domain Randomization</h3>
-            <p>物理参数随机化 (DR)、视觉域随机化。重点看“随机了什么”以及“为什么有效”。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-sim2real" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-          <article class="card">
-            <h3>System Identification</h3>
-            <p>SAGE 执行器建模、延迟建模与参数辨识。工程部署能不能站住，往往就卡在这里。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-system-identification" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section section-alt">
-      <div class="container">
-        <h2 class="section-title">4. IL & Humanoid：模仿学习与人形专项</h2>
-        <p class="section-subtitle">连接动捕数据、遥操作与全身技能协调，是后续具身智能的高价值方向。</p>
-        <div class="card-grid">
-          <article class="card">
-            <h3>Imitation Learning</h3>
-            <p>BC / DAgger 基础、Diffusion Policy、动作迁移 (Retargeting) 完整 Pipeline。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-imitation-learning" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-          <article class="card">
-            <h3>Hardware & Survey</h3>
-            <p>人形硬件平台演进、机器人学习领域综述。看清行业全景，避免陷入局部最优。</p>
-            <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-survey-papers" class="btn-secondary btn-inline">详细列表 →</a></div>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="container">
-        <h2 class="section-title">阅读建议</h2>
-        <div class="structure-list">
-          <article class="simple-card">
-            <h3>每次只打一条主线</h3>
-            <p>先吃透 2-4 篇奠基代表作，读完后务必回模块页或图谱页同步知识，不要全地图乱跳。</p>
-          </article>
-          <article class="simple-card">
-            <h3>工程细节比模型名字更重要</h3>
-            <p>多看 Deployment Reports 和失败经验，真正的财富往往在 Supplementary 中。</p>
-          </article>
-        </div>
-      </div>
-    </section>
+  <main class="container" style="padding:3rem 1rem;max-width:42rem">
+    <h1 class="hero-title" style="font-size:1.5rem">论文导航已合并</h1>
+    <p>论文主线现已与「运动控制」路线页放在同一页，便于从阶段学习到文献阅读一条龙使用。</p>
+    <p><a class="btn-primary" href="roadmap.html?id=roadmap-motion-control#paper-guide">打开技术路线指南（论文主线）</a></p>
+    <p class="data-meta" style="margin-top:2rem">若未自动跳转，请点击上方按钮。</p>
   </main>
-
-  <footer class="footer">
-    <div class="container">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
-    </div>
-  </footer>
-
-  <script src="main.js"></script>
+  <script>
+    window.location.replace('roadmap.html?id=roadmap-motion-control#paper-guide');
+  </script>
 </body>
 </html>

--- a/docs/relations/retargeting-pipeline.html
+++ b/docs/relations/retargeting-pipeline.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/rl-vs-il.html
+++ b/docs/relations/rl-vs-il.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/sim2real-pipeline.html
+++ b/docs/relations/sim2real-pipeline.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/wbc-vs-rl.html
+++ b/docs/relations/wbc-vs-rl.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../references.html">论文导航</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Robotics Notebooks 路线页：直接消费 roadmap_pages，展示路线摘要、阶段、相关项和来源链接。" />
+  <meta name="description" content="运动控制技术路线指南：数据驱动的阶段与相关项，并附论文主线（原论文导航），适合入门与工程师速查。" />
   <meta name="keywords" content="Robotics Notebooks, roadmap page, roadmap_pages, 成长路线" />
   <meta name="author" content="Chong Liu" />
-  <meta property="og:title" content="Robotics Notebooks | 路线页" />
-  <meta property="og:description" content="基于 site-data-v1.json 的真实路线页。" />
+  <meta property="og:title" content="Robotics Notebooks | 技术路线指南" />
+  <meta property="og:description" content="阶段路线 + 论文主线同一页：面向人形运动控制的学习与速查。" />
   <meta property="og:type" content="website" />
-  <title>Robotics Notebooks | 路线页</title>
+  <title>Robotics Notebooks | 技术路线指南</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛣️</text></svg>" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <header class="site-header">
     <div class="header-inner">
-      <a class="site-title" href="index.html">🛣️ Robotics Notebooks | 路线页</a>
+      <a class="site-title" href="index.html">🧭 Robotics Notebooks | 技术路线指南</a>
       <div class="header-spacer"></div>
       <div class="header-right">
         <a class="github-link" href="https://github.com/ImChong/Robotics_Notebooks" target="_blank" rel="noopener noreferrer">GitHub</a>
@@ -33,12 +33,12 @@
         <nav id="roadmapBreadcrumb" class="detail-breadcrumb data-loading" aria-label="面包屑导航">
           <a href="index.html">首页</a>
           <span>/</span>
-          <span>路线页</span>
+          <span>技术路线指南</span>
         </nav>
         <div class="detail-hero-top">
           <div>
-            <p class="hero-kicker">Data-driven roadmap page</p>
-            <h1 id="roadmapTitle">正在读取路线页…</h1>
+            <p class="hero-kicker">技术路线指南 · 数据驱动</p>
+            <h1 id="roadmapTitle">正在读取路线…</h1>
             <p id="roadmapSummary" class="detail-summary data-loading">当前页面直接消费 <code>roadmap_pages</code>，展示路线摘要、阶段和相关入口。</p>
           </div>
           <aside class="hero-panel detail-meta-panel">
@@ -56,6 +56,7 @@
         <a href="#roadmap-stages">阶段</a>
         <a href="#roadmap-related">相关项</a>
         <a href="#roadmap-sources">来源链接</a>
+        <a href="#paper-guide" id="roadmapSubnavPaper" hidden>论文主线</a>
       </div>
     </section>
 
@@ -80,6 +81,7 @@
               <li><a href="#roadmap-stages">阶段</a></li>
               <li><a href="#roadmap-related">相关项</a></li>
               <li><a href="#roadmap-sources">来源链接</a></li>
+              <li id="roadmapTocPaperItem" hidden><a href="#paper-guide">论文主线</a></li>
             </ol>
           </nav>
         </aside>
@@ -108,6 +110,114 @@
             </div>
           </section>
         </div>
+      </div>
+    </section>
+
+    <section id="paper-guide" class="section section-alt" hidden aria-label="论文主线导航">
+      <div class="container">
+        <h2 class="section-title">论文主线（原论文导航）</h2>
+        <p class="section-subtitle">按问题与主线串联阅读，与上方「阶段 / 相关项」互补：路线定结构，论文定深度。</p>
+
+        <section class="section" style="padding-top:0">
+          <h3 class="section-title" style="font-size:1.15rem">路线与论文怎么用</h3>
+          <div class="structure-list">
+            <article class="simple-card">
+              <h3>初学者</h3>
+              <p>先按上方「阶段」搭好控制概念骨架，再在本区每次只跟一条子线读 2–4 篇代表作，读完后回到 <a href="graph.html">知识图谱</a> 把概念挂回全站。</p>
+            </article>
+            <article class="simple-card">
+              <h3>有经验的运动控制工程师</h3>
+              <p>可把本页当速查：阶段区对齐培训与评审话术，论文区按 WBC/MPC、RL、Sim2Real、IL 快速跳到站内整理好的论文列表（detail）。</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section" style="padding-top:1rem">
+          <h3 class="section-title">1. Motion Control：运动控制主线</h3>
+          <p class="section-subtitle">控制主线越稳，后面看学习方法（RL/IL）越不容易飘。</p>
+          <div class="card-grid">
+            <article class="card">
+              <h3>WBC / QP / TSID</h3>
+              <p>重点看任务优先级、接触力分配与全身协调。这是人形控制论文的基本语法。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-whole-body-control" class="btn-secondary btn-inline">详细列表 →</a></div>
+            </article>
+            <article class="card">
+              <h3>Model Predictive Control</h3>
+              <p>看如何将动力学约束写成优化问题并在线实时求解。代表作：MIT Cheetah 系列、OCS2 工作。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-mpc" class="btn-secondary btn-inline">MPC 列表 →</a></div>
+            </article>
+            <article class="card">
+              <h3>Optimal Control Theory</h3>
+              <p>控制理论的数学基石。包括 DP、极大值原理与 DDP/iLQR 的推导。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-optimal-control" class="btn-secondary btn-inline">理论列表 →</a></div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-alt" style="margin-top:1rem;border-radius:12px">
+            <h3 class="section-title">2. RL：机器人强化学习主线</h3>
+            <p class="section-subtitle">适合想真正理解 Humanoid Locomotion、鲁棒训练与策略部署的人。</p>
+            <div class="card-grid">
+              <article class="card">
+                <h3>Locomotion 代表作</h3>
+                <p>PPO 基线、RMA 快速自适应、AMP 对抗运动先验。不仅仅是「走」，更要看如何「稳」。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-locomotion-rl" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+              <article class="card">
+                <h3>Latent Skill Prior</h3>
+                <p>ASE, CALM, MimicKit。当你关心「既稳又自然」的行为时，这些技能嵌入工作是核心。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-latent-skill-prior" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+            </div>
+        </section>
+
+        <section class="section" style="padding-top:1rem">
+          <h3 class="section-title">3. Sim2Real：从仿真到真机</h3>
+          <p class="section-subtitle">最能体现工程含金量的部分，弥合仿真和现实的物理失配。</p>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Domain Randomization</h3>
+              <p>物理参数随机化 (DR)、视觉域随机化。重点看「随机了什么」以及「为什么有效」。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-sim2real" class="btn-secondary btn-inline">详细列表 →</a></div>
+            </article>
+            <article class="card">
+              <h3>System Identification</h3>
+              <p>SAGE 执行器建模、延迟建模与参数辨识。工程部署能不能站住，往往就卡在这里。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-system-identification" class="btn-secondary btn-inline">详细列表 →</a></div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-alt" style="margin-top:1rem;border-radius:12px">
+            <h3 class="section-title">4. IL &amp; Humanoid：模仿学习与人形专项</h3>
+            <p class="section-subtitle">连接动捕数据、遥操作与全身技能协调，是后续具身智能的高价值方向。</p>
+            <div class="card-grid">
+              <article class="card">
+                <h3>Imitation Learning</h3>
+                <p>BC / DAgger 基础、Diffusion Policy、动作迁移 (Retargeting) 完整 Pipeline。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-imitation-learning" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+              <article class="card">
+                <h3>Hardware &amp; Survey</h3>
+                <p>人形硬件平台演进、机器人学习领域综述。看清行业全景，避免陷入局部最优。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-survey-papers" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+            </div>
+        </section>
+
+        <section class="section" style="padding-top:1rem;padding-bottom:0">
+          <h3 class="section-title">阅读建议</h3>
+          <div class="structure-list">
+            <article class="simple-card">
+              <h3>每次只打一条主线</h3>
+              <p>先吃透 2–4 篇奠基代表作，读完后务必回模块页或图谱页同步知识，不要全地图乱跳。</p>
+            </article>
+            <article class="simple-card">
+              <h3>工程细节比模型名字更重要</h3>
+              <p>多看 Deployment Reports 和失败经验，真正的财富往往在 Supplementary 中。</p>
+            </article>
+          </div>
+        </section>
       </div>
     </section>
   </main>

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -16,6 +16,7 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapStageList"',
             'id="roadmapRelatedList"',
             'id="roadmapSourceList"',
+            'id="paper-guide"',
         ]
         for marker in required_ids:
             self.assertIn(marker, content)
@@ -27,6 +28,7 @@ class RoadmapPageTests(unittest.TestCase):
             "document.getElementById('roadmapStageList')",
             "roadmap.html?id=",
             "roadmap_pages",
+            "setRoadmapPaperGuideVisible",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将原首页「开始路径」与「论文入口」合并为单一入口 **技术路线指南**，默认进入 `roadmap.html?id=roadmap-motion-control`。原 `references.html` 的论文导航内容迁入该路线页底部的 **论文主线** 区块（锚点 `#paper-guide`），并增加面向初学者与有经验运动控制工程师的简要使用说明。

## 变更要点

- `docs/index.html`：Hero 文案与 CTA 调整为「技术路线指南」+「知识图谱」两键。
- `docs/roadmap.html`：嵌入原论文导航各卡片；子导航与目录增加「论文主线」（仅 `roadmap-motion-control` 时由脚本显示）。
- `docs/main.js`：`setRoadmapPaperGuideVisible` 控制论文区块可见性。
- `docs/references.html`：保留为兼容跳转页（meta refresh + `location.replace`）。
- 模块页与关系页中「论文导航」链接改为带 hash 的路线页 URL。
- `tests/test_roadmap_page.py`：断言 `paper-guide` 挂载点与 `setRoadmapPaperGuideVisible`。

## 验证

- 已运行 `make ci-preflight`（通过）。
- 已安装 dev 依赖后运行 `make test`（55 passed）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-928f8421-4a87-4371-9112-3e1953240d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-928f8421-4a87-4371-9112-3e1953240d20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

