### PR TITLE
fix(ux): 默认深色主题，消除首屏白闪

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,6 +11,8 @@
   <meta property="og:type" content="website" />
   <title>Robotics Notebooks | 通用详情页</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧩</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
 </head>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Robotics Notebooks 知识图谱 — 75 个概念节点、429 条关联边、8 个社区的力导向可视化" />
   <title>知识图谱 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕸️</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── 图谱页专用样式（不影响其他页面）── */
@@ -719,7 +721,7 @@
     [data-theme="light"] #graph-sidebar .sb-header { border-bottom-color: rgba(0,0,0,0.08); }
   </style>
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#3b82f6" />
+  <meta name="theme-color" content="#1c1c1e" />
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="dark light" />
   <meta name="description" content="Robotics Notebooks - 面向机器人学习与工程实践的技术栈导航，系统梳理运动控制、强化学习、模仿学习、人形机器人与相关技术主线。" />
   <meta name="keywords" content="Robotics Notebooks, 机器人技术栈, Humanoid Robot, Motion Control, Reinforcement Learning, Imitation Learning, Whole-Body Control" />
   <meta name="author" content="Chong Liu" />
@@ -11,9 +12,10 @@
   <meta property="og:type" content="website" />
   <title>Robotics Notebooks | 机器人技术栈地图</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗺️</text></svg>" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#3b82f6" />
+  <meta name="theme-color" content="#1c1c1e" />
 </head>
 <body>
   <header class="site-header">

--- a/docs/main.js
+++ b/docs/main.js
@@ -3,8 +3,7 @@
   const themeToggle = document.getElementById('themeToggle');
   const key = 'robotics-notebooks-theme';
   const saved = localStorage.getItem(key);
