### PR TITLE
feat(ux): Mermaid 灯箱顶部增加平移缩放操作提示

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -746,6 +746,7 @@
       '<div class="mermaid-lightbox-backdrop" data-mermaid-lightbox-dismiss tabindex="-1" aria-hidden="true"></div>',
       '<div class="mermaid-lightbox-panel" role="dialog" aria-modal="true" aria-label="流程图放大预览">',
       '  <button type="button" class="mermaid-lightbox-close" data-mermaid-lightbox-dismiss aria-label="关闭放大预览">×</button>',
+      '  <p class="mermaid-lightbox-hint">拖拽平移 · 滚轮/双指缩放 · Esc 关闭</p>',
       '  <div class="mermaid-lightbox-body" aria-live="polite"></div>',
       '</div>'
     ].join('');

--- a/docs/style.css
+++ b/docs/style.css
@@ -854,6 +854,14 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   border-color: var(--accent);
   color: var(--accent);
 }
+.mermaid-lightbox-hint {
+  margin: 0 0 0.5rem;
+  padding-right: 2rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+  flex-shrink: 0;
+}
 .mermaid-lightbox-body {
   flex: 1;
   min-height: 0;

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -64,6 +64,8 @@ class DetailContentSyncTests(unittest.TestCase):
             "mermaid-lightbox-stage",
             "mermaid-zoomable",
             "mermaid-lightbox",
+            "mermaid-lightbox-hint",
+            "拖拽平移 · 滚轮/双指缩放 · Esc 关闭",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 在 Mermaid 流程图点击放大后的灯箱面板顶部增加操作提示：`拖拽平移 · 滚轮/双指缩放 · Esc 关闭`
- 文案与交互说明对齐 [Humanoid_Robot_Learning_Paper_Notebooks](https://github.com/ImChong/Humanoid_Robot_Learning_Paper_Notebooks) 的 `mermaid-zoom.js` 实现

## 验证
- `make test` 通过（92 passed）
- 详情页 / roadmap 页点击任意 Mermaid 图，灯箱顶部应显示灰色小字提示

## 改动文件
- `docs/main.js`：灯箱 DOM 增加 `.mermaid-lightbox-hint`
- `docs/style.css`：提示样式（居中、0.8rem、`--text-muted`）
- `tests/test_content_sync.py`：同步断言
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49f131e9-9785-4e3d-a670-525b0c183a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f131e9-9785-4e3d-a670-525b0c183a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

