### PR TITLE
[2026-05-21] feat(ux) | V22 P3 详情页关联项按类型分布小条形图

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -73,8 +73,11 @@
 
 ## P3: 交互层"关系视角"增强 (UX/UI)
 
-- [ ] **详情页"关联类型分布"小条形图**：
-    - [ ] 在 `docs/detail.html` 的"关联页面"区块新增按 `type`（method/concept/entity/formalization/...）聚类的横向条形小图，让读者一眼判断当前节点偏理论、偏工程还是偏实体。
+- [x] **详情页"关联类型分布"小条形图**：
+    - [x] 在 `docs/detail.html` 的"关联页面"区块新增按 `type`（method/concept/entity/formalization/...）聚类的横向条形小图，让读者一眼判断当前节点偏理论、偏工程还是偏实体。
+      - 实现：`docs/detail.html` 在 `#detail-related` 标题下新增 `#detailRelatedTypeDist` 容器（含 head 与 bars 两块）；`docs/main.js` 新增 `deriveDetailCategoryLabel()`（按 path/type/id 派生中文类别：概念 / 方法 / 形式化 / 对比 / Query / 任务 / 实体 / 总览 / 深挖 / 路线图 / 技术地图）与 `renderRelatedTypeDistribution()`（按计数排序、最长条占满轨道，其它按比例并保底 6% 可见宽度），在 `renderDetailPage` 正常态与未匹配态都调用一次以保持空态干净；`docs/style.css` 新增 `.related-type-dist*` 样式（标题/Meta/三列网格：标签/横向轨道/计数；540px 以下窄屏自适应缩列）。
+      - 验证：`make lint-js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；本地 `python3 -m http.server` + Puppeteer 视口截图 `wiki-concepts-armature-modeling` 详情页，按类型分布正常落稳（共 5 项 · 2 类，方法 / 概念）。
+      - 截图：`.cursor-artifacts/screenshots/detail-related-type-dist.png`。
 - [ ] **图谱页"专题视图"切换器**：
     - [ ] `docs/graph.html` 增加下拉菜单，可选"全量 / 动作重定向 / 抓取 / 触觉与通信"三个子图过滤模式，复用 V21 微地图的同套 `path → type` 元数据。
 

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -109,6 +109,13 @@
 
           <section class="section section-alt" id="detail-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">
             <h2 class="section-title">关联项</h2>
+            <div id="detailRelatedTypeDist" class="related-type-dist data-loading" aria-label="关联项按类型分布" hidden>
+              <div class="related-type-dist-head">
+                <span class="related-type-dist-title">按类型分布</span>
+                <span id="detailRelatedTypeDistMeta" class="related-type-dist-meta"></span>
+              </div>
+              <div id="detailRelatedTypeDistBars" class="related-type-dist-bars"></div>
+            </div>
             <div id="detailRelatedList" class="card-grid data-loading">
               <article class="card skeleton-card"><p>正在读取关联项…</p></article>
             </div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1618,6 +1618,82 @@
     removeLoadingState(container);
   }
 
+  // V22 P3：从 detail page 的 path/type/id 派生人类可读的类别标签，
+  // 用于「关联项按类型分布」小条形图。
+  function deriveDetailCategoryLabel(page, id) {
+    var path = (page && page.path) || '';
+    var type = (page && page.type) || '';
+    if (path.indexOf('wiki/') === 0) {
+      var seg = path.split('/')[1] || '';
+      var labels = {
+        concepts: '概念',
+        methods: '方法',
+        formalizations: '形式化',
+        comparisons: '对比',
+        queries: 'Query',
+        tasks: '任务',
+        entities: '实体',
+        overview: '总览',
+        references: '深挖'
+      };
+      if (labels[seg]) return labels[seg];
+      return seg || '其他';
+    }
+    if (type === 'entity_page') return '实体';
+    if (type === 'reference_page') return '深挖';
+    if (type === 'roadmap_page') return '路线图';
+    if (type === 'tech_map_node') return '技术地图';
+    if (typeof id === 'string') {
+      if (id.indexOf('entity-') === 0) return '实体';
+      if (id.indexOf('reference-') === 0) return '深挖';
+      if (id.indexOf('roadmap-') === 0) return '路线图';
+    }
+    return '其他';
+  }
+
+  function renderRelatedTypeDistribution(wrapperEl, ids, detailPages) {
+    if (!wrapperEl) return;
+    var barsEl = document.getElementById('detailRelatedTypeDistBars');
+    var metaEl = document.getElementById('detailRelatedTypeDistMeta');
+    var validIds = Array.isArray(ids) ? ids.filter(function (id) { return id && detailPages[id]; }) : [];
+    if (!validIds.length || !barsEl) {
+      wrapperEl.hidden = true;
+      removeLoadingState(wrapperEl);
+      return;
+    }
+    var counts = {};
+    for (var i = 0; i < validIds.length; i++) {
+      var id = validIds[i];
+      var label = deriveDetailCategoryLabel(detailPages[id] || {}, id);
+      counts[label] = (counts[label] || 0) + 1;
+    }
+    var entries = Object.keys(counts).map(function (key) {
+      return { label: key, count: counts[key] };
+    });
+    entries.sort(function (a, b) {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.label.localeCompare(b.label);
+    });
+    var maxCount = entries[0].count;
+    barsEl.innerHTML = entries.map(function (entry) {
+      var pct = Math.max(6, Math.round((entry.count / maxCount) * 100));
+      return [
+        '<div class="related-type-bar-row">',
+        '  <span class="related-type-bar-label">' + escapeHtml(entry.label) + '</span>',
+        '  <span class="related-type-bar-track" aria-hidden="true">',
+        '    <span class="related-type-bar-fill" style="width:' + pct + '%"></span>',
+        '  </span>',
+        '  <span class="related-type-bar-count">' + entry.count + '</span>',
+        '</div>'
+      ].join('');
+    }).join('');
+    if (metaEl) {
+      metaEl.textContent = '共 ' + validIds.length + ' 项 · ' + entries.length + ' 类';
+    }
+    wrapperEl.hidden = false;
+    removeLoadingState(wrapperEl);
+  }
+
   function renderInternalLinks(container, ids, detailPages, options) {
     if (!container) return;
     const emptyText = (options && options.emptyText) || '暂无内部关联项';
@@ -1935,6 +2011,7 @@
         removeLoadingState(contentEl);
       }
       renderChipList(tagEl, [], {});
+      renderRelatedTypeDistribution(document.getElementById('detailRelatedTypeDist'), [], detailPages);
       renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的关联项。' });
       if (recommendedEl) {
         recommendedEl.innerHTML = '<article class="card"><p>当前无可展示的相关推荐。</p></article>';
@@ -2033,6 +2110,7 @@
         return '<span class="data-chip">' + escapeHtml(tag) + '</span>';
       }
     });
+    renderRelatedTypeDistribution(document.getElementById('detailRelatedTypeDist'), detailPage.related, detailPages);
     renderInternalLinks(relatedEl, detailPage.related, detailPages, { emptyText: '当前 detail page 暂无 related。' });
 
     // V17: 记录并渲染阅读足迹

--- a/docs/style.css
+++ b/docs/style.css
@@ -1697,3 +1697,72 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+/* V22 P3：详情页关联项按类型分布小条形图 */
+.related-type-dist {
+  margin: 0 0 1rem;
+  padding: 12px 14px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.related-type-dist-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.related-type-dist-title {
+  font-size: .92rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.related-type-dist-meta {
+  font-size: .78rem;
+  color: var(--text-muted);
+}
+.related-type-dist-bars {
+  display: grid;
+  gap: 6px;
+}
+.related-type-bar-row {
+  display: grid;
+  grid-template-columns: 92px 1fr 56px;
+  align-items: center;
+  gap: 10px;
+  font-size: .82rem;
+}
+.related-type-bar-label {
+  color: var(--text-muted);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.related-type-bar-track {
+  position: relative;
+  background: rgba(94, 160, 235, 0.10);
+  border-radius: 4px;
+  height: 10px;
+  overflow: hidden;
+}
+.related-type-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--accent);
+  border-radius: 4px;
+  transition: width var(--transition);
+}
+.related-type-bar-count {
+  color: var(--text-muted);
+  text-align: left;
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 540px) {
+  .related-type-bar-row {
+    grid-template-columns: 78px 1fr 46px;
+    gap: 8px;
+    font-size: .78rem;
+  }
+}

--- a/log.md
+++ b/log.md
@@ -1,5 +1,15 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-21] feat(ux) | docs/detail.html、docs/main.js、docs/style.css — V22 P3 详情页「关联类型分布」小条形图
+
+- 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) P3「详情页关联类型分布小条形图」唯一子项；P0–P2 已全部落地，进入交互层关系视角增强阶段
+- 改动形态：
+  - [`docs/detail.html`](docs/detail.html)：在 `#detail-related` 标题下新增 `#detailRelatedTypeDist` 容器（含标题 / Meta / 横向条形栅格），默认 hidden，由 JS 在有关联项时显式打开
+  - [`docs/main.js`](docs/main.js)：新增 `deriveDetailCategoryLabel()`（按 `path` 优先 → `type` 兜底 → `id` 前缀兜底，输出中文标签：概念 / 方法 / 形式化 / 对比 / Query / 任务 / 实体 / 总览 / 深挖 / 路线图 / 技术地图）；新增 `renderRelatedTypeDistribution()`（统计、按计数倒序+标签字典序、最大计数为 100% 基准、其余按比例并保底 6% 可见宽度），在 `renderDetailPage` 的正常态与「未匹配 detail page」空态均调用一次以避免幽灵骨架
+  - [`docs/style.css`](docs/style.css)：新增 `.related-type-dist*` 系列样式（卡片化容器 / 三列网格 `92px 1fr 56px`：标签—轨道—计数 / `var(--accent)` 填充 / 540px 窄屏自适应缩列至 `78px 1fr 46px`）
+- 验证：`make lint-js` 通过（仅一条 pre-existing `resetMermaidLightboxView` 未使用警告，与本次改动无关）；本地 `python3 -m http.server 8765` + `puppeteer-core` 视口截图（`/opt/pw-browsers/chromium-1194/chrome-linux/chrome`）打开 `detail.html?id=wiki-concepts-armature-modeling` 锚点 `detail-related`，条形图正确显示「方法 / 概念」两类共 5 项；截图落 `.cursor-artifacts/screenshots/detail-related-type-dist.png`
+- 状态联动：V22 checklist 「详情页关联类型分布小条形图」由 `[ ]` 变 `[x]`；P3 剩余「图谱页专题视图切换器」与 DoD 收尾继续推进
+
 ## [2026-05-21] ingest | sources/papers/deeprl_locomotion_action_space_sca2017.md — Peng & van de Panne SCA 2017 四动作空间 DeepRL 对照；沉淀 wiki/entities/paper-deeprl-locomotion-action-space-sca2017.md；交叉更新 rl_pd 索引、legged-humanoid-rl-pd-gain-setting、xue-bin-peng、locomotion
 
 ## [2026-05-21] ingest | sources/papers/gencad_arxiv_2409_16294.md、sources/papers/gencad3d_arxiv_2509_15246.md、sources/sites/gencad-github-io.md、sources/sites/gencad3d-github-io.md、sources/repos/ferdous-alam-gencad.md、sources/repos/yunomi-git-gencad-3d.md — 入库 GenCAD / GenCAD-3D 论文、项目页与代码仓；沉淀 wiki/entities/gencad.md、wiki/entities/gencad-3d.md；交叉更新 wiki/concepts/text-to-cad.md、sources/sites/text-to-cad-tools.md


