### PR TITLE
feat(roadmap): 路线图页展示全站互链度 Top10

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -902,6 +902,52 @@
     removeLoadingState(container);
   }
 
+  /** 路线图页：展示 graph-stats.json 中全站 wiki 互链度数最高的条目（top_hubs）。 */
+  function renderRoadmapGraphHubs(container, topHubs, detailPages) {
+    if (!container) return;
+    var pathToId = buildPathToDetailIdIndex(detailPages);
+    var hubs = Array.isArray(topHubs) ? topHubs : [];
+    var parts = [];
+    for (var i = 0; i < hubs.length; i++) {
+      var hub = hubs[i];
+      var path = hub && hub.id;
+      if (!path) continue;
+      var detailId = pathToId[path];
+      if (!detailId) continue;
+      var page = resolveDetailPage(detailId, detailPages) || detailPages[detailId] || {};
+      var degree = hub.degree != null ? Number(hub.degree) : 0;
+      var title = page.title || hub.label || detailId;
+      var href = page.type === 'roadmap_page' ? roadmapHref(detailId) : detailHref(detailId);
+      var buttonText = page.type === 'roadmap_page' ? '打开路线页' : '打开详情页';
+      parts.push([
+        '<article class="card data-card">',
+        '  <div>',
+        '    <h3><a href="' + escapeHtml(href) + '">' + escapeHtml(title) + '</a></h3>',
+        '    <p class="card-meta">' + escapeHtml(page.type || 'wiki_page') + '</p>',
+        '    <p>' + escapeHtml(page.summary || '当前页面暂无摘要') + '</p>',
+        '  </div>',
+        '  <div class="chip-list">',
+        '    <span class="data-chip" title="无向边总数（入链+出链）">互链度 ' + escapeHtml(String(degree)) + '</span>',
+        '    <span class="data-chip"><code>' + escapeHtml(detailId) + '</code></span>',
+        '    <a class="btn-secondary btn-inline" href="' + escapeHtml(href) + '">' + buttonText + '</a>',
+        '  </div>',
+        '</article>'
+      ].join(''));
+    }
+    if (!parts.length) {
+      container.innerHTML = [
+        '<article class="card"><p>',
+        '无法从链接图统计中匹配到详情页条目。请稍后再试，或前往 ',
+        '<a href="graph.html">知识图谱</a> 浏览全站结构。',
+        '</p></article>'
+      ].join('');
+      removeLoadingState(container);
+      return;
+    }
+    container.innerHTML = parts.join('');
+    removeLoadingState(container);
+  }
+
   function renderSourceCards(container, links, emptyText) {
     if (!container) return;
     if (!Array.isArray(links) || !links.length) {
@@ -1418,7 +1464,7 @@
       metaEl.innerHTML = [
         '<p><strong>id：</strong><code>' + escapeHtml(roadmapPage.id || roadmapId) + '</code></p>',
         '<p><strong>阶段数：</strong>' + escapeHtml((roadmapPage.stages || []).length) + '</p>',
-        '<p><strong>相关项：</strong>' + escapeHtml((roadmapPage.related_items || []).length) + '</p>'
+        '<p><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面（数据来自 <code>graph-stats.json</code>）。</p>'
       ].join('');
       removeLoadingState(metaEl);
     }
@@ -1430,7 +1476,18 @@
       ].join('');
       removeLoadingState(breadcrumb);
     }
-    renderInternalLinks(relatedEl, roadmapPage.related_items, detailPages, { emptyText: '当前路线暂无相关项。' });
+    fetch('exports/graph-stats.json')
+      .then(function (r) {
+        return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status));
+      })
+      .then(function (stats) {
+        renderRoadmapGraphHubs(relatedEl, (stats && stats.top_hubs) || [], detailPages);
+      })
+      .catch(function () {
+        renderInternalLinks(relatedEl, [], detailPages, {
+          emptyText: '暂时无法加载链接图统计。请刷新页面，或在本地确认已生成 docs/exports/graph-stats.json。'
+        });
+      });
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
   }
 

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -39,7 +39,7 @@
           <div>
             <p class="hero-kicker">技术路线指南 · 数据驱动</p>
             <h1 id="roadmapTitle">正在读取路线…</h1>
