### PR TITLE
fix(docs): 修复详情页块级公式 $$ 还原时被吞掉的问题

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -263,14 +263,17 @@
 
     // 4. Restore Links
     linkTokens.forEach(function (entry) {
-      rendered = rendered.replace(entry.token, entry.html);
+      // Use a function replacer: entry.html may contain "$" sequences that
+      // String.replace interprets as substitution patterns (e.g. "$$" → "$").
+      rendered = rendered.replace(entry.token, function () { return entry.html; });
     });
 
     // 5. Restore Protected Math (safely escaped)
     mathTokens.forEach(function (entry) {
       // The math content must be escaped because it will be part of innerHTML
       // but it should NOT be processed by other markdown rules (already protected).
-      rendered = rendered.replace(entry.token, escapeHtml(entry.html));
+      const escapedMath = escapeHtml(entry.html);
+      rendered = rendered.replace(entry.token, function () { return escapedMath; });
     });
 
     return rendered;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在 `detail.html` 渲染 wiki 正文时，`$$...$$` 块级公式经 `renderInlineMarkdown` 的占位 token 还原后，会变成单 `$ ... $`，KaTeX `renderMathInElement` 未配置单美元分隔符，导致公式以原始文本显示。

## 原因

`String.prototype.replace(searchValue, replacement)` 在 **replacement 为字符串**时会把 `$` 当作替换模式（例如 `$$` 会变成单个 `$`）。数学占位还原使用了 `replace(token, escapeHtml(entry.html))`，而 `entry.html` 以 `$$` 开头和结尾，因此被错误折叠。

## 修改

对链接与数学 token 的还原改用 **函数返回值**，避免 `$` / `$$` 被解释为替换模板。

## 验证

- `npm run lint:js` 通过。
- 本地用 Node 复现：修复前段落内 `$$...$$` 还原为 `$...$`；修复后还原为完整 `$$` 并包进 `.math-block`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e977a926-f4f8-4b5c-b7a8-0b2a712ee94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e977a926-f4f8-4b5c-b7a8-0b2a712ee94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

