### PR TITLE
structural | V22 DoD 图谱规模验证回填 — 节点 421 / 边 3122

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -104,7 +104,8 @@
 
 - [x] `make lint`: 0 errors（含新引入的 `methods_without_practitioner_query` 检查全通过）。
     - 验证（2026-05-24）：`make lint` 实跑 = `python3 scripts/eval_search_quality.py`（通过率 37/37，≥ 80% 阈值）→ `python3 scripts/lint_wiki.py`（0 矛盾 / 0 空壳页 / 0 高频缺页 / 0 缺 type / 0 log.md 活跃度警告 / 0 缺摘要 / 0 Query 格式残缺 / 0 Formalization 缺公式 / 0 公式变量缺解释 / 0 README 版本不一致 / 0 图谱孤儿节点 / 0 Methods 缺 Formalization 链接 / 0 Methods 缺主要路线 / 0 Entities 缺 Methods/Tasks 出边 / 0 高频 methods 缺 queries/comparisons）；419/419 wiki/entity 页 ingest 来源覆盖率 100%；终行 "✅ 所有检查通过！"。本轮无新增代码改动，仅作"已达成"状态回填，与日志保持一致。
-- [ ] 知识图谱节点数 **≥ 312**，边数 **≥ 2050**（见 `exports/graph-stats.json`）。
+- [x] 知识图谱节点数 **≥ 312**，边数 **≥ 2050**（见 `exports/graph-stats.json`）。
+    - 验证（2026-05-24）：`exports/graph-stats.json`（`generated_at: 2026-05-23`）实测 `node_count = 421`（目标 312，超 +109 / +34.9%）、`edge_count = 3122`（目标 2050，超 +1072 / +52.3%）、`community_count = 17`、`largest_community_ratio = 0.254`、`orphan_nodes = []`。两项均自然满足且远超 V22 目标，主要由 P1（动作重定向 5 个新页 + 多向回链）/ P2（抓取知识链 3 页 + 接触/操作交叉补强 + AnyGrasp / GraspNet 互链）/ P3（详情页关联社区分布 + 图谱专题视图）累积推升。本轮无新增代码改动，仅作"已达成"状态回填，与 V22 P0–P3 各 ingest / structural 历史记录一致。
 - [x] 事实库扩展至 **155 条** 以上（重点补 motion-retargeting / grasp-pose 矛盾检测规则）。
     - 实现：`schema/canonical-facts.json` 由 140 → **156** 条；本轮新增 17 条按 V22 P1 / P2 主线分布：动作重定向 5 条（`GMR 运动学优化定位` / `ReActor 双层联合优化` / `Motion Retargeting Pipeline 端到端阶段` / `Motion Retargeting 目标函数加权组合` / `Character Humanoid 目标双重性`）、抓取与感知 10 条（`6-DoF vs 7-DoF 抓取` / `GraspNet 三代谱系演进` / `Contact-GraspNet 接触点参数化` / `AnyGrasp 跨帧时序关联` / `AnyGrasp SDK License 分发` / `MPPH 抓取吞吐指标` / `抓取候选需显式碰撞检查` / `抓取选型 检测式优先` / `GraspNet-1Billion 评测基准` / 既有 `Contact-rich 接触力建模` 等基线沿用）、近期 ingest 2 条（`BifrostUMI 无机器人示范` / `OpenLoong 全栈开源`）。每条三元组（`terms` / `pos_claims` / `neg_claims`）按 `lint_wiki._check_contradictions` 的正则匹配规范设计，覆盖 P1 / P2 新页与既有页常见提法。
     - 验证：`python3 scripts/lint_wiki.py` 退出码 0，0 contradictions、0 ⚠️ / 0 💡，"✅ 所有检查通过！"；419/419 wiki/entity 页 ingest 来源覆盖率 100%。

--- a/log.md
+++ b/log.md
@@ -1,5 +1,13 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-24] structural | docs/checklists/tech-stack-next-phase-checklist-v22.md — V22 DoD「图谱节点 ≥ 312 / 边 ≥ 2050」回填打勾
+
+- 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) DoD 余 3 项中数值最直接可验项；按"每日推进一项"节奏，今日选定图谱规模口径
+- 验证：`exports/graph-stats.json`（`generated_at: 2026-05-23`）实测 `node_count = 421`（V22 目标 312，超 +109 / +34.9%）、`edge_count = 3122`（V22 目标 2050，超 +1072 / +52.3%）、`community_count = 17`、`largest_community_ratio = 0.254`、`orphan_nodes = []`，两项数值远超 V22 目标且与 V22 P1（动作重定向 5 页 + 多向回链）/ P2（抓取链 3 页 + 接触-操作交叉 + AnyGrasp/GraspNet 互链）/ P3（详情页社区分布 + 图谱专题视图）历史推升轨迹一致
+- 状态联动：V22 checklist DoD「图谱节点 ≥ 312 边 ≥ 2050」由 `[ ]` 变 `[x]`；checklist 文件就地追加 2026-05-24 验证日期与数值快照
+- 后续：DoD 余 2 项（`community_quality_warning: false`、`log.md` 记录 V22 关键改动）按节奏继续回填，全部完成后基于 llm-wiki 与最新 graph-stats / 事实库 / 站点状态新建 V23 清单
+- 本轮无代码改动，仅清单与日志状态回填
+
 ## [2026-05-24] lint | docs/checklists/tech-stack-next-phase-checklist-v22.md — V22 DoD「`make lint`: 0 errors」回填打勾
 
 - 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) DoD 余 4 项中最确定可验项；按 2026-05-23 后续计划「每日推进一项」执行


### PR DESCRIPTION
## 摘要

按 V22 清单「每日推进一项」节奏，完成知识图谱规模 DoD 验证回填。实测 `exports/graph-stats.json`（2026-05-23）显示节点数 421（目标 312，超 +34.9%）、边数 3122（目标 2050，超 +52.3%），两项均自然满足且远超预期，与 V22 P1–P3 各阶段累积推升轨迹一致。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）

## 具体改动

1. **log.md**：新增 2026-05-24 structural 日志条目，记录图谱规模验证的触发、实测数值、状态联动及后续计划
2. **docs/checklists/tech-stack-next-phase-checklist-v22.md**：
   - 将「知识图谱节点数 ≥ 312，边数 ≥ 2050」DoD 状态由 `[ ]` 变 `[x]`
   - 追加验证日期（2026-05-24）与完整数值快照（node_count / edge_count / community_count / largest_community_ratio / orphan_nodes）
   - 补充历史推升轨迹说明（P1 动作重定向 + 多向回链、P2 抓取链 + 接触-操作交叉、P3 详情页社区分布）

## 验证

- [x] `make lint`：0 errors（既有 419/419 wiki 页覆盖率 100%，本轮无代码改动）
- [x] 清单与日志状态一致性：两文件改动互相印证，无冲突

## 相关 Issue

无

---

**说明**：本轮仅清单与日志状态回填，无新增代码改动。V22 DoD 余 2 项（`community_quality_warning: false`、`log.md` 记录 V22 关键改动）按节奏继续推进，全部完成后基于 llm-wiki 与最新 graph-stats / 事实库 / 站点状态新建 V23 清单。

https://claude.ai/code/session_01QiL4QKSTE1BTHeTCUWsvh8