### PR TITLE
feat(ux): 提高 Mermaid 流程图渲染分辨率

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -469,20 +469,12 @@
       + '</div>';
   }
 
-  function renderDetailMermaid(container) {
-    if (!container || typeof window.mermaid === 'undefined') return Promise.resolve();
-    var nodes = Array.from(container.querySelectorAll('.mermaid'));
-    if (!nodes.length) return Promise.resolve();
-    nodes.forEach(function (node) {
-      var saved = node.getAttribute('data-mermaid-source');
-      if (saved === null) {
-        node.setAttribute('data-mermaid-source', node.textContent || '');
-      } else {
-        node.removeAttribute('data-processed');
-        node.textContent = saved;
-      }
-    });
-    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  var MERMAID_FONT_SIZE_PX = 18;
+  var MERMAID_LIGHTBOX_FONT_SCALE = 1.75;
+
+  function getMermaidThemeVariables(isDark, fontSizePx) {
+    var size = Math.max(12, Math.round(fontSizePx || MERMAID_FONT_SIZE_PX));
+    var fontSize = String(size) + 'px';
     var lightThemeVars = {
       primaryColor: '#ECE8F8',
       primaryTextColor: '#1a1a2e',
@@ -497,7 +489,7 @@
       edgeLabelBackground: '#FFFFFF',
       titleColor: '#1a1a2e',
       fontFamily: 'inherit',
-      fontSize: '15px'
+      fontSize: fontSize
     };
     var darkThemeVars = {
       primaryColor: '#0d0d0d',
@@ -513,14 +505,39 @@
       edgeLabelBackground: '#0d0d0d',
       titleColor: '#ffffff',
       fontFamily: 'inherit',
-      fontSize: '15px'
+      fontSize: fontSize
     };
+    return isDark ? darkThemeVars : lightThemeVars;
+  }
+
+  function initializeMermaidRenderer(fontSizePx) {
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
     window.mermaid.initialize({
       startOnLoad: false,
       theme: 'base',
-      themeVariables: isDark ? darkThemeVars : lightThemeVars,
-      securityLevel: 'strict'
+      themeVariables: getMermaidThemeVariables(isDark, fontSizePx),
+      securityLevel: 'strict',
+      flowchart: {
+        useMaxWidth: false,
+        htmlLabels: false
+      }
     });
+  }
+
+  function renderDetailMermaid(container) {
+    if (!container || typeof window.mermaid === 'undefined') return Promise.resolve();
+    var nodes = Array.from(container.querySelectorAll('.mermaid'));
+    if (!nodes.length) return Promise.resolve();
+    nodes.forEach(function (node) {
+      var saved = node.getAttribute('data-mermaid-source');
+      if (saved === null) {
+        node.setAttribute('data-mermaid-source', node.textContent || '');
+      } else {
+        node.removeAttribute('data-processed');
+        node.textContent = saved;
+      }
+    });
+    initializeMermaidRenderer(MERMAID_FONT_SIZE_PX);
     return window.mermaid.run({ nodes: nodes }).catch(function () {}).then(function () {
       enhanceMermaidZoomTargets(container);
       bindMermaidZoom(container);
@@ -763,17 +780,32 @@
     return mermaidLightboxEl;
   }
 
+  function getMermaidSvgLayoutSize(svg) {
+    if (!svg) return { w: 0, h: 0 };
+    var vb = svg.viewBox && svg.viewBox.baseVal;
+    if (vb && vb.width > 0 && vb.height > 0) {
+      return { w: vb.width, h: vb.height };
+    }
+    var rawW = svg.getAttribute('width');
+    var rawH = svg.getAttribute('height');
+    var attrW = parseFloat(rawW);
+    var attrH = parseFloat(rawH);
+    if (attrW > 0 && attrH > 0 && String(rawW || '').indexOf('%') < 0) {
+      return { w: attrW, h: attrH };
+    }
+    var rect = svg.getBoundingClientRect();
+    return { w: rect.width, h: rect.height };
+  }
+
   function cloneMermaidSvgForLightbox(svg) {
     var clone = svg.cloneNode(true);
-    var rect = svg.getBoundingClientRect();
-    var w = rect.width;
-    var h = rect.height;
+    var layout = getMermaidSvgLayoutSize(svg);
+    var w = layout.w;
+    var h = layout.h;
     if (!(w > 0 && h > 0)) {
-      var vb = svg.viewBox && svg.viewBox.baseVal;
-      if (vb && vb.width > 0 && vb.height > 0) {
-        w = vb.width;
-        h = vb.height;
-      }
+      var rect = svg.getBoundingClientRect();
+      w = rect.width;
+      h = rect.height;
     }
     if (w > 0 && h > 0) {
       clone.setAttribute('width', String(w));
@@ -786,24 +818,64 @@
     return clone;
   }
 
-  function openMermaidLightbox(host) {
-    var svg = host && host.querySelector('svg');
-    if (!svg) return;
-    var box = ensureMermaidLightbox();
-    var body = box.querySelector('.mermaid-lightbox-body');
-    if (!body) return;
+  function renderMermaidSvgForLightbox(host) {
+    if (!host || typeof window.mermaid === 'undefined') return Promise.resolve(null);
+    var source = host.getAttribute('data-mermaid-source');
+    var inlineSvg = host.querySelector('svg');
+    if (!source || !String(source).trim()) {
+      return Promise.resolve(inlineSvg ? cloneMermaidSvgForLightbox(inlineSvg) : null);
+    }
+    var sandbox = document.createElement('div');
+    sandbox.setAttribute('aria-hidden', 'true');
+    sandbox.style.cssText = 'position:fixed;left:-10000px;top:0;visibility:hidden;pointer-events:none;width:max-content;max-width:none;';
+    var node = document.createElement('div');
+    node.className = 'mermaid';
+    node.textContent = source;
+    sandbox.appendChild(node);
+    document.body.appendChild(sandbox);
+    var hiFontPx = Math.round(MERMAID_FONT_SIZE_PX * MERMAID_LIGHTBOX_FONT_SCALE);
+    initializeMermaidRenderer(hiFontPx);
+    return window.mermaid.run({ nodes: [node] }).catch(function () {}).then(function () {
+      var hiSvg = node.querySelector('svg');
+      if (sandbox.parentNode) document.body.removeChild(sandbox);
+      initializeMermaidRenderer(MERMAID_FONT_SIZE_PX);
+      if (hiSvg) return cloneMermaidSvgForLightbox(hiSvg);
+      return inlineSvg ? cloneMermaidSvgForLightbox(inlineSvg) : null;
+    });
+  }
+
+  function mountMermaidLightboxSvg(stage, body, svgClone) {
+    if (!stage || !body || !svgClone) return;
     body.innerHTML = '';
-    var stage = document.createElement('div');
-    stage.className = 'mermaid-lightbox-stage';
-    stage.appendChild(cloneMermaidSvgForLightbox(svg));
+    stage.innerHTML = '';
+    stage.appendChild(svgClone);
     body.appendChild(stage);
-    box.hidden = false;
-    box.setAttribute('aria-hidden', 'false');
-    document.body.classList.add('mermaid-lightbox-open');
     requestAnimationFrame(function () {
       requestAnimationFrame(function () {
         fitMermaidLightboxToView(stage, body);
       });
+    });
+  }
+
+  function openMermaidLightbox(host) {
+    if (!host) return;
+    var box = ensureMermaidLightbox();
+    var body = box.querySelector('.mermaid-lightbox-body');
+    if (!body) return;
+    var stage = document.createElement('div');
+    stage.className = 'mermaid-lightbox-stage';
+    body.innerHTML = '';
+    body.appendChild(stage);
+    box.hidden = false;
+    box.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('mermaid-lightbox-open');
+    renderMermaidSvgForLightbox(host).then(function (svgClone) {
+      if (!box || box.hidden) return;
+      if (!svgClone) {
+        closeMermaidLightbox();
+        return;
+      }
+      mountMermaidLightboxSvg(stage, body, svgClone);
     });
     var closeBtn = box.querySelector('.mermaid-lightbox-close');
     if (closeBtn) closeBtn.focus();

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -51,6 +51,12 @@ class DetailContentSyncTests(unittest.TestCase):
     def test_main_js_contains_mermaid_click_zoom_lightbox(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         expected_snippets = [
+            "MERMAID_FONT_SIZE_PX",
+            "MERMAID_LIGHTBOX_FONT_SCALE",
+            "function getMermaidSvgLayoutSize(svg)",
+            "function renderMermaidSvgForLightbox(host)",
+            "flowchart: {",
+            "useMaxWidth: false",
             "function fitMermaidLightboxToView(stage, body)",
             "function cloneMermaidSvgForLightbox(svg)",
             "function openMermaidLightbox(host)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页 / 路线图正文中的 Mermaid 流程图默认字号由 15px 提升至 **18px**，并关闭 `flowchart.useMaxWidth`，避免按栏宽压缩 SVG 矢量细节；页面内仍通过 `max-width: 100%` 自适应栏宽。
- 点击灯箱放大时，使用源码 **离屏按 1.75× 字号重绘**（约 32px），再克隆高分辨率 SVG，滚轮/双指放大时文字与连线更清晰。
- 克隆 SVG 时优先读取 **viewBox 固有尺寸**，避免沿用页面内 CSS 缩放后的低像素布局尺寸。

## 验证
- `make test` 通过（92 passed）
- 静态站详情页（BFM 流程图页）渲染正常

## 验证截图
[BFM 详情页 Mermaid 流程图](https://cursor.com/agents/bc-bdf3ec51-6f72-49ea-896d-84f106e334bb/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmermaid-hi-res.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf3ec51-6f72-49ea-896d-84f106e334bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf3ec51-6f72-49ea-896d-84f106e334bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

