### PR TITLE
wiki: 新增 GMR vs NMR vs ReActor 动作重定向方法对比页

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -44,7 +44,10 @@
     - [x] `wiki/formalizations/motion-retargeting-objective.md`（重定向目标函数形式化：姿态相似项、接触/约束项、平衡项、关节限位项的数学组合）。
       - 实现：新增 `wiki/formalizations/motion-retargeting-objective.md`，给出通用目标函数 $\mathcal{L}^{\text{pose}}+\mathcal{L}^{\text{ee}}+\mathcal{L}^{\text{bal}}+\mathcal{L}^{\text{lim}}+\mathcal{L}^{\text{smooth}}$ 的形式化；逐项列出关节角/关键点/SO(3) 旋转一致、末端跟随/接触锁定/相位/摩擦锥、CoM–支撑多边形/ZMP/RFC 压制、限位四类硬罚项与平滑导数罚项；并给出 GMR（离线 QP）/ DeepMimic（指数核奖励）/ ReActor（双层）/ NMR（CEPR 硬阈值 + L1 标签）/ SPIDER（采样优化）五种工程退化形态对照表；横向回链 [TSID](./tsid-formulation.md)、[Friction Cone](./friction-cone.md)、[ZMP + LIP](./zmp-lip.md)。
       - 交叉互链：`motion-retargeting.md`、`motion-retargeting-pipeline.md` 的「关联页面」加入本页入口。
-    - [ ] `wiki/comparisons/gmr-vs-nmr-vs-reactor.md`（GMR / NMR / ReActor 重定向方法谱系对比：监督 vs 优化 vs 物理感知 RL，输入形态、依赖、产物差异）。
+    - [x] `wiki/comparisons/gmr-vs-nmr-vs-reactor.md`（GMR / NMR / ReActor 重定向方法谱系对比：监督 vs 优化 vs 物理感知 RL，输入形态、依赖、产物差异）。
+      - 实现：新增 `wiki/comparisons/gmr-vs-nmr-vs-reactor.md`，按「一句话定义 + 12 维核心对比表 + Mermaid 三路数据流并排图 + 三方适用场景 + 5 类常见误判 + 决策矩阵」结构覆盖三条路线；强调「误差修补发生位置」（下游 / 离线 / 在线）作为核心选型轴，并显式标注 NMR 仍以 GMR 为 CEPR 初值、三者实际常串联而非互斥；交叉互链 motion-retargeting / pipeline / objective / GMR / NMR / ReActor / SPIDER / SONIC / ExoActor。
+      - 关联回链：`motion-retargeting.md`、`motion-retargeting-pipeline.md`、`motion-retargeting-objective.md`、`methods/motion-retargeting-gmr.md`、`methods/neural-motion-retargeting-nmr.md`、`methods/reactor-physics-aware-motion-retargeting.md` 的「关联页面」加入本对比页入口；`index.md` Wiki Comparisons 区块插入本页摘要条目。
+      - 验证：本地 `python3 -m http.server` + `docs/detail.html?id=wiki-comparisons-gmr-vs-nmr-vs-reactor` 渲染正常（Mermaid 流程图落稳、表格未截断）；`grep "gmr-vs-nmr-vs-reactor" -r wiki/ index.md` 显示双向回链建立。
 - [ ] **角色化人形（Character Humanoid）边界澄清**：
     - [ ] `wiki/concepts/character-animation-vs-robotics.md`（角色动画 vs 机器人控制：动作风格化、表演意图与物理可控性之间的张力；面向 Disney Olaf / Roboto Origin / MotionCanvas 等案例）。
 

