### PR TITLE
test(search): search_indexing 文本解析单测与 schema 交叉链接

### DIFF
--- a/schema/linking.md
+++ b/schema/linking.md
@@ -1,6 +1,6 @@
 # Linking Rules
 
-与「内容应放进仓库哪个根目录」相关的取舍，见 [content-directories.md](content-directories.md)。
+与「内容应放进仓库哪个根目录」相关的取舍，见 [content-directories.md](content-directories.md)。**Schema 目录总索引**：[README.md](README.md)。
 
 ## 目标
 

--- a/schema/log-format.md
+++ b/schema/log-format.md
@@ -3,6 +3,8 @@
 > 本文件规定 `log.md` 的条目格式与可解析前缀约定。
 > log.md 是 Robotics_Notebooks 的 append-only 操作日志，对应 Karpathy LLM Wiki 模式中的运营层记录。
 
+其它 `schema` 文件索引见 [README.md](README.md)。
+
 ---
 
 ## 基本格式

--- a/tests/test_search_indexing_unit.py
+++ b/tests/test_search_indexing_unit.py
@@ -5,7 +5,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from search_indexing import parse_frontmatter
+from search_indexing import (
+    extract_summary,
+    extract_title,
+    parse_frontmatter,
+    strip_frontmatter,
+    tokenize_text,
+)
 from search_wiki import _filter_doc, _find_matched_lines
 
 
@@ -49,6 +55,34 @@ key: value
 """
         expected = {"title": "Test", "key": "value"}
         self.assertEqual(parse_frontmatter(content), expected)
+
+
+class TestSearchIndexingText(unittest.TestCase):
+    def test_strip_frontmatter_removes_block(self) -> None:
+        raw = "---\ntitle: X\n---\n\n# Body\n"
+        self.assertTrue(strip_frontmatter(raw).lstrip().startswith("# Body"))
+
+    def test_strip_frontmatter_no_block(self) -> None:
+        self.assertEqual(strip_frontmatter("# Only\n"), "# Only\n")
+
+    def test_extract_title(self) -> None:
+        self.assertEqual(extract_title("# Title Here\n\nx"), "Title Here")
+
+    def test_extract_title_fallback(self) -> None:
+        self.assertEqual(extract_title("no h1", "fb"), "fb")
+
+    def test_extract_summary_from_frontmatter(self) -> None:
+        fm = {"summary": "  from fm  "}
+        self.assertEqual(extract_summary("ignored body", fm), "from fm")
+
+    def test_extract_summary_first_paragraph(self) -> None:
+        body = "# T\n\nHello  world.\n"
+        self.assertEqual(extract_summary(body, {}), "Hello world.")
+
+    def test_tokenize_text_synonym_expansion(self) -> None:
+        toks = tokenize_text("强化学习")
+        self.assertIn("强化学习", toks)
+        self.assertIn("rl", toks)
 
 
 class TestSearchWikiHelpers(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本 PR 为可维护性第七批：在 `tests/test_search_indexing_unit.py` 中新增 `TestSearchIndexingText`，覆盖 `search_indexing` 的 `strip_frontmatter`、`extract_title`、`extract_summary`（frontmatter 与正文首段）及 `tokenize_text`（「强化学习」同义词展开含 `rl`）。在 `schema/linking.md` 与 `schema/log-format.md` 顶部增加指向同目录 **schema/README** 的索引链接。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`
- [x] `make ci-test`（78 passed）

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fd1ac64-1948-4c74-b066-c1272083e636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

