### PR TITLE
chore: update timestamps and add cross-references (2026-05-22)

### DIFF
--- a/wiki/concepts/force-control-basics.md
+++ b/wiki/concepts/force-control-basics.md
@@ -2,7 +2,7 @@
 type: concept
 tags: [control, manipulation, hardware, force-control]
 status: complete
-updated: 2026-04-21
+updated: 2026-05-22
 related:
   - ./impedance-control.md
   - ./hybrid-force-position-control.md

--- a/wiki/entities/gr00t-wholebodycontrol.md
+++ b/wiki/entities/gr00t-wholebodycontrol.md
@@ -2,10 +2,11 @@
 type: entity
 tags: [repo, whole-body-control, humanoid, nvidia, sonic, motionbricks, isaac-lab, vla]
 status: complete
-updated: 2026-05-14
+updated: 2026-05-22
 related:
   - ../methods/motionbricks.md
   - ../methods/sonic-motion-tracking.md
+  - ./kimodo.md
   - ../concepts/foundation-policy.md
   - ../concepts/whole-body-control.md
   - ./gr00t-visual-sim2real.md
@@ -40,6 +41,7 @@ summary: "GR00T-WholeBodyControl 是 NVlabs 的人形全身控制单仓：托管
 - [Foundation Policy](../concepts/foundation-policy.md) — GR00T 系基础策略与分层控制叙事
 - [Whole-Body Control](../concepts/whole-body-control.md) — WBC 概念层与 QP / 分层控制主线
 - [GR00T-VisualSim2Real](./gr00t-visual-sim2real.md) — 同品牌视觉 Sim2Real 仓库，任务侧重不同
+- [Kimodo](./kimodo.md) — 文生人体/人形运动学轨迹的上游；GEAR-SONIC 在线 Demo 集成「Kimodo 生成轨迹 → SONIC 仿真跟踪」工作流
 
 ## 参考来源
 

--- a/wiki/entities/legged-gym.md
+++ b/wiki/entities/legged-gym.md
@@ -1,7 +1,7 @@
 ---
 type: entity
 summary: "legged_gym"
-updated: 2026-05-12
+updated: 2026-05-22
 sources:
   - ../../sources/papers/simulation_tools.md
   - ../../sources/papers/policy_optimization.md

--- a/wiki/entities/paper-anymal-walk-minutes-parallel-drl.md
+++ b/wiki/entities/paper-anymal-walk-minutes-parallel-drl.md
@@ -3,7 +3,7 @@ type: entity
 tags: [quadruped, anymal, reinforcement-learning, isaac-gym, legged-gym, sim2real]
 status: stable
 summary: "ANYmal：单机 GPU 上千并行环境与课程式地形，在分钟级训练出行走策略；开源 legged_gym，成为 RL+PD 配置与消融的教科书入口。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../entities/legged-gym.md
   - ../entities/anymal.md

--- a/wiki/entities/paper-cassie-biped-versatile-locomotion-rl.md
+++ b/wiki/entities/paper-cassie-biped-versatile-locomotion-rl.md
@@ -3,7 +3,7 @@ type: entity
 tags: [biped, cassie, reinforcement-learning, sim2real, pd-control, domain-randomization]
 status: stable
 summary: "Cassie 双足：双历史 I/O 架构 + 任务随机化，统一多种动态技能；文中给出策略/PD 分频与 PD 增益缩放随机化等工程细节。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../queries/domain-randomization-guide.md

--- a/wiki/entities/paper-cassie-feedback-control-drl.md
+++ b/wiki/entities/paper-cassie-feedback-control-drl.md
@@ -3,14 +3,16 @@ type: entity
 tags: [cassie, reinforcement-learning, biped, sim2real, pd-control]
 status: stable
 summary: "高保真 Cassie 模型上的 DRL 反馈控制：跟踪参考运动、扰动与延迟鲁棒性，为「PD 目标空间」提供早期清晰 MDP 表述。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../entities/paper-cassie-iterative-locomotion-sim2real.md
   - ../entities/paper-cassie-biped-versatile-locomotion-rl.md
+  - ../entities/paper-deeprl-locomotion-action-space-sca2017.md
   - ../tasks/locomotion.md
 sources:
   - ../../sources/papers/rl_pd_action_interface_locomotion.md
+  - ../../sources/papers/deeprl_locomotion_action_space_sca2017.md
 ---
 
 # Feedback Control For Cassie With Deep Reinforcement Learning
@@ -20,6 +22,7 @@ sources:
 ## 为什么重要
 
 - 较早把 **「为何用位置/速度目标 + PD，而不是一上来就扭矩」** 放在 **可学习、可部署** 的框架里讲清楚：低维目标空间 **缩小探索、利用已知内环**。
+- 与图形学侧前史 [DeepRL 动作空间对比 SCA 2017](./paper-deeprl-locomotion-action-space-sca2017.md)（平面角色上四种动作语义对照）构成 **从角色动画到机器人** 的同主题前后参照。
 - 与后续 [迭代式 Cassie sim2real](./paper-cassie-iterative-locomotion-sim2real.md)、[双历史多技能](./paper-cassie-biped-versatile-locomotion-rl.md) 形成 **同一平台的方法演进链**。
 
 ## 核心机制（提炼）
