### PR TITLE
feat: bidirectional abbreviation expansion in wiki search

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -21,8 +21,10 @@
 
 ## P0: 自动化与工具链深度强化 (Engineering)
 
-- [ ] **缩写/别名归一化检索**：
-    - [ ] `scripts/search_wiki.py` 引入轻量缩写表（WBC/VLA/IL/RL/MPC/PPO/SAC/HQP/CBF/CLF 等），查询时与全称双向展开，并在 `print_results` 中提示"已展开为 …"。
+- [x] **缩写/别名归一化检索**：
+    - [x] `scripts/search_wiki.py` 引入轻量缩写表（WBC/VLA/IL/RL/MPC/PPO/SAC/HQP/CBF/CLF 等），查询时与全称双向展开，并在 `print_results` 中提示"已展开为 …"。
+      - 实现：在 `scripts/search_wiki_core.py` 新增 `WIKI_ABBREVIATIONS`（覆盖 WBC/VLA/IL/RL/MPC/PPO/SAC/HQP/CBF/CLF/BC/IK/FK/LIP/ZMP/TSID 共 16 条）与 `expand_query_aliases()`：缩写 → 全称（per word）与全称短语 → 缩写（whole-query）双向展开；`search()` 把展开后的词同时喂给 BM25 分词与 `_find_matched_lines`，并将"缩写归一化：已展开为 'X' → 'Y'"挂到 `semantic_notice`，由现有 `print_results` 渲染。
+      - 验证：`pytest tests/test_search_wiki_core.py` 21/21 通过（新增 5 个 `TestExpandQueryAliases` 用例）；CLI 实测 `search_wiki.py MPC` / `search_wiki.py "model predictive control"` / `search_wiki.py WBC --json` 均输出 "已展开为 …" 提示；`eval_search_quality.py` 36/37（与基线一致，未引入新回归）。
 - [x] **社区粒度二级拆分**：
     - [x] 优化 `scripts/generate_link_graph.py` 的社区检测：在 Locomotion 单一巨型社区（46.1%）内进一步用 Louvain `resolution > 1.0` 二级拆分，使 `largest_community_ratio ≤ 0.40` 且 `community_quality_warning` 转 `false`。
       - 实现：保留 Girvan-Newman 一级检测（`PRIMARY_COMMUNITY_CAP=8`），新增 `refine_oversized_communities` + 纯 Python `louvain_communities`（带 `resolution=1.15` 的 Reichardt-Bornholdt modularity），对占比 > 40% 且节点数 ≥ 30 的巨型社区做二级拆分；`MAX_COMMUNITIES` 提升至 16 容纳子社区命名。

--- a/log.md
+++ b/log.md
@@ -1,5 +1,7 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-14] structural | scripts/search_wiki_core.py — V22 P0 缩写/别名归一化检索：新增 `WIKI_ABBREVIATIONS`（16 条：WBC/VLA/IL/RL/MPC/PPO/SAC/HQP/CBF/CLF/BC/IK/FK/LIP/ZMP/TSID）与 `expand_query_aliases()`，缩写 ↔ 全称双向展开后同时喂给 BM25 分词与行匹配，并以"缩写归一化：已展开为 …"提示挂到 `semantic_notice`；新增 5 个单测（21/21 通过），`eval_search_quality.py` 36/37 与基线一致
+
 ## [2026-05-14] structural | roadmap & docs/main.js — 主路线 ASCII 图换 mermaid + skip-to 改交互按钮 + 4 条 depth 加 mermaid pipeline
 
 - `docs/main.js`：`renderMarkdownContent` 新增原始 HTML block 透传（div/details/summary/section/aside/figure/figcaption），让 markdown 可嵌入交互组件。

--- a/scripts/search_wiki_core.py
+++ b/scripts/search_wiki_core.py
@@ -23,6 +23,76 @@ CACHE_MAX = 30
 VECTOR_INDEX_FILE = REPO_ROOT / "exports" / "vector-index.npz"
 VECTOR_META_FILE = REPO_ROOT / "exports" / "vector-index-meta.json"
 
