### PR TITLE
路线图页：纵向手风琴 + 可选 Mermaid；移除 flow_graph/Cytoscape

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -25,7 +25,7 @@
       const detailContentEl = document.getElementById('detailContent');
       if (detailContentEl) renderDetailMermaid(detailContentEl);
       const roadmapFlowHost = document.getElementById('roadmapFlowMermaidRoot');
-      if (roadmapFlowHost && roadmapFlowHost.querySelector('.mermaid')) {
+      if (roadmapFlowHost && roadmapFlowHost.querySelector('.roadmap-mermaid-wrap[open] .mermaid')) {
         renderDetailMermaid(roadmapFlowHost);
       }
     });
@@ -472,6 +472,65 @@
   }
 
   /**
+   * Vertical collapsible tree (details/summary): one stage per row, children = related links.
+   * Primary UI for narrow screens; no extra libraries.
+   */
+  function buildRoadmapVerticalTreeHTML(stages, roadmapId, detailPages) {
+    var parts = [];
+    parts.push('<div class="roadmap-flow-primary">');
+    parts.push(
+      '<p class="data-meta roadmap-vtree-hint">纵向路线：按阶段从上到下；点标题展开站内关联（推荐手机）。下方可展开 Mermaid 总图（适合宽屏）。</p>'
+    );
+    if (roadmapId === 'roadmap-motion-control') {
+      parts.push('<div class="roadmap-vtree-dual" role="region" aria-label="两条主线">');
+      parts.push('  <div class="roadmap-vtree-dual-inner">');
+      parts.push('    <p><strong>传统控制主干：</strong>LIP/ZMP → Centroidal → MPC/TO → TSID/WBC</p>');
+      parts.push('    <p><strong>Learning 扩展层：</strong>RL 基础 → Locomotion RL → IL / Motion prior → Sim2Real</p>');
+      parts.push('    <p class="data-meta">建议先打牢传统主线，再叠学习能力。</p>');
+      parts.push('  </div>');
+      parts.push('</div>');
+    }
+    parts.push('<ol class="roadmap-vtree">');
+    var i;
+    for (i = 0; i < stages.length; i++) {
+      var stage = stages[i];
+      var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
+      var sid = String(stage.id || '');
+      var title = String(stage.title || '');
+      var openAttr = i === 0 ? ' open' : '';
+      parts.push('<li class="roadmap-vtree-item">');
+      parts.push('<details class="roadmap-vtree-stage"' + openAttr + '>');
+      parts.push('<summary class="roadmap-vtree-summary">');
+      parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(i + 1)) + '</span>');
+      parts.push(
+        '<span class="roadmap-vtree-heading">' + escapeHtml(sid.toUpperCase() + ' · ' + title) + '</span>'
+      );
+      parts.push('<span class="roadmap-vtree-count">' + escapeHtml(String(related.length)) + ' 条</span>');
+      parts.push('</summary>');
+      if (!related.length) {
+        parts.push('<p class="roadmap-vtree-empty data-meta">本阶段正文内暂无抽取到的站内链接。</p>');
+      } else {
+        parts.push('<ul class="roadmap-vtree-links">');
+        for (var k = 0; k < related.length; k++) {
+          var rid = related[k];
+          var page = detailPages[rid] || {};
+          var href = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
+          parts.push('<li class="roadmap-vtree-link-row">');
+          parts.push('<a class="roadmap-vtree-link-a" href="' + escapeHtml(href) + '">' + escapeHtml(page.title || rid) + '</a>');
+          parts.push('<code class="roadmap-vtree-link-id">' + escapeHtml(rid) + '</code>');
+          parts.push('</li>');
+        }
+        parts.push('</ul>');
+      }
+      parts.push('</details>');
+      parts.push('</li>');
+    }
+    parts.push('</ol>');
+    parts.push('</div>');
+    return parts.join('');
+  }
+
+  /**
    * Single learning-roadmap Mermaid: stage spine OV0→OVn, optional motion-control dual trunk,
    * each stage fans out to related wiki titles (max 5).
    */
@@ -552,12 +611,31 @@
       return;
     }
     setRoadmapFlowChromeVisible(true);
+    var treeHtml = buildRoadmapVerticalTreeHTML(stages, roadmapId, detailPages);
     var src = buildUnifiedRoadmapMermaidSource(stages, roadmapId, detailPages);
