### PR TITLE
路线图：阶段速览并入 L 章节，侧栏目录随正文滚动定位

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -499,6 +499,46 @@
   }
 
   /**
+   * One roadmap stage row (li > details): related wiki / roadmap links.
+   * Used by the vertical tree and by per-L–chapter embeds on roadmap pages.
+   */
+  function buildRoadmapStageRowHTML(stage, index, roadmapId, detailPages, options) {
+    var opts = options || {};
+    var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
+    var sid = String(stage.id || '');
+    var title = String(stage.title || '');
+    var openAttr = opts.openByDefault ? ' open' : '';
+    var parts = [];
+    parts.push('<li class="roadmap-vtree-item">');
+    parts.push('<details class="roadmap-vtree-stage roadmap-vtree-stage-embed"' + openAttr + '>');
+    parts.push('<summary class="roadmap-vtree-summary">');
+    parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(index + 1)) + '</span>');
+    parts.push(
+      '<span class="roadmap-vtree-heading">' + escapeHtml(sid.toUpperCase() + ' · ' + title) + '</span>'
+    );
+    parts.push('<span class="roadmap-vtree-count">' + escapeHtml(String(related.length)) + ' 条</span>');
+    parts.push('</summary>');
+    if (!related.length) {
+      parts.push('<p class="roadmap-vtree-empty data-meta">本阶段正文内暂无抽取到的站内链接。</p>');
+    } else {
+      parts.push('<ul class="roadmap-vtree-links">');
+      for (var k = 0; k < related.length; k++) {
+        var rid = related[k];
+        var page = detailPages[rid] || {};
+        var href = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
+        parts.push('<li class="roadmap-vtree-link-row">');
+        parts.push('<a class="roadmap-vtree-link-a" href="' + escapeHtml(href) + '">' + escapeHtml(page.title || rid) + '</a>');
+        parts.push('<code class="roadmap-vtree-link-id">' + escapeHtml(rid) + '</code>');
+        parts.push('</li>');
+      }
+      parts.push('</ul>');
+    }
+    parts.push('</details>');
+    parts.push('</li>');
+    return parts.join('');
+  }
+
+  /**
    * Vertical collapsible tree (details/summary): one stage per row, children = related links.
    * Primary UI for narrow screens; no extra libraries.
    */
@@ -508,41 +548,51 @@
     parts.push('<ol class="roadmap-vtree">');
     var i;
     for (i = 0; i < stages.length; i++) {
-      var stage = stages[i];
-      var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
-      var sid = String(stage.id || '');
-      var title = String(stage.title || '');
-      var openAttr = i === 0 ? ' open' : '';
-      parts.push('<li class="roadmap-vtree-item">');
-      parts.push('<details class="roadmap-vtree-stage"' + openAttr + '>');
-      parts.push('<summary class="roadmap-vtree-summary">');
-      parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(i + 1)) + '</span>');
-      parts.push(
-        '<span class="roadmap-vtree-heading">' + escapeHtml(sid.toUpperCase() + ' · ' + title) + '</span>'
-      );
-      parts.push('<span class="roadmap-vtree-count">' + escapeHtml(String(related.length)) + ' 条</span>');
-      parts.push('</summary>');
-      if (!related.length) {
-        parts.push('<p class="roadmap-vtree-empty data-meta">本阶段正文内暂无抽取到的站内链接。</p>');
-      } else {
-        parts.push('<ul class="roadmap-vtree-links">');
-        for (var k = 0; k < related.length; k++) {
-          var rid = related[k];
-          var page = detailPages[rid] || {};
-          var href = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
-          parts.push('<li class="roadmap-vtree-link-row">');
-          parts.push('<a class="roadmap-vtree-link-a" href="' + escapeHtml(href) + '">' + escapeHtml(page.title || rid) + '</a>');
-          parts.push('<code class="roadmap-vtree-link-id">' + escapeHtml(rid) + '</code>');
-          parts.push('</li>');
-        }
-        parts.push('</ul>');
-      }
-      parts.push('</details>');
-      parts.push('</li>');
+      parts.push(buildRoadmapStageRowHTML(stages[i], i, roadmapId, detailPages, { openByDefault: i === 0 }));
     }
     parts.push('</ol>');
     parts.push('</div>');
     return parts.join('');
