### PR TITLE
style(docs): 主栏宽度与 imchong.github.io 对齐（960px）

### DIFF
--- a/docs/references.html
+++ b/docs/references.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <main class="container" style="padding:3rem 1rem;max-width:42rem">
+  <main class="container" style="padding:3rem 0">
     <h1 class="hero-title" style="font-size:1.5rem">论文导航</h1>
     <p>站内「论文主线」区块已从运动控制路线页移除。技术路线与相关条目请见运动控制路线页；单篇论文深读请使用 <a href="https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks" target="_blank" rel="noopener noreferrer">Humanoid_Robot_Learning_Paper_Notebooks</a>。</p>
     <p><a class="btn-primary" href="roadmap.html?id=roadmap-motion-control">打开运动控制技术路线指南</a></p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -17,6 +17,8 @@
   --shadow-md: 0 8px 30px rgba(0, 0, 0, 0.08);
   --radius: 12px;
   --header-h: 58px;
+  /* 与 https://imchong.github.io/ 主栏 (.container / .header-inner) 一致 */
+  --content-max-width: 960px;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
 }
@@ -59,7 +61,7 @@ body {
 }
 a { color: var(--accent); text-decoration: none; transition: all var(--transition); }
 a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
-.container { max-width: 800px; margin: 0 auto; padding: 0 24px; }
+.container { max-width: var(--content-max-width); margin: 0 auto; padding: 0 24px; }
 
 .site-header {
   position: sticky;
@@ -72,7 +74,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   -webkit-backdrop-filter: blur(20px);
 }
 .header-inner {
-  max-width: 800px;
+  max-width: var(--content-max-width);
   margin: 0 auto;
   padding: 8px 24px;
   min-height: 56px;
@@ -544,7 +546,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .detail-content-main {
   flex: 1;
   min-width: 0;
-  max-width: 800px;
+  max-width: var(--content-max-width);
 }
 .detail-toc-panel {
   width: 260px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

本站 `docs/style.css` 中 `.container`、`.header-inner` 原先为 `max-width: 800px`，与作者个人主页 [imchong.github.io](https://imchong.github.io/) 使用的 `960px` 主栏不一致。本次在 `:root` 增加 `--content-max-width: 960px`，并让上述布局与详情页 `.detail-content-main` 共用该变量，使各页主内容区与顶栏在视觉上与参考站对齐。

`docs/references.html` 曾用内联 `max-width: 42rem` 收窄正文，已去掉该限制，与其它页面一致使用 `.container` 宽度。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] `make lint`（含 `lint_wiki.py` 与搜索质量回归脚本）
- [ ] `make ci-preflight`（未改动 wiki/导出链，未执行）

## 相关 Issue

无。

## 风险或回滚注意

仅 CSS 与一处 HTML 内联样式；回滚即恢复 `--content-max-width` 或改回 `800px`。

## 验证截图

本地 `python3 -m http.server` 于 `docs/` 目录下截取（viewport 约 1400×宽）。

[首页主栏与顶栏宽度](https://cursor.com/agents/bc-a6fec419-589a-4243-992c-b96dcb2be6fa/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmain-column-index.png)

[详情页主栏与顶栏宽度](https://cursor.com/agents/bc-a6fec419-589a-4243-992c-b96dcb2be6fa/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmain-column-detail.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6fec419-589a-4243-992c-b96dcb2be6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6fec419-589a-4243-992c-b96dcb2be6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

