### PR TITLE
fix(ux): 移动端图例弹出样式与原先卡片一致

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -244,22 +244,26 @@
         background: rgba(0,212,255,0.12);
       }
       #graph-legend {
+        /* 与桌面端相同的卡片外观，仅改为默认隐藏 + 自左滑入 */
         position: fixed;
-        top: calc(var(--header-h) + 46px);
-        left: 0;
-        bottom: 0;
-        width: min(86vw, 300px);
-        max-height: none;
+        bottom: 16px;
+        left: 16px;
+        top: auto;
+        width: auto;
+        max-width: calc(100vw - 32px);
+        max-height: min(72vh, calc(100dvh - var(--header-h) - 120px));
         margin: 0;
-        padding: 14px 12px 18px;
-        border-radius: 0 12px 12px 0;
-        border-left: none;
-        transform: translateX(-110%);
+        padding: 10px 13px;
+        background: rgba(13,17,23,0.88);
+        border: 1px solid rgba(255,255,255,0.08);
+        border-radius: 10px;
+        backdrop-filter: blur(6px);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.45);
+        transform: translateX(calc(-100% - 28px));
         transition: transform .28s cubic-bezier(.4,0,.2,1);
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
         z-index: 46;
-        box-shadow: 8px 0 32px rgba(0,0,0,0.45);
         pointer-events: none;
       }
       #graph-legend.graph-legend-open {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -240,8 +240,8 @@
         outline: none;
       }
       #graph-legend-fab[aria-expanded="true"] {
-        border-color: rgba(0,212,255,0.55);
-        background: rgba(0,212,255,0.12);
+        opacity: 0;
+        pointer-events: none;
       }
       #graph-legend {
         /* 与桌面端相同的卡片外观，仅改为默认隐藏 + 自左滑入 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

#354 已将移动端图谱图例改为 FAB + 左侧滑出，但合并版弹出层为全高侧栏样式，与原先左下角常驻卡片不一致。

本 PR 在 `main` 基础上补充：

- 弹出面板恢复与改版前相同的左下角卡片外观（圆角 10px、四边细边框、相同 padding/背景/毛玻璃）；
- 仍保留 FAB 触发、自左滑入、点击空白/遮罩/Esc 收起；
- 展开时隐藏 FAB，避免与卡片重叠。

## 验证

- 本地 390×844 视口确认展开样式与桌面端常驻图例一致。
- 仅改动 `docs/graph.html`，无需 `make ci-preflight`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3159f6df-5b26-414b-b82c-5860d85ed755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3159f6df-5b26-414b-b82c-5860d85ed755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

