### PR TITLE
fix(ux): 移动端专题下拉宽度限制，隐藏图标保持工具栏单行

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -383,12 +383,17 @@
       }
       .topic-view-wrap {
         height: 26px;
-        padding: 0 8px 0 7px;
+        padding: 0 6px;
         font-size: .72rem;
+        max-width: 72px;
+        overflow: hidden;
+        flex-shrink: 1;
       }
+      .topic-view-icon { display: none; }
       #topic-view {
-        padding-right: 12px;
-        background-position: calc(100% - 6px) 50%, calc(100% - 2px) 50%;
+        padding-right: 10px;
+        background-position: calc(100% - 5px) 50%, calc(100% - 1px) 50%;
+        max-width: 100%;
       }
       #physics-toggle span:first-child {
         margin-right: 0;
@@ -417,10 +422,13 @@
 
     @media (max-width: 480px) {
       #graph-search {
-        width: 100px;
+        width: 90px;
       }
       #graph-search:focus {
-        width: 140px;
+        width: 120px;
+      }
+      .topic-view-wrap {
+        max-width: 60px;
       }
     }
 

--- a/scripts/screenshot_mobile.cjs
+++ b/scripts/screenshot_mobile.cjs
@@ -1,0 +1,54 @@
+// Screenshot graph.html at mobile viewport, cycling topics to show no wrap
+const puppeteer = require('puppeteer-core');
+const path = require('path');
+const fs = require('fs');
+
+(async () => {
+  const [, , url, outDir] = process.argv;
+  const exe = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+  const d3Local = path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js');
+  const d3Body = fs.readFileSync(d3Local);
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--window-size=390,844', '--ignore-certificate-errors'],
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 390, height: 844, deviceScaleFactor: 2 });
+    await page.setRequestInterception(true);
+    page.on('request', req => {
+      if (req.url().includes('cdn.jsdelivr.net/npm/d3')) {
+        req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+      } else { req.continue(); }
+    });
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-node-count');
+      return el && el.textContent && !el.textContent.includes('加载中');
+    }, { timeout: 25000 }).catch(() => {});
+    await new Promise(r => setTimeout(r, 6000));
+    await page.evaluate(() => {
+      const ld = document.getElementById('graph-loading');
+      if (ld) ld.style.display = 'none';
+    });
+
+    // screenshot with default "全量"
+    await page.screenshot({ path: path.resolve(outDir, 'mobile-toolbar-all.png'), clip: { x:0, y:0, width:390, height:100 } });
+
+    // switch to a long topic
+    await page.select('#topic-view', 'motion-retargeting');
+    await new Promise(r => setTimeout(r, 600));
+    await page.screenshot({ path: path.resolve(outDir, 'mobile-toolbar-mr.png'), clip: { x:0, y:0, width:390, height:100 } });
+
+    await page.select('#topic-view', 'vla');
+    await new Promise(r => setTimeout(r, 600));
+    await page.screenshot({ path: path.resolve(outDir, 'mobile-toolbar-vla.png'), clip: { x:0, y:0, width:390, height:100 } });
+
+    console.log('Done');
+  } finally {
+    await browser.close();
+  }
+})().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## 摘要

- 移动端（≤768px）专题下拉框切换到长选项（如"动作重定向"、"VLA / 基础策略"）时撑宽工具栏导致换行，修复为固定最大宽度 + 超长文字截断，保持单行布局
- 隐藏 📚 图标（mobile 下节省横向空间），选项文字在 72px 内截断显示，原生 select 下拉列表仍显示完整文字
- 极窄屏（≤480px）进一步收缩至 60px，同步缩小搜索框至 90px

## 改动

```css
@media (max-width: 768px) {
  .topic-view-wrap { max-width: 72px; overflow: hidden; flex-shrink: 1; }
  .topic-view-icon { display: none; }
}
@media (max-width: 480px) {
  .topic-view-wrap { max-width: 60px; }
  #graph-search { width: 90px; }
}
```

## 验证截图（390×844 iPhone 14 Pro 尺寸，2× deviceScaleFactor）

工具栏保持单行，长选项截断显示：

`&lt;img alt="移动端工具栏 — 全量" src=".cursor-artifacts/screenshots/mobile-toolbar-all.png" /&gt;`
`&lt;img alt="移动端工具栏 — 动作重定向（截断为动作重▼）" src=".cursor-artifacts/screenshots/mobile-toolbar-mr.png" /&gt;`
`&lt;img alt="移动端工具栏 — VLA/基础策略（截断为 VLA / 基▼）" src=".cursor-artifacts/screenshots/mobile-toolbar-vla.png" /&gt;`

## Test plan

- [x] Puppeteer 390px 视口，切换全量 / 动作重定向 / VLA 三种选项，工具栏均单行不换行
- [x] `node --check` 语法无误（无 JS 改动）

https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y)_