### PR TITLE
test(wiki): 扩展 lint_wiki 单测与文档交叉引用

### DIFF
--- a/docs/contributing-ci.md
+++ b/docs/contributing-ci.md
@@ -19,6 +19,10 @@ make ci-test
 - **GitHub Pages** 以 [`docs/`](../docs/) 为站点根，因此同一条生成链会把搜索索引、sitemap、部分导出等写到 **`docs/search-index.json`**、**`docs/sitemap.xml`**、**`docs/exports/`** 等路径；它们是供站点读取的派生物，与根目录 `exports/` 等对应，不是第二套手写正文。
 - **实务**：只跑 `make graph` 或 `make export` 之一容易漏掉链上其它步骤；修改 `wiki/` 或导出相关脚本后，请优先 **`make ci-preflight`**，并对照 `GENERATED_PATHS` 把仍有变更的文件全部 stage，避免 Actions 因索引或统计不同步失败。
 
+## 正文与资料应落在哪个目录
+
+不确定 `wiki/`、`sources/`、`references/`、`resources/` 或路线类目录如何选时，见 **[schema/content-directories.md](../schema/content-directories.md)**（决策漏斗与常见混淆）。
+
 ## 对照表
 
 | 检查项 | 本地命令 | CI Workflow |

--- a/schema/linking.md
+++ b/schema/linking.md
@@ -1,5 +1,7 @@
 # Linking Rules
 
+与「内容应放进仓库哪个根目录」相关的取舍，见 [content-directories.md](content-directories.md)。
+
 ## 目标
 
 知识库底层应是图结构，而不是单树结构。

--- a/tests/test_lint_wiki_helpers.py
+++ b/tests/test_lint_wiki_helpers.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from lint_wiki import extract_internal_links, strip_code_blocks
+from lint_wiki import (
+    extract_internal_links,
+    has_section,
+    has_source_reference,
+    strip_code_blocks,
+    strip_misconception_sections,
+    word_count,
+)
 
 
 def test_strip_code_blocks_removes_fenced_and_inline() -> None:
@@ -44,3 +51,40 @@ def test_extract_internal_links_resolves_relative_path(tmp_path: Path) -> None:
     targets = extract_internal_links(content, page)
     assert len(targets) == 1
     assert targets[0] == (methods / "x.md").resolve()
+
+
+def test_has_section_matches_h2_keywords_case_insensitive() -> None:
+    body = "## 关联页面\n\n- [x](a.md)\n"
+    assert has_section(body, ["关联"])
+    assert has_section(body, ["关联页面"])
+    assert not has_section(body, ["参考来源"])
+
+
+def test_word_count_chinese_and_english() -> None:
+    assert word_count("") == 0
+    assert word_count("你好 robot learning") == 2 + 2  # 2 个汉字 + 2 个英文词
+
+
+def test_has_source_reference_detects_sources_md_links() -> None:
+    assert has_source_reference("见 [p](../sources/papers/foo.md)。")
+    assert has_source_reference("sources/repos/bar.md")
+    assert not has_source_reference("仅 wiki 正文无 sources 链接。")
+
+
+def test_strip_misconception_sections_removes_pitfall_block_until_peer_heading() -> None:
+    content = (
+        "## Intro\nkeep-intro\n## 常见误区\ndrop-body\n### 子节\ndrop-sub\n## Recovery\nkeep-tail\n"
+    )
+    out = strip_misconception_sections(content)
+    assert "keep-intro" in out
+    assert "keep-tail" in out
+    assert "drop-body" not in out
+    assert "drop-sub" not in out
+    assert "常见误区" not in out
+
+
+def test_strip_misconception_sections_strips_english_pitfall_heading() -> None:
+    content = "## OK\nbefore\n## Pitfalls to avoid\nbad\n## After\nafter\n"
+    out = strip_misconception_sections(content)
+    assert "before" in out and "after" in out
+    assert "bad" not in out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 为「再开一批」可维护性增量：在 `tests/test_lint_wiki_helpers.py` 中为 `lint_wiki.py` 的 `has_section`、`word_count`、`has_source_reference`、`strip_misconception_sections` 增加单元测试；在 `docs/contributing-ci.md` 增加「正文与资料应落在哪个目录」并指向 `schema/content-directories.md`；在 `schema/linking.md` 顶部增加与内容目录规范的交叉引用。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`
- [x] `make ci-test`

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

