### PR TITLE
refactor(docs): 移除技术路线页「来源链接」模块

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1431,7 +1431,6 @@
     const metaEl = document.getElementById('roadmapMeta');
     const stageEl = document.getElementById('roadmapStageList');
     const relatedEl = document.getElementById('roadmapRelatedList');
-    const sourceEl = document.getElementById('roadmapSourceList');
     const emptyState = document.getElementById('roadmapEmptyState');
     const breadcrumb = document.getElementById('roadmapBreadcrumb');
 
@@ -1451,7 +1450,6 @@
         removeLoadingState(stageEl);
       }
       renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的相关项。' });
-      renderSourceCards(sourceEl, [], '当前无可展示的来源链接。');
       if (breadcrumb) removeLoadingState(breadcrumb);
       setRoadmapFlowChromeVisible(false);
       var flowRootEmpty = document.getElementById('roadmapFlowMermaidRoot');
@@ -1472,8 +1470,7 @@
       metaEl.innerHTML = [
         '<p><strong>id：</strong><code>' + escapeHtml(roadmapPage.id || roadmapId) + '</code></p>',
         '<p><strong>阶段数：</strong>' + escapeHtml((roadmapPage.stages || []).length) + '</p>',
-        '<p><strong>相关项：</strong>' + escapeHtml((roadmapPage.related_items || []).length) + '</p>',
-        '<p><strong>来源链接：</strong>' + escapeHtml((roadmapPage.source_links || []).length) + '</p>'
+        '<p><strong>相关项：</strong>' + escapeHtml((roadmapPage.related_items || []).length) + '</p>'
       ].join('');
       removeLoadingState(metaEl);
     }
@@ -1515,7 +1512,6 @@
     }
 
     renderInternalLinks(relatedEl, roadmapPage.related_items, detailPages, { emptyText: '当前路线暂无相关项。' });
-    renderSourceCards(sourceEl, roadmapPage.source_links, '当前路线暂无来源链接。');
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
     setRoadmapPaperGuideVisible(roadmapId === 'roadmap-motion-control');
   }
@@ -2038,8 +2034,7 @@
             'roadmapSummary',
             'roadmapMeta',
             'roadmapStageList',
-            'roadmapRelatedList',
-            'roadmapSourceList'
+            'roadmapRelatedList'
           ]);
         }
       });

--- a/docs/plans/2026-04-12-roadmap-page-rollout.md
+++ b/docs/plans/2026-04-12-roadmap-page-rollout.md
@@ -4,7 +4,7 @@
 
 **Goal:** 把 `roadmap_pages` 从 preview 升级成真实页面，让 `roadmap.html?id=...` 可以直接渲染任一路线页。
 
-**Architecture:** 复用现有 `docs/roadmap.html` 作为统一路线页入口，直接消费 `docs/exports/site-data-v1.json` 的 `roadmap_pages`。先展示标题、摘要、阶段列表、相关项、来源链接，不额外引入路由器。
+**Architecture:** 复用现有 `docs/roadmap.html` 作为统一路线页入口，直接消费 `docs/exports/site-data-v1.json` 的 `roadmap_pages`。先展示标题、摘要、阶段列表、相关项（不在页面上单独展示「来源链接」区块；导出里的 `source_links` 仍可保留供其它用途），不额外引入路由器。
 
 **Tech Stack:** 原生 HTML / CSS / JS、现有导出结构、`unittest`
 
@@ -22,7 +22,6 @@
   - `roadmapMeta`
   - `roadmapStageList`
   - `roadmapRelatedList`
-  - `roadmapSourceList`
 - `docs/main.js` 包含：
   - `function renderRoadmapPage`
   - `document.getElementById('roadmapStageList')`

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -39,7 +39,7 @@
           <div>
             <p class="hero-kicker">技术路线指南 · 数据驱动</p>
             <h1 id="roadmapTitle">正在读取路线…</h1>
-            <p id="roadmapSummary" class="detail-summary data-loading">当前页面直接消费 <code>roadmap_pages</code>，展示路线摘要、阶段和相关入口。</p>
+            <p id="roadmapSummary" class="detail-summary data-loading">当前页面直接消费 <code>roadmap_pages</code>，展示路线摘要、阶段与相关项。</p>
           </div>
           <aside class="hero-panel detail-meta-panel">
             <h3>路线元信息</h3>
@@ -56,7 +56,6 @@
         <a href="#roadmap-flow" id="roadmapSubnavFlow" hidden>流程图</a>
         <a href="#roadmap-stages">阶段</a>
         <a href="#roadmap-related">相关项</a>
-        <a href="#roadmap-sources">来源链接</a>
         <a href="#paper-guide" id="roadmapSubnavPaper" hidden>论文主线</a>
       </div>
     </section>
@@ -82,7 +81,6 @@
               <li id="roadmapTocFlowItem" hidden><a href="#roadmap-flow">流程图</a></li>
               <li><a href="#roadmap-stages">阶段</a></li>
               <li><a href="#roadmap-related">相关项</a></li>
-              <li><a href="#roadmap-sources">来源链接</a></li>
               <li id="roadmapTocPaperItem" hidden><a href="#paper-guide">论文主线</a></li>
             </ol>
           </nav>
@@ -108,13 +106,6 @@
             <p class="section-subtitle">通往 detail route 的关联项。</p>
             <div id="roadmapRelatedList" class="card-grid data-loading">
               <article class="card skeleton-card"><p>正在读取相关项…</p></article>
-            </div>
-          </section>
-
-          <section class="section" id="roadmap-sources" style="padding: 40px 0;">
-            <h2 class="section-title">来源链接</h2>
-            <div id="roadmapSourceList" class="card-grid data-loading">
-              <article class="card skeleton-card"><p>正在读取来源链接…</p></article>
             </div>
           </section>
         </div>

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -15,7 +15,6 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapMeta"',
             'id="roadmapStageList"',
             'id="roadmapRelatedList"',
-            'id="roadmapSourceList"',
             'id="paper-guide"',
         ]
         for marker in required_ids:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在已与 `origin/main` 对齐（含已合并的 #140 Mermaid 流程图）的基础上，仅保留 **移除技术路线页「来源链接」模块** 的改动。

## 变更

- `docs/roadmap.html`：去掉来源链接子导航、TOC 与内容区；Hero 文案微调。
- `docs/main.js`：不再渲染 `roadmapSourceList` / `renderSourceCards`，元信息去掉来源链接计数；错误处理列表同步。
- `tests/test_roadmap_page.py`、`docs/plans/2026-04-12-roadmap-page-rollout.md`：与当前结构一致。

导出 JSON 中的 `source_links` 仍保留，仅不在 `roadmap.html` 展示。

## 分支

- 已 `git pull origin main` 更新本地 `main`，并将本分支 `rebase` 到 `origin/main` 后 `--force-with-lease` 推送。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f33c2d2-7104-451f-a91b-f1d119700694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f33c2d2-7104-451f-a91b-f1d119700694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

