### PR TITLE
feat(docs): 图谱与迷你子图默认按社区配色

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -750,7 +750,7 @@
     <input id="graph-search" type="search" placeholder="搜索节点…" autocomplete="off" aria-label="搜索节点" list="graph-search-list" />
     <datalist id="graph-search-list"></datalist>
     <!-- 筛选按钮 -->
-    <button id="filter-toggle" class="chip" title="按类型筛选">
+    <button id="filter-toggle" class="chip" title="按社区筛选">
       <span>🔍</span>&nbsp;<span id="filter-label">筛选</span>
       <span id="filter-count" class="filter-count" style="display:none"></span>
     </button>
@@ -838,11 +838,11 @@
         <button id="filter-close" class="filter-close" aria-label="关闭面板">✕</button>
       </div>
       <div class="filter-mode-tabs" id="filter-mode-tabs" aria-label="筛选维度">
-        <button id="filter-mode-type" class="chip active" type="button">按类型</button>
-        <button id="filter-mode-community" class="chip" type="button">按社区</button>
+        <button id="filter-mode-type" class="chip" type="button">按类型</button>
+        <button id="filter-mode-community" class="chip active" type="button">按社区</button>
         <button id="filter-mode-health" class="chip" type="button">按健康度</button>
       </div>
-      <div class="filter-subtitle" id="filter-subtitle">当前按类型着色与筛选</div>
+      <div class="filter-subtitle" id="filter-subtitle">当前按社区着色与筛选</div>
       <div id="filter-panel-body" class="filter-body"></div>
       <div class="filter-footer">
         <button id="filter-clear" class="filter-clear">清除全部</button>
@@ -935,7 +935,7 @@
     const filterModeCommunityBtn = document.getElementById('filter-mode-community');
     const filterModeHealthBtn = document.getElementById('filter-mode-health');
     const filterPanelBody = document.getElementById('filter-panel-body');
-    let colorMode = 'type';
+    let colorMode = 'community';
     let activeFilters = new Set();
     let communityColorMap = new Map();
     let communityLabelMap = new Map();

--- a/docs/main.js
+++ b/docs/main.js
@@ -1297,6 +1297,7 @@
     entity: '#fbbf24', comparison: '#c084fc', query: '#94a3b8',
     formalization: '#fb923c', '': '#64748b'
   };
+  var DETAIL_MINI_TABLEAU10 = ['#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f', '#edc948', '#b07aa1', '#ff9da7', '#9c755f', '#bab0ac'];
 
   function buildPathToDetailIdIndex(detailPages) {
     var idx = {};
@@ -1316,6 +1317,11 @@
     if (!currentPath) return;
 
     fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
+      var palette = (window.d3 && window.d3.schemeTableau10) ? window.d3.schemeTableau10 : DETAIL_MINI_TABLEAU10;
+      var communityColor = {};
+      (gd.communities || []).forEach(function (c, i) {
+        communityColor[c.id] = palette[i % palette.length];
+      });
       var nodeMap = {};
       (gd.nodes || []).forEach(function (n) { nodeMap[n.id] = n; });
       var current = nodeMap[currentPath];
@@ -1334,10 +1340,10 @@
       var pathToId = buildPathToDetailIdIndex(detailPages);
       var nodes = [{
         id: currentPath, label: current.label || currentPath,
-        type: current.type || '', isCurrent: true
+        type: current.type || '', community: current.community || '', isCurrent: true
       }].concat(neighborIds.map(function (id) {
         var n = nodeMap[id];
-        return { id: id, label: n.label || id, type: n.type || '', isCurrent: false };
+        return { id: id, label: n.label || id, type: n.type || '', community: n.community || '', isCurrent: false };
       }));
       var edges = neighborIds.map(function (id) { return { source: currentPath, target: id }; });
 
@@ -1386,7 +1392,11 @@
       nodeG.append('title').text(function (d) { return d.label; });
       nodeG.append('circle')
         .attr('r', function (d) { return d.isCurrent ? 8 : 6; })
-        .attr('fill', function (d) { return TYPE_COLOR_DETAIL_MINI[d.type] || TYPE_COLOR_DETAIL_MINI['']; })
+        .attr('fill', function (d) {
+          var cc = d.community && communityColor[d.community];
+          if (cc) return cc;
+          return TYPE_COLOR_DETAIL_MINI[d.type] || TYPE_COLOR_DETAIL_MINI[''];
+        })
         .attr('fill-opacity', 0.9);
       nodeG.append('text')
         .text(function (d) { return d.label.length > 10 ? d.label.slice(0, 10) + '…' : d.label; })

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -17,13 +17,18 @@
     };
   }
 