+  }
+
+  /**
+   * When正文里已有对应的 L 章节标题（h2），把各阶段的「阶段速览」链接块插入到该标题下方，
+   * 避免单独占一整段 mini-map 区。若任一阶段找不到匹配标题则返回 false，保留顶部整块速览。
+   */
+  function embedRoadmapStagesIntoMarkdownBody(contentEl, roadmapPage, roadmapId, detailPages) {
+    var stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
+    if (!contentEl || stages.length < 2) return false;
+    var targets = [];
+    var i;
+    for (i = 0; i < stages.length; i++) {
+      var sid = String(stages[i].id || '').toLowerCase();
+      if (!sid) return false;
+      var h2 = Array.from(contentEl.querySelectorAll('h2[id]')).find(function (h) {
+        return h.id === sid || h.id.indexOf(sid + '-') === 0;
+      });
+      if (!h2) return false;
+      targets.push(h2);
+    }
+    var seen = new Set();
+    for (i = 0; i < targets.length; i++) {
+      if (seen.has(targets[i])) return false;
+      seen.add(targets[i]);
+    }
+    for (i = 0; i < stages.length; i++) {
+      var row = buildRoadmapStageRowHTML(stages[i], i, roadmapId, detailPages, { openByDefault: i === 0 });
+      var wrap = document.createElement('div');
+      wrap.className = 'roadmap-stage-embed-wrap';
+      wrap.setAttribute('data-roadmap-stage-embed', String(stages[i].id || '').toLowerCase());
+      wrap.innerHTML = '<ol class="roadmap-vtree">' + row + '</ol>';
+      targets[i].insertAdjacentElement('afterend', wrap);
+    }
+    return true;
+  }
+
+  function clearRoadmapStandaloneFlowSection() {
+    var flowRoot = document.getElementById('roadmapFlowMermaidRoot');
+    if (flowRoot) flowRoot.innerHTML = '';
+    setRoadmapFlowChromeVisible(false);
   }
 
   function setRoadmapFlowChromeVisible(show) {
@@ -662,14 +712,27 @@
     const links = Array.from(tocContainer.querySelectorAll('a[href^="#"]'));
     if (!headings.length || !links.length) return;
 
+    let lastActiveHref = '';
+
+    function scrollTocActiveIntoView() {
+      const activeLink = tocContainer.querySelector('a.active');
+      if (!activeLink || typeof activeLink.scrollIntoView !== 'function') return;
+      activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' });
+    }
+
     function updateActiveTocLink() {
       let activeId = headings[0].id;
       headings.forEach(function (heading) {
         if (heading.getBoundingClientRect().top <= 140) activeId = heading.id;
       });
+      const activeHref = '#' + activeId;
       links.forEach(function (link) {
-        link.classList.toggle('active', link.getAttribute('href') === '#' + activeId);
+        link.classList.toggle('active', link.getAttribute('href') === activeHref);
       });
+      if (activeHref !== lastActiveHref) {
+        lastActiveHref = activeHref;
+        scrollTocActiveIntoView();
+      }
     }
 
     let tocTicking = false;
@@ -686,6 +749,13 @@
     }, { passive: true });
     window.addEventListener('hashchange', updateActiveTocLink);
     updateActiveTocLink();
+  }
+
+  /** 在程序化改变滚动位置后触发一次 TOC spy，避免初始带 hash 时高亮与侧栏滚动不同步。 */
+  function notifyTocSpyScrollSync() {
+    window.requestAnimationFrame(function () {
+      window.dispatchEvent(new Event('scroll'));
+    });
   }
 
   function scrollToDetailHashTarget(container) {
@@ -1397,8 +1467,10 @@
       window.addEventListener('hashchange', function () {
         scrollToDetailHashTarget(contentEl);
         scrollDetailPageLayoutHashIntoView(contentEl);
+        notifyTocSpyScrollSync();
       });
       scrollToDetailHashTarget(contentEl);
+      notifyTocSpyScrollSync();
       removeLoadingState(contentEl);
     }
 
@@ -1706,9 +1778,13 @@
       renderDetailMath(contentEl);
       renderDetailMermaid(contentEl);
       enhanceDetailHeadings(contentEl);
