### PR TITLE
feat(scripts): 图谱导出同步收敛与内容目录决策文档

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
 请先阅读：
 
 - 知识库维护流程：[`schema/ingest-workflow.md`](schema/ingest-workflow.md)
+- **内容进哪个目录**：[`schema/content-directories.md`](schema/content-directories.md)
 - **本地与 CI 命令对照**（提交前防踩坑）：[`docs/contributing-ci.md`](docs/contributing-ci.md)
 - 协作与提交约定：[`AGENTS.md`](AGENTS.md)（含中文 commit 格式、`make ci-preflight` 要求）
 

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,7 @@ coverage:
 graph:
 	python3 scripts/generate_link_graph.py
 	python3 scripts/generate_home_stats.py
-	cp exports/link-graph.json docs/exports/link-graph.json
-	cp exports/graph-stats.json docs/exports/graph-stats.json 2>/dev/null || true
-	cp exports/home-stats.json docs/exports/home-stats.json 2>/dev/null || true
+	python3 scripts/graph_exports_sync.py
 
 anki:
 	python3 scripts/export_anki.py

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@
 | `docs/` | **展示层**。GitHub Pages 托管的 D3.js 交互式图谱与详情页。 |
 | `docs/checklists/` | **执行清单归档**。当前技术栈推进、前端优化与历史阶段清单。 |
 
+不知道新资料或新页面该进哪个目录？见 [内容目录怎么选](schema/content-directories.md)。
+
 ---
 
 ## 维护看板

--- a/schema/content-directories.md
+++ b/schema/content-directories.md
@@ -1,0 +1,44 @@
+# 内容目录怎么选
+
+> 精炼版：新资料、新页面、新路线应落在哪个根目录。详细维护流程仍以 [ingest-workflow.md](ingest-workflow.md) 为准。
+
+---
+
+## 一句话对照
+
+| 目录 | 一句话 |
+|------|--------|
+| [`wiki/`](../wiki/) | 已提炼的**结构化知识**（概念、方法、任务、实体、对比、形式化）。读者在此「理解 + 跳转」。 |
+| [`sources/`](../sources/) | **原始资料输入**：论文摘录、仓库导航、博客笔记等；ingest 第一站，不替代 wiki 正文。 |
+| [`references/`](../references/) | **按主题索引的深挖入口**（论文列表、repo 清单、benchmark）；在已懂概念后继续扩展阅读。 |
+| [`resources/`](../resources/) | **资源沉淀层**：课程笔记、训练计划、长笔记等，不追求与全站 wiki 同粒度互链。 |
+| [`roadmap/`](../roadmap/) | **主学习路径**与条件分支路线；首页与读者默认入口。 |
+| [`wiki/roadmaps/`](../wiki/roadmaps/) | 与 wiki 主题**强绑定**的专题路线（见 ingest 步骤 4 后的说明）。 |
+| [`tech-map/`](../tech-map/) | **技术地图**模块依赖与栈全景，与路线页互补。 |
+| [`exports/`](../exports/) | **脚本生成**的 JSON 等；勿手改。站点可读副本见 `docs/exports/`（见 [contributing-ci.md](../docs/contributing-ci.md)）。 |
+
+---
+
+## 决策漏斗（维护时用）
+
+1. **是否仍是「原材料」**（链接堆砌、摘录、未形成可引用知识段落）→ 是则进 **`sources/`**（或先收进 `resources/` 再择机提炼）。
+2. **是否已是可交叉引用的知识页**（有定义、机制、误区、参考来源）→ 是则进 **`wiki/`** 下对应子目录（概念 / 方法 / 任务 / …）。
+3. **是否「已知概念、只要按主题找论文或 repo」**→ **`references/`**。
+4. **是否长材料、课程、个人训练笔记、暂不进 wiki 的沉淀**→ **`resources/`**。
+5. **是否读者要跟着走的路线**→ 默认 **`roadmap/`**；仅当与某一 wiki 子树强耦合且不必占根级主入口时考虑 **`wiki/roadmaps/`**。
+
+---
+
+## 常见混淆
+
+- **`sources/` vs `references/`**：前者是「本条资料的归档与 ingest 溯源」；后者是「按研究方向整理的阅读索引」。一篇论文可先出现在 `sources/papers/`，再在 `references/papers/` 里被归类收录。
+- **`wiki/` vs `resources/`**：能进 wiki 的应尽量满足 frontmatter、参考来源与互链规范；做不到时先放 `resources/`，避免把 wiki 变成笔记堆。
+- **手改 `exports/` 或 `docs/exports/`**：不要；用 `make ci-preflight` 等命令再生。
+
+---
+
+## 与其它规范的关系
+
+- Ingest 操作步骤：[ingest-workflow.md](ingest-workflow.md)
+- 内链写法：[linking.md](linking.md)
+- 仓库总览：[README.md](../README.md) 中「项目结构」表