-  const preferDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const dark = saved ? saved === 'dark' : preferDark;
+  const dark = saved ? saved === 'dark' : true;
   root.setAttribute('data-theme', dark ? 'dark' : 'light');
 
   function updateThemeToggle() {

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,7 +6,7 @@
   "scope": "/Robotics_Notebooks/",
   "display": "standalone",
   "background_color": "#0f172a",
-  "theme_color": "#3b82f6",
+  "theme_color": "#1c1c1e",
   "lang": "zh-CN",
   "icons": [
     {

--- a/docs/module.html
+++ b/docs/module.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,6 +11,8 @@
   <meta property="og:type" content="website" />
   <title>Robotics Notebooks | 模块页</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧱</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/docs/modules/imitation-learning.html
+++ b/docs/modules/imitation-learning.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>机器人模仿学习总览 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎭</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/modules/motion-control.html
+++ b/docs/modules/motion-control.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>运动控制总览 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦿</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/modules/reinforcement-learning.html
+++ b/docs/modules/reinforcement-learning.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>机器人强化学习总览 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/references.html
+++ b/docs/references.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,6 +7,8 @@
   <title>论文导航 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📚</text></svg>" />
   <meta http-equiv="refresh" content="0; url=roadmap.html?id=roadmap-motion-control" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/docs/relations/retargeting-pipeline.html
+++ b/docs/relations/retargeting-pipeline.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Motion Retargeting Pipeline | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕺</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/rl-vs-il.html
+++ b/docs/relations/rl-vs-il.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>RL vs IL | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧪</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/sim2real-pipeline.html
+++ b/docs/relations/sim2real-pipeline.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sim2Real Pipeline | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌉</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/wbc-vs-rl.html
+++ b/docs/relations/wbc-vs-rl.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>WBC vs RL | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚖️</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="../theme-init.js"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,6 +11,8 @@
   <meta property="og:type" content="website" />
   <title>Robotics Notebooks | 技术路线指南</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
 </head>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,31 @@
 :root {
+  color-scheme: dark;
+  /* Dark Mode（默认）：柔和深灰 + 淡蓝点缀 */
+  --bg: #1c1c1e;
+  --bg-alt: #2c2c2e;
+  --surface: rgba(44, 44, 46, 0.85);
+  --surface-strong: #2c2c2e;
+  --border: #3a3a3c;
+  --border-strong: #6e6e73;
+  --text: #f5f5f7;
+  --text-muted: #9b9ba0;
+  --accent: #5ea0eb;
+  --accent-hover: #7fb6f0;
+  --quote-bg: rgba(94, 160, 235, 0.08);
+  --header-bg: rgba(28, 28, 30, 0.85);
+  --header-border: rgba(255, 255, 255, 0.08);
+  --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 8px 30px rgba(0, 0, 0, 0.08);
+  --radius: 12px;
+  --header-h: 58px;
+  /* 与 https://imchong.github.io/ 主栏 (.container / .header-inner) 一致 */
+  --content-max-width: 960px;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
+  --transition: 0.3s ease;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
   /* Light Mode (imchong.github.io style + warm quote block) */
   --bg: #ffffff;
   --bg-alt: #f5f5f7;
@@ -13,31 +40,6 @@
   --quote-bg: #fef7f5;
   --header-bg: rgba(255, 255, 255, 0.8);
   --header-border: rgba(0, 0, 0, 0.1);
-  --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 8px 30px rgba(0, 0, 0, 0.08);
-  --radius: 12px;
-  --header-h: 58px;
-  /* 与 https://imchong.github.io/ 主栏 (.container / .header-inner) 一致 */
-  --content-max-width: 960px;
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
-  --transition: 0.3s ease;
-}
-
-[data-theme="dark"] {
-  /* Dark Mode (Humanoid Paper Notebooks 风格：柔和深灰 + 淡蓝点缀) */
-  --bg: #1c1c1e;
-  --bg-alt: #2c2c2e;
-  --surface: rgba(44, 44, 46, 0.85);
-  --surface-strong: #2c2c2e;
-  --border: #3a3a3c;
-  --border-strong: #6e6e73;
-  --text: #f5f5f7;
-  --text-muted: #9b9ba0;
-  --accent: #5ea0eb;
-  --accent-hover: #7fb6f0;
-  --quote-bg: rgba(94, 160, 235, 0.08);
-  --header-bg: rgba(28, 28, 30, 0.85);
-  --header-border: rgba(255, 255, 255, 0.08);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -136,10 +138,10 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   border-color: var(--accent);
   color: var(--accent);
 }
-.icon-sun { display: none; }
-.icon-moon { display: inline; }
-[data-theme="dark"] .icon-sun { display: inline; }
-[data-theme="dark"] .icon-moon { display: none; }
+.icon-sun { display: inline; }
+.icon-moon { display: none; }
+[data-theme="light"] .icon-sun { display: none; }
+[data-theme="light"] .icon-moon { display: inline; }
 
 .hero { padding: 40px 0 40px; }
 .hero-kicker {
@@ -325,7 +327,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
 }
-[data-theme="dark"] .section-alt {
+:root:not([data-theme="light"]) .section-alt {
   background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0)), var(--bg-alt);
 }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
@@ -338,7 +340,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
   background: linear-gradient(180deg, rgba(255,255,255,.76), rgba(255,255,255,.92));
 }
-[data-theme="dark"] .card {
+:root:not([data-theme="light"]) .card {
   background: linear-gradient(180deg, rgba(56,56,56,.75), rgba(39,39,39,.94));
 }
 .card:hover {
@@ -367,7 +369,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   padding: 18px 20px;
   background: linear-gradient(180deg, rgba(255,255,255,.8), rgba(255,255,255,.94));
 }
-[data-theme="dark"] .simple-card {
+:root:not([data-theme="light"]) .simple-card {
   background: linear-gradient(180deg, rgba(58,58,58,.7), rgba(39,39,39,.94));
 }
 .simple-card ul { margin-top: 8px; padding-left: 18px; }
@@ -978,7 +980,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   line-height: 1.55;
   white-space: pre;
 }
-[data-theme="dark"] .detail-markdown-body .detail-code-block {
+:root:not([data-theme="light"]) .detail-markdown-body .detail-code-block {
   border-color: #3c3c3c;
   background: #1e1e1e;
 }
@@ -1000,7 +1002,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   background: #ffffff;
   user-select: none;
 }
-[data-theme="dark"] .detail-markdown-body .code-ln {
+:root:not([data-theme="light"]) .detail-markdown-body .code-ln {
   color: #6e7681;
   background: #1e1e1e;
 }
@@ -1021,17 +1023,17 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .detail-markdown-body .tok-punctuation,
 .detail-markdown-body .tok-name { color: #24292f; }
 .detail-markdown-body .tok-attr { color: #116329; }
-[data-theme="dark"] .detail-markdown-body .tok-comment { color: #6272a4; }
-[data-theme="dark"] .detail-markdown-body .tok-keyword,
-[data-theme="dark"] .detail-markdown-body .tok-operator { color: #ff79c6; }
-[data-theme="dark"] .detail-markdown-body .tok-builtin,
-[data-theme="dark"] .detail-markdown-body .tok-class { color: #bd93f9; }
-[data-theme="dark"] .detail-markdown-body .tok-function { color: #50fa7b; }
-[data-theme="dark"] .detail-markdown-body .tok-string { color: #f1fa8c; }
-[data-theme="dark"] .detail-markdown-body .tok-number { color: #bd93f9; }
-[data-theme="dark"] .detail-markdown-body .tok-punctuation,
-[data-theme="dark"] .detail-markdown-body .tok-name { color: #f8f8f2; }
-[data-theme="dark"] .detail-markdown-body .tok-attr { color: #8be9fd; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-comment { color: #6272a4; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-keyword,
+:root:not([data-theme="light"]) .detail-markdown-body .tok-operator { color: #ff79c6; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-builtin,
+:root:not([data-theme="light"]) .detail-markdown-body .tok-class { color: #bd93f9; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-function { color: #50fa7b; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-string { color: #f1fa8c; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-number { color: #bd93f9; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-punctuation,
+:root:not([data-theme="light"]) .detail-markdown-body .tok-name { color: #f8f8f2; }
+:root:not([data-theme="light"]) .detail-markdown-body .tok-attr { color: #8be9fd; }
 .detail-markdown-body blockquote {
   margin-left: 0;
   padding: .8em 1em .8em 1.2em;
@@ -1070,17 +1072,17 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .detail-markdown-body .math-block .katex * {
   color: var(--text);
 }
-[data-theme="dark"] .detail-markdown-body .math-inline {
+:root:not([data-theme="light"]) .detail-markdown-body .math-inline {
   background: rgba(105,163,255,.12);
   border-color: rgba(105,163,255,.28);
 }
-[data-theme="dark"] .detail-markdown-body .math-block {
+:root:not([data-theme="light"]) .detail-markdown-body .math-block {
   background: rgba(105,163,255,.06);
 }
-[data-theme="dark"] .detail-toc-list a.active,
-[data-theme="dark"] .heading-anchor-link:hover,
-[data-theme="dark"] .heading-anchor-link:focus-visible,
-[data-theme="dark"] .heading-anchor-link.copied {
+:root:not([data-theme="light"]) .detail-toc-list a.active,
+:root:not([data-theme="light"]) .heading-anchor-link:hover,
+:root:not([data-theme="light"]) .heading-anchor-link:focus-visible,
+:root:not([data-theme="light"]) .heading-anchor-link.copied {
   background: rgba(105,163,255,.14);
 }
 .tech-map-group {

--- a/docs/tech-map.html
+++ b/docs/tech-map.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN"> 
+<html lang="zh-CN" data-theme="dark"> 
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,6 +11,8 @@
   <meta property="og:type" content="website" />
   <title>技术栈地图 | Robotics Notebooks</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧭</text></svg>" />
+  <meta name="color-scheme" content="dark light" />
+  <script src="theme-init.js"></script>
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── 筛选浮窗（参照 physics-panel）── */

--- a/docs/theme-init.js
+++ b/docs/theme-init.js
@@ -1,0 +1,6 @@
+(function () {
+  var key = 'robotics-notebooks-theme';
+  var saved = localStorage.getItem(key);
+  var dark = saved ? saved === 'dark' : true;
+  document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 站点默认使用深色主题（黑夜模式），不再在未保存偏好时跟随系统 `prefers-color-scheme` 落到浅色。
- 新增 `docs/theme-init.js`，在各页 `style.css` 之前同步执行，根据 `localStorage` 设置 `data-theme`，避免先渲染白底再切换。
- `style.css` 将深色变量放到 `:root`，浅色改由 `[data-theme="light"]` 覆盖；浏览器 UI 的 `theme-color` / `color-scheme` 与深色默认对齐。

## 验证
- `make test` 通过（95 passed）
- `make ci-preflight` 通过

## 行为说明
- 用户曾手动选择「白天模式」时，仍会在首屏前恢复为浅色（`localStorage` 键 `robotics-notebooks-theme=light`）。
- 首次访问或未保存偏好时，首屏即为深色，无白→黑闪烁。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1272b998-28dc-4c8d-96a5-51811214cd6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1272b998-28dc-4c8d-96a5-51811214cd6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