-  var TYPE_COLOR = {
-    concept:'#60a5fa', method:'#34d399', task:'#f472b6',
-    entity:'#fbbf24', comparison:'#c084fc', query:'#94a3b8',
-    formalization:'#fb923c', '':'#64748b'
-  };
+  var TABLEAU10 = ['#4e79a7','#f28e2b','#e15759','#76b7b2','#59a14f','#edc948','#b07aa1','#ff9da7','#9c755f','#bab0ac'];
 
   fetch('exports/link-graph.json').then(function(r){ return r.json(); }).then(function(gd) {
+    var palette = (typeof d3 !== 'undefined' && d3.schemeTableau10) ? d3.schemeTableau10 : TABLEAU10;
+    var communityFill = {};
+    (gd.communities || []).forEach(function(c, idx) {
+      communityFill[c.id] = palette[idx % palette.length];
+    });
+    function nodeFill(d) {
+      if (d.community && communityFill[d.community]) return communityFill[d.community];
+      return palette[palette.length - 1];
+    }
     fetch('exports/graph-stats.json').then(function(r){ return r.json(); }).then(function(stats) {
       var totalNodes = gd.nodes.length, totalEdges = gd.edges.length;
       var degreeMap = {};
@@ -39,7 +44,7 @@
       );
 
       var nodes = gd.nodes.filter(function(n){ return topIds.has(n.id); }).map(function(n){
-        return { id:n.id, label:n.label||n.id, type:n.type||'', _degree:degreeMap[n.id]||0 };
+        return { id:n.id, label:n.label||n.id, type:n.type||'', community:n.community||'', _degree:degreeMap[n.id]||0 };
       });
       var nodeIdSet = new Set(nodes.map(function(n){ return n.id; }));
       var edges = gd.edges.filter(function(e){
@@ -96,7 +101,7 @@
 
       nodeG.append('circle')
         .attr('r', function(d){ return Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2)); })
-        .attr('fill', function(d){ return TYPE_COLOR[d.type]||TYPE_COLOR['']; })
+        .attr('fill', function(d){ return nodeFill(d); })
         .attr('fill-opacity', 0.9);
 
       var label = nodeG.append('text')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将 **`docs/graph.html`** 知识图谱的默认着色维度从「按类型」改为「**按社区**」：`colorMode` 初始为 `community`，筛选 Tab 与副标题、工具栏筛选按钮的默认文案与 `active` 状态与之一致；图例、磁吸聚类、节点颜色与筛选面板在首屏即与全站 `link-graph.json` 中的社区划分对齐。

同步将 **首页迷你图**（`docs/mini-graph.js`）与 **详情页 1-hop 邻居子图**（`docs/main.js` 中 `renderDetailMiniMap`）的节点填充色改为与主图谱相同的 **Tableau10 社区色板**（与 `d3.schemeTableau10` 一致），无 `community` 字段时迷你图落回调色板末色，详情子图仍回退到原类型色。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`
- [ ] `make test`（未改 Python 逻辑）

## 相关 Issue

无。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a915ef6-7a71-4fee-89a5-b885c07a6f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

