### PR TITLE
style(docs): 移动端搜索社区下拉宽度与省略号

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1170,6 +1170,15 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    /* 去掉系统外观后，选中项文字才能稳定被裁切并显示省略号（WebKit / 部分 Android） */
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: var(--bg);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%2364748b' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 6px center;
+    background-size: 12px;
+    padding-right: 22px;
   }
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1149,6 +1149,28 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   .cta-row a { width: 100%; }
   .page-hero h1 { font-size: 2rem; }
   .container { padding: 0 18px; }
+  /* 首页 Wiki 搜索：移动端下拉约占整条搜索栏宽度的 1/3，过长文案省略 */
+  .search-bar-wrap {
+    min-width: 0;
+  }
+  .search-bar-wrap input[type="search"] {
+    flex: 1 1 0;
+    min-width: 0;
+    padding: 12px 12px;
+    font-size: 1rem;
+  }
+  #wikiCommunityFilter {
+    flex: 0 0 33.333%;
+    width: 33.333%;
+    max-width: 33.333%;
+    min-width: 0;
+    box-sizing: border-box;
+    padding: 10px 8px;
+    font-size: 0.78rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 /* ── Wiki 搜索框 ─────────────────────────────────────── */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

延续首页 Wiki 搜索的 **社区筛选** 功能，并在 **移动端**（`max-width: 860px`）将社区下拉宽度限制为搜索条约 **三分之一**，输入框占据剩余空间；对过长社区名称使用 `text-overflow: ellipsis`，并通过 `appearance: none` 与自定义箭头改善 WebKit / Android 下选中项文字的裁切显示。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`（此前已通过；本次仅 `docs/style.css`）
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`
- [x] 其他：样式审查

## 相关 Issue

无。

## 验证截图

[首页搜索区（含社区下拉）](https://cursor.com/agents/bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fhome-wiki-search-community.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