+      if (embedRoadmapStagesIntoMarkdownBody(contentEl, roadmapPage, roadmapId, detailPages)) {
+        clearRoadmapStandaloneFlowSection();
+      }
       bindDetailTocSpy(contentEl, tocEl);
-      window.addEventListener('hashchange', function () { scrollToDetailHashTarget(contentEl); });
+      window.addEventListener('hashchange', function () { scrollToDetailHashTarget(contentEl); notifyTocSpyScrollSync(); });
       scrollToDetailHashTarget(contentEl);
+      notifyTocSpyScrollSync();
       removeLoadingState(contentEl);
     }
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1363,6 +1363,13 @@ th {
   margin: 0;
   border-top: 1px solid var(--border);
 }
+/* 嵌入正文各 L 章节下的单阶段「速览」块（与顶部整块二选一） */
+.roadmap-stage-embed-wrap {
+  margin: 12px 0 22px;
+}
+.roadmap-stage-embed-wrap .roadmap-vtree-item {
+  margin-bottom: 0;
+}
 .roadmap-flow-details,
 .roadmap-stage-flow-details {
   margin-bottom: 1rem;

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -135,7 +135,11 @@ class DetailContentSyncTests(unittest.TestCase):
             "decodeURIComponent(rawHash)",
             "container.querySelector('#' +",
             "target.scrollIntoView({ behavior: 'smooth', block: 'start' });",
-            "window.addEventListener('hashchange', function () { scrollToDetailHashTarget(contentEl); });",
+            "function notifyTocSpyScrollSync()",
+            "window.addEventListener('hashchange', function () {",
+            "scrollToDetailHashTarget(contentEl);",
+            "scrollDetailPageLayoutHashIntoView(contentEl);",
+            "notifyTocSpyScrollSync();",
             "scrollToDetailHashTarget(contentEl);",
         ]
         for snippet in expected_snippets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- **阶段速览与正文融合**：在 `roadmap.html` 且正文来自 `detail_pages` 的 markdown 时，若 `roadmap_pages` 的 `stages` 数量 ≥ 2，则按阶段 `id`（`l0`…`l7`）匹配正文里对应 `h2` 的锚点 `id`，将原先顶部「垂直阶段树」的**单行**折叠块插入到各 L 章节标题**正下方**；全部匹配成功时清空并隐藏顶部独立的 `#roadmap-flow` 区域，避免重复展示。任一阶段找不到对应 `h2` 时回退为原有顶部整块速览（兼容未来其它含 `stages` 的路线页）。
- **侧栏 TOC 自动滚入视口**：`bindDetailTocSpy` 在激活目录项变化时，对当前 `a.active` 调用 `scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' })`，在桌面端目录列表有纵向滚动条时无需手拖即可看到当前章节；仍保留用户手动滚动。详情页 `detail.html` 共用同一逻辑。
- **带 hash 打开时**：在 `scrollToDetailHashTarget` 之后增加一次 `requestAnimationFrame` + 合成 `scroll` 事件，使初始高亮与侧栏滚动与锚点位置一致。

## 样式

- `docs/style.css`：为 `.roadmap-stage-embed-wrap` 增加与正文衔接的上下间距，并去掉嵌套单行的多余 `li` 下边距。

## CI 修复

- `tests/test_content_sync.py`：`test_main_js_contains_hash_navigation_hooks_for_detail_content` 原先断言单行 `hashchange` 监听器，与现有多行实现（含 `notifyTocSpyScrollSync`）不一致导致 pytest 失败，已更新为与 `docs/main.js` 同步的片段列表。

## 验证

- 本地已运行完整 `pytest`（通过）。
- 验证截图（本地 `docs/` 静态服务 + Playwright，`roadmap.html?id=roadmap-motion-control`）：

![运动控制路线图页：侧栏目录与正文（含嵌入阶段块）](https://cursor.com/artifacts/c/art-5b84d092-d625-49ab-bb35-44a5bfbf1e9b)

## 风险 / 回滚

- 仅当**每个** `stage` 都能匹配到唯一 `h2` 时才嵌入；若日后某路线 `stages` 与正文标题不同步，会自动保留顶部速览，不会出现半嵌入状态。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d0b995-e8ac-47ef-aabb-2778e66e0097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d0b995-e8ac-47ef-aabb-2778e66e0097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

