### PR TITLE
fix(docs): 路线元信息「互链枢纽」行撑满元信息卡片宽度

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -381,6 +381,10 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   gap: .45rem;
 }
 .page-hero p { color: var(--text-muted); max-width: 76ch; font-size: .98rem; }
+/* 元信息卡片也在 .page-hero 内，勿继承 76ch：否则「互链枢纽」等说明行在宽卡片里提前换行 */
+.page-hero .detail-meta-list p {
+  max-width: none;
+}
 .page-subnav-wrap {
   padding: 0 0 24px;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

路线页 hero 内的「路线元信息」卡片由 `#roadmapMeta.detail-meta-list` 动态写入多段 `<p>`。这些段落落在 `.page-hero` 下，会命中全局规则 `.page-hero p { max-width: 76ch }`，导致说明文字（含「互链枢纽」一行）在宽卡片里仍被限制在约 76 字符宽度，从而提前换行、视觉上未撑满卡片。

为 `.page-hero .detail-meta-list p` 增加 `max-width: none`，仅解除元信息列表段落的限宽，不影响主摘要等仍需要 76ch 的阅读行长。

## 风险

- 若未来在元信息卡片内加入极长无空格字符串，可能撑宽布局；当前内容为正常中文与短 `code` 片段，风险可忽略。

## 验证

- 本地已执行 `make ci-preflight`（通过）。
- 验证截图（本地 `docs/` 静态服务 + headless Chrome，`roadmap.html?id=roadmap-motion-control`）：

![路线页元信息卡片：互链枢纽说明行占满卡片宽度](https://cursor.com/artifacts/c/art-5232e226-2e47-496b-a4a8-228e24a6ebad)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fe1c2af-6dcb-48d6-9a79-03ce82dc4689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fe1c2af-6dcb-48d6-9a79-03ce82dc4689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