@@ -51,6 +54,7 @@ flowchart LR
 ## 关联页面
 
 - [Legged / Humanoid RL 中 Kp/Kd 设置](../queries/legged-humanoid-rl-pd-gain-setting.md)
+- [DeepRL 动作空间对比 SCA 2017](./paper-deeprl-locomotion-action-space-sca2017.md)
 - [Cassie 迭代式 sim2real](./paper-cassie-iterative-locomotion-sim2real.md)
 - [Cassie 双足多技能 RL](./paper-cassie-biped-versatile-locomotion-rl.md)
 - [Reinforcement Learning](../methods/reinforcement-learning.md)

--- a/wiki/entities/paper-cassie-iterative-locomotion-sim2real.md
+++ b/wiki/entities/paper-cassie-iterative-locomotion-sim2real.md
@@ -3,7 +3,7 @@ type: entity
 tags: [cassie, reinforcement-learning, sim2real, reward-design, legged]
 status: stable
 summary: "Cassie 行走：记录 reward / observation / action 接口多轮迭代的 sim2real 设计史，含 DASS 等跨迭代经验复用。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../entities/paper-cassie-feedback-control-drl.md

--- a/wiki/entities/paper-digit-humanoid-locomotion-rl.md
+++ b/wiki/entities/paper-digit-humanoid-locomotion-rl.md
@@ -3,7 +3,7 @@ type: entity
 tags: [humanoid, reinforcement-learning, sim2real, legged, digit, pd-control]
 status: stable
 summary: "UC Berkeley：全尺寸 Digit 人形上大规模并行 RL + 因果 Transformer 策略，零样本户外行走与 sim2real 流水线（含关节 PD 部署链）。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../tasks/locomotion.md

--- a/wiki/entities/paper-quadruped-agile-sim2real-rss2018.md
+++ b/wiki/entities/paper-quadruped-agile-sim2real-rss2018.md
@@ -3,7 +3,7 @@ type: entity
 tags: [quadruped, sim2real, reinforcement-learning, legged]
 status: stable
 summary: "RSS 2018：随机化动力学与感知，在仿真中学敏捷四足运动并迁移真机；建立早期 sim2real 扭矩/敏捷控制参照系。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../entities/paper-quadruped-torque-control-rl.md

--- a/wiki/entities/paper-quadruped-torque-control-rl.md
+++ b/wiki/entities/paper-quadruped-torque-control-rl.md
@@ -3,7 +3,7 @@ type: entity
 tags: [quadruped, reinforcement-learning, sim2real, torque-control]
 status: stable
 summary: "四足 RL：策略直接输出关节扭矩（高频），弱化固定 PD 内环，与位置目标+PD 路线形成对照，用于判断何时应弃用 PD 先验。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../entities/paper-quadruped-agile-sim2real-rss2018.md

--- a/wiki/entities/paper-variable-impedance-contact-rl.md
+++ b/wiki/entities/paper-variable-impedance-contact-rl.md
@@ -3,7 +3,7 @@ type: entity
 tags: [manipulation, reinforcement-learning, impedance, contact, sim2real]
 status: stable
 summary: "RA-L：关节空间同时学习期望轨迹与可变阻抗参数，并加正则以改善接触敏感任务中的样本效率与真机迁移；为可变刚度腿足提供思想前史。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../entities/paper-variable-stiffness-locomotion-rl.md
   - ../queries/legged-humanoid-rl-pd-gain-setting.md

--- a/wiki/entities/paper-variable-stiffness-locomotion-rl.md
+++ b/wiki/entities/paper-variable-stiffness-locomotion-rl.md
@@ -3,7 +3,7 @@ type: entity
 tags: [legged, reinforcement-learning, impedance, quadruped, sim2real]
 status: stable
 summary: "腿足 RL：将可变刚度纳入动作空间，与关节位置联合学习；比较逐关节/分腿/混合参数化，并讨论阻尼等结构约束。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../queries/legged-humanoid-rl-pd-gain-setting.md
   - ../entities/paper-variable-impedance-contact-rl.md

--- a/wiki/entities/paper-walk-these-ways-quadruped-mob.md
+++ b/wiki/entities/paper-walk-these-ways-quadruped-mob.md
@@ -3,7 +3,7 @@ type: entity
 tags: [quadruped, reinforcement-learning, sim2real, generalization, legged-gym]
 status: stable
 summary: "四足 MoB：单一策略嵌入多种步态与风格参数，部署时人类可调参以适配分布外地形与任务；开源 Walk These Ways 控制器。"
-updated: 2026-05-12
+updated: 2026-05-22
 related:
   - ../entities/legged-gym.md
   - ../entities/paper-anymal-walk-minutes-parallel-drl.md

--- a/wiki/entities/protomotions.md
+++ b/wiki/entities/protomotions.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [framework, simulation, humanoid, sim2real, nvidia, newton, mujoco, isaac-gym]
 status: complete