--- a/schema/ingest-workflow.md
+++ b/schema/ingest-workflow.md
@@ -43,6 +43,8 @@ python3 scripts/ingest_paper.py my_topic --title "..." --desc "..."
 
 原始资料先收录到 `sources/` 对应位置，保留来源信息。
 
+若不确定应落在 `sources/`、`references/`、`resources/` 还是直接进 `wiki/`，先看 [内容目录怎么选](content-directories.md) 的决策漏斗。
+
 建议记录：
 - 标题、链接、类型
 - 一句话说明

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,6 +20,7 @@
 | `generate_home_stats.py` | 生成首页 Hero 用轻量统计 JSON | `make graph`；`sync_all_stats` / preflight |
 | `generate_link_graph.py` | 生成知识图谱边数据等 | `make graph`；`sync_all_stats` / preflight |
 | `generate_page_catalog.py` | 生成 `index.md` 页面目录 | `make catalog`；`make ci-preflight` |
+| `graph_exports_sync.py` | 将图谱相关 JSON 从 `exports/` 复制到 `docs/exports/` | `make graph`；`sync_all_stats`；`sync_wiki.sh` |
 | `ingest_coverage.py` | 与覆盖率/ingest 相关的辅助脚本 | `make coverage` |
 | `ingest_paper.py` | 生成 `sources/papers/` 论文 ingest 模板 | `make ingest` |
 | `lint_wiki.py` | Wiki 健康检查（断链、孤儿页、frontmatter 等） | `make lint`；`make ci-preflight`（`--report`） |

--- a/scripts/graph_exports_sync.py
+++ b/scripts/graph_exports_sync.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Copy graph-related JSON from exports/ to docs/exports/ for GitHub Pages.
+
+Single place for filenames and copy logic: used by ``make graph``,
+``sync_all_stats.py``, and ``sync_wiki.sh`` to avoid drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+GRAPH_EXPORT_FILES: tuple[str, ...] = ("link-graph.json", "graph-stats.json", "home-stats.json")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def copy_graph_exports_to_docs() -> None:
+    root = repo_root()
+    dst_dir = root / "docs" / "exports"
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    for name in GRAPH_EXPORT_FILES:
+        src = root / "exports" / name
+        dst = dst_dir / name
+        if src.exists():
+            dst.write_bytes(src.read_bytes())
+            print(f"✅ 已同步: {name} -> docs/exports/")
+
+
+def main() -> None:
+    copy_graph_exports_to_docs()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_all_stats.py
+++ b/scripts/sync_all_stats.py
@@ -17,6 +17,8 @@ import sys
 from datetime import date
 from pathlib import Path
 
+from graph_exports_sync import copy_graph_exports_to_docs
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INDEX_HTML = REPO_ROOT / "docs" / "index.html"
 README_MD = REPO_ROOT / "README.md"
@@ -42,17 +44,8 @@ def main():
     # 2. 生成首页统计 JSON (内部会调用 lint_wiki.py)
     run_command(["python3", "scripts/generate_home_stats.py"], "生成首页统计 JSON")
 
-    # 3. 确保 docs/exports 目录存在并同步文件
-    docs_exports = REPO_ROOT / "docs" / "exports"
-    docs_exports.mkdir(parents=True, exist_ok=True)
-
-    files_to_sync = ["link-graph.json", "graph-stats.json", "home-stats.json"]
-    for f in files_to_sync:
-        src = REPO_ROOT / "exports" / f
-        dst = docs_exports / f
-        if src.exists():
-            dst.write_bytes(src.read_bytes())
-            print(f"✅ 已同步: {f} -> docs/exports/")
+    # 3. 确保 docs/exports 目录存在并同步图谱相关 JSON（与 make graph 共用逻辑）
+    copy_graph_exports_to_docs()
 
     # 读取最新统计数据
     if not HOME_STATS_JSON.exists():

