### PR TITLE
docs: V22 DoD「make lint: 0 errors」验收回填

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -102,7 +102,8 @@
 
 ## 验收标准 (Definition of DoD)
 
-- [ ] `make lint`: 0 errors（含新引入的 `methods_without_practitioner_query` 检查全通过）。
+- [x] `make lint`: 0 errors（含新引入的 `methods_without_practitioner_query` 检查全通过）。
+    - 验证（2026-05-24）：`make lint` 实跑 = `python3 scripts/eval_search_quality.py`（通过率 37/37，≥ 80% 阈值）→ `python3 scripts/lint_wiki.py`（0 矛盾 / 0 空壳页 / 0 高频缺页 / 0 缺 type / 0 log.md 活跃度警告 / 0 缺摘要 / 0 Query 格式残缺 / 0 Formalization 缺公式 / 0 公式变量缺解释 / 0 README 版本不一致 / 0 图谱孤儿节点 / 0 Methods 缺 Formalization 链接 / 0 Methods 缺主要路线 / 0 Entities 缺 Methods/Tasks 出边 / 0 高频 methods 缺 queries/comparisons）；419/419 wiki/entity 页 ingest 来源覆盖率 100%；终行 "✅ 所有检查通过！"。本轮无新增代码改动，仅作"已达成"状态回填，与日志保持一致。
 - [ ] 知识图谱节点数 **≥ 312**，边数 **≥ 2050**（见 `exports/graph-stats.json`）。
 - [x] 事实库扩展至 **155 条** 以上（重点补 motion-retargeting / grasp-pose 矛盾检测规则）。
     - 实现：`schema/canonical-facts.json` 由 140 → **156** 条；本轮新增 17 条按 V22 P1 / P2 主线分布：动作重定向 5 条（`GMR 运动学优化定位` / `ReActor 双层联合优化` / `Motion Retargeting Pipeline 端到端阶段` / `Motion Retargeting 目标函数加权组合` / `Character Humanoid 目标双重性`）、抓取与感知 10 条（`6-DoF vs 7-DoF 抓取` / `GraspNet 三代谱系演进` / `Contact-GraspNet 接触点参数化` / `AnyGrasp 跨帧时序关联` / `AnyGrasp SDK License 分发` / `MPPH 抓取吞吐指标` / `抓取候选需显式碰撞检查` / `抓取选型 检测式优先` / `GraspNet-1Billion 评测基准` / 既有 `Contact-rich 接触力建模` 等基线沿用）、近期 ingest 2 条（`BifrostUMI 无机器人示范` / `OpenLoong 全栈开源`）。每条三元组（`terms` / `pos_claims` / `neg_claims`）按 `lint_wiki._check_contradictions` 的正则匹配规范设计，覆盖 P1 / P2 新页与既有页常见提法。

--- a/log.md
+++ b/log.md
@@ -1,5 +1,13 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-24] lint | docs/checklists/tech-stack-next-phase-checklist-v22.md — V22 DoD「`make lint`: 0 errors」回填打勾
+
+- 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) DoD 余 4 项中最确定可验项；按 2026-05-23 后续计划「每日推进一项」执行
+- 验证：`make lint` 实跑 = `python3 scripts/eval_search_quality.py`（通过率 37/37，≥ 80% 阈值）→ `python3 scripts/lint_wiki.py`（0 矛盾 / 0 空壳页 / 0 高频缺页 / 0 缺 type / 0 log.md 活跃度警告 / 0 缺摘要 / 0 Query 格式残缺 / 0 Formalization 缺公式 / 0 公式变量缺解释 / 0 README 版本不一致 / 0 图谱孤儿节点 / 0 Methods 缺 Formalization / Concept / 主要路线 / 0 Entities 缺 Methods/Tasks 出边 / 0 高频 methods 缺 queries/comparisons）；419/419 wiki/entity 页 ingest 来源覆盖率 100%；终行 "✅ 所有检查通过！"
+- 状态联动：V22 checklist DoD「`make lint`: 0 errors」由 `[ ]` 变 `[x]`；checklist 文件就地追加验证日期与项目级 0 警告快照
+- 后续：DoD 余 3 项（图谱节点 ≥ 312 边 ≥ 2050、`community_quality_warning: false`、log.md 记录 V22 关键改动）按节奏继续回填，全部完成后基于 llm-wiki 与最新 graph-stats / 事实库 / 站点状态新建 V23 清单
+- 本轮无代码改动，仅清单与日志状态回填
+
 ## [2026-05-23] structural | schema/canonical-facts.json — V22 DoD 事实库扩展：140 → 156 条，补全动作重定向 / 抓取 / 近期 ingest 矛盾检测规则
 
 - 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) DoD「事实库扩展至 155 条以上（重点补 motion-retargeting / grasp-pose 矛盾检测规则）」尚未打勾；P1 / P2 主线已沉淀大量新页（motion-retargeting-pipeline / motion-retargeting-objective / gmr-vs-nmr-vs-reactor / character-animation-vs-robotics / grasp-pose-estimation / grasp-policy-selection / anygrasp-vs-graspnet）以及 OpenLoong / BifrostUMI 实体页，需要让 `lint_wiki._check_contradictions` 覆盖到位


### PR DESCRIPTION
## 摘要

标记 V22 清单中「`make lint`: 0 errors」DoD 项为已完成，并在 log.md 中记录验证详情。本轮无代码改动，仅作状态回填与验证日志记录。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 变更说明

### `docs/checklists/tech-stack-next-phase-checklist-v22.md`
- 将「`make lint`: 0 errors」DoD 项从 `[ ]` 标记为 `[x]`
- 追加验证日期（2026-05-24）与完整的 lint 检查通过快照：
  - `eval_search_quality.py` 通过率 37/37（≥ 80% 阈值）
  - `lint_wiki.py` 全 12 项检查 0 错误
  - 419/419 wiki/entity 页 ingest 来源覆盖率 100%
  - 终行确认"✅ 所有检查通过！"

### `log.md`
- 新增 [2026-05-24] 条目，记录本次验收的触发背景、验证过程、状态联动与后续计划
- 说明 V22 DoD 余 3 项的推进节奏，以及完成后的 V23 清单新建计划

## 验证

- [x] 无代码改动，仅清单与日志状态回填，无需 `make ci-preflight`
- [x] 日志与清单内容保持一致

## 相关 Issue

无

https://claude.ai/code/session_01MdjP8sHrMkxe8bhfJoYHcD