-updated: 2026-05-15
+updated: 2026-05-22
 related:
   - ./amass.md
   - ./kimodo.md

--- a/wiki/entities/urdf-studio.md
+++ b/wiki/entities/urdf-studio.md
@@ -3,7 +3,7 @@ type: entity
 title: URDF-Studio
 tags: [utility, design, workstation, hardware, ai]
 summary: "URDF-Studio 是专业级 Web 机器人设计与组装工作站，支持模块化设计流、硬件 BOM 管理及 AI 辅助建模。"
-updated: 2026-05-16
+updated: 2026-05-22
 ---
 
 # URDF-Studio
@@ -40,6 +40,7 @@ updated: 2026-05-16
 - [open-source-humanoid-hardware](open-source-humanoid-hardware.md) (开源硬件参考)
 - [Articraft](./articraft.md)（agent + SDK + harness：可关节 3D 仿真资产生成，与 URDF/网格下游对照）
 - [文字生成 CAD（Text-to-CAD）](../concepts/text-to-cad.md)（自然语言 → STEP 等上游几何与机器人描述衔接）
+- [GenCAD](./gencad.md) / [GenCAD-3D](./gencad-3d.md)（图像 / 点云 / 网格 → CAD program 的逆向工程上游，输出可推入 Part Studio，再经 URDF-Studio 转 URDF/MJCF/USD）
 
 ## 参考来源
 - [URDF-Studio 原始资料](../../sources/repos/urdf-studio.md)

--- a/wiki/methods/motionbricks.md
+++ b/wiki/methods/motionbricks.md
@@ -2,7 +2,7 @@
 type: method
 tags: [generative-model, wbc, humanoid, motion-synthesis, gr00t, nvidia]
 status: complete
-updated: 2026-04-30
+updated: 2026-05-22
 related:
   - ../concepts/whole-body-control.md
   - ../entities/gr00t-wholebodycontrol.md

--- a/wiki/queries/domain-randomization-guide.md
+++ b/wiki/queries/domain-randomization-guide.md
@@ -2,6 +2,7 @@
 type: query
 tags: [sim2real, domain-randomization, rl, locomotion, training, parameters]
 status: complete
+updated: 2026-05-22
 summary: "如何为 sim2real 任务设计 domain randomization 参数与分布范围：涵盖物理参数、延迟、感知噪声和几何随机化的完整指导手册。"
 sources:
   - ../../sources/papers/locomotion_rl.md


### PR DESCRIPTION
## 摘要

批量更新 wiki 页面的 `updated` 时间戳至 2026-05-22，并补充关键跨域引用链接：
- 在 Cassie DRL 反馈控制页面新增与图形学侧 DeepRL 动作空间对比的前后参照
- 在 GR00T 全身控制页面补充 Kimodo 文生轨迹的上游关联
- 在 URDF-Studio 页面补充 GenCAD 逆向工程工作流的衔接
- 在 domain-randomization-guide 补充 `updated` 字段

## 变更类型

- [x] 知识入库（ingest / wiki 内容）

## 详细说明

### 主要改动

1. **paper-cassie-feedback-control-drl.md**
   - 新增关联：`paper-deeprl-locomotion-action-space-sca2017.md`（图形学侧 DeepRL 动作空间对比）
   - 新增源文献：`deeprl_locomotion_action_space_sca2017.md`
   - 在「为什么重要」章节补充说明与 SCA 2017 论文的同主题前后参照关系

2. **gr00t-wholebodycontrol.md**
   - 新增关联：`kimodo.md`（文生人体/人形运动学轨迹）
   - 在「关联页面」补充 Kimodo 与 GEAR-SONIC 在线 Demo 集成工作流的说明

3. **urdf-studio.md**
   - 在「关联页面」补充 GenCAD / GenCAD-3D 的逆向工程工作流衔接说明

4. **domain-randomization-guide.md**
   - 补充缺失的 `updated: 2026-05-22` 字段

5. **其他页面**
   - 批量更新 `updated` 时间戳至 2026-05-22：
     - legged-gym.md
     - paper-anymal-walk-minutes-parallel-drl.md
     - paper-cassie-biped-versatile-locomotion-rl.md
     - paper-cassie-iterative-locomotion-sim2real.md
     - paper-digit-humanoid-locomotion-rl.md
     - paper-quadruped-agile-sim2real-rss2018.md
     - paper-quadruped-torque-control-rl.md
     - paper-variable-impedance-contact-rl.md
     - paper-variable-stiffness-locomotion-rl.md
     - paper-walk-these-ways-quadruped-mob.md
     - protomotions.md
     - motionbricks.md
     - force-control-basics.md

## 验证

- [x] `make ci-preflight`（wiki 链接与 frontmatter 验证）
- [x] 所有新增关联页面已存在或在同批次创建
- [x] 时间戳格式一致（YYYY-MM-DD）

## 相关 Issue

无

https://claude.ai/code/session_01CfK5atMR2UXcLJZ3QreQr2