### PR TITLE
docs: schema 索引入口扩展与断链索引边界单测

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@
 
 本知识库采用 **Karpathy LLM Wiki 模式**：LLM 是维护者，人类是 curator。
 
-核心操作规范在 `schema/ingest-workflow.md`，每次维护本仓库前必须先读该文件。
+核心操作规范在 `schema/ingest-workflow.md`，每次维护本仓库前必须先读该文件。规范文件总索引见 [schema/README.md](schema/README.md)。
 
 三种核心 Op：
 - **`ingest`** — 新资料进入知识库（先 `sources/`，再判断是否升格 `wiki/`）

--- a/docs/contributing-ci.md
+++ b/docs/contributing-ci.md
@@ -2,6 +2,8 @@
 
 提交前尽量跑齐与 GitHub Actions 相同的检查，避免 PR 反复红。
 
+规范与数据文件索引：[schema/README.md](../schema/README.md)。
+
 ## 一键对齐 Tests 工作流
 
 与 [`.github/workflows/tests.yml`](../.github/workflows/tests.yml) 中 **Ruff / Mypy / pip-audit / ESLint / Pytest** 顺序一致（不含 Wiki 专项 lint）：

--- a/schema/naming.md
+++ b/schema/naming.md
@@ -1,5 +1,7 @@
 # Naming Rules
 
+其它 `schema` 文件索引见 [README.md](README.md)。
+
 ## 总原则
 
 命名追求：

--- a/schema/page-types.md
+++ b/schema/page-types.md
@@ -1,5 +1,7 @@
 # Page Types
 
+其它 `schema` 文件索引见 [README.md](README.md)。
+
 本文件定义 `wiki/` 中的页面类型。
 
 ---

--- a/tests/test_lint_wiki_link_index.py
+++ b/tests/test_lint_wiki_link_index.py
@@ -37,3 +37,20 @@ def test_build_link_index_reports_broken_relative_to_repo_root(tmp_path: Path, m
     broken_paths = next(iter(broken.values()))
     assert len(broken_paths) == 1
     assert broken_paths[0].replace("\\", "/") == "wiki/missing.md"
+
+
+def test_build_link_index_no_broken_when_target_exists_but_outside_page_set(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """链接指向磁盘上存在的 .md，但该页未纳入本次 page_set 时，不计入断链。"""
+    monkeypatch.setattr(lw, "REPO_ROOT", tmp_path)
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    a = wiki / "a.md"
+    c = wiki / "c.md"
+    a.write_text("See [c](c.md).\n", encoding="utf-8")
+    c.write_text("not in lint page list\n", encoding="utf-8")
+    pages = [a]
+    page_set = {a.resolve()}
+    _inbound, broken = lw._build_link_index(pages, page_set)
+    assert not broken


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 为可维护性第六批：在 [AGENTS.md](https://github.com/ImChong/Robotics_Notebooks/blob/cursor/batch6-maintainability-e636/AGENTS.md) 的 LLM Wiki Ops 段落与 [docs/contributing-ci.md](https://github.com/ImChong/Robotics_Notebooks/blob/cursor/batch6-maintainability-e636/docs/contributing-ci.md) 文首增加 **schema/README** 索引链接；在 [schema/naming.md](https://github.com/ImChong/Robotics_Notebooks/blob/cursor/batch6-maintainability-e636/schema/naming.md) 与 [schema/page-types.md](https://github.com/ImChong/Robotics_Notebooks/blob/cursor/batch6-maintainability-e636/schema/page-types.md) 顶部增加同目录 README 交叉引用。新增单测覆盖 `_build_link_index`：当链接目标 `.md` 在磁盘上存在但未列入本次 `page_set` 时，**不计入断链**（与当前实现一致并防止回归）。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`
- [x] `make ci-test`（71 passed）

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