--- a/index.md
+++ b/index.md
@@ -487,6 +487,7 @@ SORT type ASC
 - [CLF vs CBF：稳定性与安全性的对偶工具](comparisons/clf-vs-cbf.md) —  工具 | 全称 | 核心角色  `📅unknown` `[comparison_page]`
 - [数据手套 vs 视觉遥操作 (灵巧数据采集选型)](comparisons/data-gloves-vs-vision-teleop.md) — 在训练灵巧手（Dexterous Hand）执行复杂任务时，获取高质量的人类演示数据是第一步。目前，**穿戴式数据手套 (Data Gloves)** 和 **基于视觉的遥操作 (Vision-bas `📅unknown` `[comparison_page]`
 - [EtherCAT vs EtherNet/IP（工业总线选型对比）](comparisons/ethercat-vs-ethernet-ip.md) — 在人形机器人、工业机械臂、移动操作平台落地时，"主控板 ↔ 关节驱动器"的连接几乎都跑在工业以太网上。**EtherCAT** 和 **EtherNet/IP** 是当前装机量最大的两种以太网现场总线 `📅unknown` `[comparison_page]`
+- [GMR vs NMR vs ReActor：动作重定向方法谱系对比](comparisons/gmr-vs-nmr-vs-reactor.md) — 三条主流路线（运动学 QP / 学习式整段映射 / 物理感知 RL 双层优化）在「误差修补位置、训练与推理成本、跨形态能力」上的选型坐标；强调三者实际常串联而非互斥。 `📅2026-05-18` `[comparison_page]`
 - [HumanNet Table 1：代表性人类视频语料与具身向关系](comparisons/humannet-table1-human-video-corpora.md) — HumanNet** 在与既有语料对比时，用一张表同时强调 **规模、视点、活动语义粒度** 以及论文中称为 **Embodied Use** 的定性列（与「能否直接支撑机器人学习接口」相关，但仍 `📅unknown` `[comparison_page]`
 - [Kalman Filter vs. Optimization-based Estimation (状态估计选型)](comparisons/kalman-filter-vs-optimization-based-estimation.md) — 在机器人（特别是人形和四足机器人）中，实时估计 Base 的位置、速度和姿态是所有算法的基础。目前主要存在两大技术路线：以 **EKF** 为代表的递归滤波派，和以 **滑窗优化 (Sliding W `📅unknown` `[comparison_page]`
 - [Model-Based vs Model-Free RL 对比](comparisons/model-based-vs-model-free.md) —  维度 | Model-Free RL | Model-Based RL  `📅unknown` `[comparison_page]`

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-18] structural | wiki/comparisons/gmr-vs-nmr-vs-reactor.md — V22 P1 动作重定向知识链 (3/3)：新增 GMR / NMR / ReActor 三方对比页
+
+- 沉淀页面：`wiki/comparisons/gmr-vs-nmr-vs-reactor.md`（一句话定义 + 12 维核心对比表 + Mermaid 三路数据流并排图 + 三方适用场景 + 5 类常见误判 + 决策矩阵；强调「误差修补发生位置」（下游 / 离线 / 在线）作为核心选型轴；显式标注 NMR 仍以 GMR 为 CEPR 初值、三者实际常串联而非互斥）
+- 交叉更新：`wiki/concepts/motion-retargeting.md`、`wiki/concepts/motion-retargeting-pipeline.md`、`wiki/formalizations/motion-retargeting-objective.md`、`wiki/methods/motion-retargeting-gmr.md`、`wiki/methods/neural-motion-retargeting-nmr.md`、`wiki/methods/reactor-physics-aware-motion-retargeting.md`（关联页面区块回链本对比页）、`index.md`（Wiki Comparisons 目录插入 GMR vs NMR vs ReActor 条目）、`docs/checklists/tech-stack-next-phase-checklist-v22.md`（P1 第 3 项打勾，含实现摘要；至此 V22 P1「动作重定向知识链 (+3)」3/3 全部完成）
+- 派生再生成：保持当前状态，待后续 ingest 或 P2 推进时统一 `make ci-preflight` 同步 `exports/`、`docs/exports/`、`docs/search-index.json`、`docs/sitemap.xml`、`README.md`、`docs/index.html`、`index.md` 等
+
 ## [2026-05-18] ingest | sources/papers/capvector_arxiv_2605_10903.md、sources/sites/capvector-github-io.md、sources/repos/openhelix_team_capvector.md — CapVector（参数空间 capability vector + 正交正则标准 SFT）arXiv:2605.10903 入库
 
 - 原始资料：`sources/papers/capvector_arxiv_2605_10903.md`、`sources/sites/capvector-github-io.md`、`sources/repos/openhelix_team_capvector.md`（PDF <https://arxiv.org/pdf/2605.10903>、项目页 <https://capvector.github.io/>、代码 <https://github.com/OpenHelix-Team/CapVector>）；索引 `sources/README.md`

--- a/wiki/comparisons/gmr-vs-nmr-vs-reactor.md
+++ b/wiki/comparisons/gmr-vs-nmr-vs-reactor.md
@@ -1,0 +1,204 @@
+---
+type: comparison
+tags: [motion-retargeting, humanoid, kinematics, reinforcement-learning, imitation-learning, bilevel-optimization, comparison, engineering-selection]
+status: complete
+updated: 2026-05-18
+sources:
+  - ../../sources/papers/motion_control_projects.md
+  - ../../sources/papers/neural_motion_retargeting_nmr.md
+  - ../../sources/papers/reactor_rl_physics_aware_motion_retargeting.md
+related:
+  - ../concepts/motion-retargeting.md
+  - ../concepts/motion-retargeting-pipeline.md
+  - ../formalizations/motion-retargeting-objective.md
+  - ../methods/motion-retargeting-gmr.md
+  - ../methods/neural-motion-retargeting-nmr.md
+  - ../methods/reactor-physics-aware-motion-retargeting.md
+  - ../methods/spider-physics-informed-dexterous-retargeting.md
+  - ../methods/sonic-motion-tracking.md
+summary: "GMR / NMR / ReActor 三种动作重定向方法谱系对比：监督优化（运动学 QP/IK）vs 学习式整段映射（神经网络 + 仿真锚定监督）vs 物理感知 RL（双层联合优化参考与跟踪策略），从输入形态、依赖、产物、训练 / 推理成本与适用场景给出选型坐标。"
+---
+
+# GMR vs NMR vs ReActor：动作重定向方法谱系对比
+
+**背景**：当源动作（动捕、视频估计、生成模型）要喂给目标人形 / 异构机器人时，重定向是必须穿过的一道闸。围绕「**像不像**」与「**能不能跟得上**」两条评价线，社区涌现了三类代表性路线——以 **GMR** 为代表的**运动学优化**、以 **NMR** 为代表的**学习式整段映射**、以 **ReActor** 为代表的**物理感知 RL 双层优化**。三者并非互斥，工程上常组合使用，但在「数据来自哪里、误差在哪里修、推理预算多大」三个维度上的取舍泾渭分明。
+
+> **一句话区分**：GMR 是「**先几何对齐、物理留给下游**」；NMR 是「**离线用 RL 把几何参考拉进可行流形，再训前向网络批量推断**」；ReActor 是「**在线把参考形变与跟踪策略放进同一个仿真双层优化里联合更新**」。
+
+---
+
+## 一句话定义
+
+| 方法 | 一句话 | 论文 / 仓库 |
+|------|--------|-------------|
+| **GMR**（General Motion Retargeting） | 关键点 IK + QP 在运动学层做骨架对齐与限位平滑，CPU 实时输出关节轨迹。 | [arXiv:2505.02833](https://arxiv.org/abs/2505.02833) ；[YanjieZe/GMR](https://github.com/YanjieZe/GMR) |
+| **NMR**（Neural Motion Retargeting） | 用 CEPR 数据管线（GMR 初值 → 聚类 → 每簇 PPO 专家跟踪 → 仿真 rollout）造**物理一致的人机配对**，训练 CNN–Transformer 做非自回归整段重定向。 | [arXiv:2603.22201](https://arxiv.org/abs/2603.22201) |
+| **ReActor** | 把**参数化参考** \(\mathbf{p}\) 与**单一跟踪策略** \(\pi_\phi\) 写进双层目标，在物理仿真内交替更新；上层用结构化近似梯度，避免 Hessian 求逆。 | [arXiv:2605.06593](https://arxiv.org/abs/2605.06593) |
+
+---
+
+## 核心维度对比
+
+| 维度 | **GMR**（运动学优化） | **NMR**（监督学习 + 仿真锚定） | **ReActor**（物理感知 RL 双层优化） |
+|------|----------------------|--------------------------------|------------------------------------|
+| **范式定位** | 单次几何 IK / QP 优化 | 离线构造配对数据 + 学习式整段映射 | 在线双层优化（参考 + 策略协同） |
+| **典型输入** | MoCap / SMPL / 视频估计单帧或滑窗 | 整段 SMPL 序列 | 源动捕序列 + 稀疏语义刚体对应 + 根对应 |
+| **输出形态** | 机器人关节轨迹 \(q_t\) | 机器人全身参考序列（整段并行） | 仿真内可执行参考 \(\mathbf{g}_t(\mathbf{p})\) + 跟踪策略 \(\pi_\phi\) |
+| **物理一致性** | ❌ 仅运动学，下游须补动力学 | ✅ 数据级锚定到 RL 仿真可行流形 | ✅ 仿真内闭环，接触/自碰内生化 |
+| **接触/自碰处理** | 启发式罚项 + 速度上限 | 通过 RL 专家的奖励内化 | 仿真接触求解器 + RFC 根残差力 |
+| **训练成本** | 无（即开即用 QP） | 高：每簇 PPO + 网络两阶段训练 | 高：单环双层 + 大动作库 RL |
+| **推理速度** | CPU 毫秒级 | GPU 前向 < 10ms / 段（非自回归） | 训练态产物；部署仍需独立跟踪策略 |
+| **跨形态能力** | 重新配置骨架/关键点；与机型耦合 | 需重训 CEPR 与网络头 | 通过有界 \(\mathbf{p}\) 参数化跨人形/四足报告 |
+| **对源噪声敏感性** | 高（脚滑/漂移会被刚性放大，见 ExoActor 反例） | 中（CEPR 物理筛选可吸收部分噪声） | 中–低（仿真闭环吸收，但受 \(\alpha\) 近似假设制约） |
+| **核心假设** | 模型骨架与源骨架可在 IK 误差容忍内对齐 | RL 专家覆盖动作分布；TMR/聚类语义合理 | \(\partial \ell / \partial \mathbf{p}\) 可由策略响应标量化近似 |
+| **是否需大网络/算力** | 否 | 是（CNN–Transformer + 多专家训练） | 否（无大网络，但需多环 RL 训练） |
+| **典型代码产物** | `motion_retargeting.py` + URDF/MJCF 配置 | 预训练 + 微调 checkpoint + 推理脚本 | 训练得到的 \(\mathbf{p}^\*\) 参考 + 跟踪策略权重 |
+
+---
+
+## 数据流对比（Mermaid）
+
+把三条路线放在同一张「**人体源动作 → 机器人参考 → 下游跟踪**」的坐标里，差异主要在**误差修补发生的位置**：
+
+```mermaid
+flowchart TD
+  Src[人体源动作<br/>MoCap / 视频估计 / 生成]
+
+  subgraph gmr_path["GMR：几何前端 + 下游兜底"]
+    G1[关键点 IK / QP]
+    G2[限位 + 速度上限 + 平滑]
+  end
+
+  subgraph nmr_path["NMR：CEPR 离线锚定 + 前向网络"]
+    N1[GMR 初值]
+    N2[硬阈值过滤<br/>速度/自碰/脚离地]
+    N3[TMR 聚类 + 每簇 PPO 跟踪]
+    N4[仿真 rollout → 配对数据集]
+    N5[CNN–Transformer 训练<br/>预训练 + 微调]
+  end
+
+  subgraph reactor_path["ReActor：在线双层 RL"]
+    R1[参数化参考 g_t(p)]
+    R2[策略 π_φ + PD + RFC]
+    R3[物理仿真<br/>接触 / 自碰 / 限位]
+    R4[上层近似梯度 → 更新 p]
+  end
+
+  Src --> G1 --> G2 --> DownK[下游：动力学滤波 / RL tracking / WBC]
+  Src --> N1 --> N2 --> N3 --> N4 --> N5 --> DownN[下游：WBC / RL tracking]
+  Src --> R1 --> R2 --> R3 --> R4
+  R3 -.-> R1
+  R4 -.-> R2
+  R3 --> DownR[产物即「参考 + 策略」]
+```
+
+要点：
+- **GMR** 的误差修补点在**下游**（动力学滤波 / RL tracking）；
+- **NMR** 把误差修补集中到**离线数据构造阶段**（仿真锚定为「物理真值」），换得推理侧的快速前向；
+- **ReActor** 把误差修补放进**在线双层闭环**，参考与策略相互塑形。
+
+---
+
+## 适用场景
+
+### 选 GMR 的场景
+
+1. **源动作干净**（专业 MoCap / 标定良好的遥操作），人机骨架比例差异不大；
+2. **需要 CPU 实时 / 低延迟**（在线遥操作、教师演示流式生成）；
+3. **下游已有强 tracking**（如 BeyondMimic / SONIC），GMR 仅作前端覆盖；
+4. **工程预算紧**：无需训练管线，几小时即可在新机型上跑通；
+5. **作为更大流水线的零件**：NMR 自身仍依赖 GMR 做 CEPR 初值。
+
+> **避坑**：源动作来自视频估计 / 生成模型时，GMR 的「刚性几何对齐」会放大全局漂移与脚滑——见 [ExoActor](../methods/exoactor.md) 中「跳过重定向直接喂 SONIC」的消融。
+
+### 选 NMR 的场景
+
+1. **存在大规模 SMPL / 同源人体库**（≥ 数千段），值得一次性把数据「拉进可行流形」；
+2. **部署阶段需要毫秒级整段映射**（实时生成式控制、视频→人形流水线）；
+3. **目标机型相对固定**（如论文以 Unitree G1 为主），可承担 CEPR + 网络训练沉没成本；
+4. **下游策略希望吃到「时序一致、低伪影」的参考**以加速 IL/RL 收敛。
+
+> **避坑**：CEPR 的「物理真值」由 RL 奖励与专家分簇决定，**分布外动作**（如非典型杂技、灵巧手细操作）仍可能被刚性映射到簇心附近；上肢精细 / 手部任务需单独评估。
+
+### 选 ReActor 的场景
+
+1. **强异构形态**（人形 ↔ 四足、不同肢长比例）下需要**统一**的参考生成框架；
+2. **想把「参考形变」本身当作可优化对象**长期联合训练，而非「先做几何、再修动力学」的分阶段管道；
+3. **接触/自碰约束希望内生化**而不是靠下游 QP 兜底；
+4. **不需要前向重定向网络**——可以接受「训练态产物 = 参考 + 跟踪策略」一同部署。
+
+> **避坑**：**RFC 根残差力**降低跨形态训练难度，但与「零辅助力、纯物理可复现」不是同一目标——阅读实验时需区分*参考质量*与*是否完全物理一致*；上层近似梯度依赖 \(\alpha\) 标量化策略响应，对分布外形态或奖励重塑需评估稳定性。
+
+---
+
+## 常见误判
+
+1. **「NMR 取代 GMR」**：错。NMR 的 **CEPR 管线**显式以 GMR 输出为运动学初值，再用仿真 RL 做物理修补——是**叠加增强**而非替代关系。
+2. **「ReActor 比 NMR 更先进」**：维度不同。ReActor 强调**在线双层优化**的算法贡献与跨形态适用性；NMR 强调**离线大规模配对 + 快速前向推断**。部署端是否需要毫秒级前向网络，往往是首要分水岭。
+3. **「GMR 不物理一致 = 没用」**：GMR 在 MoCap → 机器人这种「源动作干净」的链路上仍是**收益项**，且是 NMR / SPIDER 等学习/采样路线的关键前端；其「非物理性」是分工问题，不是路线缺陷。
+4. **「物理一致 = 上真机就稳」**：NMR / ReActor 的物理一致性是**仿真内**的，sim-to-real gap 仍会传导。真机部署仍需域随机化、SysID 校正与下游 WBC / RL tracking 的鲁棒性补强。
+5. **「三者只能三选一」**：实际系统常**串联**：GMR 出运动学初值 → CEPR/ReActor 式仿真修补 → 下游 RL tracking。三条路线在「**误差修补位置**」这条轴上是连续谱，而非二元对立。
+
+---
+
+## 决策矩阵
+
+```
+你的主要约束是什么？
+│
+├── 源动作干净 + 部署要 CPU 实时 → GMR（必要时下游接动力学滤波）
+├── 已有大规模 SMPL 库 + 部署要毫秒级前向 → NMR（CEPR + 神经网络）
+├── 跨形态（人形/四足）联合参考生成 + 接触约束内生化 → ReActor
+├── 工程预算紧 / 没有 GPU 集群 → GMR（再视下游 tracking 选型）
+├── 想把「参考」当可微/可优化对象长期迭代 → ReActor
+├── 源动作来自视频估计或生成模型，且有明显漂移 → 先评估「跳过重定向直接 tracking」（参考 ExoActor / SONIC 路线）
+└── 灵巧手 / 接触歧义重的操作数据 → 考虑 SPIDER 类「采样优化 + 虚拟接触」前端
+```
+
+---
+
+## 与其它对比页的区别
+
+- 本页关注**三种重定向算法的谱系对比**（监督优化 / 学习式 / 物理感知 RL）；
+- [RL vs IL](./rl-vs-il.md) 在**策略学习范式**层面对比，重定向只是数据预处理；
+- [MPC vs RL](./mpc-vs-rl.md) 在**控制范式**层面对比，与重定向不在同一抽象层；
+- [Sim2Real 方法横向对比](./sim2real-approaches.md) 关注的是「仿真→真机」的差距弥合，与本页「人体→机器人参考」是上下游关系。
+
+---
+
+## 参考来源
+
+- [sources/papers/motion_control_projects.md](../../sources/papers/motion_control_projects.md) — 飞书公开文档《开源运动控制项目》对 GMR 的工程定位与局限点评。
+- [sources/papers/neural_motion_retargeting_nmr.md](../../sources/papers/neural_motion_retargeting_nmr.md) — NMR / CEPR 管线与 CNN–Transformer 网络细节。
+- [sources/papers/reactor_rl_physics_aware_motion_retargeting.md](../../sources/papers/reactor_rl_physics_aware_motion_retargeting.md) — ReActor 双层优化与近似梯度的算法叙事。
+- Ze Y., et al. *GMR: General Motion Retargeting* — [arXiv:2505.02833](https://arxiv.org/abs/2505.02833)；技术报告 [arXiv:2510.02252](https://arxiv.org/abs/2510.02252)。
+- NMR 项目主页：<https://nju3dv-humanoidgroup.github.io/nmr.github.io/> ；arXiv：<https://arxiv.org/abs/2603.22201>。
+- ReActor arXiv 摘要页：<https://arxiv.org/abs/2605.06593> ；HTML 全文：<https://arxiv.org/html/2605.06593v1>。
+
+---
+
+## 关联页面
+
+- [Motion Retargeting（动作重定向）](../concepts/motion-retargeting.md) — 任务定义与坐标系。
+- [Motion Retargeting Pipeline（动作重定向流水线）](../concepts/motion-retargeting-pipeline.md) — 把三种方法放进同一条 8 阶段端到端管线的工程视角。
+- [Motion Retargeting Objective（动作重定向目标函数形式化）](../formalizations/motion-retargeting-objective.md) — GMR / NMR / ReActor 在统一目标函数下的退化形态对照。
+- [GMR（通用动作重定向）](../methods/motion-retargeting-gmr.md) — 几何前端方法细节。
+- [NMR（神经运动重定向与人形全身控制）](../methods/neural-motion-retargeting-nmr.md) — CEPR 管线与网络结构。
+- [ReActor（物理感知 RL 运动重定向）](../methods/reactor-physics-aware-motion-retargeting.md) — 双层优化与近似梯度。
+- [SPIDER（物理感知采样式灵巧重定向）](../methods/spider-physics-informed-dexterous-retargeting.md) — 另一条「采样优化 + 虚拟接触」的物理感知前端。
+- [SONIC（规模化运动跟踪）](../methods/sonic-motion-tracking.md) — 与「跳过重定向直接 tracking」路线对照。
+- [ExoActor（视频生成驱动的人形控制）](../methods/exoactor.md) — 在估计/生成源动作上「何时跳过 GMR」的反例。
+
+---
+
+## 推荐继续阅读
+
+- Peng X. B., et al. *DeepMimic: Example-Guided Deep Reinforcement Learning of Physics-Based Character Skills* — 角色动画侧「跟踪固定参考」的经典 RL 设定，与 ReActor「先造参考」对照。
+- Müller M., et al. *ReActor: Reinforcement Learning for Physics-Aware Motion Retargeting*（SIGGRAPH 2026 预印本） — 双层优化与跨形态报告。
+- He T., et al. *Learning Human-to-Humanoid Real-Time Whole-Body Teleoperation*（H2O / OmniH2O 系列） — 与 GMR + RL tracking 流水线衔接的工程参考。
+
+---
+
+## 一句话记忆
+
+> **GMR 几何**、**NMR 监督**、**ReActor 物理**——三者按「误差修补发生在下游 / 离线 / 在线」分占谱系三端，工程系统往往不是三选一而是按需串联。

--- a/wiki/concepts/motion-retargeting-pipeline.md
+++ b/wiki/concepts/motion-retargeting-pipeline.md
@@ -179,6 +179,7 @@ flowchart TD
 - [NMR（神经运动重定向）](../methods/neural-motion-retargeting-nmr.md) — 流水线中"前端 + 配对数据 + 神经推断"的实例
 - [ReActor（物理感知 RL 运动重定向）](../methods/reactor-physics-aware-motion-retargeting.md) — 把参考形变与跟踪策略联合训练的流水线变体
 - [SPIDER（物理感知采样式灵巧重定向）](../methods/spider-physics-informed-dexterous-retargeting.md) — 运动学参考后在并行仿真里做采样轨迹优化与接触课程
+- [GMR vs NMR vs ReActor（重定向方法谱系对比）](../comparisons/gmr-vs-nmr-vs-reactor.md) — 三条主流路线如何在同一条流水线上占据不同位置的选型视角
 - [SONIC（规模化运动跟踪）](../methods/sonic-motion-tracking.md) — "跳过中间重定向"流水线的下游通用 tracker
 - [Whole-Body Control](./whole-body-control.md) — 下游消费参考的控制器接口
 - [Imitation Learning](../methods/imitation-learning.md) — 离线产物的主要下游消费方

--- a/wiki/concepts/motion-retargeting.md
+++ b/wiki/concepts/motion-retargeting.md
@@ -175,6 +175,7 @@ Motion Retargeting 的质量直接决定 AMP 能学到多自然的动作。
 - [NMR（神经运动重定向与人形全身控制）](../methods/neural-motion-retargeting-nmr.md) — 学习式整段映射 + 仿真 RL 修补监督
 - [ReActor（物理感知 RL 运动重定向）](../methods/reactor-physics-aware-motion-retargeting.md) — 双层：可学习参考 + 同环 RL 跟踪，近似上层梯度
 - [SPIDER（物理感知采样式灵巧重定向）](../methods/spider-physics-informed-dexterous-retargeting.md) — 运动学参考 + 并行仿真采样优化 + 课程式虚拟接触引导
+- [GMR vs NMR vs ReActor（重定向方法谱系对比）](../comparisons/gmr-vs-nmr-vs-reactor.md) — 三条主流路线在误差修补位置、训练/推理成本、跨形态能力上的选型坐标
 - [ExoActor](../methods/exoactor.md) — 视频生成驱动的人形控制流水线，提供"中间重定向并非永远收益项"的反例
 - [MotionCode](../entities/motioncode.md) — 商业运动数据与「人形/具身 + RL」叙事样本
 - [FreeMoCap](../entities/freemocap.md) — 低成本开源动捕软件栈，与重定向 / 仿真训练组合使用时的入口之一

--- a/wiki/formalizations/motion-retargeting-objective.md
+++ b/wiki/formalizations/motion-retargeting-objective.md
@@ -211,6 +211,7 @@ $$
 - [NMR（神经运动重定向）](../methods/neural-motion-retargeting-nmr.md) — CEPR 把罚项硬阈值化 + 配对监督。
 - [ReActor（物理感知 RL 运动重定向）](../methods/reactor-physics-aware-motion-retargeting.md) — 双层优化下的参数化参考。
 - [SPIDER（物理感知采样式灵巧重定向）](../methods/spider-physics-informed-dexterous-retargeting.md) — 采样轨迹优化形态。
+- [GMR vs NMR vs ReActor（重定向方法谱系对比）](../comparisons/gmr-vs-nmr-vs-reactor.md) — 三种工程退化形态在选型坐标里的直接对照。
 - [DeepMimic](../methods/deepmimic.md) — 把目标函数写成 RL tracking 奖励的范式。
 - [TSID 形式化](./tsid-formulation.md) — 下游消费重定向参考的 QP 控制层。
 - [Friction Cone 形式化](./friction-cone.md) — 动力学一致化阶段的接触约束。

--- a/wiki/methods/motion-retargeting-gmr.md
+++ b/wiki/methods/motion-retargeting-gmr.md
@@ -173,4 +173,5 @@ $$
 - [NMR（神经运动重定向与人形全身控制）](./neural-motion-retargeting-nmr.md) — 用 GMR + 仿真 RL 构造监督的学习式重定向。
 - [ReActor（物理感知 RL 运动重定向）](./reactor-physics-aware-motion-retargeting.md) — 双层联合优化参考与跟踪策略。
 - [SPIDER（物理感知采样式灵巧重定向）](./spider-physics-informed-dexterous-retargeting.md) — 并行仿真采样优化 + 虚拟接触引导的数据生成外壳。
+- [GMR vs NMR vs ReActor（重定向方法谱系对比）](../comparisons/gmr-vs-nmr-vs-reactor.md) — 三种路线的并排选型对照。
 - [SONIC（规模化运动跟踪）](./sonic-motion-tracking.md) — 与「跳过重定向、直接 tracking」路线对照阅读。

--- a/wiki/methods/neural-motion-retargeting-nmr.md
+++ b/wiki/methods/neural-motion-retargeting-nmr.md
@@ -96,6 +96,7 @@ flowchart TD
 - [Motion Retargeting（动作重定向）](../concepts/motion-retargeting.md) — 问题定义与常见流水线。
 - [GMR（通用动作重定向）](./motion-retargeting-gmr.md) — NMR 数据管线中的运动学前端。
 - [ReActor（物理感知 RL 运动重定向）](./reactor-physics-aware-motion-retargeting.md) — 双层联合优化参考与跟踪策略的对照路线。
+- [GMR vs NMR vs ReActor（重定向方法谱系对比）](../comparisons/gmr-vs-nmr-vs-reactor.md) — 三种主流路线在「误差修补位置 / 训练成本 / 部署预算」上的选型坐标。
 - [SONIC（规模化运动跟踪）](./sonic-motion-tracking.md) — 另一类「人体/参考 → 人形执行」的大规模跟踪基线视角。
 - [Whole-Body Control](../concepts/whole-body-control.md) — 下游 QP / 分层控制与参考跟踪接口。
 - [Unitree G1](../entities/unitree-g1.md) — 论文实验平台。

--- a/wiki/methods/reactor-physics-aware-motion-retargeting.md
+++ b/wiki/methods/reactor-physics-aware-motion-retargeting.md
@@ -77,6 +77,7 @@ flowchart LR
 - [Motion Retargeting（动作重定向）](../concepts/motion-retargeting.md) — 任务定义与分类坐标。
 - [GMR（通用动作重定向）](./motion-retargeting-gmr.md) — 运动学前端基线与工程生态。
 - [NMR（神经运动重定向与人形全身控制）](./neural-motion-retargeting-nmr.md) — 学习式整段映射 + 仿真修补监督的另一条主线。
+- [GMR vs NMR vs ReActor（重定向方法谱系对比）](../comparisons/gmr-vs-nmr-vs-reactor.md) — 三方并排对比与选型矩阵。
 - [DeepMimic](./deepmimic.md) — 「跟踪固定参考」的经典 RL 设定，可与本文「先造参考」对照。
 - [Imitation Learning](./imitation-learning.md) — 下游如何利用高质量参考与奖励 shaping。
 - [Locomotion](../tasks/locomotion.md) — 四足与人形步态参考在任务层的落点。


### PR DESCRIPTION
## 摘要

新增 `wiki/comparisons/gmr-vs-nmr-vs-reactor.md`，沉淀三种主流动作重定向方法的谱系对比。按「误差修补发生位置」（下游 / 离线 / 在线）为核心选型轴，通过一句话定义、12 维对比表、Mermaid 数据流图、适用场景与常见误判，帮助工程师在 GMR（运动学优化）/ NMR（学习式整段映射）/ ReActor（物理感知 RL 双层优化）间做出知情决策。同步更新相关概念、方法、形式化页面的关联链接与 V22 P1 检查清单。

## 变更类型

- [x] 知识入库（wiki 内容）
- [x] 维护脚本 / 文档

## 核心内容

### 新增页面：`wiki/comparisons/gmr-vs-nmr-vs-reactor.md`

**结构**：
1. **一句话定义表** — 三种方法的核心算法与论文来源
2. **12 维核心对比表** — 范式、输入、输出、物理一致性、接触处理、训练/推理成本、跨形态能力、噪声敏感性、核心假设、网络需求、产物形态
3. **Mermaid 数据流图** — 并排展示三条路线的「人体源动作 → 机器人参考 → 下游跟踪」流程，强调误差修补发生位置的差异
4. **适用场景** — 各方法的最佳应用场景与避坑指南
5. **常见误判** — 澄清「NMR 取代 GMR」「ReActor 比 NMR 更先进」等常见误解
6. **决策矩阵** — 按工程约束快速选型
7. **与其它对比页的区别** — 与 RL vs IL、MPC vs RL、Sim2Real 等页面的关系定位

**关键观点**：
- NMR 的 CEPR 管线显式以 GMR 输出为运动学初值，是**叠加增强**而非替代
- 三者在「误差修补位置」上形成连续谱，实际系统常**串联**使用而非二元对立
- 物理一致性是**仿真内**的，sim-to-real gap 仍需下游 WBC / RL tracking 补强

### 交叉更新

- `wiki/concepts/motion-retargeting.md` — 关联页面区块加入本对比页入口
- `wiki/concepts/motion-retargeting-pipeline.md` — 同上
- `wiki/formalizations/motion-retargeting-objective.md` — 同上
- `wiki/methods/motion-retargeting-gmr.md` — 同上
- `wiki/methods/neural-motion-retargeting-nmr.md` — 同上
- `wiki/methods/reactor-physics-aware-motion-retargeting.md` — 同上
- `index.md` — Wiki Comparisons 目录插入 GMR vs NMR vs ReActor 条目
- `docs/checklists/tech-stack-next-phase-checklist-v22.md` — P1 第 3 项（动作重定向知识链）标记完成，含实现摘要

## 验证

https://claude.ai/code/session_01AFBSzWdXp2AVDATsY2w4Qs