### PR TITLE
docs(roadmap): 移除运动控制路线页论文主线模块

### DIFF
--- a/docs/frontend-redesign-plan.md
+++ b/docs/frontend-redesign-plan.md
@@ -50,7 +50,7 @@ Phase 3（长期）：设计系统整体升级
 | `tech-map.html` | 技术栈节点，按 layer 卡片展示 | 静态卡片，不体现节点间依赖关系 |
 | `roadmap.html` | 学习路径页 | 功能完整，低优先级改动 |
 | `module.html` | 模块聚合页 | 功能完整，低优先级改动 |
-| `references.html` | 重定向到 `roadmap.html?id=roadmap-motion-control#paper-guide`（论文主线已并入路线页） |
+| `references.html` | 重定向到 `roadmap.html?id=roadmap-motion-control`（兼容旧「论文导航」书签） |
 
 ### 1.2 核心问题
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -1452,15 +1452,6 @@
     });
   }
 
-  function setRoadmapPaperGuideVisible(show) {
-    const paperGuide = document.getElementById('paper-guide');
-    const paperSubnav = document.getElementById('roadmapSubnavPaper');
-    const paperToc = document.getElementById('roadmapTocPaperItem');
-    if (paperGuide) paperGuide.hidden = !show;
-    if (paperSubnav) paperSubnav.hidden = !show;
-    if (paperToc) paperToc.hidden = !show;
-  }
-
   function renderRoadmapPage(siteData) {
     if (!siteData || !siteData.pages) return;
 
@@ -1498,7 +1489,6 @@
       setRoadmapFlowChromeVisible(false);
       var flowRootEmpty = document.getElementById('roadmapFlowMermaidRoot');
       if (flowRootEmpty) flowRootEmpty.innerHTML = '';
-      setRoadmapPaperGuideVisible(false);
       return;
     }
 