### PR DESCRIPTION
## 摘要

- 推进 [V22 P3「详情页关联类型分布小条形图」](docs/checklists/tech-stack-next-phase-checklist-v22.md) 唯一子项落地：在 `docs/detail.html` 的「关联项」区块顶部，新增按 `path/type/id` 派生分类（概念 / 方法 / 形式化 / 对比 / Query / 任务 / 实体 / 总览 / 深挖 / 路线图 / 技术地图）的横向条形小图，读者可一眼判断当前节点是偏理论、偏工程还是偏实体。
- V22 P0 / P1 / P2 全部子项已落地，P3 由此进入首项 `[x]`，剩余「图谱页专题视图切换器」与 DoD 收尾继续推进。

## 变更要点

- [`docs/detail.html`](docs/detail.html)：在 `#detail-related` 标题下新增 `#detailRelatedTypeDist` 容器（标题 / Meta / 横向条形栅格），默认 `hidden`，由 JS 在有关联项时显式开启。
- [`docs/main.js`](docs/main.js)：
  - 新增 `deriveDetailCategoryLabel()`：按 `path` 优先（解析 `wiki/<segment>/`）→ `type` 兜底（`entity_page` / `reference_page` / `roadmap_page` / `tech_map_node`）→ `id` 前缀兜底，统一输出中文标签。
  - 新增 `renderRelatedTypeDistribution()`：统计、按计数倒序 + 标签字典序、最大计数为 100% 基准、其余按比例并保底 6% 可见宽度；在 `renderDetailPage` 正常态与未匹配 detail page 空态都调用一次，避免幽灵骨架。
