### PR TITLE
fix(docs): 收紧路线图页移动端主内容区纵向留白

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -938,6 +938,10 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   .detail-content-main {
     max-width: 100%;
   }
+  /* 侧栏改为固定抽屉后不再需要与「学习路线」标题对齐的顶距，避免残留空白 */
+  .roadmap-content-section .detail-content-layout:has(#roadmap-flow:not([hidden])) .detail-toc-panel {
+    margin-top: 0;
+  }
 }
 
 @media (max-width: 860px) {
@@ -998,6 +1002,14 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   .page-subnav a {
     padding: 7px 12px;
     font-size: 0.82rem;
+  }
+  /* 路线图页外层与内层都曾套用 .section，移动端会双倍「章节」留白；收紧顶距 */
+  .roadmap-content-section.section {
+    padding-top: 14px;
+    padding-bottom: 28px;
+  }
+  .roadmap-content-section .roadmap-flow-section.section {
+    padding-top: 0;
   }
   .section {
     padding: 30px 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

技术路线指南页（`roadmap.html`）在窄屏下外层 `.roadmap-content-section` 与内层 `#roadmap-flow` 都带有 `.section`，会叠加 `@media (max-width: 860px)` 中的 `padding: 30px 0`，在「路线 / 相关项」按钮与「学习路线」标题之间出现过大空白。

## 改动

- 在 **≤860px** 下为路线图外层单独设定较小的上下内边距，并将内层 `.roadmap-flow-section` 的 **顶内边距置 0**，去掉双倍章节留白。
- 在 **≤1200px**（侧栏改为固定抽屉）时，将原先为与桌面 TOC 对齐而设的 `.detail-toc-panel` `margin-top: 44px` 置 **0**，避免在移动端产生多余顶距。

## 网页验证截图

本地 `python3 -m http.server` 提供 `docs/`，使用 Chrome headless、视口 **390×1500** 打开 `roadmap.html?id=roadmap-motion-control`，截取路线图主内容区（含「路线 / 相关项」与「学习路线」之间的间距）。

![移动端技术路线页：路线切换与学习路线标题间距验证（390px 宽）](https://cursor.com/artifacts/c/art-b40d32e8-15e1-4cc8-88fb-3554c6af13f5)

## 验证

- 本地执行 `make ci-preflight` 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ac4958a-2e15-4fd8-acc6-25d9b2c4779c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ac4958a-2e15-4fd8-acc6-25d9b2c4779c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