@@ -1528,7 +1518,6 @@
     }
     renderInternalLinks(relatedEl, roadmapPage.related_items, detailPages, { emptyText: '当前路线暂无相关项。' });
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
-    setRoadmapPaperGuideVisible(roadmapId === 'roadmap-motion-control');
   }
 
   function renderTechMapNodeCard(node, detailPages) {

--- a/docs/modules/imitation-learning.html
+++ b/docs/modules/imitation-learning.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/modules/motion-control.html
+++ b/docs/modules/motion-control.html
@@ -34,7 +34,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/modules/reinforcement-learning.html
+++ b/docs/modules/reinforcement-learning.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/references.html
+++ b/docs/references.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="论文导航已并入运动控制技术路线指南；正在为你跳转。" />
-  <title>论文导航已合并 | Robotics Notebooks</title>
+  <meta name="description" content="论文导航入口已调整；正在为你跳转到运动控制技术路线指南。" />
+  <title>论文导航 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>" />
-  <meta http-equiv="refresh" content="0; url=roadmap.html?id=roadmap-motion-control#paper-guide" />
+  <meta http-equiv="refresh" content="0; url=roadmap.html?id=roadmap-motion-control" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <main class="container" style="padding:3rem 1rem;max-width:42rem">
-    <h1 class="hero-title" style="font-size:1.5rem">论文导航已合并</h1>
-    <p>论文主线现已与「运动控制」路线页放在同一页，便于从阶段学习到文献阅读一条龙使用。</p>
-    <p><a class="btn-primary" href="roadmap.html?id=roadmap-motion-control#paper-guide">打开技术路线指南（论文主线）</a></p>
+    <h1 class="hero-title" style="font-size:1.5rem">论文导航</h1>
+    <p>站内「论文主线」区块已从运动控制路线页移除。技术路线与相关条目请见运动控制路线页；单篇论文深读请使用 <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">Humanoid_Robot_Learning_Paper_Notebooks</a>。</p>
+    <p><a class="btn-primary" href="roadmap.html?id=roadmap-motion-control">打开运动控制技术路线指南</a></p>
     <p class="data-meta" style="margin-top:2rem">若未自动跳转，请点击上方按钮。</p>
   </main>
   <script>
-    window.location.replace('roadmap.html?id=roadmap-motion-control#paper-guide');
+    window.location.replace('roadmap.html?id=roadmap-motion-control');
   </script>
 </body>
 </html>

--- a/docs/relations/retargeting-pipeline.html
+++ b/docs/relations/retargeting-pipeline.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/rl-vs-il.html
+++ b/docs/relations/rl-vs-il.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/sim2real-pipeline.html
+++ b/docs/relations/sim2real-pipeline.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/relations/wbc-vs-rl.html
+++ b/docs/relations/wbc-vs-rl.html
@@ -35,7 +35,7 @@
           <a href="../index.html">首页</a>
           <a href="../roadmap.html">成长路线</a>
           <a href="../tech-map.html">技术栈地图</a>
-          <a href="../roadmap.html?id=roadmap-motion-control#paper-guide">论文导航</a>
+          <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">论文导航</a>
         </nav>
       </div>
     </section>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="运动控制技术路线指南：数据驱动的阶段与相关项，并附论文主线（原论文导航），适合入门与工程师速查。" />
+  <meta name="description" content="运动控制技术路线指南：数据驱动的阶段与相关项，适合入门与工程师速查。" />
   <meta name="keywords" content="Robotics Notebooks, roadmap page, roadmap_pages, 成长路线" />
   <meta name="author" content="Chong Liu" />
   <meta property="og:title" content="Robotics Notebooks | 技术路线指南" />
-  <meta property="og:description" content="阶段路线 + 论文主线同一页：面向人形运动控制的学习与速查。" />
+  <meta property="og:description" content="阶段路线与相关项：面向人形运动控制的学习与速查。" />
   <meta property="og:type" content="website" />
   <title>Robotics Notebooks | 技术路线指南</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>" />
@@ -55,7 +55,6 @@
       <div class="container page-subnav">
         <a href="#roadmap-flow" id="roadmapSubnavFlow" hidden>路线</a>
         <a href="#roadmap-related">相关项</a>
-        <a href="#paper-guide" id="roadmapSubnavPaper" hidden>论文主线</a>
       </div>
     </section>
 
@@ -79,7 +78,6 @@
             <ol>
               <li id="roadmapTocFlowItem" hidden><a href="#roadmap-flow">路线</a></li>
               <li><a href="#roadmap-related">相关项</a></li>
-              <li id="roadmapTocPaperItem" hidden><a href="#paper-guide">论文主线</a></li>
             </ol>
           </nav>
         </aside>
@@ -99,114 +97,6 @@
             </div>
           </section>
         </div>
-      </div>
-    </section>
-
-    <section id="paper-guide" class="section section-alt" hidden aria-label="论文主线导航">
-      <div class="container">
-        <h2 class="section-title">论文主线（原论文导航）</h2>
-        <p class="section-subtitle">按问题与主线串联阅读，与上方「路线 / 相关项」互补：路线定结构，论文定深度。</p>
-
-        <section class="section" style="padding-top:0">
-          <h3 class="section-title" style="font-size:1.15rem">路线与论文怎么用</h3>
-          <div class="structure-list">
-            <article class="simple-card">
-              <h3>初学者</h3>
-              <p>先按上方「阶段」搭好控制概念骨架，再在本区每次只跟一条子线读 2–4 篇代表作，读完后回到 <a href="graph.html">知识图谱</a> 把概念挂回全站。</p>
-            </article>
-            <article class="simple-card">
-              <h3>有经验的运动控制工程师</h3>
-              <p>可把本页当速查：阶段区对齐培训与评审话术，论文区按 WBC/MPC、RL、Sim2Real、IL 快速跳到站内整理好的论文列表（detail）。</p>
-            </article>
-          </div>
-        </section>
-
-        <section class="section" style="padding-top:1rem">
-          <h3 class="section-title">1. Motion Control：运动控制主线</h3>
-          <p class="section-subtitle">控制主线越稳，后面看学习方法（RL/IL）越不容易飘。</p>
-          <div class="card-grid">
-            <article class="card">
-              <h3>WBC / QP / TSID</h3>
-              <p>重点看任务优先级、接触力分配与全身协调。这是人形控制论文的基本语法。</p>
-              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-whole-body-control" class="btn-secondary btn-inline">详细列表 →</a></div>
-            </article>
-            <article class="card">
-              <h3>Model Predictive Control</h3>
-              <p>看如何将动力学约束写成优化问题并在线实时求解。代表作：MIT Cheetah 系列、OCS2 工作。</p>
-              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-mpc" class="btn-secondary btn-inline">MPC 列表 →</a></div>
-            </article>
-            <article class="card">
-              <h3>Optimal Control Theory</h3>
-              <p>控制理论的数学基石。包括 DP、极大值原理与 DDP/iLQR 的推导。</p>
-              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-optimal-control" class="btn-secondary btn-inline">理论列表 →</a></div>
-            </article>
-          </div>
-        </section>
-
-        <section class="section section-alt" style="margin-top:1rem;border-radius:12px">
-            <h3 class="section-title">2. RL：机器人强化学习主线</h3>
-            <p class="section-subtitle">适合想真正理解 Humanoid Locomotion、鲁棒训练与策略部署的人。</p>
-            <div class="card-grid">
-              <article class="card">
-                <h3>Locomotion 代表作</h3>
-                <p>PPO 基线、RMA 快速自适应、AMP 对抗运动先验。不仅仅是「走」，更要看如何「稳」。</p>
-                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-locomotion-rl" class="btn-secondary btn-inline">详细列表 →</a></div>
-              </article>
-              <article class="card">
-                <h3>Latent Skill Prior</h3>
-                <p>ASE, CALM, MimicKit。当你关心「既稳又自然」的行为时，这些技能嵌入工作是核心。</p>
-                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-latent-skill-prior" class="btn-secondary btn-inline">详细列表 →</a></div>
-              </article>
-            </div>
-        </section>
-
-        <section class="section" style="padding-top:1rem">
-          <h3 class="section-title">3. Sim2Real：从仿真到真机</h3>
-          <p class="section-subtitle">最能体现工程含金量的部分，弥合仿真和现实的物理失配。</p>
-          <div class="card-grid">
-            <article class="card">
-              <h3>Domain Randomization</h3>
-              <p>物理参数随机化 (DR)、视觉域随机化。重点看「随机了什么」以及「为什么有效」。</p>
-              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-sim2real" class="btn-secondary btn-inline">详细列表 →</a></div>
-            </article>
-            <article class="card">
-              <h3>System Identification</h3>
-              <p>SAGE 执行器建模、延迟建模与参数辨识。工程部署能不能站住，往往就卡在这里。</p>
-              <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-system-identification" class="btn-secondary btn-inline">详细列表 →</a></div>
-            </article>
-          </div>
-        </section>
-
-        <section class="section section-alt" style="margin-top:1rem;border-radius:12px">
-            <h3 class="section-title">4. IL &amp; Humanoid：模仿学习与人形专项</h3>
-            <p class="section-subtitle">连接动捕数据、遥操作与全身技能协调，是后续具身智能的高价值方向。</p>
-            <div class="card-grid">
-              <article class="card">
-                <h3>Imitation Learning</h3>
-                <p>BC / DAgger 基础、Diffusion Policy、动作迁移 (Retargeting) 完整 Pipeline。</p>
-                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-imitation-learning" class="btn-secondary btn-inline">详细列表 →</a></div>
-              </article>
-              <article class="card">
-                <h3>Hardware &amp; Survey</h3>
-                <p>人形硬件平台演进、机器人学习领域综述。看清行业全景，避免陷入局部最优。</p>
-                <div style="margin-top:12px;"><a href="detail.html?id=reference-papers-survey-papers" class="btn-secondary btn-inline">详细列表 →</a></div>
-              </article>
-            </div>
-        </section>
-
-        <section class="section" style="padding-top:1rem;padding-bottom:0">
-          <h3 class="section-title">阅读建议</h3>
-          <div class="structure-list">
-            <article class="simple-card">
-              <h3>每次只打一条主线</h3>
-              <p>先吃透 2–4 篇奠基代表作，读完后务必回模块页或图谱页同步知识，不要全地图乱跳。</p>
-            </article>
-            <article class="simple-card">
-              <h3>工程细节比模型名字更重要</h3>
-              <p>多看 Deployment Reports 和失败经验，真正的财富往往在 Supplementary 中。</p>
-            </article>
-          </div>
-        </section>
       </div>
     </section>
   </main>

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -15,7 +15,6 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapMeta"',
             'id="roadmapFlowMermaidRoot"',
             'id="roadmapRelatedList"',
-            'id="paper-guide"',
         ]
         for marker in required_ids:
             self.assertIn(marker, content)
