### PR TITLE
[2026-05-23] feat(ux) | V22 P3 图谱页"专题视图"切换器（全量 / 动作重定向 / 抓取 / 触觉与通信）

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -79,8 +79,12 @@
       - 第一版本（type 分桶）由社区分桶替代后不再保留：理由是 type 维度（概念/方法/实体/...）与现有 frontmatter type 字段重复，区分度不如 link-graph 社区聚类高（V22 P0 已把社区切到 17 个 ≤ 40% 阈值之内，刚好可用于"邻域属于哪些主题"的快速判断）。
       - 验证：`make lint-js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；本地 `python3 -m http.server` + Puppeteer 视口截图 `wiki-concepts-whole-body-control` 详情页（共 12 项 · 8 个社区：Whole-Body Control 4 / Imitation Learning 1 / Locomotion 1 / Motion Retargeting 3 / Sim2Real 1 / Unitree G1 1 / 1 / 未分类 1）与 `wiki-concepts-armature-modeling`（共 5 项 · 3 个社区：WBC 3 / Motion Retargeting 1 / Sim2Real 1），桌面端 1280px 与移动端 375px 双视口落稳。
       - 截图：`.cursor-artifacts/screenshots/detail-related-community-dist-wbc.png`、`detail-related-community-dist-wbc-mobile.png`、`detail-related-community-dist.png`。
-- [ ] **图谱页"专题视图"切换器**：
-    - [ ] `docs/graph.html` 增加下拉菜单，可选"全量 / 动作重定向 / 抓取 / 触觉与通信"三个子图过滤模式，复用 V21 微地图的同套 `path → type` 元数据。
+- [x] **图谱页"专题视图"切换器**：
+    - [x] `docs/graph.html` 增加下拉菜单，可选"全量 / 动作重定向 / 抓取 / 触觉与通信"三个子图过滤模式，复用 V21 微地图的同套 `path → type` 元数据。
+      - 实现：`docs/graph.html` 顶部工具栏在搜索框右侧新增 `<label#topic-view-wrap><select#topic-view>`（4 个选项：全量 / 动作重定向 / 抓取 / 触觉与通信），样式上沿用 `chip` 视觉规范并在激活态切换为高亮（深色：`rgba(0,212,255,0.14)` 边框+背景；浅色：`#e6f7ff` + `#1659b4` 描边）。JS 侧定义 `TOPIC_FILTERS`：动作重定向以 `community === 'community-8'` 为主信号叠加 17 个 path 片段（retargeting / gmr / nmr / reactor / sonic / exoactor / spider / wilor / mocap / teleoperation / deepmimic / amp / character / animation / keyframe / pipeline）；抓取以 9 个片段（grasp / graspnet / anygrasp / dexterous / manipulation / pick / place / bimanual / curobo）匹配；触觉与通信以 19 个片段（tactile / haptic / impedance / force / contact / visuo / ethercat / can / uart / dds / foxglove / rs485 / rs232 / serial / communication / protocol / bus / protocols / firmware）匹配并显式排除 `reinforcement` 误命中。新增 `nodeSegments(d)`（按 `/._-` 切分并 memo 化到 `d._segs`）+ `nodeMatchesTopic(d)`，并接入既有 `applyFilters()` 与 `link` 边权重透明度链路（与社区/类型/健康度/搜索筛选叠加，互不冲突），非命中节点保持 opacity 0.08 不丢失上下文。切换专题时调用新增的 `fitToVisibleNodes()` 自动缩放到该专题子图，切回"全量"恢复 `fitToScreen()`。
+      - 数据规模：MR 25 / Grasp 16 / Tactile-Comm 25（总节点 419），覆盖 V22 P1/P2 新增页（gmr-vs-nmr-vs-reactor、character-animation-vs-robotics、motion-retargeting-objective、grasp-pose-estimation、grasp-policy-selection、anygrasp-vs-graspnet、contact-rich-manipulation、visuo-tactile-fusion 等）。
+      - 验证：`npm run lint:js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；`node --check` 对 graph.html 提取的内联脚本通过；本地 `python3 -m http.server 8765` + Puppeteer 在 1440×900 视口对 4 种模式各截图一张，全部正常落稳。新增 `scripts/screenshot_graph_topic.cjs`（puppeteer-core + 本地 d3 注入兜底，便于离线/受限环境复现）。
+      - 截图：`.cursor-artifacts/screenshots/graph-topic-all.png`、`graph-topic-motion-retargeting.png`、`graph-topic-grasp.png`、`graph-topic-tactile-comm.png`。
 
 ---
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -51,6 +51,47 @@
     }
     #graph-search::placeholder { color: rgba(255,255,255,0.3); }
     #graph-search:focus { border-color: rgba(0,212,255,0.5); width: 240px; }
+    .topic-view-wrap {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      height: 28px;
+      padding: 0 10px 0 9px;
+      border-radius: 20px;
+      border: 1px solid rgba(255,255,255,0.12);
+      background: rgba(255,255,255,0.04);
+      color: rgba(255,255,255,0.55);
+      font-size: .78rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: border-color .15s, color .15s, background .15s;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .topic-view-wrap:hover { border-color: rgba(255,255,255,0.3); color: rgba(255,255,255,0.85); }
+    .topic-view-wrap.is-active {
+      background: rgba(0,212,255,0.14);
+      border-color: rgba(0,212,255,0.55);
+      color: #e6edf3;
+    }
+    .topic-view-icon { font-size: .82rem; line-height: 1; }
+    #topic-view {
+      appearance: none;
+      -webkit-appearance: none;
+      background: transparent;
+      border: none;
+      outline: none;
+      color: inherit;
+      font: inherit;
+      cursor: pointer;
+      padding-right: 14px;
+      background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                        linear-gradient(135deg, currentColor 50%, transparent 50%);
+      background-position: calc(100% - 7px) 50%, calc(100% - 3px) 50%;
+      background-size: 4px 4px, 4px 4px;
+      background-repeat: no-repeat;
+    }
+    #topic-view option { background: #0d1117; color: #e6edf3; }
     .chip-group { display: flex; gap: 6px; flex-wrap: wrap; }
     .chip {
       height: 28px;
@@ -340,6 +381,15 @@
       #filter-toggle {
         padding: 0 6px;
       }
+      .topic-view-wrap {
+        height: 26px;
+        padding: 0 8px 0 7px;
+        font-size: .72rem;
+      }
+      #topic-view {
+        padding-right: 12px;
+        background-position: calc(100% - 6px) 50%, calc(100% - 2px) 50%;
+      }
       #physics-toggle span:first-child {
         margin-right: 0;
       }
@@ -411,6 +461,21 @@
       border-color: rgba(0,0,0,0.28);
       color: rgba(0,0,0,0.8);
     }
+    [data-theme="light"] .topic-view-wrap {
+      border-color: rgba(0,0,0,0.1);
+      background: rgba(0,0,0,0.04);
+      color: rgba(0,0,0,0.55);
+    }
+    [data-theme="light"] .topic-view-wrap:hover {
+      border-color: rgba(0,0,0,0.28);
+      color: rgba(0,0,0,0.85);
+    }
+    [data-theme="light"] .topic-view-wrap.is-active {
+      background: #e6f7ff;
+      border-color: rgba(22,90,180,0.45);
+      color: #1659b4;
+    }
+    [data-theme="light"] #topic-view option { background: #fafaf6; color: #2f2d29; }
     [data-theme="light"] .toolbar-sep { background: rgba(0,0,0,0.1); }
     [data-theme="light"] #graph-node-count { color: rgba(0,0,0,0.38); }
     [data-theme="light"] #graph-back {
@@ -905,6 +970,16 @@
   <div id="graph-toolbar">
     <input id="graph-search" type="search" placeholder="搜索节点…" autocomplete="off" aria-label="搜索节点" list="graph-search-list" />
     <datalist id="graph-search-list"></datalist>
+    <!-- 专题视图切换器 -->
+    <label id="topic-view-wrap" class="topic-view-wrap" title="按专题子图过滤显示">
+      <span class="topic-view-icon" aria-hidden="true">📚</span>
+      <select id="topic-view" aria-label="专题视图">
+        <option value="all">全量</option>
+        <option value="motion-retargeting">动作重定向</option>
+        <option value="grasp">抓取</option>
+        <option value="tactile-comm">触觉与通信</option>
+      </select>
+    </label>
     <!-- 筛选按钮 -->
     <button id="filter-toggle" class="chip" title="按社区筛选">
       <span>🔍</span>&nbsp;<span id="filter-label">筛选</span>
@@ -1158,6 +1233,54 @@
     let focusedCommunityId = null;
     let focusedType = null;
     let focusedHealth = null;
+
+    /* ── 专题视图（V22 P3）：复用 link-graph.json 的 path / community 元数据 ── */
+    // 每个专题给一组路径片段，命中即视为属于该专题；MR 同时叠加 community-8。
+    const TOPIC_FILTERS = {
+      'motion-retargeting': {
+        community: 'community-8',
+        segments: new Set([
+          'retargeting','retarget','gmr','nmr','reactor','sonic','exoactor',
+          'spider','wilor','mocap','teleoperation','deepmimic','amp',
+          'character','animation','keyframe','pipeline'
+        ])
+      },
+      'grasp': {
+        segments: new Set([
+          'grasp','graspnet','anygrasp','dexterous','manipulation',
+          'pick','place','bimanual','curobo'
+        ])
+      },
+      'tactile-comm': {
+        segments: new Set([
+          'tactile','haptic','impedance','force','contact','visuo',
+          'ethercat','can','uart','dds','foxglove','rs485','rs232',
+          'serial','communication','protocol','bus','protocols','firmware'
+        ]),
+        excludeSegments: new Set(['reinforcement'])
+      }
+    };
+    let currentTopic = 'all';
+
+    function nodeSegments(d) {
+      if (d._segs) return d._segs;
+      const base = (d.id || '').toLowerCase().replace(/\.md$/, '');
+      d._segs = new Set(base.split(/[/._-]/).filter(Boolean));
+      return d._segs;
+    }
+
+    function nodeMatchesTopic(d) {
+      if (currentTopic === 'all') return true;
+      const cfg = TOPIC_FILTERS[currentTopic];
+      if (!cfg) return true;
+      if (cfg.community && d.community === cfg.community) return true;
+      const segs = nodeSegments(d);
+      if (cfg.excludeSegments) {
+        for (const ex of cfg.excludeSegments) if (segs.has(ex)) return false;
+      }
+      for (const seg of cfg.segments) if (segs.has(seg)) return true;
+      return false;
+    }
 
     /* ── 可变物理参数（由滑动块控制）── */
     let chargeStrength = -800;   // 排斥力（负值）
@@ -1859,6 +1982,19 @@
       applyFilters();
     });
 
+    /* ── 专题视图切换 ── */
+    const topicViewSelect = document.getElementById('topic-view');
+    const topicViewWrap = document.getElementById('topic-view-wrap');
+    if (topicViewSelect) {
+      topicViewSelect.addEventListener('change', ev => {
+        currentTopic = ev.target.value || 'all';
+        if (topicViewWrap) topicViewWrap.classList.toggle('is-active', currentTopic !== 'all');
+        applyFilters();
+        if (currentTopic !== 'all') fitToVisibleNodes();
+        else fitToScreen();
+      });
+    }
+
     /* 当前可见节点 ID 集合（供 hover 检查筛选状态用） */
     const visibleNodeIds = new Set();
 
@@ -1898,14 +2034,16 @@
 
     function applyFilters() {
       const hasFilter = topDegreeIds !== null || activeFilters.size > 0 || searchQuery.length > 0
-        || focusedCommunityId || focusedType || focusedHealth !== null;
+        || focusedCommunityId || focusedType || focusedHealth !== null
+        || currentTopic !== 'all';
       visibleNodeIds.clear();
       let visible = 0;
-      
+
       node.each(function(d) {
-        const ok = nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d) && nodeMatchesSearch(d);
+        const ok = nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
+          && nodeMatchesSearch(d) && nodeMatchesTopic(d);
         if (ok) { visible++; visibleNodeIds.add(d.id); }
-        
+
         // V21 修复：显式重置节点整体 opacity (移除 openSidebar 可能留下的残留)
         d3.select(this).style('opacity', hasFilter ? (ok ? 1 : 0.08) : 1);
 
@@ -1923,8 +2061,8 @@
           const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
           if (!s || !t) return 0.2;
           return (nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
-                  && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s)
-                  && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t)) ? 1 : 0.2;
+                  && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s)
+                  && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t)) ? 1 : 0.2;
         })
         .attr('stroke-width', e => {
           if (!hasFilter) return linkWidthBase;
@@ -1932,12 +2070,28 @@
           const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
           if (!s || !t) return linkWidthBase * 0.5;
           const edgeOk = nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
-            && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s)
-            && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t);
+            && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s)
+            && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t);
           return edgeOk ? linkWidthBase : linkWidthBase * 0.5;
         });
       updateCount(visible);
       if (searchQuery) flyToVisible();
+    }
+
+    function fitToVisibleNodes() {
+      const visNodes = nodes.filter(n => visibleNodeIds.has(n.id) && n.x != null);
+      if (visNodes.length === 0) return;
+      const xs = visNodes.map(n => n.x), ys = visNodes.map(n => n.y);
+      const x0 = Math.min(...xs), x1 = Math.max(...xs);
+      const y0 = Math.min(...ys), y1 = Math.max(...ys);
+      const cx = (x0 + x1) / 2, cy = (y0 + y1) / 2;
+      const pad = 140;
+      const scale = Math.min(5, Math.max(0.4,
+        Math.min(W / Math.max(x1 - x0 + pad, 200), H / Math.max(y1 - y0 + pad, 200))));
+      svg.transition().duration(650).call(
+        zoom.transform,
+        d3.zoomIdentity.translate(W / 2 - scale * cx, H / 2 - scale * cy).scale(scale)
+      );
     }
 
     /* ── 适配屏幕到所有节点 ── */

--- a/scripts/screenshot_graph_topic.cjs
+++ b/scripts/screenshot_graph_topic.cjs
@@ -1,0 +1,69 @@
+// Headless screenshot of docs/graph.html, exercising the V22 topic-view dropdown.
+// Usage: node screenshot_graph_topic.cjs <url> <out.png> [topicValue]
+const puppeteer = require('puppeteer-core');
+const path = require('path');
+const fs = require('fs');
+
+(async () => {
+  const [, , url, out, topic] = process.argv;
+  if (!url || !out) {
+    console.error('Usage: node screenshot_graph_topic.cjs <url> <out.png> [topic]');
+    process.exit(2);
+  }
+  const exe = process.env.PUPPETEER_EXECUTABLE_PATH || '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--window-size=1440,900', '--ignore-certificate-errors'],
+    ignoreHTTPSErrors: true,
+  });
+  // local d3 source as fallback when CDN is blocked in cloud env
+  const d3LocalCandidates = [
+    path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js'),
+  ];
+  const d3Local = d3LocalCandidates.find(p => fs.existsSync(p));
+  try {
+    const page = await browser.newPage();
+    page.on('console', msg => {
+      if (msg.type() === 'error' || msg.type() === 'warning') {
+        console.log('[browser]', msg.type(), msg.text());
+      }
+    });
+    page.on('pageerror', err => console.log('[pageerror]', err.message));
+    if (d3Local) {
+      const d3Body = fs.readFileSync(d3Local);
+      await page.setRequestInterception(true);
+      page.on('request', req => {
+        const u = req.url();
+        if (/\/d3@7\/dist\/d3(\.min)?\.js$/.test(u) || u.includes('cdn.jsdelivr.net/npm/d3')) {
+          req.respond({
+            status: 200,
+            contentType: 'application/javascript',
+            body: d3Body,
+          });
+        } else {
+          req.continue();
+        }
+      });
+    }
+    await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-node-count');
+      return el && el.textContent && !el.textContent.includes('加载中');
+    }, { timeout: 25000 }).catch(() => {});
+    await new Promise(r => setTimeout(r, 6000));
+    await page.evaluate(() => {
+      const ld = document.getElementById('graph-loading');
+      if (ld) ld.style.display = 'none';
+    });
+    if (topic && topic !== 'all') {
+      await page.select('#topic-view', topic);
+      await new Promise(r => setTimeout(r, 1800));
+    }
+    await page.screenshot({ path: path.resolve(out), fullPage: false });
+    console.log('Saved:', out);
+  } finally {
+    await browser.close();
+  }
+})().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## 摘要

- 收口 V22 P3 最后一项：`docs/graph.html` 顶部工具栏新增「专题视图」下拉菜单，可在「全量 / 动作重定向 / 抓取 / 触觉与通信」之间切换；复用 `exports/link-graph.json` 的 `path` 片段与 `community` 元数据，非命中节点保持 opacity 0.08，与已有社区/类型/健康度/搜索筛选互不冲突。
- 切换专题时自动调用新增的 `fitToVisibleNodes()` 缩放到子图，切回「全量」恢复 `fitToScreen()`，避免用户手动拖拽定位。
- V22 checklist 该子项打勾并落地实现 / 数据规模 / 验证三段说明；至此 V22 全部条目完成。

## 实现要点

- HTML：`<label#topic-view-wrap><select#topic-view>` 4 个选项，沿用 `chip` 视觉规范，激活态在深色 / 浅色双主题下各自高亮。
- JS：`TOPIC_FILTERS` 字面量声明 3 个专题的命中规则（MR 叠加 `community-8` + 17 个 path 片段；Grasp 9 个片段；Tactile-Comm 19 个片段并显式排除 `reinforcement` 误命中）；新增 `nodeSegments(d)` 按 `/._-` 切分并 memo 化、`nodeMatchesTopic(d)` 接入 `applyFilters()` 与 `link` 边权重透明度链路。
- 移动端（≤768px）下拉菜单按 26px 高度收缩，工具栏不溢出。
- 离线验证：`scripts/screenshot_graph_topic.cjs`（puppeteer-core + 本地 d3 注入兜底）方便受限/Cloud 环境复现。

