### PR TITLE
feat(docs): 路线页正文大章节默认折叠

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -580,6 +580,42 @@
   }
 
   /**
+   * 路线正文：将 article 下每个顶层 h2 及其后内容包进默认收起的 <details>，首屏只保留章节标题行。
+   * 须在 embedRoadmapStagesIntoMarkdownBody 之后调用，使各 L 阶段嵌入块留在对应章节内。
+   */
+  function wrapRoadmapCollapsibleMajorHeadings(container) {
+    if (!container) return;
+    var top = Array.from(container.querySelectorAll(':scope > h2[id]'));
+    if (!top.length) return;
+    var idx;
+    for (idx = top.length - 1; idx >= 0; idx--) {
+      var h2 = top[idx];
+      if (typeof h2.closest === 'function' && h2.closest('details.roadmap-major-section')) continue;
+      var details = document.createElement('details');
+      details.className = 'roadmap-major-section';
+      var summary = document.createElement('summary');
+      summary.className = 'roadmap-major-section-summary';
+      var body = document.createElement('div');
+      body.className = 'roadmap-major-section-body';
+      h2.parentNode.insertBefore(details, h2);
+      summary.appendChild(h2);
+      details.appendChild(summary);
+      details.appendChild(body);
+      var node = details.nextSibling;
+      while (node) {
+        var next = node.nextSibling;
+        if (node.nodeType === 1) {
+          var el = node;
+          if (el.tagName === 'H2' && el.id) break;
+          if (el.classList && el.classList.contains('roadmap-major-section')) break;
+        }
+        body.appendChild(node);
+        node = next;
+      }
+    }
+  }
+
+  /**
    * When正文里已有对应的 L 章节标题（h2），把各阶段的「阶段速览」链接块插入到该标题下方，
    * 避免单独占一整段 mini-map 区。若任一阶段找不到匹配标题则返回 false，保留顶部整块速览。
    */
@@ -804,6 +840,9 @@
       node.classList.remove('detail-hash-target');
     });
     target.classList.add('detail-hash-target');
+    var roadmapFold =
+      typeof target.closest === 'function' ? target.closest('details.roadmap-major-section') : null;
+    if (roadmapFold) roadmapFold.open = true;
     target.scrollIntoView({ behavior: 'smooth', block: 'start' });
     window.setTimeout(function () {
       target.classList.remove('detail-hash-target');
@@ -1816,6 +1855,7 @@
       if (embedRoadmapStagesIntoMarkdownBody(contentEl, roadmapPage, roadmapId, detailPages)) {
         clearRoadmapStandaloneFlowSection();
       }
+      wrapRoadmapCollapsibleMajorHeadings(contentEl);
       bindDetailTocSpy(contentEl, tocEl);
       window.addEventListener('hashchange', function () { scrollToDetailHashTarget(contentEl); notifyTocSpyScrollSync(); });
       scrollToDetailHashTarget(contentEl);

--- a/docs/style.css
+++ b/docs/style.css
@@ -1382,6 +1382,58 @@ th {
 .roadmap-stage-embed-wrap .roadmap-vtree-item {
   margin-bottom: 0;
 }
+/* 路线正文：顶层 h2 章节默认折叠（wrapRoadmapCollapsibleMajorHeadings） */
+.roadmap-major-section {
+  margin: 0 0 1rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-strong, var(--bg-alt));
+  overflow: hidden;
+}
+.roadmap-major-section-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  list-style: none;
+}
+.roadmap-major-section-summary::-webkit-details-marker {
+  display: none;
+}
+.roadmap-major-section-summary::marker {
+  content: "";
+}
+.roadmap-major-section-summary::before {
+  content: "";
+  flex-shrink: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-right: 2px solid var(--text-muted);
+  border-bottom: 2px solid var(--text-muted);
+  transform: rotate(-45deg);
+  margin-top: -0.2rem;
+  opacity: 0.7;
+  transition: transform 0.15s ease, opacity var(--transition);
+}
+.roadmap-major-section[open] > .roadmap-major-section-summary::before {
+  transform: rotate(45deg);
+  margin-top: -0.35rem;
+}
+.roadmap-major-section-summary > h2.detail-heading {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 1.12rem;
+  line-height: 1.35;
+}
+.roadmap-major-section-body {
+  padding: 0 1rem 1rem;
+  border-top: 1px solid var(--border);
+}
+.roadmap-major-section-body > :first-child {
+  margin-top: 0.85rem;
+}
 .roadmap-flow-details,
 .roadmap-stage-flow-details {
   margin-bottom: 1rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在 `roadmap.html` 渲染路线正文（`#roadmapContent`）时，将每个**顶层二级标题（`h2`）**及其后内容包进默认收起的 `<details>`，首屏只显示章节标题行，点击展开后再阅读全文，减轻长路线页（如 `roadmap-motion-control`）的视觉压力。侧栏目录锚点、哈希跳转时仍会**自动展开**对应章节。

## 验证

- `make ci-preflight` 已通过；`npx eslint docs/main.js` 已通过。
- 本地 `docs` 静态服务下用 headless Chrome 截取 `roadmap.html?id=roadmap-motion-control`，确认章节为折叠态。

## 验证截图

[运动控制路线页：正文大章节默认折叠](https://cursor.com/agents/bc-df3b0609-3e2b-4f00-915f-10fe79060384/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-motion-control-sections.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df3b0609-3e2b-4f00-915f-10fe79060384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df3b0609-3e2b-4f00-915f-10fe79060384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