@@ -27,7 +26,6 @@ class RoadmapPageTests(unittest.TestCase):
             "document.getElementById('roadmapTitle')",
             "roadmap.html?id=",
             "roadmap_pages",
-            "setRoadmapPaperGuideVisible",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

运动控制技术路线页（`roadmap.html?id=roadmap-motion-control`）已去掉整段「论文主线（原论文导航）」区块，以及顶部子导航与侧栏 TOC 中的「论文主线」入口；`main.js` 中对应的显隐逻辑已删除。

`references.html` 改为跳转到同一路线页（无 `#paper-guide` 锚点），并在页内说明单篇深读请使用 [Humanoid_Robot_Learning_Paper_Notebooks](https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks)。各模块/关系页顶栏「论文导航」亦改为指向该外部仓库，避免死链。

单测 `tests/test_roadmap_page.py` 已同步去掉对 `#paper-guide` 与 `setRoadmapPaperGuideVisible` 的断言。

本地已通过 `make ci-preflight`。

## 改完后页面截图

（本地静态服务加载 `roadmap.html?id=roadmap-motion-control`）

[运动控制路线页：子导航仅含路线与相关项，正文无论文主线区块](https://cursor.com/agents/bc-633987f3-6ac2-44ab-9d97-6a9272550642/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Froadmap-motion-control-after.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-633987f3-6ac2-44ab-9d97-6a9272550642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-633987f3-6ac2-44ab-9d97-6a9272550642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