## 数据规模

- 动作重定向：25 节点（GMR/NMR/ReActor/SONIC/ExoActor/SPIDER/WiLoR/DeepMimic/AMP/Character-Animation/Keyframe-Editors 等）
- 抓取：16 节点（GraspNet 家族 / AnyGrasp / Grasp-Pose-Estimation / Dexterous / Bimanual-Manipulation / cuRobo 等）
- 触觉与通信：25 节点（Tactile-Sensing / Visuo-Tactile-Fusion / Force / Impedance / Contact / EtherCAT / CAN / UART / Motor-Drive-Firmware-Bus-Protocols 等）

总节点 419，命中数与 V22 P1/P2 新增的 8 篇专题页（gmr-vs-nmr-vs-reactor / character-animation-vs-robotics / motion-retargeting-objective / grasp-pose-estimation / grasp-policy-selection / anygrasp-vs-graspnet / contact-rich-manipulation / visuo-tactile-fusion）形成闭环。

## 验证

- `npm run lint:js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）
- `node --check` 对 `docs/graph.html` 提取的内联脚本通过
- 本地 `python3 -m http.server 8765` + Puppeteer 在 1440×900 视口对 4 种模式各截图一张，全部正常落稳；动作重定向 / 抓取 / 触觉与通信子图明显聚焦，非命中节点保持 0.08 透明度可见

## 验证截图

`&lt;img alt="V22 专题视图 — 全量" src=".cursor-artifacts/screenshots/graph-topic-all.png" /&gt;`
`&lt;img alt="V22 专题视图 — 动作重定向" src=".cursor-artifacts/screenshots/graph-topic-motion-retargeting.png" /&gt;`
`&lt;img alt="V22 专题视图 — 抓取" src=".cursor-artifacts/screenshots/graph-topic-grasp.png" /&gt;`
`&lt;img alt="V22 专题视图 — 触觉与通信" src=".cursor-artifacts/screenshots/graph-topic-tactile-comm.png" /&gt;`

## Test plan

- [x] `npm run lint:js`
- [x] `node --check` 对 graph.html 内联脚本通过
- [x] 本地静态服务 + Puppeteer 4 种模式截图全部落稳
- [x] V22 checklist 同步打勾 + 实现/数据/验证三段说明

https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y)_