### PR TITLE
feat(docs): 主页搜索按知识图谱社区筛选

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -62,14 +62,8 @@
             aria-label="搜索知识页面"
             autocomplete="off"
           />
-          <select id="wikiTypeFilter" aria-label="按类型过滤">
-            <option value="">全部类型</option>
-            <option value="concept">概念 (concept)</option>
-            <option value="method">方法 (method)</option>
-            <option value="task">任务 (task)</option>
-            <option value="comparison">对比 (comparison)</option>
-            <option value="entity">工具/平台 (entity)</option>
-            <option value="query">Query 产物</option>
+          <select id="wikiCommunityFilter" aria-label="按社区过滤">
+            <option value="">全部社区</option>
           </select>
         </div>
         <div id="wikiTagCloud" class="tag-cloud" aria-label="热门标签"></div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2419,7 +2419,7 @@
   // ── Wiki 全文搜索（index.html 搜索框） ────────────────────────────────────
   var searchInput = document.getElementById('wikiSearchInput');
   var searchResults = document.getElementById('wikiSearchResults');
-  var typeFilter = document.getElementById('wikiTypeFilter');
+  var communityFilter = document.getElementById('wikiCommunityFilter');
   var tagCloudEl = document.getElementById('wikiTagCloud');
   if (searchInput && searchResults) {
     var _indexData = null;
@@ -2428,6 +2428,55 @@
     var _searchIndex = null;
     var _searchIndexPromise = null;
     var _searchIndexFailed = false;
+
+    var _communityByPath = null;
+    var _communityByPathPromise = null;
+    var _communitySelectPopulated = false;
+
+    function populateCommunitySelect(communities) {
+      if (!communityFilter || _communitySelectPopulated) return;
+      _communitySelectPopulated = true;
+      var preserved = communityFilter.value;
+      var opts = ['<option value="">全部社区</option>'];
+      for (var ci = 0; ci < communities.length; ci++) {
+        var c = communities[ci];
+        if (!c || !c.id) continue;
+        opts.push(
+          '<option value="' + escapeHtml(c.id) + '">' + escapeHtml(c.label || c.id) + '</option>'
+        );
+      }
+      communityFilter.innerHTML = opts.join('');
+      if (preserved) {
+        communityFilter.value = preserved;
+        if (communityFilter.value !== preserved) communityFilter.value = '';
+      }
+    }
+
+    function ensureCommunityByPath() {
+      if (_communityByPath) return Promise.resolve(_communityByPath);
+      if (_communityByPathPromise) return _communityByPathPromise;
+      _communityByPathPromise = fetch('exports/link-graph.json')
+        .then(function(r) {
+          if (!r.ok) throw new Error('HTTP ' + r.status);
+          return r.json();
+        })
+        .then(function(data) {
+          var m = new Map();
+          var nodes = data.nodes || [];
+          for (var ni = 0; ni < nodes.length; ni++) {
+            var node = nodes[ni];
+            if (node.id && node.community) m.set(node.id, node.community);
+          }
+          _communityByPath = m;
+          populateCommunitySelect(data.communities || []);
+          return m;
+        })
+        .catch(function() {
+          _communityByPath = new Map();
+          return _communityByPath;
+        });
+      return _communityByPathPromise;
+    }
 
     fetch('exports/index-v1.json')
       .then(function(r) { return r.json(); })
@@ -2685,11 +2734,13 @@
     function renderSearchResults(query) {
       _selectedIndex = -1;
       var q = query.trim();
-      var typeVal = typeFilter ? typeFilter.value : '';
-      if (!q && !typeVal) { renderEmptyState(); return; }
+      var communityVal = communityFilter ? communityFilter.value : '';
+      if (!q && !communityVal) { renderEmptyState(); return; }
       searchResults.innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1">加载离线搜索索引中…</p>';
-      ensureSearchIndex()
-        .then(function(indexData) {
+      Promise.all([ensureSearchIndex(), ensureCommunityByPath()])
+        .then(function(results) {
+          var indexData = results[0];
+          var communityMap = results[1] || new Map();
           var docs = (indexData && indexData.docs) || [];
           var queryTokens = tokenizeQuery(q);
           // ⚡ Bolt Optimization: Single-pass search filtering
@@ -2697,7 +2748,10 @@
           var matched = [];
           for (var i = 0; i < docs.length; i++) {
             var doc = docs[i];
-            if (typeVal && doc.page_type !== typeVal) continue;
+            if (communityVal) {
+              var docCommunity = communityMap.get(doc.path);
+              if (docCommunity !== communityVal) continue;
+            }
 
             var partial = 0;
             var bm25 = 0;
@@ -2732,7 +2786,12 @@
             return String(a.title || '').localeCompare(String(b.title || ''));
           }).slice(0, 10);
           if (!matched.length) {
-            renderNoResults(q);
+            if (communityVal && !q) {
+              searchResults.innerHTML = '<div style="grid-column:1/-1;color:var(--text-muted)">'
+                + '<p>当前社区下暂无索引条目，或该社区数据仍在加载。</p></div>';
+            } else {
+              renderNoResults(q);
+            }
           } else {
             renderCards(matched, queryTokens);
           }
@@ -2768,7 +2827,7 @@
         searchInput.value = '';
         searchResults.innerHTML = '';
         _selectedIndex = -1;
-        if (typeFilter) typeFilter.value = '';
+        if (communityFilter) communityFilter.value = '';
       }
     });
 
@@ -2791,8 +2850,9 @@
       clearTimeout(_searchTimer);
       _searchTimer = setTimeout(triggerSearch, 120);
     });
-    if (typeFilter) {
-      typeFilter.addEventListener('change', triggerSearch);
+    if (communityFilter) {
+      communityFilter.addEventListener('change', triggerSearch);
+      ensureCommunityByPath();
     }
 
     document.addEventListener('click', function(e) {
@@ -2801,7 +2861,7 @@
       var term = tag.getAttribute('data-wiki-tag');
       if (term && searchInput) {
         searchInput.value = term;
-        if (typeFilter) typeFilter.value = '';
+        if (communityFilter) communityFilter.value = '';
         triggerSearch();
         searchInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1170,7 +1170,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--text);
   outline: none;
 }
-#wikiTypeFilter {
+#wikiCommunityFilter {
   border: none;
   background: var(--bg);
   border-radius: 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将 `docs/index.html` 首页「Wiki 全文搜索」旁的下拉框从按页面 **类型**（concept / method 等）过滤，改为按知识图谱 **社区**（与 `graph.html` 中 Girvan–Newman / Louvain 划分结果一致）过滤。选项与节点归属来自 `docs/exports/link-graph.json`，搜索仍基于 `search-index.json`；仅出现在索引中、但不在图谱节点集合内的页面（如部分 `tech-map/`、`references/`）在选中具体社区时会被排除，「全部社区」下行为与原先未选类型时一致。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`（若改动 wiki/导出链）
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`
- [x] 其他：本地 `docs` 静态服务下对 `index.html#wiki-search` 进行 headless 截图确认下拉为社区列表

## 相关 Issue

无。

## 验证截图

[首页搜索区：社区下拉与搜索框](https://cursor.com/agents/bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fhome-wiki-search-community.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

