### PR TITLE
fix(ux): PC 端首页搜索框社区筛选下拉固定为 1/3 宽度

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1316,35 +1316,15 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   .cta-row a { width: 100%; }
   .page-hero h1 { font-size: 2rem; }
   .container { padding: 0 18px; }
-  /* 首页 Wiki 搜索：移动端下拉约占整条搜索栏宽度的 1/3，过长文案省略 */
-  .search-bar-wrap {
-    min-width: 0;
-  }
+  /* 首页 Wiki 搜索：移动端收紧内边距与字号 */
   .search-bar-wrap input[type="search"] {
-    flex: 1 1 0;
-    min-width: 0;
     padding: 12px 12px;
     font-size: 1rem;
   }
   #wikiCommunityFilter {
-    flex: 0 0 33.333%;
-    width: 33.333%;
-    max-width: 33.333%;
-    min-width: 0;
-    box-sizing: border-box;
     padding: 10px 8px;
     font-size: 0.78rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    /* 去掉系统外观后，选中项文字才能稳定被裁切并显示省略号（WebKit / 部分 Android） */
-    -webkit-appearance: none;
-    appearance: none;
-    background-color: var(--bg);
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%2364748b' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
     background-position: right 6px center;
-    background-size: 12px;
     padding-right: 22px;
   }
 }
@@ -1358,9 +1338,11 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   border-radius: 14px;
   padding: 6px;
   margin-bottom: 32px;
+  min-width: 0;
 }
 .search-bar-wrap input[type="search"] {
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
   border: none;
   background: transparent;
   padding: 12px 18px;
@@ -1368,15 +1350,32 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--text);
   outline: none;
 }
+/* 社区筛选下拉约占整条搜索栏宽度的 1/3，过长文案省略 */
 #wikiCommunityFilter {
+  flex: 0 0 33.333%;
+  width: 33.333%;
+  max-width: 33.333%;
+  min-width: 0;
+  box-sizing: border-box;
   border: none;
-  background: var(--bg);
   border-radius: 10px;
   padding: 10px 14px;
+  padding-right: 28px;
   font-size: 0.9rem;
   color: var(--text);
   cursor: pointer;
   font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* 去掉系统外观后，选中项文字才能稳定被裁切并显示省略号（WebKit / 部分 Android） */
+  -webkit-appearance: none;
+  appearance: none;
+  background-color: var(--bg);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%2364748b' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px;
 }
 .ingest-badge {
   display: inline-block;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 将首页 `#wikiCommunityFilter` 的 **1/3 宽度** 与 **过长文案省略号** 样式从仅移动端（`max-width: 860px`）提升到全局基础样式，PC 端与移动端表现一致。
- 搜索输入框使用 `flex: 1 1 0` + `min-width: 0`，避免 flex 子项撑破布局导致下拉无法稳定占 1/3。
- 移动端媒体查询仅保留更紧凑的内边距与字号覆盖，避免重复声明。

## 验证

- 仅改动 `docs/style.css`，未涉及 wiki / 派生导出，无需 `make ci-preflight`。
- 本地 `http://127.0.0.1:8765/index.html`（1440×900）headless 截图确认搜索栏布局。

## 验证截图

[PC 端首页搜索框：社区筛选约占 1/3 宽度](https://cursor.com/agents/bc-a364e019-4113-4749-a635-ed170382a3e8/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fhome-search-filter-pc.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a364e019-4113-4749-a635-ed170382a3e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a364e019-4113-4749-a635-ed170382a3e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

