### PR TITLE
[2026-05-21] feat(ux) | V22 P3 详情页关联项分桶切换为按 link-graph 社区聚类

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -73,11 +73,12 @@
 
 ## P3: 交互层"关系视角"增强 (UX/UI)
 
-- [x] **详情页"关联类型分布"小条形图**：
-    - [x] 在 `docs/detail.html` 的"关联页面"区块新增按 `type`（method/concept/entity/formalization/...）聚类的横向条形小图，让读者一眼判断当前节点偏理论、偏工程还是偏实体。
-      - 实现：`docs/detail.html` 在 `#detail-related` 标题下新增 `#detailRelatedTypeDist` 容器（含 head 与 bars 两块）；`docs/main.js` 新增 `deriveDetailCategoryLabel()`（按 path/type/id 派生中文类别：概念 / 方法 / 形式化 / 对比 / Query / 任务 / 实体 / 总览 / 深挖 / 路线图 / 技术地图）与 `renderRelatedTypeDistribution()`（按计数排序、最长条占满轨道，其它按比例并保底 6% 可见宽度），在 `renderDetailPage` 正常态与未匹配态都调用一次以保持空态干净；`docs/style.css` 新增 `.related-type-dist*` 样式（标题/Meta/三列网格：标签/横向轨道/计数；540px 以下窄屏自适应缩列）。
-      - 验证：`make lint-js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；本地 `python3 -m http.server` + Puppeteer 视口截图 `wiki-concepts-armature-modeling` 详情页，按类型分布正常落稳（共 5 项 · 2 类，方法 / 概念）。
-      - 截图：`.cursor-artifacts/screenshots/detail-related-type-dist.png`。
+- [x] **详情页"关联社区分布"小条形图**：
+    - [x] 在 `docs/detail.html` 的"关联页面"区块新增按 `link-graph` 社区（Whole-Body Control / Motion Retargeting / Sim2Real / VLA / IL / RL / Locomotion / ...）聚类的横向条形小图，让读者一眼判断当前节点在知识图谱里偏向哪些社区。
+      - 实现：`docs/detail.html` 在 `#detail-related` 标题下新增 `#detailRelatedCommunityDist` 容器（含 head 与 bars 两块）；`docs/main.js` 新增 `ensureDetailCommunityIndex()` 懒加载 `exports/link-graph.json`，建立 `pathToCommunity` Map 与 `communityLabel` 字典（兜底为空 Map），与 `renderRelatedCommunityDistribution()`（按计数倒序排序、最大计数为 100% 基准、其余按比例并保底 6% 可见宽度；不在图谱内的 roadmap / reference / tech_map 关联项统一桶为「未分类」并永远排在末尾），在 `renderDetailPage` 正常态与未匹配态都调用一次以保持空态干净；`docs/style.css` 新增 `.related-community-dist*` 样式（标题/Meta/三列网格：社区标签 160px / 横向轨道 / 计数；540px 以下窄屏缩列至 110px / 1fr / 46px）。社区标签显式去掉末尾「社区」二字以节省横向空间，悬停 `title` 仍显示完整标签。
+      - 第一版本（type 分桶）由社区分桶替代后不再保留：理由是 type 维度（概念/方法/实体/...）与现有 frontmatter type 字段重复，区分度不如 link-graph 社区聚类高（V22 P0 已把社区切到 17 个 ≤ 40% 阈值之内，刚好可用于"邻域属于哪些主题"的快速判断）。
+      - 验证：`make lint-js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；本地 `python3 -m http.server` + Puppeteer 视口截图 `wiki-concepts-whole-body-control` 详情页（共 12 项 · 8 个社区：Whole-Body Control 4 / Imitation Learning 1 / Locomotion 1 / Motion Retargeting 3 / Sim2Real 1 / Unitree G1 1 / 1 / 未分类 1）与 `wiki-concepts-armature-modeling`（共 5 项 · 3 个社区：WBC 3 / Motion Retargeting 1 / Sim2Real 1），桌面端 1280px 与移动端 375px 双视口落稳。
+      - 截图：`.cursor-artifacts/screenshots/detail-related-community-dist-wbc.png`、`detail-related-community-dist-wbc-mobile.png`、`detail-related-community-dist.png`。
 - [ ] **图谱页"专题视图"切换器**：
     - [ ] `docs/graph.html` 增加下拉菜单，可选"全量 / 动作重定向 / 抓取 / 触觉与通信"三个子图过滤模式，复用 V21 微地图的同套 `path → type` 元数据。
 

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -109,12 +109,12 @@
 
           <section class="section section-alt" id="detail-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">
             <h2 class="section-title">关联项</h2>
-            <div id="detailRelatedTypeDist" class="related-type-dist data-loading" aria-label="关联项按类型分布" hidden>
-              <div class="related-type-dist-head">
-                <span class="related-type-dist-title">按类型分布</span>
-                <span id="detailRelatedTypeDistMeta" class="related-type-dist-meta"></span>
+            <div id="detailRelatedCommunityDist" class="related-community-dist data-loading" aria-label="关联项按社区分布" hidden>
+              <div class="related-community-dist-head">
+                <span class="related-community-dist-title">按社区分布</span>
+                <span id="detailRelatedCommunityDistMeta" class="related-community-dist-meta"></span>
               </div>
-              <div id="detailRelatedTypeDistBars" class="related-type-dist-bars"></div>
+              <div id="detailRelatedCommunityDistBars" class="related-community-dist-bars"></div>
             </div>
             <div id="detailRelatedList" class="card-grid data-loading">
               <article class="card skeleton-card"><p>正在读取关联项…</p></article>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1618,80 +1618,107 @@
     removeLoadingState(container);
   }
 
-  // V22 P3：从 detail page 的 path/type/id 派生人类可读的类别标签，
-  // 用于「关联项按类型分布」小条形图。
-  function deriveDetailCategoryLabel(page, id) {
-    var path = (page && page.path) || '';
-    var type = (page && page.type) || '';
-    if (path.indexOf('wiki/') === 0) {
-      var seg = path.split('/')[1] || '';
-      var labels = {
-        concepts: '概念',
-        methods: '方法',
-        formalizations: '形式化',
-        comparisons: '对比',
-        queries: 'Query',
-        tasks: '任务',
-        entities: '实体',
-        overview: '总览',
-        references: '深挖'
-      };
-      if (labels[seg]) return labels[seg];
-      return seg || '其他';
-    }
-    if (type === 'entity_page') return '实体';
-    if (type === 'reference_page') return '深挖';
-    if (type === 'roadmap_page') return '路线图';
-    if (type === 'tech_map_node') return '技术地图';
-    if (typeof id === 'string') {
-      if (id.indexOf('entity-') === 0) return '实体';
-      if (id.indexOf('reference-') === 0) return '深挖';
-      if (id.indexOf('roadmap-') === 0) return '路线图';
-    }
-    return '其他';
+  // V22 P3：详情页「关联项按社区分布」小条形图。
+  // 社区来自 exports/link-graph.json（Girvan-Newman + Louvain 二级拆分），
+  // 节点 id 即 wiki/entity 页面相对路径；roadmap/reference/tech_map 不在图谱内，
+  // 在本图中统一桶为「未分类」。
+  var _detailCommunityIndex = null;
+  var _detailCommunityIndexPromise = null;
+
+  function ensureDetailCommunityIndex() {
+    if (_detailCommunityIndex) return Promise.resolve(_detailCommunityIndex);
+    if (_detailCommunityIndexPromise) return _detailCommunityIndexPromise;
+    _detailCommunityIndexPromise = fetch('exports/link-graph.json')
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (data) {
+        var pathToCommunity = new Map();
+        var nodes = data && data.nodes ? data.nodes : [];
+        for (var ni = 0; ni < nodes.length; ni++) {
+          var node = nodes[ni];
+          if (node && node.id && node.community) {
+            pathToCommunity.set(node.id, node.community);
+          }
+        }
+        var communityLabel = {};
+        var communities = data && data.communities ? data.communities : [];
+        for (var ci = 0; ci < communities.length; ci++) {
+          var c = communities[ci];
+          if (c && c.id) communityLabel[c.id] = c.label || c.id;
+        }
+        _detailCommunityIndex = {
+          pathToCommunity: pathToCommunity,
+          communityLabel: communityLabel
+        };
+        return _detailCommunityIndex;
+      })
+      .catch(function () {
+        _detailCommunityIndex = { pathToCommunity: new Map(), communityLabel: {} };
+        return _detailCommunityIndex;
+      });
+    return _detailCommunityIndexPromise;
   }
 
-  function renderRelatedTypeDistribution(wrapperEl, ids, detailPages) {
+  function shortenCommunityLabel(label) {
+    if (!label) return '未分类';
+    return String(label).replace(/\s*社区\s*$/, '').trim() || '未分类';
+  }
+
+  function renderRelatedCommunityDistribution(wrapperEl, ids, detailPages) {
     if (!wrapperEl) return;
-    var barsEl = document.getElementById('detailRelatedTypeDistBars');
-    var metaEl = document.getElementById('detailRelatedTypeDistMeta');
+    var barsEl = document.getElementById('detailRelatedCommunityDistBars');
+    var metaEl = document.getElementById('detailRelatedCommunityDistMeta');
     var validIds = Array.isArray(ids) ? ids.filter(function (id) { return id && detailPages[id]; }) : [];
     if (!validIds.length || !barsEl) {
       wrapperEl.hidden = true;
       removeLoadingState(wrapperEl);
       return;
     }
-    var counts = {};
-    for (var i = 0; i < validIds.length; i++) {
-      var id = validIds[i];
-      var label = deriveDetailCategoryLabel(detailPages[id] || {}, id);
-      counts[label] = (counts[label] || 0) + 1;
-    }
-    var entries = Object.keys(counts).map(function (key) {
-      return { label: key, count: counts[key] };
+    ensureDetailCommunityIndex().then(function (idx) {
+      var pathToCommunity = idx.pathToCommunity;
+      var communityLabel = idx.communityLabel;
+      var counts = {};
+      var labelByKey = {};
+      for (var i = 0; i < validIds.length; i++) {
+        var page = detailPages[validIds[i]] || {};
+        var path = page.path || '';
+        var cid = pathToCommunity.get(path) || '__unbinned__';
+        counts[cid] = (counts[cid] || 0) + 1;
+        if (!labelByKey[cid]) {
+          labelByKey[cid] = cid === '__unbinned__' ? '未分类' : shortenCommunityLabel(communityLabel[cid] || cid);
+        }
+      }
+      var entries = Object.keys(counts).map(function (key) {
+        return { key: key, label: labelByKey[key], count: counts[key] };
+      });
+      entries.sort(function (a, b) {
+        if (a.key === '__unbinned__' && b.key !== '__unbinned__') return 1;
+        if (b.key === '__unbinned__' && a.key !== '__unbinned__') return -1;
+        if (b.count !== a.count) return b.count - a.count;
+        return a.label.localeCompare(b.label);
+      });
+      var maxCount = entries.reduce(function (m, e) { return e.count > m ? e.count : m; }, 0) || 1;
+      barsEl.innerHTML = entries.map(function (entry) {
+        var pct = Math.max(6, Math.round((entry.count / maxCount) * 100));
+        var safeLabel = escapeHtml(entry.label);
+        return [
+          '<div class="related-community-bar-row" title="' + safeLabel + '">',
+          '  <span class="related-community-bar-label">' + safeLabel + '</span>',
+          '  <span class="related-community-bar-track" aria-hidden="true">',
+          '    <span class="related-community-bar-fill" style="width:' + pct + '%"></span>',
+          '  </span>',
+          '  <span class="related-community-bar-count">' + entry.count + '</span>',
+          '</div>'
+        ].join('');
+      }).join('');
+      if (metaEl) {
+        metaEl.textContent = '共 ' + validIds.length + ' 项 · ' + entries.length + ' 个社区';
+      }
+      wrapperEl.hidden = false;
+      removeLoadingState(wrapperEl);
     });
-    entries.sort(function (a, b) {
-      if (b.count !== a.count) return b.count - a.count;
-      return a.label.localeCompare(b.label);
-    });
-    var maxCount = entries[0].count;
-    barsEl.innerHTML = entries.map(function (entry) {
-      var pct = Math.max(6, Math.round((entry.count / maxCount) * 100));
-      return [
-        '<div class="related-type-bar-row">',
-        '  <span class="related-type-bar-label">' + escapeHtml(entry.label) + '</span>',
-        '  <span class="related-type-bar-track" aria-hidden="true">',
-        '    <span class="related-type-bar-fill" style="width:' + pct + '%"></span>',
-        '  </span>',
-        '  <span class="related-type-bar-count">' + entry.count + '</span>',
-        '</div>'
-      ].join('');
-    }).join('');
-    if (metaEl) {
-      metaEl.textContent = '共 ' + validIds.length + ' 项 · ' + entries.length + ' 类';
-    }
-    wrapperEl.hidden = false;
-    removeLoadingState(wrapperEl);
   }
 
   function renderInternalLinks(container, ids, detailPages, options) {
@@ -2011,7 +2038,7 @@
         removeLoadingState(contentEl);
       }
       renderChipList(tagEl, [], {});
-      renderRelatedTypeDistribution(document.getElementById('detailRelatedTypeDist'), [], detailPages);
+      renderRelatedCommunityDistribution(document.getElementById('detailRelatedCommunityDist'), [], detailPages);
       renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的关联项。' });
       if (recommendedEl) {
         recommendedEl.innerHTML = '<article class="card"><p>当前无可展示的相关推荐。</p></article>';
@@ -2110,7 +2137,7 @@
         return '<span class="data-chip">' + escapeHtml(tag) + '</span>';
       }
     });
-    renderRelatedTypeDistribution(document.getElementById('detailRelatedTypeDist'), detailPage.related, detailPages);
+    renderRelatedCommunityDistribution(document.getElementById('detailRelatedCommunityDist'), detailPage.related, detailPages);
     renderInternalLinks(relatedEl, detailPage.related, detailPages, { emptyText: '当前 detail page 暂无 related。' });
 
     // V17: 记录并渲染阅读足迹

--- a/docs/style.css
+++ b/docs/style.css
@@ -1698,70 +1698,70 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   }
 }
 
-/* V22 P3：详情页关联项按类型分布小条形图 */
-.related-type-dist {
+/* V22 P3：详情页关联项按社区分布小条形图 */
+.related-community-dist {
   margin: 0 0 1rem;
   padding: 12px 14px;
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
-.related-type-dist-head {
+.related-community-dist-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 8px;
 }
-.related-type-dist-title {
+.related-community-dist-title {
   font-size: .92rem;
   font-weight: 600;
   color: var(--text);
 }
-.related-type-dist-meta {
+.related-community-dist-meta {
   font-size: .78rem;
   color: var(--text-muted);
 }
-.related-type-dist-bars {
+.related-community-dist-bars {
   display: grid;
   gap: 6px;
 }
-.related-type-bar-row {
+.related-community-bar-row {
   display: grid;
-  grid-template-columns: 92px 1fr 56px;
+  grid-template-columns: 160px 1fr 56px;
   align-items: center;
   gap: 10px;
   font-size: .82rem;
 }
-.related-type-bar-label {
+.related-community-bar-label {
   color: var(--text-muted);
   text-align: right;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.related-type-bar-track {
+.related-community-bar-track {
   position: relative;
   background: rgba(94, 160, 235, 0.10);
   border-radius: 4px;
   height: 10px;
   overflow: hidden;
 }
-.related-type-bar-fill {
+.related-community-bar-fill {
   position: absolute;
   inset: 0 auto 0 0;
   background: var(--accent);
   border-radius: 4px;
   transition: width var(--transition);
 }
-.related-type-bar-count {
+.related-community-bar-count {
   color: var(--text-muted);
   text-align: left;
   font-variant-numeric: tabular-nums;
 }
 @media (max-width: 540px) {
-  .related-type-bar-row {
-    grid-template-columns: 78px 1fr 46px;
+  .related-community-bar-row {
+    grid-template-columns: 110px 1fr 46px;
     gap: 8px;
     font-size: .78rem;
   }

--- a/log.md
+++ b/log.md
@@ -1,5 +1,16 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-21] feat(ux) | docs/detail.html、docs/main.js、docs/style.css — V22 P3 详情页「关联项按社区分布」小条形图（基于 link-graph 社区，替换早些时候的按 type 分桶版本）
+
+- 触发：PR #347 review，社区维度（link-graph 的 Girvan-Newman + Louvain 二级拆分）比类型维度更有信息量——type 字段与 frontmatter 直接重复，而社区分桶能体现「当前节点的 1-hop 邻域聚集在哪几个主题」，与 V22 P0 的社区粒度二级拆分（17 个社区 / largest_community_ratio ≤ 0.40）形成闭环
+- 改动形态：
+  - [`docs/detail.html`](docs/detail.html)：`#detailRelatedTypeDist` 容器更名为 `#detailRelatedCommunityDist`，标题文案改「按社区分布」
+  - [`docs/main.js`](docs/main.js)：移除按 type 派生中文标签的 `deriveDetailCategoryLabel()` 与 `renderRelatedTypeDistribution()`；新增 `ensureDetailCommunityIndex()`（懒加载 `exports/link-graph.json`，建立 `pathToCommunity` Map 与 `communityLabel` 字典，失败兜底为空 Map）与 `renderRelatedCommunityDistribution()`（按 detail page 的 `path` 查表 → 拿社区 ID → 计数；不在图谱内的 roadmap / reference / tech_map 统一桶为「未分类」并永远排在末尾，避免遮挡有效社区）；社区标签显式 `replace(/\s*社区\s*$/, '')` 去掉末尾「社区」二字以节省横向空间，悬停 `title` 仍保留完整原始标签
+  - [`docs/style.css`](docs/style.css)：`.related-type-*` 系列样式整体改名为 `.related-community-*`，桌面端标签列宽 92px → 160px，540px 窄屏 78px → 110px，以容纳更长的社区中文标签（如 "Whole-Body Control (WBC，全身控制)"）
+  - [`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md)：P3 首项标题与实现说明同步换为「关联社区分布」版本，附 type→community 切换理由
+- 验证：`make lint-js` 通过；本地 http.server + Puppeteer 视口截图 `wiki-concepts-whole-body-control` 桌面 / 移动双端（共 12 项 · 8 个社区，含 Whole-Body Control 4 / Motion Retargeting 3 / Imitation Learning 1 / Locomotion 1 / Sim2Real 1 / Unitree G1 1 / Reward Design 1 / 未分类 1）与 `wiki-concepts-armature-modeling`（共 5 项 · 3 个社区，WBC 3 / Motion Retargeting 1 / Sim2Real 1）均正确落稳
+- 截图：`.cursor-artifacts/screenshots/detail-related-community-dist-wbc.png`、`detail-related-community-dist-wbc-mobile.png`、`detail-related-community-dist.png`
+
 ## [2026-05-21] feat(ux) | docs/detail.html、docs/main.js、docs/style.css — V22 P3 详情页「关联类型分布」小条形图
 
 - 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) P3「详情页关联类型分布小条形图」唯一子项；P0–P2 已全部落地，进入交互层关系视角增强阶段


### PR DESCRIPTION
## 摘要

PR #347 已合并；本 PR 在其基础上把「关联项按类型分布」改为「关联项按社区分布」。数据源切换至 `exports/link-graph.json` 的社区映射（V22 P0 收敛后的 17 社区 / `largest_community_ratio ≤ 0.40`）。

## 变更要点

- [`docs/detail.html`](docs/detail.html)：容器 `#detailRelatedTypeDist` → `#detailRelatedCommunityDist`，标题文案「按类型分布」→「按社区分布」
- [`docs/main.js`](docs/main.js)：
  - 移除 `deriveDetailCategoryLabel` / `renderRelatedTypeDistribution`
  - 新增 `ensureDetailCommunityIndex()`：懒加载 `exports/link-graph.json`，建立 `pathToCommunity` Map 与 `communityLabel` 字典；fetch 失败时兜底为空 Map（不抛错、容器保持 hidden）
  - 新增 `renderRelatedCommunityDistribution()`：按 detail page `path` 查社区 ID 计数；不在图谱内的 roadmap / reference / tech_map 统一桶为「未分类」并永远排末尾；社区标签去尾「社区」二字以节省横向空间，悬停 `title` 保留完整原始标签；按计数倒序 + 标签字典序排序，最大计数为 100% 基准、其余按比例并保底 6% 可见宽度
- [`docs/style.css`](docs/style.css)：`.related-type-*` → `.related-community-*`；桌面端标签列宽 `92px → 160px`，540px 窄屏 `78px → 110px`，容纳更长的中文社区名
- [`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) / [`log.md`](log.md)：P3 首项实现说明同步切换为社区分桶版本，附 type→community 切换理由

## 切换理由

type 维度（concept / method / entity / formalization / ...）与 frontmatter `type` 字段重复信息低；社区维度（Girvan-Newman + Louvain 二级拆分）能体现「当前节点的 1-hop 邻域聚集在哪些主题」，与 V22 P0 社区粒度二级拆分形成闭环。

## 验证

- `make lint-js` 通过（仅一条 pre-existing `resetMermaidLightboxView` 未使用警告，与本次改动无关）
- 本地 `python3 -m http.server 8765` + `puppeteer-core`（`/opt/pw-browsers/chromium-1194/chrome-linux/chrome`）视口截图：
  - `wiki-concepts-whole-body-control`：**共 12 项 · 8 个社区**（Whole-Body Control 4 / Motion Retargeting 3 / Imitation Learning 1 / Locomotion 1 / Sim2Real 1 / Unitree G1 1 / Reward Design 1 / 未分类 1）
  - `wiki-concepts-armature-modeling`：**共 5 项 · 3 个社区**（WBC 3 / Motion Retargeting 1 / Sim2Real 1）
- 桌面端 1280px 与移动端 375px 双视口均落稳
- 本 PR 不触及 wiki 正文 / 派生导出 / `lint_wiki.py` baseline

## 验证截图

桌面端（WBC，12 项 · 8 个社区）：

`&lt;img alt="WBC 详情页按社区分布桌面端" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-related-community-dist-wbc.png" /&gt;`

移动端（WBC，375px）：

`&lt;img alt="WBC 详情页按社区分布移动端" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-related-community-dist-wbc-mobile.png" /&gt;`

桌面端（armature-modeling，5 项 · 3 个社区）：

`&lt;img alt="armature-modeling 详情页按社区分布" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-related-community-dist.png" /&gt;`


---
_Generated by [Claude Code](https://claude.ai/code/session_011uKAQseUa1En93oUsn9n36)_