### PR TITLE
revert(docs): 恢复技术路线页完整布局与论文主线、Mermaid

### DIFF
--- a/docs/frontend-redesign-plan.md
+++ b/docs/frontend-redesign-plan.md
@@ -50,7 +50,7 @@ Phase 3（长期）：设计系统整体升级
 | `tech-map.html` | 技术栈节点，按 layer 卡片展示 | 静态卡片，不体现节点间依赖关系 |
 | `roadmap.html` | 学习路径页 | 功能完整，低优先级改动 |
 | `module.html` | 模块聚合页 | 功能完整，低优先级改动 |
-| `references.html` | 重定向到 `roadmap.html?id=roadmap-motion-control`（技术路线页） |
+| `references.html` | 重定向到 `roadmap.html?id=roadmap-motion-control#paper-guide`（论文主线已并入路线页） |
 
 ### 1.2 核心问题
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -24,6 +24,10 @@
       updateThemeToggle();
       const detailContentEl = document.getElementById('detailContent');
       if (detailContentEl) renderDetailMermaid(detailContentEl);
+      const roadmapFlowHost = document.getElementById('roadmapFlowMermaidRoot');
+      if (roadmapFlowHost && roadmapFlowHost.querySelector('.roadmap-mermaid-wrap[open] .mermaid')) {
+        renderDetailMermaid(roadmapFlowHost);
+      }
     });
   }
 
@@ -453,6 +457,23 @@
     window.mermaid.run({ nodes: nodes }).catch(function () {});
   }
 
+  function sanitizeMermaidLabel(text, maxLen) {
+    var max = maxLen == null ? 44 : maxLen;
+    var t = String(text || '')
+      .replace(/\[/g, ' ')
+      .replace(/\]/g, ' ')
+      .replace(/"/g, ' ')
+      .replace(/[()#`]/g, ' ')
+      .replace(/</g, ' ')
+      .replace(/&/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (t.length > max) {
+      t = t.slice(0, Math.max(0, max - 1)) + '…';
+    }
+    return t || '—';
+  }
+
   /**
    * Vertical collapsible tree (details/summary): one stage per row, children = related links.
    * Primary UI for narrow screens; no extra libraries.
@@ -505,6 +526,69 @@
     return parts.join('');
   }
 
+  /**
+   * Single learning-roadmap Mermaid: stage spine OV0→OVn, optional motion-control dual trunk,
+   * each stage fans out to related wiki titles (max 5).
+   */
+  function buildUnifiedRoadmapMermaidSource(stages, roadmapId, detailPages) {
+    var lines = ['flowchart TB'];
+    lines.push('  %% roadmap unified diagram');
+    var n = stages.length;
+    var i;
+    for (i = 0; i < n; i++) {
+      var st = stages[i];
+      var ovLbl = sanitizeMermaidLabel(
+        String(st.id || '').toUpperCase() + ' · ' + String(st.title || ''),
+        46
+      );
+      lines.push('  OV' + i + '["' + ovLbl + '"]');
+    }
+    for (i = 0; i < n - 1; i++) {
+      lines.push('  OV' + i + ' --> OV' + (i + 1));
+    }
+    if (roadmapId === 'roadmap-motion-control') {
+      lines.push('  MC_DT["控制主干<br/>LIP→Centroidal→MPC→TSID/WBC"]');
+      lines.push('  MC_DL["学习方法<br/>RL→Loco RL→IL→Sim2Real"]');
+      lines.push('  MC_DT -->|先主干| MC_DL');
+      var mid = Math.min(3, Math.max(0, n - 1));
+      lines.push('  OV' + mid + ' -.->|主线对照| MC_DT');
+    }
+    for (i = 0; i < n; i++) {
+      var stage = stages[i];
+      var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 5) : [];
+      if (!related.length) {
+        lines.push('  EMP' + i + '["暂无关联详情页"]');
+        lines.push('  OV' + i + ' --> EMP' + i);
+      } else {
+        for (var k = 0; k < related.length; k++) {
+          var rid = related[k];
+          var page = detailPages[rid] || {};
+          var nid = 'RX' + i + 'Y' + k;
+          var nlbl = sanitizeMermaidLabel(page.title || rid, 36);
+          lines.push('  ' + nid + '["' + nlbl + '"]');
+          lines.push('  OV' + i + ' --> ' + nid);
+        }
+      }
+    }
+    return lines.join('\n');
+  }
+
+  function scheduleRoadmapMermaidRender(container) {
+    if (!container) return;
+    var attempts = 0;
+    function tryRender() {
+      attempts += 1;
+      if (typeof window.mermaid !== 'undefined') {
+        renderDetailMermaid(container);
+        return;
+      }
+      if (attempts < 100) {
+        window.requestAnimationFrame(tryRender);
+      }
+    }
+    tryRender();
+  }
+
   function setRoadmapFlowChromeVisible(show) {
     var flowSection = document.getElementById('roadmap-flow');
     var sub = document.getElementById('roadmapSubnavFlow');
@@ -515,7 +599,7 @@
   }
 
   function renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages) {
-    var flowRoot = document.getElementById('roadmapFlowRoot');
+    var flowRoot = document.getElementById('roadmapFlowMermaidRoot');
     var stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
     if (!flowRoot || stages.length < 2) {
       setRoadmapFlowChromeVisible(false);
@@ -523,7 +607,31 @@
       return;
     }
     setRoadmapFlowChromeVisible(true);
-    flowRoot.innerHTML = buildRoadmapVerticalTreeHTML(stages, roadmapId, detailPages);
+    var treeHtml = buildRoadmapVerticalTreeHTML(stages, roadmapId, detailPages);
+    var src = buildUnifiedRoadmapMermaidSource(stages, roadmapId, detailPages);
+    flowRoot.innerHTML =
+      treeHtml
+      + '<details class="roadmap-mermaid-wrap">'
+      + '<summary class="roadmap-mermaid-wrap-summary">Mermaid 线框总图（适合宽屏 / 对照结构）</summary>'
+      + '<p class="data-meta roadmap-mermaid-hint">展开后渲染；与上方阶段一致。</p>'
+      + '<div class="mermaid roadmap-mermaid-diagram">' + src + '</div>'
+      + '</details>';
+
+    var wrap = flowRoot.querySelector('.roadmap-mermaid-wrap');
+    function renderMermaidBlock() {
+      if (typeof window.mermaid !== 'undefined') {
+        renderDetailMermaid(flowRoot);
+      } else {
+        scheduleRoadmapMermaidRender(flowRoot);
+      }
+    }
+    if (wrap) {
+      wrap.addEventListener('toggle', function onWrapToggle() {
+        if (!wrap.open) return;
+        renderMermaidBlock();
+        wrap.removeEventListener('toggle', onWrapToggle);
+      });
+    }
   }
 
   function renderDetailMath(container) {
@@ -1344,6 +1452,15 @@
     });
   }
 
