### PR TITLE
fix(ux): Mermaid 放大预览提示与关闭按钮垂直齐平

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -810,7 +810,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   max-height: 88vh;
   overflow: hidden;
   margin: 0;
-  padding: 2.75rem 1rem 1rem;
+  padding: 3.25rem 1rem 1rem;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -857,12 +857,22 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--accent);
 }
 .mermaid-lightbox-hint {
-  margin: 0 0 0.5rem;
-  padding-right: 2rem;
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  z-index: 1;
+  margin: 0;
+  padding: 0 2.5rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 0.8rem;
   color: var(--text-muted);
   text-align: center;
   flex-shrink: 0;
+  pointer-events: none;
 }
 .mermaid-lightbox-body {
   flex: 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将 Mermaid 流程图放大预览顶栏中的操作提示「拖拽平移 · 滚轮/双指缩放 · Esc 关闭」与右上角关闭按钮对齐到同一水平行（`top: 0.75rem`、`height: 2rem`），避免提示文字相对按钮下沉。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_content_sync.py`（内容同步片段检查通过）
- [ ] `make ci-preflight`（N/A，仅 CSS，未改 wiki/导出链）

## 实现说明

- `.mermaid-lightbox-hint` 改为与 `.mermaid-lightbox-close` 相同的绝对定位顶栏区域，使用 `display: flex; align-items: center` 垂直居中。
- 面板 `padding-top` 由 `2.75rem` 调整为 `3.25rem`，为绝对定位的顶栏留出与内容区的间距。

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2745e314-6f38-4d43-89f9-4f999140b329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2745e314-6f38-4d43-89f9-4f999140b329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