--- a/scripts/sync_wiki.sh
+++ b/scripts/sync_wiki.sh
@@ -17,9 +17,7 @@ python3 scripts/generate_page_catalog.py
 echo "--- 📊 步骤 2: 生成图谱与主页统计 (make graph) ---"
 python3 scripts/generate_link_graph.py
 python3 scripts/generate_home_stats.py
-cp exports/link-graph.json docs/exports/link-graph.json
-cp exports/graph-stats.json docs/exports/graph-stats.json 2>/dev/null || true
-cp exports/home-stats.json docs/exports/home-stats.json 2>/dev/null || true
+python3 scripts/graph_exports_sync.py
 
 echo "--- 🚀 步骤 3: 导出全站数据 (make export) ---"
 python3 scripts/export_minimal.py

--- a/tests/test_graph_exports_sync.py
+++ b/tests/test_graph_exports_sync.py
@@ -1,0 +1,16 @@
+"""Sanity checks for graph export sync constants."""
+
+from __future__ import annotations
+
+from graph_exports_sync import GRAPH_EXPORT_FILES, repo_root
+
+
+def test_graph_export_filenames_include_core_graph_json() -> None:
+    assert "link-graph.json" in GRAPH_EXPORT_FILES
+    assert "home-stats.json" in GRAPH_EXPORT_FILES
+
+
+def test_repo_root_points_at_workspace() -> None:
+    root = repo_root()
+    assert (root / "scripts" / "graph_exports_sync.py").exists()
+    assert (root / "wiki").is_dir()

--- a/tests/test_lint_wiki_helpers.py
+++ b/tests/test_lint_wiki_helpers.py
@@ -1,0 +1,46 @@
+"""Unit tests for link parsing helpers in lint_wiki.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lint_wiki import extract_internal_links, strip_code_blocks
+
+
+def test_strip_code_blocks_removes_fenced_and_inline() -> None:
+    content = "intro\n```py\n[bad](x.md)\n```\n`inline [z](z.md)`\n[good](y.md)\n"
+    out = strip_code_blocks(content)
+    assert "x.md" not in out
+    assert "z.md" not in out
+    assert "[good](y.md)" in out
+
+
+def test_extract_internal_links_skips_http_and_anchor(tmp_path: Path) -> None:
+    page = tmp_path / "wiki" / "concepts" / "example.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    content = "[a](https://x.com/y.md)\n[b](#sec)\n[c](rel.md)\n"
+    targets = extract_internal_links(content, page)
+    assert len(targets) == 1
+    assert targets[0] == (page.parent / "rel.md").resolve()
+
+
+def test_extract_internal_links_ignores_links_inside_code_fence(tmp_path: Path) -> None:
+    wiki_methods = tmp_path / "wiki" / "methods"
+    wiki_methods.mkdir(parents=True)
+    page = wiki_methods / "foo.md"
+    content = "[keep](a.md)\n```text\n[skip](b.md)\n```\n[c](c.md)\n"
+    targets = extract_internal_links(content, page)
+    names = sorted(p.name for p in targets)
+    assert names == ["a.md", "c.md"]
+
+
+def test_extract_internal_links_resolves_relative_path(tmp_path: Path) -> None:
+    concepts = tmp_path / "wiki" / "concepts"
+    methods = tmp_path / "wiki" / "methods"
+    concepts.mkdir(parents=True)
+    methods.mkdir(parents=True)
+    page = concepts / "page.md"
+    content = "See [m](../methods/x.md)."
+    targets = extract_internal_links(content, page)
+    assert len(targets) == 1
+    assert targets[0] == (methods / "x.md").resolve()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 为「再开一批」可维护性改动：新增 `schema/content-directories.md`（内容根目录对照表与决策漏斗），在 `README`、`CONTRIBUTING`、`ingest-workflow` 中链入；用 `scripts/graph_exports_sync.py` 统一 `link-graph.json` / `graph-stats.json` / `home-stats.json` 从 `exports/` 到 `docs/exports/` 的复制逻辑，供 `make graph`、`sync_all_stats.py`、`sync_wiki.sh` 共用；为 `lint_wiki` 的 `strip_code_blocks` / `extract_internal_links` 及 graph 导出常量补充 pytest。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`（若改动 wiki/导出链）
- [x] `make ci-test`（Ruff、Mypy、pip-audit、ESLint、pytest 已通过）

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