-            <p id="roadmapSummary" class="detail-summary data-loading">当前页面读取 <code>roadmap_pages</code>，展示路线摘要、学习路线与相关项。</p>
+            <p id="roadmapSummary" class="detail-summary data-loading">当前页面读取 <code>roadmap_pages</code>，展示路线摘要、学习路线与全站互链度最高的知识页入口。</p>
           </div>
           <aside class="hero-panel detail-meta-panel">
             <h3>路线元信息</h3>
@@ -54,7 +54,7 @@
     <section class="page-subnav-wrap">
       <div class="container page-subnav">
         <a href="#roadmap-flow" id="roadmapSubnavFlow" hidden>路线</a>
-        <a href="#roadmap-related">相关项</a>
+        <a href="#roadmap-related">互链枢纽</a>
       </div>
     </section>
 
@@ -77,7 +77,7 @@
           <nav class="detail-toc-list">
             <ol>
               <li id="roadmapTocFlowItem" hidden><a href="#roadmap-flow">路线</a></li>
-              <li><a href="#roadmap-related">相关项</a></li>
+              <li><a href="#roadmap-related">互链枢纽</a></li>
             </ol>
           </nav>
         </aside>
@@ -89,10 +89,10 @@
           </section>
 
           <section class="section section-alt" id="roadmap-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">
-            <h2 class="section-title">相关项</h2>
-            <p class="section-subtitle">通往 detail route 的关联项。</p>
+            <h2 class="section-title">全站互链枢纽 · Top 10</h2>
+            <p class="section-subtitle">按 wiki 知识页之间的站内互链总数（无向度数）排序，优先浏览与其他条目连接最多的核心页。</p>
             <div id="roadmapRelatedList" class="card-grid data-loading">
-              <article class="card skeleton-card"><p>正在读取相关项…</p></article>
+              <article class="card skeleton-card"><p>正在加载互链统计…</p></article>
             </div>
           </section>
         </div>

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -26,6 +26,7 @@ class RoadmapPageTests(unittest.TestCase):
             "document.getElementById('roadmapTitle')",
             "roadmap.html?id=",
             "roadmap_pages",
+            "graph-stats.json",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将 `roadmap.html` 原「相关项」区块改为异步读取 `exports/graph-stats.json` 中的 `top_hubs`（全站 wiki 链接图无向度数最高的 10 个节点），经 `path`→详情页 `id` 映射后渲染与原先一致的卡片布局，并在每张卡片上展示「互链度」数值。模块标题改为「全站互链枢纽 · Top 10」，侧栏与次导航文案同步为「互链枢纽」。路线元信息中第三段改为说明该模块的数据来源。

## 变更类型

- [x] 前端（`docs/`）
- [x] 维护脚本 / CI / 文档（单元测试断言更新）

## 验证

- [x] `npm ci` 与 `npm run lint:js`（`docs/main.js` 通过 ESLint）
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_roadmap_page.py -q -o addopts=`

## 验证截图

本地 `cd docs && python3 -m http.server 8765` 后，对 `http://127.0.0.1:8765/roadmap.html?id=roadmap-motion-control` 使用 headless Chrome 截图；可见路线元信息中的互链枢纽说明，以及「全站互链枢纽 · Top 10」卡片网格与互链度标签。

![路线图页 roadmap-motion-control：全站互链枢纽 Top10 渲染效果](https://cursor.com/artifacts/c/art-10aca01a-a74c-421b-a3f3-3c20e8e148ad)

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9cc8db5-1e7b-4416-bbf9-f4b54d465fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9cc8db5-1e7b-4416-bbf9-f4b54d465fe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

