### PR TITLE
chore: 对齐 Python 3.12 并完善贡献指南与派生说明

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements-ci-lite.txt
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements-ci-lite.txt
 

--- a/.github/workflows/search-regression.yml
+++ b/.github/workflows/search-regression.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements-ci-lite.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements-dev.txt
 

--- a/.github/workflows/weekly-lint.yml
+++ b/.github/workflows/weekly-lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements-ci-lite.txt
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,14 @@
 # 贡献指南
 
-感谢你愿意改进本知识库。请先阅读：
+感谢你愿意改进本知识库。**提交前可先按下面三步选对命令**，不必一次背完整工作流。
+
+## 提交前跑什么（三步）
+
+1. **改了 `wiki/`，或会影响页面目录、导出 JSON、搜索索引、图谱、sitemap、`README` 统计区、`docs/index.html` 等派生物** → 运行 **`make ci-preflight`**，并把命令重新生成后有变化的文件与本次编辑的源文件一并提交。
+2. **只改了 `scripts/`、`tests/`、`docs/main.js` 或本地工具配置**（不动上述派生链）→ 运行 **`make ci-test`**（与 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) 对齐：Ruff、Mypy、pip-audit、ESLint、pytest）。
+3. **只在本地查词、搜页、阅读 markdown，不写回仓库** → 不必跑 CI 全套；需要时可单独用 `make lint` 或 `python3 scripts/search_wiki.py <关键词>` 做轻量检查。
+
+请先阅读：
 
 - 知识库维护流程：[`schema/ingest-workflow.md`](schema/ingest-workflow.md)
 - **本地与 CI 命令对照**（提交前防踩坑）：[`docs/contributing-ci.md`](docs/contributing-ci.md)
@@ -9,11 +17,9 @@
 ## 快速开始
 
 1. Fork / 分支开发（推荐前缀 `cursor/` 之类由维护者约定）。
-2. 安装开发依赖：`pip install -r requirements-dev.txt`，若参与前端脚本检查则 `npm ci`。
-3. 修改维护脚本或测试后，建议运行 **`make ci-test`**（与 `tests.yml` 对齐：Ruff、Mypy、pip-audit、ESLint、pytest）。
-4. 修改 `wiki/` 或导出/索引链时运行 **`make ci-preflight`**，并提交其生成的导出与统计文件。
-5. 日常也可用 `make test` 仅跑 pytest（含覆盖率阈值）。
-6. 发起 Pull Request，按模板填写摘要与验证方式。
+2. 安装开发依赖：`pip install -r requirements-dev.txt`（Python 版本见 [`docs/contributing-ci.md`](docs/contributing-ci.md)），若参与前端脚本检查则 `npm ci`。
+3. 按上文 **「提交前跑什么（三步）」** 选择 `make ci-preflight` 或 `make ci-test`；日常也可 `make test` 仅跑 pytest（含覆盖率阈值）。
+4. 发起 Pull Request，按模板填写摘要与验证方式。
 
 ## 代码风格
 

--- a/docs/contributing-ci.md
+++ b/docs/contributing-ci.md
@@ -13,6 +13,12 @@ make ci-test
 
 说明：变更 `wiki/` 或导出/索引链时，仍需执行 `make ci-preflight`（见下表）。
 
+## 派生文件与 `exports/`、`docs/` 下的副本
+
+- 维护脚本写入的导出与统计，以仓库根目录为主（例如 **`exports/`** 下的 JSON、以及 **`index.md`**、**`README.md`** 中带自动更新标记的区块等）。[`scripts/ci_preflight.py`](../scripts/ci_preflight.py) 文件内的 **`GENERATED_PATHS`** 列表，是「跑完 `make ci-preflight` 后若仍有 diff，就应提交」的权威清单。
+- **GitHub Pages** 以 [`docs/`](../docs/) 为站点根，因此同一条生成链会把搜索索引、sitemap、部分导出等写到 **`docs/search-index.json`**、**`docs/sitemap.xml`**、**`docs/exports/`** 等路径；它们是供站点读取的派生物，与根目录 `exports/` 等对应，不是第二套手写正文。
+- **实务**：只跑 `make graph` 或 `make export` 之一容易漏掉链上其它步骤；修改 `wiki/` 或导出相关脚本后，请优先 **`make ci-preflight`**，并对照 `GENERATED_PATHS` 把仍有变更的文件全部 stage，避免 Actions 因索引或统计不同步失败。
+
 ## 对照表
 
 | 检查项 | 本地命令 | CI Workflow |
@@ -32,6 +38,8 @@ make ci-test
 轻量 Python 工作流（`lint.yml`、`search-regression.yml`、`export.yml`、`weekly-lint.yml`）共用依赖声明文件 [`requirements-ci-lite.txt`](../requirements-ci-lite.txt)（与 `requirements-dev.txt` 区分），便于 Actions **pip 缓存**命中。
 
 ## 依赖安装
+
+各 Python 工作流使用 **Python 3.12**（见 `.github/workflows/*.yml`）；本地建议与 CI 一致，以减少「本机通过、远端失败」的差异。
 
 ```bash
 pip install -r requirements-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 100
 extend-exclude = [
     "docs/exports/",
@@ -34,7 +34,7 @@ source = ["scripts"]
 omit = ["*/tests/*"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 ignore_missing_imports = true
 explicit_package_bases = true
 mypy_path = "scripts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 落实先前评审中的三项「小改动、高收益」建议：将 CI 与 `pyproject.toml` 统一到 Python 3.12（与 `AGENTS.md` 一致）；在 `docs/contributing-ci.md` 说明 `exports/` 与 `docs/` 下派生副本的关系及 `GENERATED_PATHS` 的用法；在 `CONTRIBUTING.md` 顶部增加「提交前跑什么」三步指引并精简「快速开始」。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`（若改动 wiki/导出链）
- [x] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`（已运行完整 `make ci-test`，含 Ruff、Mypy、pip-audit、ESLint、pytest）
- [x] 其他：环境中曾缺少 `python3.12-venv` 导致 pip-audit 失败，安装后 `make ci-test` 已通过。

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

