### PR TITLE
docs(schema): 规范目录 README 与 lint_wiki 断链索引单测

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
 
 请先阅读：
 
+- **Schema 与流程索引**：[`schema/README.md`](schema/README.md)
 - 知识库维护流程：[`schema/ingest-workflow.md`](schema/ingest-workflow.md)
 - **内容进哪个目录**：[`schema/content-directories.md`](schema/content-directories.md)
 - **本地与 CI 命令对照**（提交前防踩坑）：[`docs/contributing-ci.md`](docs/contributing-ci.md)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 | `tech-map/` | **技术地图**。展示模块间依赖关系与技术栈全景。 |
 | `sources/` | **原始资料**。Ingest 之前的原始论文摘录、GitHub 仓库导航。 |
 | `references/` | **论文/Repo 索引**。按主题分类的深度阅读资源。 |
+| `schema/` | **维护规范**（ingest、命名、内链、页面类型、log 与 lint 用 JSON）。索引见 [schema/README.md](schema/README.md)。 |
 | `scripts/` | **维护工具**。用于 lint、搜索、索引生成和统计更新；脚本一览见 [scripts/README.md](scripts/README.md)。 |
 | `docs/` | **展示层**。GitHub Pages 托管的 D3.js 交互式图谱与详情页。 |
 | `docs/checklists/` | **执行清单归档**。当前技术栈推进、前端优化与历史阶段清单。 |

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,22 @@
+# Schema 目录说明
+
+本目录存放知识库的**维护规则与机器可读数据**，不是面向读者的 wiki 正文。维护前建议先读 [ingest-workflow.md](ingest-workflow.md)。
+
+## 文件索引
+
+| 文件 | 用途 |
+|------|------|
+| [ingest-workflow.md](ingest-workflow.md) | Ingest / Query / Lint / Index 等日常操作步骤与约定 |
+| [content-directories.md](content-directories.md) | `wiki/`、`sources/`、`references/` 等根目录如何选用 |
+| [linking.md](linking.md) | 内链相对路径写法与关联区块建议 |
+| [naming.md](naming.md) | 文件与目录命名约定 |
+| [page-types.md](page-types.md) | Wiki 页面类型与 frontmatter 字段 |
+| [log-format.md](log-format.md) | `log.md` 条目格式与前缀约定 |
+| [canonical-facts.json](canonical-facts.json) | `lint_wiki.py` 矛盾检测用的事实规则数据 |
+| [search-regression-cases.json](search-regression-cases.json) | 搜索质量回归测试用例数据 |
+
+## 与其它文档的关系
+
+- 提交与 CI 命令：[../docs/contributing-ci.md](../docs/contributing-ci.md)
+- 贡献总入口：[../CONTRIBUTING.md](../CONTRIBUTING.md)
+- 自动化维护者说明：[../AGENTS.md](../AGENTS.md)

--- a/schema/content-directories.md
+++ b/schema/content-directories.md
@@ -39,6 +39,7 @@
 
 ## 与其它规范的关系
 
+- Schema 总索引：[README.md](README.md)
 - Ingest 操作步骤：[ingest-workflow.md](ingest-workflow.md)
 - 内链写法：[linking.md](linking.md)
 - 仓库总览：[README.md](../README.md) 中「项目结构」表

--- a/schema/ingest-workflow.md
+++ b/schema/ingest-workflow.md
@@ -4,6 +4,8 @@
 > 基于 Karpathy LLM Wiki 模式：LLM 是维护者，人类是 curator。
 > 四种核心 ops：Ingest（吃进）、Query（查询）、Lint（体检）、Index（索引）。
 
+维护者入口：**[schema 目录索引](README.md)**（本目录各规范与数据文件一览）。
+
 ---
 
 ## Op 1：Ingest — 新资料进入知识库

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # `scripts/` 维护脚本一览
 
-本目录脚本由 `PYTHONPATH=scripts` 调用（见 `Makefile` 与 [贡献指南里的 CI 对照](../docs/contributing-ci.md)）。下表便于快速定位「改什么 / 跑什么」；权威调用方式仍以仓库根目录 **`Makefile`** 为准。
+本目录脚本由 `PYTHONPATH=scripts` 调用（见 `Makefile` 与 [贡献指南里的 CI 对照](../docs/contributing-ci.md)）。维护规范总览见 [schema/README.md](../schema/README.md)。下表便于快速定位「改什么 / 跑什么」；权威调用方式仍以仓库根目录 **`Makefile`** 为准。
 
 ## 入口脚本（按名字母序）
 

--- a/tests/test_lint_wiki_canonical_facts.py
+++ b/tests/test_lint_wiki_canonical_facts.py
@@ -1,0 +1,20 @@
+"""Tests for lint_wiki.load_canonical_facts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import lint_wiki as lw
+
+
+def test_load_canonical_facts_returns_empty_when_file_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(lw, "CANONICAL_FACTS_FILE", tmp_path / "missing.json")
+    assert lw.load_canonical_facts() == {}
+
+
+def test_load_canonical_facts_reads_json(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "cf.json"
+    path.write_text(json.dumps({"rules": []}), encoding="utf-8")
+    monkeypatch.setattr(lw, "CANONICAL_FACTS_FILE", path)
+    assert lw.load_canonical_facts() == {"rules": []}

--- a/tests/test_lint_wiki_link_index.py
+++ b/tests/test_lint_wiki_link_index.py
@@ -1,0 +1,39 @@
+"""Tests for lint_wiki._build_link_index."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import lint_wiki as lw
+
+
+def test_build_link_index_records_inbound(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(lw, "REPO_ROOT", tmp_path)
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    a = wiki / "a.md"
+    b = wiki / "b.md"
+    a.write_text("Link [b](b.md).\n", encoding="utf-8")
+    b.write_text("No backlink\n", encoding="utf-8")
+    pages = [a, b]
+    page_set = {p.resolve() for p in pages}
+    inbound, broken = lw._build_link_index(pages, page_set)
+    assert not broken
+    br = b.resolve()
+    assert br in inbound
+    assert a.resolve() in inbound[br]
+
+
+def test_build_link_index_reports_broken_relative_to_repo_root(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(lw, "REPO_ROOT", tmp_path)
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    page = wiki / "a.md"
+    page.write_text("[ghost](missing.md)\n", encoding="utf-8")
+    pages = [page]
+    page_set = {page.resolve()}
+    _inbound, broken = lw._build_link_index(pages, page_set)
+    assert len(broken) == 1
+    broken_paths = next(iter(broken.values()))
+    assert len(broken_paths) == 1
+    assert broken_paths[0].replace("\\", "/") == "wiki/missing.md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 包含两批可维护性增量：

**第一批**：新增 `schema/README.md` 作为规范目录总索引；根 `README` 项目结构增加 `schema/` 行；`CONTRIBUTING` 与 `content-directories` 链入该索引；新增 `test_lint_wiki_link_index` 覆盖 `_build_link_index`。

**第二批（追加）**：在 `schema/ingest-workflow.md` 顶部增加指向同目录 `README.md`（schema 索引）的维护者入口；在 `scripts/README.md` 首段增加 `schema/README.md` 链接；新增 `test_lint_wiki_canonical_facts.py` 覆盖 `load_canonical_facts`（文件缺失返回 `{}`、正常 JSON 解析）。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`
- [x] `make ci-test`（两批变更后均为 70 passed）

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

