### PR TITLE
路线图页去重：移除重复「阶段」卡片；导航与挂载调整

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -479,7 +479,7 @@
     var parts = [];
     parts.push('<div class="roadmap-flow-primary">');
     parts.push(
-      '<p class="data-meta roadmap-vtree-hint">纵向路线：按阶段从上到下；点标题展开站内关联（推荐手机）。下方可展开 Mermaid 总图（适合宽屏）。</p>'
+      '<p class="data-meta roadmap-vtree-hint">点阶段标题展开关联条目。</p>'
     );
     if (roadmapId === 'roadmap-motion-control') {
       parts.push('<div class="roadmap-vtree-dual" role="region" aria-label="两条主线">');
@@ -1482,7 +1482,6 @@
     const titleEl = document.getElementById('roadmapTitle');
     const summaryEl = document.getElementById('roadmapSummary');
     const metaEl = document.getElementById('roadmapMeta');
-    const stageEl = document.getElementById('roadmapStageList');
     const relatedEl = document.getElementById('roadmapRelatedList');
     const emptyState = document.getElementById('roadmapEmptyState');
     const breadcrumb = document.getElementById('roadmapBreadcrumb');
@@ -1497,10 +1496,6 @@
       if (metaEl) {
         metaEl.innerHTML = '<p class="data-meta">当前没有匹配到 roadmap_pages 项。</p>';
         removeLoadingState(metaEl);
-      }
-      if (stageEl) {
-        stageEl.innerHTML = '<article class="card"><p>当前无可展示的阶段。</p></article>';
-        removeLoadingState(stageEl);
       }
       renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的相关项。' });
       if (breadcrumb) removeLoadingState(breadcrumb);
@@ -1535,35 +1530,6 @@
       ].join('');
       removeLoadingState(breadcrumb);
     }
-    if (stageEl) {
-      const stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
-      stageEl.innerHTML = stages.length ? stages.map(function (stage) {
-        const related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
-        const linksHtml = related.length ? [
-          '    <div class="chip-list stage-link-list">',
-               related.map(function (id) {
-                 const page = detailPages[id] || {};
-                 const href = page.type === 'roadmap_page' ? roadmapHref(id) : detailHref(id);
-                 return '<a class="data-chip" href="' + escapeHtml(href) + '" title="' + escapeHtml(id) + '">' + escapeHtml(page.title || id) + '</a>';
-               }).join(''),
-          '    </div>'
-        ].join('') : '    <p class="data-meta">当前阶段暂无内部链接。</p>';
-        return [
-          '<article class="card data-card">',
-          '  <div>',
-          '    <h3>' + escapeHtml(stage.title || stage.id || '未命名阶段') + '</h3>',
-          '    <p class="card-meta">阶段 ID：' + escapeHtml(stage.id || '-') + '</p>',
-          '    <p class="card-meta">关联入口：' + escapeHtml(related.length) + '</p>',
-          '  </div>',
-          '  <div>',
-          linksHtml,
-          '  </div>',
-          '</article>'
-        ].join('');
-      }).join('') : '<article class="card"><p>当前路线暂无阶段定义。</p></article>';
-      removeLoadingState(stageEl);
-    }
-
     renderInternalLinks(relatedEl, roadmapPage.related_items, detailPages, { emptyText: '当前路线暂无相关项。' });
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
     setRoadmapPaperGuideVisible(roadmapId === 'roadmap-motion-control');
@@ -2016,10 +1982,10 @@
   const detailRoot = document.getElementById('detailTitle');
   const techMapRoot = document.getElementById('techMapNodeGrid');
   const moduleRoot = document.getElementById('moduleEntryList');
-  const roadmapRoot = document.getElementById('roadmapStageList');
+  const roadmapPageMount = document.getElementById('roadmapTitle');
   const homeStatsRoot = document.getElementById('heroNodeCount') || document.getElementById('wikiSearchSubtitle');
 