- [`docs/style.css`](docs/style.css)：新增 `.related-type-dist*` 样式（卡片化容器、三列网格 `92px 1fr 56px`：标签 — 轨道 — 计数；`var(--accent)` 填充；≤540px 窄屏自适应缩列至 `78px 1fr 46px`）。
- [`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md)：P3 首项由 `[ ]` 变 `[x]`，并附实现与验证说明。
- [`log.md`](log.md)：顶部追加 `feat(ux)` 改动记录。

## 验证

- `make lint-js` 通过（仅一条 pre-existing `resetMermaidLightboxView` 未使用警告，与本次改动无关）。
- 本地 `python3 -m http.server 8765` + `puppeteer-core`（`/opt/pw-browsers/chromium-1194/chrome-linux/chrome`）视口截图 `detail.html?id=wiki-concepts-armature-modeling` 锚点 `detail-related`，按类型分布条形图正常显示「方法 / 概念」两类共 5 项。
- 本 PR 不触及 wiki 正文 / 派生导出 / `lint_wiki.py` baseline；CI preflight 中的 22 项 `stale_pages` 均为 2026-05-21 早些 ingest 累积的历史 baseline（详见 PR #343 末尾说明），与本次纯前端改动无关。

## 验证截图

`&lt;img alt="详情页关联项按类型分布小条形图（wiki-concepts-armature-modeling）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-related-type-dist.png" /&gt;`


---
_Generated by [Claude Code](https://claude.ai/code/session_011uKAQseUa1En93oUsn9n36)_