### PR TITLE
[2026-05-23] feat(ux) | 拆分"触觉与通信"并扩充图谱专题视图至 10 项

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -81,10 +81,22 @@
       - 截图：`.cursor-artifacts/screenshots/detail-related-community-dist-wbc.png`、`detail-related-community-dist-wbc-mobile.png`、`detail-related-community-dist.png`。
 - [x] **图谱页"专题视图"切换器**：
     - [x] `docs/graph.html` 增加下拉菜单，可选"全量 / 动作重定向 / 抓取 / 触觉与通信"三个子图过滤模式，复用 V21 微地图的同套 `path → type` 元数据。
-      - 实现：`docs/graph.html` 顶部工具栏在搜索框右侧新增 `<label#topic-view-wrap><select#topic-view>`（4 个选项：全量 / 动作重定向 / 抓取 / 触觉与通信），样式上沿用 `chip` 视觉规范并在激活态切换为高亮（深色：`rgba(0,212,255,0.14)` 边框+背景；浅色：`#e6f7ff` + `#1659b4` 描边）。JS 侧定义 `TOPIC_FILTERS`：动作重定向以 `community === 'community-8'` 为主信号叠加 17 个 path 片段（retargeting / gmr / nmr / reactor / sonic / exoactor / spider / wilor / mocap / teleoperation / deepmimic / amp / character / animation / keyframe / pipeline）；抓取以 9 个片段（grasp / graspnet / anygrasp / dexterous / manipulation / pick / place / bimanual / curobo）匹配；触觉与通信以 19 个片段（tactile / haptic / impedance / force / contact / visuo / ethercat / can / uart / dds / foxglove / rs485 / rs232 / serial / communication / protocol / bus / protocols / firmware）匹配并显式排除 `reinforcement` 误命中。新增 `nodeSegments(d)`（按 `/._-` 切分并 memo 化到 `d._segs`）+ `nodeMatchesTopic(d)`，并接入既有 `applyFilters()` 与 `link` 边权重透明度链路（与社区/类型/健康度/搜索筛选叠加，互不冲突），非命中节点保持 opacity 0.08 不丢失上下文。切换专题时调用新增的 `fitToVisibleNodes()` 自动缩放到该专题子图，切回"全量"恢复 `fitToScreen()`。
-      - 数据规模：MR 25 / Grasp 16 / Tactile-Comm 25（总节点 419），覆盖 V22 P1/P2 新增页（gmr-vs-nmr-vs-reactor、character-animation-vs-robotics、motion-retargeting-objective、grasp-pose-estimation、grasp-policy-selection、anygrasp-vs-graspnet、contact-rich-manipulation、visuo-tactile-fusion 等）。
-      - 验证：`npm run lint:js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；`node --check` 对 graph.html 提取的内联脚本通过；本地 `python3 -m http.server 8765` + Puppeteer 在 1440×900 视口对 4 种模式各截图一张，全部正常落稳。新增 `scripts/screenshot_graph_topic.cjs`（puppeteer-core + 本地 d3 注入兜底，便于离线/受限环境复现）。
-      - 截图：`.cursor-artifacts/screenshots/graph-topic-all.png`、`graph-topic-motion-retargeting.png`、`graph-topic-grasp.png`、`graph-topic-tactile-comm.png`。
+      - 实现：`docs/graph.html` 顶部工具栏在搜索框右侧新增 `<label#topic-view-wrap><select#topic-view>`，样式沿用 `chip` 视觉规范并在激活态切换高亮（深色 `rgba(0,212,255,0.14)` / 浅色 `#e6f7ff` + `#1659b4` 描边）。JS 侧 `TOPIC_FILTERS` 字面量声明每个专题的命中规则，按 community id 集合 + path 片段集合双路并集判定（任一命中即可），可选 `excludeSegments` 抑制误命中。新增 `nodeSegments(d)`（按 `/._-` 切分并 memo 化到 `d._segs`）+ `nodeMatchesTopic(d)`，接入既有 `applyFilters()` 与 `link` 边权重透明度链路（与社区/类型/健康度/搜索筛选叠加，互不冲突），非命中节点保持 opacity 0.08 不丢失上下文。切换专题时调用新增的 `fitToVisibleNodes()` 自动缩放到该子图，切回"全量"恢复 `fitToScreen()`。
+      - 专题（共 10 项，按用户反馈在初版"触觉与通信"基础上拆分并扩充）：
+        | 专题 | 命中规则 | 节点数 |
+        |------|----------|--------|
+        | 动作重定向 | community-8 + retargeting/gmr/nmr/reactor/sonic/exoactor/spider/wilor/mocap/teleoperation/deepmimic/amp/character/animation/keyframe/pipeline | 25 |
+        | 抓取 | grasp/graspnet/anygrasp/dexterous/manipulation/pick/place/bimanual/curobo | 16 |
+        | 触觉 | tactile/haptic/impedance/force/contact/visuo（exclude reinforcement） | 16 |
+        | 通信协议 | ethercat/can/uart/dds/foxglove/rs485/rs232/serial/communication/protocol/bus/protocols/firmware | 9 |
+        | WBC 全身控制 | community-2 + community-15 + wbc/tsid/hqp/cbf/clf/whole/body/balance/hierarchical | ≈32 |
+        | Locomotion 步态 | community-14 + locomotion/gait/mpc/zmp/lip/walking/swing/stance/capture | ≈25 |
+        | VLA / 基础策略 | community-0 + community-5 + vla/foundation/octo/openvla/rt/pi0/gr00t | ≈111 |
+        | 学习范式 IL/RL | community-3 + community-4 + imitation/reinforcement/ppo/sac/behavior/cloning/dreamer | ≈40 |
+        | Sim2Real | community-11 + sim2real/randomization | ≈25 |
+        | 状态估计 | community-10 + estimation/ekf/ukf/slam/vio/odometry | ≈15 |
+      - 验证：`npm run lint:js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告，与本次改动无关）；`node --check` 对 graph.html 提取的内联脚本通过；本地 `python3 -m http.server 8765` + Puppeteer 在 1440×900 视口对全部 11 种模式各截图一张，全部正常落稳。新增 `scripts/screenshot_graph_topic.cjs`（puppeteer-core + 本地 d3 注入兜底，便于离线/受限环境复现）。
+      - 截图：`.cursor-artifacts/screenshots/graph-topic-{all,motion-retargeting,grasp,tactile,communication,wbc,locomotion,vla,learning,sim2real,state-estimation}.png`。
 
 ---
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -977,7 +977,14 @@
         <option value="all">全量</option>
         <option value="motion-retargeting">动作重定向</option>
         <option value="grasp">抓取</option>
-        <option value="tactile-comm">触觉与通信</option>
+        <option value="tactile">触觉</option>
+        <option value="communication">通信协议</option>
+        <option value="wbc">WBC 全身控制</option>
+        <option value="locomotion">Locomotion 步态</option>
+        <option value="vla">VLA / 基础策略</option>
+        <option value="learning">学习范式 IL/RL</option>
+        <option value="sim2real">Sim2Real</option>
+        <option value="state-estimation">状态估计</option>
       </select>
     </label>
     <!-- 筛选按钮 -->
@@ -1235,10 +1242,10 @@
     let focusedHealth = null;
 
     /* ── 专题视图（V22 P3）：复用 link-graph.json 的 path / community 元数据 ── */
-    // 每个专题给一组路径片段，命中即视为属于该专题；MR 同时叠加 community-8。
+    // 每个专题给一组路径片段或 community id，命中即视为属于该专题（叠加关系，任一命中即可）。
     const TOPIC_FILTERS = {
       'motion-retargeting': {
-        community: 'community-8',
+        communities: new Set(['community-8']),
         segments: new Set([
           'retargeting','retarget','gmr','nmr','reactor','sonic','exoactor',
           'spider','wilor','mocap','teleoperation','deepmimic','amp',
@@ -1251,13 +1258,53 @@
           'pick','place','bimanual','curobo'
         ])
       },
-      'tactile-comm': {
+      'tactile': {
         segments: new Set([
-          'tactile','haptic','impedance','force','contact','visuo',
-          'ethercat','can','uart','dds','foxglove','rs485','rs232',
-          'serial','communication','protocol','bus','protocols','firmware'
+          'tactile','haptic','impedance','force','contact','visuo'
         ]),
         excludeSegments: new Set(['reinforcement'])
+      },
+      'communication': {
+        segments: new Set([
+          'ethercat','can','uart','dds','foxglove','rs485','rs232',
+          'serial','communication','protocol','bus','protocols','firmware'
+        ])
+      },
+      'wbc': {
+        communities: new Set(['community-2','community-15']),
+        segments: new Set([
+          'wbc','tsid','hqp','cbf','clf','whole','body','balance','hierarchical'
+        ])
+      },
+      'locomotion': {
+        communities: new Set(['community-14']),
+        segments: new Set([
+          'locomotion','gait','mpc','zmp','lip','walking','swing','stance','capture'
+        ])
+      },
+      'vla': {
+        communities: new Set(['community-0','community-5']),
+        segments: new Set([
+          'vla','foundation','octo','openvla','rt','pi0','gr00t'
+        ])
+      },
+      'learning': {
+        communities: new Set(['community-3','community-4']),
+        segments: new Set([
+          'imitation','reinforcement','ppo','sac','behavior','cloning','dreamer'
+        ])
+      },
+      'sim2real': {
+        communities: new Set(['community-11']),
+        segments: new Set([
+          'sim2real','randomization'
+        ])
+      },
+      'state-estimation': {
+        communities: new Set(['community-10']),
+        segments: new Set([
+          'estimation','ekf','ukf','slam','vio','odometry'
+        ])
       }
     };
     let currentTopic = 'all';
@@ -1273,12 +1320,14 @@
       if (currentTopic === 'all') return true;
       const cfg = TOPIC_FILTERS[currentTopic];
       if (!cfg) return true;
-      if (cfg.community && d.community === cfg.community) return true;
       const segs = nodeSegments(d);
       if (cfg.excludeSegments) {
         for (const ex of cfg.excludeSegments) if (segs.has(ex)) return false;
       }
-      for (const seg of cfg.segments) if (segs.has(seg)) return true;
+      if (cfg.communities && cfg.communities.has(d.community)) return true;
+      if (cfg.segments) {
+        for (const seg of cfg.segments) if (segs.has(seg)) return true;
+      }
       return false;
     }
 


### PR DESCRIPTION
## 摘要

承接 #359（V22 P3 专题视图切换器初版），按用户反馈把「触觉与通信」拆开并扩充专题维度：

- 「触觉与通信」 → 拆为「触觉」(16 节点) + 「通信协议」(9 节点)，避免一个专题混两套语义
- 新增 6 个专题：WBC 全身控制 / Locomotion 步态 / VLA 基础策略 / 学习范式 IL/RL / Sim2Real / 状态估计
- TOPIC_FILTERS 重构为 `communities`(Set) + `segments`(Set) + 可选 `excludeSegments`，统一并集判定
- `nodeMatchesTopic(d)` 同步支持 `communities` 多 community 集合（原仅支持单 community 字段）

## 专题命中规则

| 专题 | 命中规则 | 节点数 |
|------|----------|--------|
| 动作重定向 | community-8 + retargeting/gmr/nmr/reactor/sonic/exoactor/spider/wilor/mocap/teleoperation/deepmimic/amp/character/animation/keyframe/pipeline | 25 |
| 抓取 | grasp/graspnet/anygrasp/dexterous/manipulation/pick/place/bimanual/curobo | 16 |
| 触觉 | tactile/haptic/impedance/force/contact/visuo（exclude reinforcement） | 16 |
| 通信协议 | ethercat/can/uart/dds/foxglove/rs485/rs232/serial/communication/protocol/bus/protocols/firmware | 9 |
| WBC 全身控制 | community-2 + community-15 + wbc/tsid/hqp/cbf/clf/whole/body/balance/hierarchical | ≈32 |
| Locomotion 步态 | community-14 + locomotion/gait/mpc/zmp/lip/walking/swing/stance/capture | ≈25 |
| VLA / 基础策略 | community-0 + community-5 + vla/foundation/octo/openvla/rt/pi0/gr00t | ≈111 |
| 学习范式 IL/RL | community-3 + community-4 + imitation/reinforcement/ppo/sac/behavior/cloning/dreamer | ≈40 |
| Sim2Real | community-11 + sim2real/randomization | ≈25 |
| 状态估计 | community-10 + estimation/ekf/ukf/slam/vio/odometry | ≈15 |

## 验证

- `npm run lint:js` 通过（仅一条 pre-existing 的 `resetMermaidLightboxView` 未使用警告）
- `node --check` 对 graph.html 提取的内联脚本通过
- 本地 `python3 -m http.server 8765` + Puppeteer 在 1440×900 视口对全部 11 种模式（含全量）各截图一张，全部正常落稳

## 验证截图

`&lt;img alt="V22 专题视图 — 触觉" src=".cursor-artifacts/screenshots/graph-topic-tactile.png" /&gt;`
`&lt;img alt="V22 专题视图 — 通信协议" src=".cursor-artifacts/screenshots/graph-topic-communication.png" /&gt;`
`&lt;img alt="V22 专题视图 — WBC" src=".cursor-artifacts/screenshots/graph-topic-wbc.png" /&gt;`
`&lt;img alt="V22 专题视图 — Locomotion" src=".cursor-artifacts/screenshots/graph-topic-locomotion.png" /&gt;`
`&lt;img alt="V22 专题视图 — VLA / 基础策略" src=".cursor-artifacts/screenshots/graph-topic-vla.png" /&gt;`
`&lt;img alt="V22 专题视图 — IL/RL" src=".cursor-artifacts/screenshots/graph-topic-learning.png" /&gt;`
`&lt;img alt="V22 专题视图 — Sim2Real" src=".cursor-artifacts/screenshots/graph-topic-sim2real.png" /&gt;`
`&lt;img alt="V22 专题视图 — 状态估计" src=".cursor-artifacts/screenshots/graph-topic-state-estimation.png" /&gt;`

## Test plan

- [x] `npm run lint:js` + `node --check`
- [x] Puppeteer 截图覆盖 11 种模式（全量 + 10 专题）
- [x] V22 checklist 同步更新命中规则表（含节点数）

https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y)_