### PR TITLE
fix(docs): 修复路线元信息中 graph-stats.json 在连字符处折断

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1709,7 +1709,7 @@
       metaEl.innerHTML = [
         '<p><strong>id：</strong><code>' + escapeHtml(roadmapPage.id || roadmapId) + '</code></p>',
         '<p><strong>阶段数：</strong>' + escapeHtml((roadmapPage.stages || []).length) + '</p>',
-        '<p><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面（数据来自 <code>graph-stats.json</code>）。</p>'
+        '<p><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面（数据来自\u00A0<code>graph-stats.json</code>）。</p>'
       ].join('');
       removeLoadingState(metaEl);
     }

--- a/docs/main.js
+++ b/docs/main.js
@@ -1709,7 +1709,7 @@
       metaEl.innerHTML = [
         '<p><strong>id：</strong><code>' + escapeHtml(roadmapPage.id || roadmapId) + '</code></p>',
         '<p><strong>阶段数：</strong>' + escapeHtml((roadmapPage.stages || []).length) + '</p>',
-        '<p><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面（数据来自\u00A0<code>graph-stats.json</code>）。</p>'
+        '<p><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面<span class="detail-meta-source-tail">（数据来自 <code>graph-stats.json</code>）</span>。</p>'
       ].join('');
       removeLoadingState(metaEl);
     }

--- a/docs/style.css
+++ b/docs/style.css
@@ -533,6 +533,14 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   overflow-wrap: normal;
   word-break: normal;
 }
+/* 括注整段 nowrap：避免汉字间（如「来|自」）与「来自|code」被窄栏拆开；过长时横向滚动 */
+.detail-meta-source-tail {
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow-x: auto;
+  vertical-align: bottom;
+}
 .empty-state code {
   white-space: normal;
   overflow-wrap: anywhere;

--- a/docs/style.css
+++ b/docs/style.css
@@ -330,7 +330,8 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
 .home-latest-wiki-card h3 { margin-top: 4px; }
-.section-subtitle { color: var(--text-muted); font-size: .97rem; margin-bottom: 28px; max-width: 72ch; }
+/* 不设 max-width：原 72ch 在 detail/roadmap 主栏内常短于下方全宽卡片栅格，副标题提前换行、右侧留白 */
+.section-subtitle { color: var(--text-muted); font-size: .97rem; margin-bottom: 28px; }
 .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
 .card {
   padding: 20px;

--- a/docs/style.css
+++ b/docs/style.css
@@ -525,14 +525,15 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   background: var(--bg-alt);
   border: 1px solid var(--border);
   font-size: .92em;
-  white-space: normal;
 }
-/* 元信息栏宽度有限：anywhere 会在 graph-stats.json 等标识符中间断行；改为 normal 优先整段 code 换行 */
+/* 元信息栏窄：连字符仍是合法断点，graph-stats.json 会在「graph-」处折断；code 作标识符保持单行 */
 .detail-meta-list code {
+  white-space: nowrap;
   overflow-wrap: normal;
   word-break: normal;
 }
 .empty-state code {
+  white-space: normal;
   overflow-wrap: anywhere;
 }
 .empty-state {

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -29,6 +29,7 @@ class RoadmapPageTests(unittest.TestCase):
             "roadmap.html?id=",
             "roadmap_pages",
             "graph-stats.json",
+            "来自\\u00A0<code>",
             "renderRoadmapMarkdownBody",
         ]
         for snippet in expected_snippets:

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -29,7 +29,7 @@ class RoadmapPageTests(unittest.TestCase):
             "roadmap.html?id=",
             "roadmap_pages",
             "graph-stats.json",
-            "来自\\u00A0<code>",
+            "detail-meta-source-tail",
             "renderRoadmapMarkdownBody",
         ]
         for snippet in expected_snippets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

1. **路线元信息**内联 `<code>`：`.detail-meta-list code` 使用 `white-space: nowrap`，避免 `graph-stats.json` 在连字符处拆开。
2. **副标题**：去掉 `.section-subtitle` 的 `max-width: 72ch`。
3. **「数据来自 …」断行**：普通空格会在「来自」与 `<code>` 间断行；`\u00A0` 只粘住「自」与 code，**中文在窄栏仍可在任意相邻汉字间断行**，故出现「数据来｜自…」。现用 `<span class="detail-meta-source-tail">（数据来自 <code>graph-stats.json</code>）</span>` 整段 `nowrap`，并 `inline-block; max-width: 100%; overflow-x: auto` 以防极窄屏横向溢出。

## 验证截图（已更新）

![路线元信息：括注整段不换行拆开](https://cursor.com/artifacts/c/art-9720990f-02c1-426a-aff7-d5977844c293)

## 测试

`make test`（91 passed），`npm run lint:js` 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed47b8c2-e86d-434d-a9e5-3dee45dab7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed47b8c2-e86d-434d-a9e5-3dee45dab7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

