### PR TITLE
fix(docs): 移动端首页 Hero 与按钮与搜索条同宽对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1114,10 +1114,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   #hero.hero {
     padding-bottom: 12px;
   }
-  .hero .container {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
   .page-hero {
     padding: 34px 0 12px;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在 `max-width: 860px` 断点下，`.hero .container` 曾以更高特异性将左右 `padding` 设为 `12px`，而同断点内全局 `.container` 为 `18px`，导致首页 Hero 文案与 `width: 100%` 的 CTA 按钮比 `#wiki-search` 内的搜索条更「顶满」屏幕。

已删除该条覆盖规则，Hero 与搜索区共用同一 `.container` 水平留白，三者内容区左右边缘一致。

## 验证

- 本地 `pytest` 已通过。
- 验证截图（390px 视口，`docs/index.html`）：

![移动端首页 Hero、按钮与搜索条左右对齐](https://cursor.com/artifacts/c/art-503b3b10-17ad-4d3c-b147-4f95a6c6d50e)

## 风险

无功能性风险；若曾有意让 Hero 更贴边，现与全站该断点主栏一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d79cab50-a267-4d4c-b23f-037b91137ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d79cab50-a267-4d4c-b23f-037b91137ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

