### PR TITLE
fix(ux): 调小 Mermaid 节点字号并增加内边距，改善裁切

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -54,6 +54,7 @@
 - [x] 首页搜索索引修复：将 `tech-map/`、roadmap 与 references 纳入 `search-index.json`，支持搜索 `tech-map`。
 - [x] 技术路线页 `roadmap.html`：基于导出阶段数据渲染可折叠阶段树（垂直 `<details>` 列表）；已移除折叠 Mermaid 线框总图与路线页内 Mermaid CDN。
 - [x] 技术路线页 `roadmap.html`：favicon、顶栏统一为 🚀（与首页「技术路线指南」CTA 一致）；主题切换仍为 ☀️/🌙。
+- [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
 ---
 
 ## 验收标准 (DoD)

--- a/docs/main.js
+++ b/docs/main.js
@@ -514,11 +514,20 @@
       + '</div>';
   }
 
-  var MERMAID_FONT_SIZE_PX = 18;
+  var MERMAID_FONT_SIZE_PX = 14;
+  var MERMAID_FONT_SIZE_MOBILE_PX = 12;
   var MERMAID_LIGHTBOX_FONT_SCALE = 1.75;
 
+  function getMermaidFontSizePx() {
+    if (typeof window !== 'undefined' && window.matchMedia
+      && window.matchMedia('(max-width: 640px)').matches) {
+      return MERMAID_FONT_SIZE_MOBILE_PX;
+    }
+    return MERMAID_FONT_SIZE_PX;
+  }
+
   function getMermaidThemeVariables(isDark, fontSizePx) {
-    var size = Math.max(12, Math.round(fontSizePx || MERMAID_FONT_SIZE_PX));
+    var size = Math.max(11, Math.round(fontSizePx || getMermaidFontSizePx()));
     var fontSize = String(size) + 'px';
     var lightThemeVars = {
       primaryColor: '#ECE8F8',
@@ -564,7 +573,11 @@
       securityLevel: 'strict',
       flowchart: {
         useMaxWidth: false,
-        htmlLabels: false
+        htmlLabels: false,
+        padding: 18,
+        nodeSpacing: 42,
+        rankSpacing: 48,
+        wrappingWidth: 150
       }
     });
   }
@@ -582,7 +595,7 @@
         node.textContent = saved;
       }
     });
-    initializeMermaidRenderer(MERMAID_FONT_SIZE_PX);
+    initializeMermaidRenderer(getMermaidFontSizePx());
     return window.mermaid.run({ nodes: nodes }).catch(function () {}).then(function () {
       enhanceMermaidZoomTargets(container);
       bindMermaidZoom(container);
@@ -878,12 +891,12 @@
     node.textContent = source;
     sandbox.appendChild(node);
     document.body.appendChild(sandbox);
-    var hiFontPx = Math.round(MERMAID_FONT_SIZE_PX * MERMAID_LIGHTBOX_FONT_SCALE);
+    var hiFontPx = Math.round(getMermaidFontSizePx() * MERMAID_LIGHTBOX_FONT_SCALE);
     initializeMermaidRenderer(hiFontPx);
     return window.mermaid.run({ nodes: [node] }).catch(function () {}).then(function () {
       var hiSvg = node.querySelector('svg');
       if (sandbox.parentNode) document.body.removeChild(sandbox);
-      initializeMermaidRenderer(MERMAID_FONT_SIZE_PX);
+      initializeMermaidRenderer(getMermaidFontSizePx());
       if (hiSvg) return cloneMermaidSvgForLightbox(hiSvg);
       return inlineSvg ? cloneMermaidSvgForLightbox(inlineSvg) : null;
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页 Mermaid 正文渲染字号由 **18px 下调为 14px**（视口 ≤640px 时为 **12px**），在保持矢量清晰度的前提下减轻节点内文字过大、贴边或与边框重叠的问题。
- 增加 `flowchart` 的 `padding`、`nodeSpacing`、`rankSpacing` 与 `wrappingWidth`，让多行中文标签更易换行、完整显示。
- 灯箱高清预览仍按 **1.75×** 离屏重绘，放大查看时清晰度不变。

## 背景
近期为提升分辨率将字号从 15px 提到 18px（`d28ef93`），在移动端窄屏下出现「对比学习」等标签顶到边框、单行显示不全等现象（如 GenCAD-3D 流程图）。

## 验证
- `pytest tests/test_content_sync.py::DetailContentSyncTests::test_main_js_contains_mermaid_click_zoom_lightbox` 通过
- 本地 headless 截图 `entity-gencad-3d` 详情页 Mermaid 区块

## 验证截图
[GenCAD-3D 详情页 Mermaid 渲染（调小字号后）](https://cursor.com/agents/bc-1a9c94b0-671d-47a5-9332-987f98bde13f/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fentity-gencad-3d-mermaid.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a9c94b0-671d-47a5-9332-987f98bde13f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a9c94b0-671d-47a5-9332-987f98bde13f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

