### PR TITLE
fix(ux): 详情页摘要宽度与主栏对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -381,7 +381,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   align-items: center;
   gap: .45rem;
 }
-.page-hero p { color: var(--text-muted); max-width: 76ch; font-size: .98rem; }
+.page-hero p:not(.detail-summary) { color: var(--text-muted); max-width: 76ch; font-size: .98rem; }
 /* 元信息卡片也在 .page-hero 内，勿继承 76ch：否则「互链枢纽」等说明行在宽卡片里提前换行 */
 .page-hero .detail-meta-list p {
   max-width: none;
@@ -426,7 +426,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 #roadmapSummary.detail-summary {
   line-height: 1.72;
   margin-top: 6px;
-  max-width: 92ch;
 }
 /* 阶段速览嵌在「正文」主标题下：与主栏大标题共用 #roadmap-content.section 顶距，侧栏 TOC 与之对齐 */
 .roadmap-content-section #roadmap-content #roadmap-flow.roadmap-flow-in-content {
@@ -469,9 +468,10 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   font-size: .88rem;
   color: var(--text-muted);
 }
+/* 与下方元信息卡 / 知识地图 / 正文主栏同宽（勿用 76ch 限宽） */
 .detail-summary {
   color: var(--text-muted);
-  max-width: 76ch;
+  max-width: none;
   font-size: .98rem;
 }
 .detail-meta-panel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页 / 路线页 / 模块页顶部的 `.detail-summary` 原先被 `max-width: 76ch`（路线页为 `92ch`）限制，摘要段落比下方「页面元信息」「知识地图」等主栏卡片窄约 230px。
- 取消摘要的 ch 限宽，使其与 `.container` 内主栏卡片同宽（100%）。

## 验证
- 本地 Puppeteer 测量：`#detailSummary` 与 `.detail-meta-panel` 宽度均为 912px，右缘对齐。
- `npm run lint:js` 通过（仅 CSS 改动）。

## 验证截图
[CAN 总线详情页：摘要与元信息卡同宽](https://cursor.com/agents/bc-9e365a4b-1613-4d26-b31f-5d173b630d56/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fwiki-concepts-can-bus-protocol.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e365a4b-1613-4d26-b31f-5d173b630d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e365a4b-1613-4d26-b31f-5d173b630d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