+  function setRoadmapPaperGuideVisible(show) {
+    const paperGuide = document.getElementById('paper-guide');
+    const paperSubnav = document.getElementById('roadmapSubnavPaper');
+    const paperToc = document.getElementById('roadmapTocPaperItem');
+    if (paperGuide) paperGuide.hidden = !show;
+    if (paperSubnav) paperSubnav.hidden = !show;
+    if (paperToc) paperToc.hidden = !show;
+  }
+
   function renderRoadmapPage(siteData) {
     if (!siteData || !siteData.pages) return;
 
@@ -1379,8 +1496,9 @@
       renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的相关项。' });
       if (breadcrumb) removeLoadingState(breadcrumb);
       setRoadmapFlowChromeVisible(false);
-      var flowRootEmpty = document.getElementById('roadmapFlowRoot');
+      var flowRootEmpty = document.getElementById('roadmapFlowMermaidRoot');
       if (flowRootEmpty) flowRootEmpty.innerHTML = '';
+      setRoadmapPaperGuideVisible(false);
       return;
     }
 
@@ -1393,14 +1511,11 @@
       removeLoadingState(summaryEl);
     }
     if (metaEl) {
-      metaEl.innerHTML =
-        '<span class="data-meta"><code>' +
-        escapeHtml(roadmapPage.id || roadmapId) +
-        '</code> · ' +
-        escapeHtml((roadmapPage.stages || []).length) +
-        ' 阶段 · ' +
-        escapeHtml((roadmapPage.related_items || []).length) +
-        ' 相关项</span>';
+      metaEl.innerHTML = [
+        '<p><strong>id：</strong><code>' + escapeHtml(roadmapPage.id || roadmapId) + '</code></p>',
+        '<p><strong>阶段数：</strong>' + escapeHtml((roadmapPage.stages || []).length) + '</p>',
+        '<p><strong>相关项：</strong>' + escapeHtml((roadmapPage.related_items || []).length) + '</p>'
+      ].join('');
       removeLoadingState(metaEl);
     }
     if (breadcrumb) {
@@ -1413,6 +1528,7 @@
     }
     renderInternalLinks(relatedEl, roadmapPage.related_items, detailPages, { emptyText: '当前路线暂无相关项。' });
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
+    setRoadmapPaperGuideVisible(roadmapId === 'roadmap-motion-control');
   }
 
   function renderTechMapNodeCard(node, detailPages) {

--- a/docs/modules/imitation-learning.html
+++ b/docs/modules/imitation-learning.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/modules/motion-control.html
+++ b/docs/modules/motion-control.html
@@ -34,7 +34,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/modules/reinforcement-learning.html
+++ b/docs/modules/reinforcement-learning.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/references.html
+++ b/docs/references.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="原论文导航入口已指向运动控制技术路线页；正在为你跳转。" />
-  <title>论文导航入口 | Robotics Notebooks</title>
+  <meta name="description" content="论文导航已并入运动控制技术路线指南；正在为你跳转。" />
+  <title>论文导航已合并 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>" />
-  <meta http-equiv="refresh" content="0; url=roadmap.html?id=roadmap-motion-control" />
+  <meta http-equiv="refresh" content="0; url=roadmap.html?id=roadmap-motion-control#paper-guide" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <main class="container" style="padding:3rem 1rem;max-width:42rem">
-    <h1 class="hero-title" style="font-size:1.5rem">论文导航入口</h1>
-    <p>文献列表仍在各 <code>detail</code> 页；本入口跳转到运动控制技术路线页（学习路线与相关项）。</p>
-    <p><a class="btn-primary" href="roadmap.html?id=roadmap-motion-control">打开技术路线</a></p>
+    <h1 class="hero-title" style="font-size:1.5rem">论文导航已合并</h1>
+    <p>论文主线现已与「运动控制」路线页放在同一页，便于从阶段学习到文献阅读一条龙使用。</p>
+    <p><a class="btn-primary" href="roadmap.html?id=roadmap-motion-control#paper-guide">打开技术路线指南（论文主线）</a></p>
     <p class="data-meta" style="margin-top:2rem">若未自动跳转，请点击上方按钮。</p>
   </main>
   <script>
-    window.location.replace('roadmap.html?id=roadmap-motion-control');
+    window.location.replace('roadmap.html?id=roadmap-motion-control#paper-guide');
   </script>
 </body>
 </html>

--- a/docs/relations/retargeting-pipeline.html
+++ b/docs/relations/retargeting-pipeline.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/rl-vs-il.html
+++ b/docs/relations/rl-vs-il.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/sim2real-pipeline.html
+++ b/docs/relations/sim2real-pipeline.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/wbc-vs-rl.html
+++ b/docs/relations/wbc-vs-rl.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control">技术路线</a>
+          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="技术路线：学习阶段与相关站内页。" />
-  <meta name="keywords" content="Robotics Notebooks, roadmap, 学习路线" />
+  <meta name="description" content="运动控制技术路线指南：数据驱动的阶段与相关项，并附论文主线（原论文导航），适合入门与工程师速查。" />
+  <meta name="keywords" content="Robotics Notebooks, roadmap page, roadmap_pages, 成长路线" />
   <meta name="author" content="Chong Liu" />
-  <meta property="og:title" content="Robotics Notebooks | 技术路线" />
-  <meta property="og:description" content="学习路线与相关项。" />
+  <meta property="og:title" content="Robotics Notebooks | 技术路线指南" />
+  <meta property="og:description" content="阶段路线 + 论文主线同一页：面向人形运动控制的学习与速查。" />
   <meta property="og:type" content="website" />
-  <title>技术路线 | Robotics Notebooks</title>
+  <title>Robotics Notebooks | 技术路线指南</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="roadmap-page">
+<body>
   <header class="site-header">
     <div class="header-inner">
-      <a class="site-title" href="index.html">Robotics Notebooks</a>
+      <a class="site-title" href="index.html">🚀 Robotics Notebooks | 技术路线指南</a>
       <div class="header-spacer"></div>
       <div class="header-right">
         <a class="github-link" href="https://github.com/ImChong/Robotics_Notebooks" target="_blank" rel="noopener noreferrer">GitHub</a>
@@ -28,49 +28,218 @@
     </div>
   </header>
   <main>
-    <div class="container roadmap-page-intro">
-      <nav id="roadmapBreadcrumb" class="roadmap-breadcrumb data-loading" aria-label="面包屑导航">
-        <a href="index.html">首页</a>
-        <span class="roadmap-bc-sep">/</span>
-        <span>技术路线</span>
-      </nav>
-      <h1 id="roadmapTitle">正在读取路线…</h1>
-      <p id="roadmapSummary" class="roadmap-summary data-loading">读取路线数据中。</p>
-      <p id="roadmapMeta" class="roadmap-meta-line data-loading">…</p>
-    </div>
+    <section class="page-hero detail-hero">
+      <div class="container detail-hero-stack">
+        <nav id="roadmapBreadcrumb" class="detail-breadcrumb data-loading" aria-label="面包屑导航">
+          <a href="index.html">首页</a>
+          <span>/</span>
+          <span>技术路线指南</span>
+        </nav>
+        <div class="detail-hero-top">
+          <div>
+            <p class="hero-kicker">技术路线指南 · 数据驱动</p>
+            <h1 id="roadmapTitle">正在读取路线…</h1>
+            <p id="roadmapSummary" class="detail-summary data-loading">当前页面读取 <code>roadmap_pages</code>，展示路线摘要、学习路线与相关项。</p>
+          </div>
+          <aside class="hero-panel detail-meta-panel">
+            <h3>路线元信息</h3>
+            <div id="roadmapMeta" class="detail-meta-list data-loading">
+              <p class="data-meta">正在读取路线元信息…</p>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="page-subnav-wrap">
+      <div class="container page-subnav">
+        <a href="#roadmap-flow" id="roadmapSubnavFlow" hidden>路线</a>
+        <a href="#roadmap-related">相关项</a>
+        <a href="#paper-guide" id="roadmapSubnavPaper" hidden>论文主线</a>
+      </div>
+    </section>
 
     <section class="section" id="roadmap-empty-section">
       <div class="container">
-        <article id="roadmapEmptyState" class="roadmap-empty card" hidden>
-          <h2>未找到路线</h2>
-          <p>请在 URL 使用 <code>?id=…</code>，例如 <code>roadmap.html?id=roadmap-motion-control</code></p>
-          <p><a class="btn-secondary" href="index.html">返回首页</a></p>
+        <article id="roadmapEmptyState" class="card empty-state" hidden>
+          <h2>未找到对应 roadmap page</h2>
+          <p>请在 URL 里传入合法的 <code>?id=...</code>。例如：<code>roadmap.html?id=roadmap-motion-control</code></p>
+          <div class="cta-row">
+            <a class="btn-secondary" href="index.html">回到首页</a>
+          </div>
         </article>
       </div>
     </section>
 
-    <div class="container roadmap-page-sections">
-      <section id="roadmap-flow" class="section roadmap-flow-section" hidden>
-        <h2 class="section-title">学习路线</h2>
-        <p class="section-subtitle">点击阶段标题展开关联页面。</p>
-        <div id="roadmapFlowRoot" class="roadmap-flow-host" aria-live="polite"></div>
-      </section>
+    <section class="section roadmap-content-section">
+      <div class="container detail-content-layout">
+        <aside class="detail-toc-panel">
+          <h2 class="section-title">路线导航</h2>
+          <nav class="detail-toc-list">
+            <ol>
+              <li id="roadmapTocFlowItem" hidden><a href="#roadmap-flow">路线</a></li>
+              <li><a href="#roadmap-related">相关项</a></li>
+              <li id="roadmapTocPaperItem" hidden><a href="#paper-guide">论文主线</a></li>
+            </ol>
+          </nav>
+        </aside>
 
-      <section id="roadmap-related" class="section roadmap-related-section">
-        <h2 class="section-title">相关项</h2>
-        <p class="section-subtitle">与本路线相关的站内页面。</p>
-        <div id="roadmapRelatedList" class="card-grid data-loading">
-          <article class="card skeleton-card"><p>正在读取相关项…</p></article>
+        <div class="detail-content-main">
+          <section id="roadmap-flow" class="section roadmap-flow-section" hidden>
+            <h2 class="section-title">学习路线</h2>
+            <p class="section-subtitle">点击阶段标题展开关联页面；需要时再展开下方 Mermaid。</p>
+            <div id="roadmapFlowMermaidRoot" class="roadmap-flow-mermaid-host" aria-live="polite"></div>
+          </section>
+
+          <section class="section section-alt" id="roadmap-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">
+            <h2 class="section-title">相关项</h2>
+            <p class="section-subtitle">通往 detail route 的关联项。</p>
+            <div id="roadmapRelatedList" class="card-grid data-loading">
+              <article class="card skeleton-card"><p>正在读取相关项…</p></article>
+            </div>
+          </section>
         </div>
-      </section>
-    </div>
+      </div>
+    </section>
+
+    <section id="paper-guide" class="section section-alt" hidden aria-label="论文主线导航">
+      <div class="container">
+        <h2 class="section-title">论文主线（原论文导航）</h2>
+        <p class="section-subtitle">按问题与主线串联阅读，与上方「路线 / 相关项」互补：路线定结构，论文定深度。</p>
+
+        <section class="section" style="padding-top:0">
+          <h3 class="section-title" style="font-size:1.15rem">路线与论文怎么用</h3>
+          <div class="structure-list">
+            <article class="simple-card">
+              <h3>初学者</h3>
+              <p>先按上方「阶段」搭好控制概念骨架，再在本区每次只跟一条子线读 2–4 篇代表作，读完后回到 <a href="graph.html">知识图谱</a> 把概念挂回全站。</p>
+            </article>
+            <article class="simple-card">
+              <h3>有经验的运动控制工程师</h3>
+              <p>可把本页当速查：阶段区对齐培训与评审话术，论文区按 WBC/MPC、RL、Sim2Real、IL 快速跳到站内整理好的论文列表（detail）。</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section" style="padding-top:1rem">
+          <h3 class="section-title">1. Motion Control：运动控制主线</h3>
+          <p class="section-subtitle">控制主线越稳，后面看学习方法（RL/IL）越不容易飘。</p>
+          <div class="card-grid">
+            <article class="card">
+              <h3>WBC / QP / TSID</h3>
+              <p>重点看任务优先级、接触力分配与全身协调。这是人形控制论文的基本语法。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-whole-body-control" class="btn-secondary btn-inline">详细列表 →</a></div>
+            </article>
+            <article class="card">
+              <h3>Model Predictive Control</h3>
+              <p>看如何将动力学约束写成优化问题并在线实时求解。代表作：MIT Cheetah 系列、OCS2 工作。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-mpc" class="btn-secondary btn-inline">MPC 列表 →</a></div>
+            </article>
+            <article class="card">
+              <h3>Optimal Control Theory</h3>
+              <p>控制理论的数学基石。包括 DP、极大值原理与 DDP/iLQR 的推导。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-optimal-control" class="btn-secondary btn-inline">理论列表 →</a></div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-alt" style="margin-top:1rem;border-radius:12px">
+            <h3 class="section-title">2. RL：机器人强化学习主线</h3>
+            <p class="section-subtitle">适合想真正理解 Humanoid Locomotion、鲁棒训练与策略部署的人。</p>
+            <div class="card-grid">
+              <article class="card">
+                <h3>Locomotion 代表作</h3>
+                <p>PPO 基线、RMA 快速自适应、AMP 对抗运动先验。不仅仅是「走」，更要看如何「稳」。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-locomotion-rl" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+              <article class="card">
+                <h3>Latent Skill Prior</h3>
+                <p>ASE, CALM, MimicKit。当你关心「既稳又自然」的行为时，这些技能嵌入工作是核心。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-latent-skill-prior" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+            </div>
+        </section>
+
+        <section class="section" style="padding-top:1rem">
+          <h3 class="section-title">3. Sim2Real：从仿真到真机</h3>
+          <p class="section-subtitle">最能体现工程含金量的部分，弥合仿真和现实的物理失配。</p>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Domain Randomization</h3>
+              <p>物理参数随机化 (DR)、视觉域随机化。重点看「随机了什么」以及「为什么有效」。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-sim2real" class="btn-secondary btn-inline">详细列表 →</a></div>
+            </article>
+            <article class="card">
+              <h3>System Identification</h3>
+              <p>SAGE 执行器建模、延迟建模与参数辨识。工程部署能不能站住，往往就卡在这里。</p>
+              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-system-identification" class="btn-secondary btn-inline">详细列表 →</a></div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-alt" style="margin-top:1rem;border-radius:12px">
+            <h3 class="section-title">4. IL &amp; Humanoid：模仿学习与人形专项</h3>
+            <p class="section-subtitle">连接动捕数据、遥操作与全身技能协调，是后续具身智能的高价值方向。</p>
+            <div class="card-grid">
+              <article class="card">
+                <h3>Imitation Learning</h3>
+                <p>BC / DAgger 基础、Diffusion Policy、动作迁移 (Retargeting) 完整 Pipeline。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-imitation-learning" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+              <article class="card">
+                <h3>Hardware &amp; Survey</h3>
+                <p>人形硬件平台演进、机器人学习领域综述。看清行业全景，避免陷入局部最优。</p>
+                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-survey-papers" class="btn-secondary btn-inline">详细列表 →</a></div>
+              </article>
+            </div>
+        </section>
+
+        <section class="section" style="padding-top:1rem;padding-bottom:0">
+          <h3 class="section-title">阅读建议</h3>
+          <div class="structure-list">
+            <article class="simple-card">
+              <h3>每次只打一条主线</h3>
+              <p>先吃透 2–4 篇奠基代表作，读完后务必回模块页或图谱页同步知识，不要全地图乱跳。</p>
+            </article>
+            <article class="simple-card">
+              <h3>工程细节比模型名字更重要</h3>
+              <p>多看 Deployment Reports 和失败经验，真正的财富往往在 Supplementary 中。</p>
+            </article>
+          </div>
+        </section>
+      </div>
+    </section>
   </main>
+
+  <button class="sidebar-toggle" id="sidebarToggle" aria-label="切换目录侧边栏">
+    <svg viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+  </button>
+  <div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+  <script>
+    (function() {
+      var toggle = document.getElementById('sidebarToggle');
+      var overlay = document.getElementById('sidebarOverlay');
+      var sidebar = document.querySelector('.detail-toc-panel');
+      if (!toggle || !sidebar) { if (toggle) toggle.style.display = 'none'; return; }
+      function open() { sidebar.classList.add('open'); overlay.classList.add('show'); document.body.style.overflow = 'hidden'; }
+      function close() { sidebar.classList.remove('open'); overlay.classList.remove('show'); document.body.style.overflow = ''; }
+      toggle.addEventListener('click', function(e) { e.stopPropagation(); sidebar.classList.contains('open') ? close() : open(); });
+      if (overlay) overlay.addEventListener('click', close);
+      sidebar.addEventListener('click', function(e) {
+        if (e.target.tagName === 'A' || e.target.closest('a')) {
+          close(); // Close immediately to allow hash jump
+        }
+      });
+    })();
+  </script>
 
   <footer class="footer">
     <div class="container footer-stack">
       <p>© Chong Liu 2026 · Robotics Notebooks</p>
     </div>
   </footer>
+  <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script defer src="main.js"></script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1128,11 +1128,11 @@ th {
 .search-tier-heading.search-tier-exact { color:var(--accent, #1659b4); }
 .search-tier-heading .data-meta { font-weight:400; opacity:.75; margin-left:4px; }
 
-/* --- Roadmap page: vertical tree --- */
+/* --- Roadmap page: vertical tree + optional folded Mermaid --- */
 .roadmap-flow-section {
   padding-bottom: 0;
 }
-.roadmap-flow-host .roadmap-vtree-hint {
+.roadmap-flow-mermaid-host .roadmap-vtree-hint {
   margin: 0 0 0.75rem;
 }
 .roadmap-vtree-dual {
@@ -1231,6 +1231,35 @@ th {
   margin: 0;
   border-top: 1px solid var(--border);
 }
+.roadmap-mermaid-wrap {
+  margin-top: 1.25rem;
+  padding: 0.65rem 1rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-strong, var(--bg-alt));
+}
+.roadmap-mermaid-wrap-summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.25rem 0;
+}
+.roadmap-flow-mermaid-host .roadmap-mermaid-hint {
+  margin: 0.5rem 0 0.6rem;
+}
+.roadmap-flow-mermaid-host .mermaid {
+  text-align: center;
+  margin: 0.35rem 0 0;
+  overflow-x: auto;
+}
+.roadmap-flow-mermaid-host .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+.roadmap-flow-mermaid-host .roadmap-mermaid-diagram {
+  padding: 0.5rem 0;
+  min-height: 8rem;
+}
 .roadmap-flow-details,
 .roadmap-stage-flow-details {
   margin-bottom: 1rem;
@@ -1265,48 +1294,4 @@ th {
   .roadmap-flow-stage-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-}
-
-/* --- Roadmap page (minimal layout) --- */
-.roadmap-page .roadmap-page-intro {
-  padding: 1.75rem 0 0.5rem;
-  max-width: 44rem;
-}
-.roadmap-page .roadmap-breadcrumb {
-  font-size: 0.85rem;
-  margin-bottom: 0.75rem;
-}
-.roadmap-page .roadmap-bc-sep {
-  margin: 0 0.35rem;
-  opacity: 0.6;
-}
-.roadmap-page h1 {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.35rem, 4vw, 1.75rem);
-  line-height: 1.25;
-}
-.roadmap-page .roadmap-summary {
-  margin: 0 0 0.5rem;
-  color: var(--text-muted);
-  font-size: 0.95rem;
-  line-height: 1.5;
-}
-.roadmap-page .roadmap-meta-line {
-  margin: 0 0 1.25rem;
-  font-size: 0.82rem;
-}
-.roadmap-page .roadmap-page-sections {
-  padding-bottom: 2.5rem;
-}
-.roadmap-page .roadmap-page-sections .section-title {
-  margin-top: 0;
-}
-.roadmap-page .roadmap-flow-section {
-  margin-bottom: 1.5rem;
-}
-.roadmap-page .roadmap-related-section {
-  padding-top: 0.25rem;
-}
-.roadmap-page .roadmap-empty h2 {
-  margin-top: 0;
 }

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -13,12 +13,12 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapTitle"',
             'id="roadmapSummary"',
             'id="roadmapMeta"',
-            'id="roadmapFlowRoot"',
+            'id="roadmapFlowMermaidRoot"',
             'id="roadmapRelatedList"',
+            'id="paper-guide"',
         ]
         for marker in required_ids:
             self.assertIn(marker, content)
-        self.assertNotIn("mermaid", content.lower())
 
     def test_main_js_contains_roadmap_page_renderer(self):
         content = MAIN_JS.read_text(encoding="utf-8")
@@ -27,7 +27,7 @@ class RoadmapPageTests(unittest.TestCase):
             "document.getElementById('roadmapTitle')",
             "roadmap.html?id=",
             "roadmap_pages",
-            "roadmapFlowRoot",
+            "setRoadmapPaperGuideVisible",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

撤回 PR #166 的极简改版，恢复技术路线页完整布局（Hero 双栏、子导航、侧栏 TOC、论文主线、Mermaid 等），与合并 #166 前 `8f6c24c` 一致。

## 预览截图（合 PR 前可在浏览器直接打开）

- 首屏（约 1280×720）：https://raw.githubusercontent.com/ImChong/Robotics_Notebooks/cursor/revert-roadmap-minimal-dedd/docs/screenshots/roadmap-motion-control-first.png
- 整页长图：https://raw.githubusercontent.com/ImChong/Robotics_Notebooks/cursor/revert-roadmap-minimal-dedd/docs/screenshots/roadmap-motion-control-full.png

截图基于本地 `docs/` + `exports/site-data-v1.json` 渲染，与线上 Pages 可能略有数据时间差，版式一致。

## 验证

- `make ci-preflight` 已通过（截图提交前）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28c226ff-9879-49bd-8133-3c22eafbdedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28c226ff-9879-49bd-8133-3c22eafbdedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

