### PR TITLE
fix(docs): 路线页 TOC 加宽与侧栏滚动条样式

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -575,7 +575,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   box-sizing: border-box;
 }
 .detail-toc-panel {
-  width: 260px;
+  width: 320px;
   flex-shrink: 0;
   position: sticky;
   top: 92px;
@@ -587,17 +587,33 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 }
 @media (min-width: 1200px) {
   .detail-toc-panel {
-    margin-left: -300px; /* Float to the left of the container */
+    /* width(320) + .detail-content-layout gap(40) — 与主栏对齐且不占横向滚动 */
+    margin-left: -360px;
     display: flex;
     flex-direction: column;
     /* 长目录超出视口时：卡片高度封顶，仅目录列表区域滚动 */
     max-height: calc(100vh - 92px - 20px);
     box-sizing: border-box;
+    overflow-x: hidden;
   }
   .detail-toc-panel .detail-toc-list {
     min-height: 0;
+    min-width: 0;
+    overflow-x: hidden;
     overflow-y: auto;
     overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 48%, transparent) transparent;
+  }
+  .detail-toc-panel .detail-toc-list::-webkit-scrollbar {
+    width: 10px;
+  }
+  .detail-toc-panel .detail-toc-list::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .detail-toc-panel .detail-toc-list::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
+    border-radius: 999px;
   }
 }
 .detail-toc-panel[hidden] {
@@ -622,6 +638,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   padding: 2px 6px;
   margin-left: -6px;
   transition: color var(--transition), background var(--transition);
+  overflow-wrap: anywhere;
 }
 .detail-toc-list a.active {
   color: var(--accent);
@@ -989,7 +1006,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
     top: 16px;
     bottom: 96px; /* Avoid overlapping sidebar-toggle button */
     left: -300px;
-    width: 280px;
+    width: 300px;
     height: auto;
     margin: 0;
     padding: 20px;
@@ -997,10 +1014,23 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
     box-shadow: 2px 0 12px rgba(0,0,0,0.15);
     border-radius: 0 16px 16px 0;
     z-index: 1000;
+    overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 48%, transparent) transparent;
     transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     display: block;
     max-height: none;
+  }
+  .detail-toc-panel::-webkit-scrollbar {
+    width: 10px;
+  }
+  .detail-toc-panel::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .detail-toc-panel::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
+    border-radius: 999px;
   }
   .detail-toc-panel .detail-toc-list {
     overflow-y: visible;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

针对 `roadmap.html`（及共用样式的详情页侧栏）做了两处调整：

1. **TOC 宽度与横向滚动**：将 `.detail-toc-panel` 由 `260px` 调整为 `320px`，并在宽屏布局下把左移量改为 `margin-left: -360px`（与 `width + gap(40px)` 对齐）。在目录列表上增加 `min-width: 0`、`overflow-x: hidden`，并为 TOC 链接增加 `overflow-wrap: anywhere`，避免长标题把容器撑出横向滚动条。
2. **纵向滚动条**：在目录滚动区（宽屏下为 `.detail-toc-list`，窄屏抽屉下为整块 `.detail-toc-panel`）使用 `scrollbar-color`（Firefox）与 `::-webkit-scrollbar`（Chromium）将**轨道设为透明**、滑块使用与 `--text-muted` 混合的半透明色，视觉上更接近浏览器整页滚动条、去掉白条感。

窄屏抽屉侧栏宽度由 `280px` 略增至 `300px`，并同样加上透明轨道的滚动条样式。

## 风险

- `scrollbar-color` 与 `color-mix` 依赖较新的浏览器；极旧环境可能回退为系统默认滚动条（功能不受影响）。

## 验证

- 本地已执行 `make ci-preflight`，通过。
- 本地 `docs` 静态服务 + headless Chrome 截取 `roadmap.html?id=roadmap-motion-control`（1440×900）：

![路线页 TOC 区域（加宽与滚动条）](https://cursor.com/artifacts/c/art-ea586cbe-92a2-4a18-ac05-5f620871ab6d)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14e76972-f47f-4434-8781-3bae60a0d28d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14e76972-f47f-4434-8781-3bae60a0d28d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

