### PR TITLE
fix(ux): 详情页表格支持横向滚动并保持自然列宽

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1394,39 +1394,62 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   font-weight: 400;
 }
 
-/* Tables */
-.table-wrapper {
+/* Tables — align with Humanoid paper notes: scroll inside wrapper, natural column width */
+.detail-markdown-body .table-wrapper {
+  width: 100%;
+  max-width: 100%;
   overflow-x: auto;
   margin: 1.5rem 0;
   border-radius: 8px;
   border: 1px solid var(--border);
   background: var(--surface-strong);
+  -webkit-overflow-scrolling: touch;
+  contain: inline-size;
 }
-table {
-  width: 100%;
+.detail-markdown-body .table-wrapper table {
+  width: max-content;
+  min-width: 100%;
+  max-width: none;
   border-collapse: collapse;
   font-size: 0.95rem;
+  table-layout: auto;
 }
-th, td {
+.detail-markdown-body .table-wrapper th,
+.detail-markdown-body .table-wrapper td {
   border-bottom: 1px solid var(--border);
   padding: 10px 14px;
   text-align: left;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
-th:not(:last-child), td:not(:last-child) {
+.detail-markdown-body .table-wrapper th:not(:last-child),
+.detail-markdown-body .table-wrapper td:not(:last-child) {
   border-right: 1px solid var(--border);
 }
-th {
+.detail-markdown-body .table-wrapper th {
   background: var(--bg-alt);
   font-weight: 600;
+}
+/* Inline code in tables: keep tokens on one line; wrapper scroll handles overflow */
+.detail-markdown-body .table-wrapper th code,
+.detail-markdown-body .table-wrapper td code {
+  white-space: nowrap;
+}
+/* Key–value tables (e.g. 基本信息): short labels stay on one line when possible */
+.detail-markdown-body .table-wrapper th:first-child,
+.detail-markdown-body .table-wrapper td:first-child {
+  white-space: nowrap;
+  overflow-wrap: normal;
+  word-break: normal;
 }
 
 /* Horizontal scroll hint for tables */
 @media (max-width: 768px) {
-  .table-wrapper {
+  .detail-markdown-body .table-wrapper {
     position: relative;
     padding-bottom: 1.5rem;
   }
-  .table-wrapper::after {
+  .detail-markdown-body .table-wrapper::after {
     content: '↔ 左右滑动查看更多';
     position: absolute;
     bottom: 0.2rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页与路线页（`detail-markdown-body`）内的 Markdown 表格此前使用 `table { width: 100% }`，宽表会被强行压进主栏（960px），列宽过窄、文字竖排成「一长列」，可读性差。

本次对齐 [Humanoid 论文笔记 DeepMimic 页](https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/01_Foundational_RL/DeepMimic_Example-Guided_Deep_RL_of_Physics-Based_Character_Skills/DeepMimic_Example-Guided_Deep_RL_of_Physics-Based_Character_Skills.html) 的表格策略：

- `.table-wrapper`：`overflow-x: auto` + `contain: inline-size`，在容器内横向滑动
- `table`：`width: max-content; min-width: 100%`，按内容自然列宽，窄表仍铺满容器
- 单元格：`word-break: normal`；表内 `code` 与首列标签 `nowrap`，避免无意义断行

## 验证

- 仅改 `docs/style.css`，未动 wiki / 导出链路
- 本地静态站对比页截图（含宽表）

## 验证截图

[对比页表格横向滚动样式](https://cursor.com/agents/bc-2b129b39-178e-4b8d-af2c-f880649ddfa4/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Ftable-scroll.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b129b39-178e-4b8d-af2c-f880649ddfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b129b39-178e-4b8d-af2c-f880649ddfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