-    flowRoot.innerHTML = [
-      '<p class="data-meta roadmap-mermaid-hint">以下为整张学习路线 Mermaid 图（阶段顺序、双主线示意与各阶段摘录关联）；详细入口以下方「阶段」卡片为准。</p>',
-      '<div class="mermaid roadmap-mermaid-diagram">' + src + '</div>'
-    ].join('');
-    scheduleRoadmapMermaidRender(flowRoot);
+    flowRoot.innerHTML =
+      treeHtml
+      + '<details class="roadmap-mermaid-wrap">'
+      + '<summary class="roadmap-mermaid-wrap-summary">Mermaid 线框总图（适合宽屏 / 对照结构）</summary>'
+      + '<p class="data-meta roadmap-mermaid-hint">展开后渲染图表；结构信息与上方纵向路线一致。</p>'
+      + '<div class="mermaid roadmap-mermaid-diagram">' + src + '</div>'
+      + '</details>';
+
+    var wrap = flowRoot.querySelector('.roadmap-mermaid-wrap');
+    function renderMermaidBlock() {
+      if (typeof window.mermaid !== 'undefined') {
+        renderDetailMermaid(flowRoot);
+      } else {
+        scheduleRoadmapMermaidRender(flowRoot);
+      }
+    }
+    if (wrap) {
+      wrap.addEventListener('toggle', function onWrapToggle() {
+        if (!wrap.open) return;
+        renderMermaidBlock();
+        wrap.removeEventListener('toggle', onWrapToggle);
+      });
+    }
   }
 
   function renderDetailMath(container) {

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -89,7 +89,7 @@
         <div class="detail-content-main">
           <section id="roadmap-flow" class="section roadmap-flow-section" hidden>
             <h2 class="section-title">路线流程图</h2>
-            <p class="section-subtitle">下方为整张学习路线的 <strong>Mermaid</strong> 总图（阶段链、运动控制双主线示意、各阶段摘录关联）；与 <code>roadmap/*.md</code> 中 <code>## L*</code> 标题对应。</p>
+            <p class="section-subtitle">上方为<strong>纵向可展开路线</strong>（父节点为阶段，点击展开子链接，适合手机）；下方可展开 <strong>Mermaid</strong> 线框总图作宽屏对照。数据与 <code>roadmap/*.md</code> 中 <code>## L*</code> 一致。</p>
             <div id="roadmapFlowMermaidRoot" class="roadmap-flow-mermaid-host" aria-live="polite"></div>
           </section>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1118,12 +1118,124 @@ th {
 .search-tier-heading.search-tier-exact { color:var(--accent, #1659b4); }
 .search-tier-heading .data-meta { font-weight:400; opacity:.75; margin-left:4px; }
 
-/* --- Roadmap page: unified Mermaid diagram --- */
+/* --- Roadmap page: vertical tree + optional folded Mermaid --- */
 .roadmap-flow-section {
   padding-bottom: 0;
 }
+.roadmap-flow-mermaid-host .roadmap-vtree-hint {
+  margin: 0 0 0.75rem;
+}
+.roadmap-vtree-dual {
+  margin: 0.5rem 0 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--quote-bg);
+}
+.roadmap-vtree-dual-inner p {
+  margin: 0.35rem 0;
+  font-size: 0.9rem;
+}
+.roadmap-vtree {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.roadmap-vtree-item {
+  margin-bottom: 0.5rem;
+}
+.roadmap-vtree-stage {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-strong, var(--bg-alt));
+  overflow: hidden;
+}
+.roadmap-vtree-summary {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.65rem 0.85rem;
+  cursor: pointer;
+  list-style: none;
+  font-weight: 600;
+}
+.roadmap-vtree-summary::-webkit-details-marker {
+  display: none;
+}
+.roadmap-vtree-summary::marker {
+  content: "";
+}
+.roadmap-vtree-step {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.roadmap-vtree-heading {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+.roadmap-vtree-count {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  padding-top: 0.1rem;
+}
+.roadmap-vtree-links {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem 0.85rem 0.65rem 2.45rem;
+  border-top: 1px solid var(--border);
+}
+.roadmap-vtree-link-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px dashed var(--border);
+}
+.roadmap-vtree-link-row:last-child {
+  border-bottom: none;
+}
+.roadmap-vtree-link-a {
+  font-weight: 500;
+  word-break: break-word;
+}
+.roadmap-vtree-link-id {
+  font-size: 0.72rem;
+  opacity: 0.8;
+  word-break: break-all;
+}
+.roadmap-vtree-empty {
+  padding: 0.45rem 0.85rem 0.65rem 2.45rem;
+  margin: 0;
+  border-top: 1px solid var(--border);
+}
+.roadmap-mermaid-wrap {
+  margin-top: 1.25rem;
+  padding: 0.65rem 1rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-strong, var(--bg-alt));
+}
+.roadmap-mermaid-wrap-summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.25rem 0;
+}
 .roadmap-flow-mermaid-host .roadmap-mermaid-hint {
-  margin: 0 0 0.6rem;
+  margin: 0.5rem 0 0.6rem;
 }
 .roadmap-flow-mermaid-host .mermaid {
   text-align: center;
@@ -1136,7 +1248,7 @@ th {
 }
 .roadmap-flow-mermaid-host .roadmap-mermaid-diagram {
   padding: 0.5rem 0;
-  min-height: 12rem;
+  min-height: 8rem;
 }
 .roadmap-flow-details,
 .roadmap-stage-flow-details {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

### 路线图交互（`docs/main.js` / `roadmap.html` / `style.css`）

- **默认**：纵向 **`<details>` 手风琴**，阶段为父节点（序号圆标），展开后为站内关联链接列表（最多 8 条）；运动控制路线顶部保留「两条主线」文案。
- **可选**：底部折叠 **Mermaid 线框总图**（宽屏对照）；首次展开时才调用 `renderDetailMermaid` / `scheduleRoadmapMermaidRender`。
- **主题**：切换明暗时，若 Mermaid 区块已展开则刷新图表样式。

### 导出（`scripts/export_minimal.py`）

- 移除 **`flow_graph`** 及 Cytoscape 相关生成逻辑；`roadmap_pages` 恢复为仅含 `stages` 等字段。

### 文档与测试

- `exports/minimal-schema-v1.md`：说明路线图为前端由 `stages` 生成。
- 删除 `tests/test_roadmap_flow_graph.py`。

### 验收

- `make ci-preflight` 已通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68475799-3cc8-4102-ae1f-c6670141b87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68475799-3cc8-4102-ae1f-c6670141b87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

