### PR TITLE
style(docs): 收紧首页技术路线/图谱与搜索框间距

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -178,6 +178,14 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   gap: 16px;
   margin-top: 16px;
 }
+
+/* 首页：技术路线/图谱按钮与下方搜索区更紧凑 */
+#hero.hero {
+  padding-bottom: 18px;
+}
+#wiki-search.section {
+  padding-top: 22px;
+}
 .btn-primary, .btn-secondary {
   display: inline-flex;
   align-items: center;
@@ -964,6 +972,9 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   .hero {
     padding: 28px 0 28px;
   }
+  #hero.hero {
+    padding-bottom: 12px;
+  }
   .hero .container {
     padding-left: 12px;
     padding-right: 12px;
@@ -983,6 +994,9 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   }
   .section {
     padding: 30px 0;
+  }
+  #wiki-search.section {
+    padding-top: 16px;
   }
   .hero-grid, .card-grid, .preview-home-layout, .preview-split-grid, .detail-hero-top, .route-card-grid { grid-template-columns: 1fr; }
   .hero-title { font-size: 2.15rem; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

首页 `#hero` 与 `#wiki-search` 之间的垂直留白由原来的 hero 下内边距 40px + section 上内边距 44px（合计约 84px）收紧为 18px + 22px（约 40px）。窄屏下 hero 底 12px、搜索区顶 16px，相对原先 28px + 30px 同样明显减小。

## 验证

- 本地已执行 `make ci-preflight`，通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0761c19c-cf54-45f7-9ebc-f19ebb7bcb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0761c19c-cf54-45f7-9ebc-f19ebb7bcb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

