### PR TITLE
fix(ux): 修复 Mermaid 流程图点击放大预览 SVG 塌缩

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -655,6 +655,29 @@
     return mermaidLightboxEl;
   }
 
+  function cloneMermaidSvgForLightbox(svg) {
+    var clone = svg.cloneNode(true);
+    var rect = svg.getBoundingClientRect();
+    var w = rect.width;
+    var h = rect.height;
+    if (!(w > 0 && h > 0)) {
+      var vb = svg.viewBox && svg.viewBox.baseVal;
+      if (vb && vb.width > 0 && vb.height > 0) {
+        w = vb.width;
+        h = vb.height;
+      }
+    }
+    if (w > 0 && h > 0) {
+      clone.setAttribute('width', String(w));
+      clone.setAttribute('height', String(h));
+      clone.style.width = w + 'px';
+      clone.style.height = h + 'px';
+      clone.style.maxWidth = 'none';
+      clone.style.maxHeight = 'none';
+    }
+    return clone;
+  }
+
   function openMermaidLightbox(host) {
     var svg = host && host.querySelector('svg');
     if (!svg) return;
@@ -664,7 +687,7 @@
     body.innerHTML = '';
     var stage = document.createElement('div');
     stage.className = 'mermaid-lightbox-stage';
-    stage.appendChild(svg.cloneNode(true));
+    stage.appendChild(cloneMermaidSvgForLightbox(svg));
     body.appendChild(stage);
     resetMermaidLightboxView(stage);
     box.hidden = false;

--- a/docs/style.css
+++ b/docs/style.css
@@ -799,22 +799,23 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .mermaid-lightbox-panel {
   position: relative;
   z-index: 1;
+  width: min(96vw, 1400px);
   max-width: min(96vw, 1400px);
   max-height: 92vh;
   overflow: auto;
   margin: 0;
-  padding: 1rem 1.25rem 1.25rem;
+  padding: 2.75rem 1.25rem 1.25rem;
   border-radius: 14px;
   border: 1px solid var(--border);
   background: var(--surface-strong, var(--bg));
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.22);
 }
 .mermaid-lightbox-close {
-  position: sticky;
-  top: 0;
-  float: right;
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
   z-index: 2;
-  margin: 0 0 0.5rem 0.5rem;
+  margin: 0;
   width: 2rem;
   height: 2rem;
   border: 1px solid var(--border);
@@ -830,7 +831,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--accent);
 }
 .mermaid-lightbox-body {
-  clear: both;
   overflow: auto;
   touch-action: none;
   cursor: grab;

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -51,6 +51,7 @@ class DetailContentSyncTests(unittest.TestCase):
     def test_main_js_contains_mermaid_click_zoom_lightbox(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         expected_snippets = [
+            "function cloneMermaidSvgForLightbox(svg)",
             "function openMermaidLightbox(host)",
             "function bindMermaidZoom(container)",
             "function bindMermaidLightboxWheel(body)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复详情页 Mermaid 点击放大后流程图不可见（克隆 SVG 因 `width="100%"` 在无父容器宽度时塌缩为 0×0）
- 克隆时写入源图 `getBoundingClientRect()` 尺寸，并清除 `max-width: 100%` 约束
- 关闭按钮改为面板右上角绝对定位，避免与流程图区域重叠

## 根因
Mermaid 渲染的 SVG 常带 `width="100%"`。在正文 `.mermaid` 中有可用宽度，显示正常；放入 lightbox 的 `.mermaid-lightbox-stage` 后父级无宽度，百分比解析为 0，导致放大层几乎只剩关闭按钮。

## 验证
- `pytest tests/test_content_sync.py` 通过
- 浏览器实测：打开 `wiki-concepts-processor-in-the-loop-sim2real` 详情页，点击流程图后 lightbox 内 SVG 为 870×202px（修复前为 0×0）

## 验证截图
[PIL Sim2Real 详情页 Mermaid 放大预览](https://cursor.com/agents/bc-6b68395b-12ae-4145-a2f4-8dceda87da69/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmermaid-lightbox-fixed.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b68395b-12ae-4145-a2f4-8dceda87da69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b68395b-12ae-4145-a2f4-8dceda87da69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

