### PR TITLE
fix(docs): 路线折叠章节内移除末尾水平分割线

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -612,6 +612,10 @@
         body.appendChild(node);
         node = next;
       }
+      // 章节之间原稿常用 --- 分隔；折叠块自带底框，去掉落在本块末尾的 <hr> 避免重复分割线。
+      while (body.lastChild && body.lastChild.nodeType === 1 && body.lastChild.tagName === 'HR') {
+        body.removeChild(body.lastChild);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

路线页正文在按顶层 `h2` 包成默认折叠块之后，各节之间 Markdown 里的 `---` 会变成块内末尾的 `<hr>`，与折叠卡片边框叠在一起显得多余。本 PR 在 `wrapRoadmapCollapsibleMajorHeadings` 组装完每个折叠块正文后，**移除该块末尾连续的 `<hr>`**。

## 验证

- `npx eslint docs/main.js` 已通过。

## 验证截图

[运动控制路线页：折叠章节与正文区（无块尾重复分割线）](https://cursor.com/agents/bc-df3b0609-3e2b-4f00-915f-10fe79060384/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-strip-hr-fix.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df3b0609-3e2b-4f00-915f-10fe79060384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df3b0609-3e2b-4f00-915f-10fe79060384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