-  if (previewRoot || detailRoot || techMapRoot || moduleRoot || roadmapRoot) {
+  if (previewRoot || detailRoot || techMapRoot || moduleRoot || roadmapPageMount) {
     fetch('exports/site-data-v1.json')
       .then(function (response) {
         if (!response.ok) {
@@ -2032,7 +1998,7 @@
         if (detailRoot) renderDetailPage(siteData);
         if (techMapRoot) renderTechMapPage(siteData);
         if (moduleRoot) renderModulePage(siteData);
-        if (roadmapRoot) renderRoadmapPage(siteData);
+        if (roadmapPageMount) renderRoadmapPage(siteData);
       })
       .catch(function (error) {
         if (previewRoot) {
@@ -2081,12 +2047,11 @@
             'moduleRelatedModules'
           ]);
         }
-        if (roadmapRoot) {
+        if (roadmapPageMount) {
           handlePageDataError(error, [
             'roadmapBreadcrumb',
             'roadmapSummary',
             'roadmapMeta',
-            'roadmapStageList',
             'roadmapRelatedList'
           ]);
         }

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -39,7 +39,7 @@
           <div>
             <p class="hero-kicker">技术路线指南 · 数据驱动</p>
             <h1 id="roadmapTitle">正在读取路线…</h1>
-            <p id="roadmapSummary" class="detail-summary data-loading">当前页面直接消费 <code>roadmap_pages</code>，展示路线摘要、阶段与相关项。</p>
+            <p id="roadmapSummary" class="detail-summary data-loading">当前页面读取 <code>roadmap_pages</code>，展示路线摘要、学习路线与相关项。</p>
           </div>
           <aside class="hero-panel detail-meta-panel">
             <h3>路线元信息</h3>
@@ -53,8 +53,7 @@
 
     <section class="page-subnav-wrap">
       <div class="container page-subnav">
-        <a href="#roadmap-flow" id="roadmapSubnavFlow" hidden>流程图</a>
-        <a href="#roadmap-stages">阶段</a>
+        <a href="#roadmap-flow" id="roadmapSubnavFlow" hidden>路线</a>
         <a href="#roadmap-related">相关项</a>
         <a href="#paper-guide" id="roadmapSubnavPaper" hidden>论文主线</a>
       </div>
@@ -78,8 +77,7 @@
           <h2 class="section-title">路线导航</h2>
           <nav class="detail-toc-list">
             <ol>
-              <li id="roadmapTocFlowItem" hidden><a href="#roadmap-flow">流程图</a></li>
-              <li><a href="#roadmap-stages">阶段</a></li>
+              <li id="roadmapTocFlowItem" hidden><a href="#roadmap-flow">路线</a></li>
               <li><a href="#roadmap-related">相关项</a></li>
               <li id="roadmapTocPaperItem" hidden><a href="#paper-guide">论文主线</a></li>
             </ol>
@@ -88,17 +86,9 @@
 
         <div class="detail-content-main">
           <section id="roadmap-flow" class="section roadmap-flow-section" hidden>
-            <h2 class="section-title">路线流程图</h2>
-            <p class="section-subtitle">上方为<strong>纵向可展开路线</strong>（父节点为阶段，点击展开子链接，适合手机）；下方可展开 <strong>Mermaid</strong> 线框总图作宽屏对照。数据与 <code>roadmap/*.md</code> 中 <code>## L*</code> 一致。</p>
+            <h2 class="section-title">学习路线</h2>
+            <p class="section-subtitle">纵向阶段可展开查看站内关联；底部可展开 <strong>Mermaid</strong> 线框图（宽屏对照）。数据与 <code>roadmap/*.md</code> 中 <code>## L*</code> 一致。</p>
             <div id="roadmapFlowMermaidRoot" class="roadmap-flow-mermaid-host" aria-live="polite"></div>
-          </section>
-
-          <section id="roadmap-stages">
-            <h2 class="section-title">阶段</h2>
-            <p class="section-subtitle">先把路线阶段可视化。</p>
-            <div id="roadmapStageList" class="card-grid roadmap-stage-list data-loading">
-              <article class="card skeleton-card"><p>正在读取路线阶段…</p></article>
-            </div>
           </section>
 
           <section class="section section-alt" id="roadmap-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">
@@ -115,7 +105,7 @@
     <section id="paper-guide" class="section section-alt" hidden aria-label="论文主线导航">
       <div class="container">
         <h2 class="section-title">论文主线（原论文导航）</h2>
-        <p class="section-subtitle">按问题与主线串联阅读，与上方「阶段 / 相关项」互补：路线定结构，论文定深度。</p>
+        <p class="section-subtitle">按问题与主线串联阅读，与上方「路线 / 相关项」互补：路线定结构，论文定深度。</p>
 
         <section class="section" style="padding-top:0">
           <h3 class="section-title" style="font-size:1.15rem">路线与论文怎么用</h3>

--- a/docs/style.css
+++ b/docs/style.css
@@ -321,10 +321,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
 .section-subtitle { color: var(--text-muted); font-size: .97rem; margin-bottom: 28px; max-width: 72ch; }
 .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
-.roadmap-stage-list {
-  grid-template-columns: minmax(0, 1fr);
-  max-width: 920px;
-}
 .card {
   padding: 20px;
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -13,7 +13,7 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapTitle"',
             'id="roadmapSummary"',
             'id="roadmapMeta"',
-            'id="roadmapStageList"',
+            'id="roadmapFlowMermaidRoot"',
             'id="roadmapRelatedList"',
             'id="paper-guide"',
         ]
@@ -24,7 +24,7 @@ class RoadmapPageTests(unittest.TestCase):
         content = MAIN_JS.read_text(encoding="utf-8")
         expected_snippets = [
             "function renderRoadmapPage",
-            "document.getElementById('roadmapStageList')",
+            "document.getElementById('roadmapTitle')",
             "roadmap.html?id=",
             "roadmap_pages",
             "setRoadmapPaperGuideVisible",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

### 去重（本次）
- 移除 **「阶段」卡片区**：与 **「学习路线」** 纵向手风琴（同 `stages` + `related_items`）重复；现仅在一处展示。
- 顶栏/侧栏 **「阶段」** 导航删除；**「流程图」→「路线」**，锚点 `#roadmap-flow`。
- `renderRoadmapPage` 挂载判断改为 **`roadmapTitle`**（不再使用 `roadmapStageList`）。
- Hero / 论文区文案与 `test_roadmap_page.py` 挂载点已对齐。

### 既有 PR 目标（路线页整体）
- 纵向 `<details>` 手风琴 + 可选折叠 Mermaid；`roadmap_pages` 无 `flow_graph`。

## 验收
- `make ci-preflight` 已通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68475799-3cc8-4102-ae1f-c6670141b87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68475799-3cc8-4102-ae1f-c6670141b87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

