### PR TITLE
feat(ux): 专题视图改为可折叠 details 下拉栏，summary 显示当前选中

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -51,18 +51,53 @@
     }
     #graph-search::placeholder { color: rgba(255,255,255,0.3); }
     #graph-search:focus { border-color: rgba(0,212,255,0.5); width: 240px; }
-    /* 专题视图区块（在筛选面板里）*/
+    /* 专题视图区块（在筛选面板里，可折叠 <details>）*/
     .filter-topic-section {
-      padding: 10px 14px 12px;
       border-bottom: 1px solid rgba(255,255,255,0.06);
     }
-    .filter-topic-section .filter-section-title {
-      margin-bottom: 8px;
+    .filter-topic-summary {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      cursor: pointer;
+      list-style: none;
+      user-select: none;
+      transition: background .12s;
     }
+    .filter-topic-summary:hover { background: rgba(255,255,255,0.03); }
+    .filter-topic-summary::-webkit-details-marker { display: none; }
+    .filter-topic-summary::after {
+      content: '▾';
+      margin-left: auto;
+      font-size: 10px;
+      color: rgba(255,255,255,0.45);
+      transition: transform .18s;
+    }
+    .filter-topic-section[open] .filter-topic-summary::after {
+      transform: rotate(180deg);
+    }
+    .filter-topic-summary-label {
+      font-size: .68rem;
+      font-weight: 700;
+      color: rgba(255,255,255,0.34);
+      text-transform: uppercase;
+      letter-spacing: .06em;
+    }
+    .filter-topic-summary-current {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      font-size: .75rem;
+      font-weight: 600;
+      color: rgba(255,255,255,0.78);
+    }
+    .filter-topic-summary-current span:first-child { font-size: .92rem; line-height: 1; }
     .filter-topic-chips {
       display: flex;
       flex-wrap: wrap;
       gap: 6px;
+      padding: 2px 14px 12px;
     }
     .filter-topic-chip {
       display: inline-flex;
@@ -453,6 +488,10 @@
     [data-theme="light"] .filter-topic-section {
       border-bottom-color: rgba(0,0,0,0.07);
     }
+    [data-theme="light"] .filter-topic-summary:hover { background: rgba(0,0,0,0.03); }
+    [data-theme="light"] .filter-topic-summary::after { color: rgba(0,0,0,0.45); }
+    [data-theme="light"] .filter-topic-summary-label { color: rgba(0,0,0,0.4); }
+    [data-theme="light"] .filter-topic-summary-current { color: rgba(0,0,0,0.7); }
     [data-theme="light"] .filter-topic-chip {
       border-color: rgba(0,0,0,0.1);
       background: rgba(0,0,0,0.04);
@@ -1053,8 +1092,11 @@
         <span id="filter-panel-title">🔍 图谱筛选</span>
         <button id="filter-close" class="filter-close" aria-label="关闭面板">✕</button>
       </div>
-      <div class="filter-topic-section" aria-label="专题视图">
-        <div class="filter-section-title">专题视图</div>
+      <details class="filter-topic-section" id="filter-topic-section">
+        <summary class="filter-topic-summary">
+          <span class="filter-topic-summary-label">专题视图</span>
+          <span class="filter-topic-summary-current" id="filter-topic-current"><span>🌐</span><span>全量</span></span>
+        </summary>
         <div class="filter-topic-chips" id="filter-topic-chips">
           <button class="filter-topic-chip is-active" type="button" data-topic="all" title="全量"><span>🌐</span><span>全量</span></button>
           <button class="filter-topic-chip" type="button" data-topic="motion-retargeting" title="动作重定向"><span>🤸</span><span>动作重定向</span></button>
@@ -1068,7 +1110,7 @@
           <button class="filter-topic-chip" type="button" data-topic="sim2real" title="Sim2Real"><span>🔁</span><span>Sim2Real</span></button>
           <button class="filter-topic-chip" type="button" data-topic="state-estimation" title="状态估计"><span>📊</span><span>状态估计</span></button>
         </div>
-      </div>
+      </details>
       <div class="filter-mode-tabs" id="filter-mode-tabs" aria-label="筛选维度">
         <button id="filter-mode-type" class="chip" type="button">按类型</button>
         <button id="filter-mode-community" class="chip active" type="button">按社区</button>
@@ -2020,15 +2062,20 @@
       applyFilters();
     });
 
-    /* ── 专题视图切换（已合入筛选面板内）── */
+    /* ── 专题视图切换（已合入筛选面板内 <details> 区块）── */
     const topicChipsEl = document.getElementById('filter-topic-chips');
+    const topicCurrentEl = document.getElementById('filter-topic-current');
     function setActiveTopic(topic) {
       currentTopic = topic || 'all';
+      let activeBtn = null;
       if (topicChipsEl) {
         topicChipsEl.querySelectorAll('.filter-topic-chip').forEach(btn => {
-          btn.classList.toggle('is-active', btn.getAttribute('data-topic') === currentTopic);
+          const on = btn.getAttribute('data-topic') === currentTopic;
+          btn.classList.toggle('is-active', on);
+          if (on) activeBtn = btn;
         });
       }
+      if (topicCurrentEl && activeBtn) topicCurrentEl.innerHTML = activeBtn.innerHTML;
       applyFilters();
       updateFilterCount();
       if (currentTopic !== 'all') fitToVisibleNodes();

--- a/scripts/screenshot_filter_panel.cjs
+++ b/scripts/screenshot_filter_panel.cjs
@@ -35,6 +35,12 @@ const fs = require('fs');
     // open filter panel
     await page.click('#filter-toggle');
     await new Promise(r => setTimeout(r, 400));
+    // open the collapsed topic <details> so chips are visible / clickable
+    await page.evaluate(() => {
+      const det = document.getElementById('filter-topic-section');
+      if (det && !det.open) det.open = true;
+    });
+    await new Promise(r => setTimeout(r, 300));
     // optionally select a topic chip
     if (topic && topic !== 'all') {
       await page.click(`.filter-topic-chip[data-topic="${topic}"]`);

--- a/scripts/screenshot_mobile.cjs
+++ b/scripts/screenshot_mobile.cjs
@@ -41,6 +41,11 @@ const fs = require('fs');
     // activate a topic via filter panel, close, screenshot toolbar to verify badge
     await page.click('#filter-toggle');
     await new Promise(r => setTimeout(r, 300));
+    await page.evaluate(() => {
+      const det = document.getElementById('filter-topic-section');
+      if (det && !det.open) det.open = true;
+    });
+    await new Promise(r => setTimeout(r, 200));
     await page.click('.filter-topic-chip[data-topic="motion-retargeting"]');
     await new Promise(r => setTimeout(r, 800));
     await page.click('#filter-close');


### PR DESCRIPTION
## 摘要

承接 #365（专题视图合入筛选面板），按用户反馈"专题视图可以在现有基础上再做成下拉栏"，把 11 个 chip 包进可折叠 `<details>`，默认折叠节省垂直空间，summary 处实时显示当前选中。

## 改动

**HTML** — 将 `<div class="filter-topic-section">` 改为 `<details>` + `<summary>`：

```html
<details class="filter-topic-section" id="filter-topic-section">
  <summary class="filter-topic-summary">
    <span class="filter-topic-summary-label">专题视图</span>
    <span class="filter-topic-summary-current" id="filter-topic-current">
      <span>🌐</span><span>全量</span>
    </span>
  </summary>
  <div class="filter-topic-chips" id="filter-topic-chips">...</div>
</details>
```

**CSS**
- `.filter-topic-summary`：hover 高亮、隐藏原生 marker、右侧 ▾ 箭头
- `[open]` 状态箭头 `transform: rotate(180deg)` 反转
- `.filter-topic-summary-current` 显示当前 emoji + 简称，与展开后 chip 视觉一致
- 浅色模式同步覆盖 hover / 箭头 / 标签 / 当前选中颜色

**JS** — `setActiveTopic` 把激活 chip 的 `innerHTML` 拷给 summary：
```js
if (topicCurrentEl && activeBtn) topicCurrentEl.innerHTML = activeBtn.innerHTML;
```

## 验证截图

**桌面端 — 折叠态（全量）：summary 只一行**

`&lt;img alt="桌面端 折叠态 全量" src=".cursor-artifacts/screenshots/filter-details-desktop-collapsed.png" /&gt;`

**桌面端 — 折叠态（动作重定向）：summary 直接显示 🤸 动作重定向，无需展开**

`&lt;img alt="桌面端 折叠态 动作重定向" src=".cursor-artifacts/screenshots/filter-details-desktop-collapsed-mr.png" /&gt;`

**桌面端 — 展开态（动作重定向）：11 chip 完整可见，▾ 翻转为 ▴**

`&lt;img alt="桌面端 展开态 动作重定向" src=".cursor-artifacts/screenshots/filter-details-desktop-expanded-mr.png" /&gt;`

**移动端 — 折叠态（VLA）：单行展示当前选中**

`&lt;img alt="移动端 折叠态 VLA" src=".cursor-artifacts/screenshots/filter-details-mobile-collapsed-vla.png" /&gt;`

**移动端 — 展开态（VLA）：chip 展开 + 当前 VLA 高亮**

`&lt;img alt="移动端 展开态 VLA" src=".cursor-artifacts/screenshots/filter-details-mobile-expanded-vla.png" /&gt;`

## Test plan

- [x] `node --check` 通过
- [x] Puppeteer 桌面/移动 × 折叠/展开 × 全量/单专题 多组合截图正常
- [x] 折叠态 summary 显示当前选中（emoji + 名称）
- [x] 切换 chip 后 summary 即时同步
- [x] 「清除全部」复位后 summary 回到 🌐 全量
- [x] 浅色模式 summary 颜色正确

https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7fNbSbxjooeqhghi7mp7y)_