+# 缩写/别名归一化表：检索时与全称双向展开，命中后在 print_results 中给出"已展开为 …"提示。
+WIKI_ABBREVIATIONS: dict[str, list[str]] = {
+    "wbc": ["whole-body control"],
+    "vla": ["vision-language-action"],
+    "il": ["imitation learning"],
+    "rl": ["reinforcement learning"],
+    "mpc": ["model predictive control"],
+    "ppo": ["proximal policy optimization"],
+    "sac": ["soft actor-critic"],
+    "hqp": ["hierarchical quadratic program"],
+    "cbf": ["control barrier function"],
+    "clf": ["control lyapunov function"],
+    "bc": ["behavior cloning"],
+    "ik": ["inverse kinematics"],
+    "fk": ["forward kinematics"],
+    "lip": ["linear inverted pendulum"],
+    "zmp": ["zero moment point"],
+    "tsid": ["task-space inverse dynamics"],
+}
+
+
+def _build_alias_indexes() -> tuple[dict[str, list[str]], dict[str, str]]:
+    forward = {k.lower(): list(v) for k, v in WIKI_ABBREVIATIONS.items()}
+    reverse: dict[str, str] = {}
+    for abbrev, fulls in forward.items():
+        for full in fulls:
+            reverse[full.lower()] = abbrev
+    return forward, reverse
+
+
+_ALIAS_FORWARD, _ALIAS_REVERSE = _build_alias_indexes()
+
+
+def expand_query_aliases(
+    query_words: list[str],
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """检索时双向展开缩写与全称。
+
+    返回 ``(expanded_words, expansions)``：``expanded_words`` 在原始 query 之上追加
+    规范化别名（缩写→全称、全称短语→缩写），``expansions`` 记录 ``(原输入, 展开形式)``
+    供 CLI 在结果上方提示"已展开为 …"。
+    """
+    if not query_words:
+        return [], []
+
+    expansions: list[tuple[str, str]] = []
+    expanded: list[str] = list(query_words)
+    seen = {w.lower() for w in expanded}
+
+    joined = " ".join(query_words).strip().lower()
+    if joined and joined in _ALIAS_REVERSE:
+        abbrev = _ALIAS_REVERSE[joined]
+        if abbrev not in seen:
+            expanded.append(abbrev.upper())
+            seen.add(abbrev)
+            expansions.append((" ".join(query_words), abbrev.upper()))
+
+    for word in query_words:
+        key = word.lower()
+        if key not in _ALIAS_FORWARD:
+            continue
+        for full in _ALIAS_FORWARD[key]:
+            if full.lower() in seen:
+                continue
+            expanded.append(full)
+            seen.add(full.lower())
+            expansions.append((word, full))
+
+    return expanded, expansions
+
 
 def extract_related_links(content: str, source_path: Path) -> list[str]:
     related: list[str] = []
@@ -290,13 +360,22 @@ def search(
     vector_matrix = None
     vector_meta = None
     semantic_notice = None
-    query_text = " ".join(query_words).strip()
+
+    effective_query_words, alias_expansions = expand_query_aliases(query_words)
+    if alias_expansions:
+        alias_notice = "缩写归一化：已展开为 " + "；".join(
+            f"'{src}' → '{dst}'" for src, dst in alias_expansions
+        )
+        semantic_notice = alias_notice
+
+    query_text = " ".join(effective_query_words).strip()
     query_tokens = tokenize_text(query_text)
 
     if semantic:
         vector_matrix, vector_meta = load_vector_resources()
         if vector_matrix is None or vector_meta is None:
-            semantic_notice = "语义索引不存在，已回退到纯 BM25。请先运行：make vectors"
+            fallback = "语义索引不存在，已回退到纯 BM25。请先运行：make vectors"
+            semantic_notice = f"{semantic_notice}；{fallback}" if semantic_notice else fallback
             semantic = False
 
     prepared = []
@@ -321,7 +400,7 @@ def search(
             continue
 
         lines = body.splitlines()
-        matched_lines = _find_matched_lines(lines, query_words, context_lines)
+        matched_lines = _find_matched_lines(lines, effective_query_words, context_lines)
         if not matched_lines:
             summary_line = doc["summary"] or (lines[0] if lines else "")
             matched_lines = [(1, [summary_line], 0)]
@@ -349,7 +428,7 @@ def search(
         assert vector_matrix is not None and vector_meta is not None
         new_notice = _apply_vector_scores(prepared, query_text, vector_matrix, vector_meta)
         if new_notice:
-            semantic_notice = new_notice
+            semantic_notice = f"{semantic_notice}；{new_notice}" if semantic_notice else new_notice
             prepared.sort(key=lambda r: r["score"], reverse=True)
     else:
         prepared.sort(key=lambda r: r["score"], reverse=True)

--- a/tests/test_search_wiki_core.py
+++ b/tests/test_search_wiki_core.py
@@ -15,6 +15,7 @@ from search_wiki_core import (
     collect_known_terms,
     compute_avgdl,
     compute_score,
+    expand_query_aliases,
     extract_related_links,
     levenshtein_distance,
     normalize_scores,
@@ -132,6 +133,32 @@ class TestExtractRelatedLinks(unittest.TestCase):
         content = "## 关联页面\n\n- [LIP ZMP](lip-zmp.md)\n"
         links = extract_related_links(content, src)
         self.assertTrue(any("lip-zmp.md" in entry for entry in links))
+
+
+class TestExpandQueryAliases(unittest.TestCase):
+    def test_empty_query(self):
+        self.assertEqual(expand_query_aliases([]), ([], []))
+
+    def test_abbreviation_expands_to_full(self):
+        expanded, expansions = expand_query_aliases(["MPC"])
+        self.assertIn("MPC", expanded)
+        self.assertIn("model predictive control", expanded)
+        self.assertTrue(any(src == "MPC" and "model predictive" in dst for src, dst in expansions))
+
+    def test_full_phrase_expands_to_abbreviation(self):
+        expanded, expansions = expand_query_aliases(["model", "predictive", "control"])
+        self.assertIn("MPC", expanded)
+        self.assertEqual(len(expansions), 1)
+        self.assertEqual(expansions[0][1], "MPC")
+
+    def test_no_expansion_for_unknown(self):
+        expanded, expansions = expand_query_aliases(["locomotion"])
+        self.assertEqual(expanded, ["locomotion"])
+        self.assertEqual(expansions, [])
+
+    def test_case_insensitive_match(self):
+        _, expansions = expand_query_aliases(["wbc"])
+        self.assertTrue(any("whole-body control" == dst for _, dst in expansions))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

实现缩写/别名归一化检索功能：在 `search_wiki_core.py` 中新增 16 条常用缩写表（WBC/VLA/IL/RL/MPC/PPO/SAC/HQP/CBF/CLF/BC/IK/FK/LIP/ZMP/TSID），支持缩写 ↔ 全称双向展开，展开后的词同时用于 BM25 分词和行匹配，并在搜索结果上方显示"缩写归一化：已展开为 …"提示。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### 核心实现

1. **`WIKI_ABBREVIATIONS` 字典**：定义 16 条缩写与全称的映射关系
2. **`_build_alias_indexes()` 函数**：构建双向索引（缩写→全称、全称→缩写）
3. **`expand_query_aliases()` 函数**：
   - 对单个词进行缩写→全称展开（case-insensitive）
   - 对整个查询短语进行全称→缩写展开（e.g., `["model", "predictive", "control"]` → `"MPC"`）
   - 返回展开后的词列表和展开记录，供 CLI 显示提示

4. **`search()` 函数集成**：
   - 调用 `expand_query_aliases()` 获取展开词和展开记录
   - 将展开词用于 BM25 分词和 `_find_matched_lines()` 行匹配
   - 将展开提示挂到 `semantic_notice`，由现有 `print_results` 渲染

### 测试覆盖

新增 5 个单测（`TestExpandQueryAliases`）：
- 空查询处理
- 缩写→全称展开
- 全称短语→缩写展开
- 未知词不展开
- 大小写不敏感匹配

## 验证

- [x] `pytest tests/test_search_wiki_core.py` — 21/21 通过（新增 5 个用例）
- [x] CLI 实测：`search_wiki.py MPC` / `search_wiki.py "model predictive control"` / `search_wiki.py WBC --json` 均正确输出"已展开为 …"提示
- [x] `eval_search_quality.py` — 36/37（与基线一致，无新回归）

## 相关 Issue

无

https://claude.ai/code/session_01EnQqZek7AiJ1GTWS5Xksq7