### PR TITLE
fix(ux): 移动端专题切换器改为圆形 emoji 按钮，去掉右侧多余下拉箭头

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -386,23 +386,30 @@
       #filter-toggle {
         padding: 0 6px;
       }
-      /* 移动端：closed state 仅显示 overlay emoji，select 自身文字隐藏 (text-indent off-screen)；下拉列表仍走原生渲染，显示完整文字 */
+      /* 移动端：将专题切换器做成圆形 emoji 按钮 — overlay span 居中显示，select 覆盖整圆透明接管点击 */
       .topic-view-wrap {
-        height: 26px;
-        padding: 0 6px;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        border-radius: 50%;
+        justify-content: center;
         flex-shrink: 0;
-        gap: 0;
       }
       .topic-view-emoji {
         display: inline-block;
         font-size: 14px;
+        line-height: 1;
       }
       #topic-view {
-        width: 14px;
-        text-indent: -9999px;
-        padding: 0 8px 0 0;
-        background-position: calc(100% - 0px) 50%, calc(100% + 4px) 50%;
-        color: transparent;
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        padding: 0;
+        margin: 0;
+        opacity: 0;
+        background-image: none;
+        cursor: pointer;
       }
       #physics-toggle span:first-child {
         margin-right: 0;
@@ -437,7 +444,9 @@
         width: 120px;
       }
       .topic-view-wrap {
-        padding: 0 5px;
+        width: 26px;
+        height: 26px;
+        padding: 0;
       }
     }
 


### PR DESCRIPTION
## 摘要

承接 #363（emoji overlay 方案），用户反馈"专题下拉列表用圆形就可以，当前的下拉列表看起来右侧空了一块不协调"。本 PR 把移动端切换器改为干净的圆形 emoji 按钮：

- 移动端 `.topic-view-wrap` → 28×28 圆形（≤480px 时 26×26），`border-radius: 50%`，emoji 居中
- 移除背景下拉箭头（之前的 `linear-gradient` 双三角 hack）
- `#topic-view` 用 `position: absolute; inset: 0; opacity: 0` 全覆盖，接管点击仍触发原生下拉
- 桌面端样式不变（仍是带文字 + 下拉箭头的胶囊状）

## 验证截图

**移动端（390×844, 2×）— 圆形 emoji 按钮，右侧无多余空间：**

`&lt;img alt="移动端 — 🌐 全量" src=".cursor-artifacts/screenshots/mobile-toolbar-all.png" /&gt;`
`&lt;img alt="移动端 — 🤸 动作重定向（激活态青色边框）" src=".cursor-artifacts/screenshots/mobile-toolbar-mr.png" /&gt;`
`&lt;img alt="移动端 — 👀 VLA / 基础策略" src=".cursor-artifacts/screenshots/mobile-toolbar-vla.png" /&gt;`

**桌面端（1440×900）— 不变：**

`&lt;img alt="桌面端 — 🤸 动作重定向" src=".cursor-artifacts/screenshots/graph-topic-motion-retargeting.png" /&gt;`

## Test plan

- [x] `node --check` 通过
- [x] Puppeteer 移动端 / 桌面端双视口截图核验
- [x] 三种激活态（全量 / 动作重定向 / VLA）切换正常

https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y)_