### PR TITLE
fix(ux): 图谱物理参数面板磁吸模式复选框与文字同行

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -382,6 +382,8 @@
     [data-theme="light"] .physics-close { color: rgba(0,0,0,0.3); }
     [data-theme="light"] .physics-close:hover { color: rgba(0,0,0,0.72); }
     [data-theme="light"] .slider-label { color: rgba(0,0,0,0.45); }
+    [data-theme="light"] .physics-toggle { color: rgba(0,0,0,0.45); }
+    [data-theme="light"] .physics-toggle input[type=checkbox] { accent-color: #1659b4; }
     [data-theme="light"] .slider-divider { background: rgba(0,0,0,0.06); }
     [data-theme="light"] input[type=range] { background: rgba(0,0,0,0.1); }
     /* 提示文字 */
@@ -501,6 +503,17 @@
     .slider-divider {
       height: 1px; background: rgba(255,255,255,0.05);
       margin: 0 14px;
+    }
+    .physics-toggle {
+      display: flex; align-items: center; gap: 9px;
+      font-size: .74rem; color: rgba(255,255,255,0.4);
+      cursor: pointer; user-select: none;
+    }
+    .physics-toggle input[type=checkbox] {
+      width: 18px; height: 18px;
+      accent-color: #60a5fa;
+      cursor: pointer;
+      flex-shrink: 0;
     }
 
     /* ── 筛选按钮计数徽章 ── */
@@ -827,9 +840,11 @@
 
       <div class="slider-divider"></div>
 
-      <div class="slider-row" style="flex-direction:row; justify-content:space-between; align-items:center;">
-        <span class="slider-label" style="margin-bottom:0">🧲 磁吸模式</span>
-        <input type="checkbox" id="check-magnetic" style="width:18px; height:18px; cursor:pointer;" />
+      <div class="slider-row">
+        <label class="physics-toggle" for="check-magnetic">
+          <input type="checkbox" id="check-magnetic" />
+          <span>🧲 磁吸模式</span>
+        </label>
       </div>
     </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 `docs/graph.html` 物理参数面板中「磁吸模式」复选框换行显示的问题：复选框与「🧲 磁吸模式」文字同一行，且复选框在文字左侧。
- 采用与筛选面板一致的 `<label>` + flex 行布局（`.physics-toggle`），移除无效的 inline flex 与 `.slider-label` 误用。

## 验证
- 本地 `http://127.0.0.1:8765/graph.html` 打开参数面板，磁吸模式行布局正确。
- 本改动仅涉及静态 HTML/CSS，未改 wiki 导出链路；无需 `make ci-preflight`。

## 验证截图
[物理参数面板：磁吸模式复选框与文字同一行且在前](https://cursor.com/agents/bc-a5b1871c-3f76-490f-9aa3-5ce473d6e01f/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-magnetic-checkbox.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5b1871c-3f76-490f-9aa3-5ce473d6e01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5b1871c-3f76-490f-9aa3-5ce473d6e01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

