### PR TITLE
fix(ux): 首页「最新知识节点」元数据与卡片增加垂直间距

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -329,6 +329,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0)), var(--bg-alt);
 }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
+.home-latest-wiki-intro { margin-bottom: 20px; }
 .home-latest-wiki-card h3 { margin-top: 4px; }
 .section-subtitle { color: var(--text-muted); font-size: .97rem; margin-bottom: 28px; max-width: 72ch; }
 .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

首页「最新知识节点」区块中，维护日志说明行（`p.home-latest-wiki-intro`）与下方卡片网格几乎贴在一起。原因是全局样式 `* { margin: 0 }` 取消了段落默认外边距。为 `.home-latest-wiki-intro` 增加 `margin-bottom: 20px`，与 `.card-grid` 的 `gap: 18px` 量级一致，使说明与卡片之间有清晰分隔。

## 验证

- 已运行 `make ci-preflight`，通过（含 lint、导出一致性、搜索回归等）。
- 合并后可在 `docs/index.html` 本地起静态服务查看「最新知识节点」区块间距。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e207dba-354d-4a49-82a0-d55846bf6cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e207dba-354d-4a49-82a0-d55846bf6cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

