### PR TITLE
structural: V22 DoD「community_quality_warning: false」状态回填

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v22.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v22.md
@@ -109,7 +109,8 @@
 - [x] 事实库扩展至 **155 条** 以上（重点补 motion-retargeting / grasp-pose 矛盾检测规则）。
     - 实现：`schema/canonical-facts.json` 由 140 → **156** 条；本轮新增 17 条按 V22 P1 / P2 主线分布：动作重定向 5 条（`GMR 运动学优化定位` / `ReActor 双层联合优化` / `Motion Retargeting Pipeline 端到端阶段` / `Motion Retargeting 目标函数加权组合` / `Character Humanoid 目标双重性`）、抓取与感知 10 条（`6-DoF vs 7-DoF 抓取` / `GraspNet 三代谱系演进` / `Contact-GraspNet 接触点参数化` / `AnyGrasp 跨帧时序关联` / `AnyGrasp SDK License 分发` / `MPPH 抓取吞吐指标` / `抓取候选需显式碰撞检查` / `抓取选型 检测式优先` / `GraspNet-1Billion 评测基准` / 既有 `Contact-rich 接触力建模` 等基线沿用）、近期 ingest 2 条（`BifrostUMI 无机器人示范` / `OpenLoong 全栈开源`）。每条三元组（`terms` / `pos_claims` / `neg_claims`）按 `lint_wiki._check_contradictions` 的正则匹配规范设计，覆盖 P1 / P2 新页与既有页常见提法。
     - 验证：`python3 scripts/lint_wiki.py` 退出码 0，0 contradictions、0 ⚠️ / 0 💡，"✅ 所有检查通过！"；419/419 wiki/entity 页 ingest 来源覆盖率 100%。
-- [ ] `community_quality_warning` 在 `exports/graph-stats.json` 中变为 `false`。
+- [x] `community_quality_warning` 在 `exports/graph-stats.json` 中变为 `false`。
+    - 验证（2026-05-24）：`exports/graph-stats.json`（`generated_at: 2026-05-24`）实测 `community_count = 17`、`largest_community_ratio = 0.248`（最大社区 = "VLA（Vision-Language-Action） 社区" 105 / 423 = 24.8%，远低于 V22 ≤ 40% 阈值）、`community_quality_warning = false`、`singleton_communities = []`。该结果由 V22 P0「社区粒度二级拆分」（Girvan-Newman 一级 + Louvain `resolution=1.15` 二级对占比 > 40% 且节点数 ≥ 30 的巨型社区做二级拆分）持续生效，叠加 P1 / P2 / P3 累积新增页面（motion-retargeting × 5 / 抓取链 × 3 / 接触-操作交叉 / VLA-WAM / BifrostUMI / OpenLoong / WorldVLN / easy_quadruped 等），最大社区占比由 V21 的 46.1% → V22 当前的 24.8%（再降 21.3 pp），且 17 个社区中 ≥ 10 项节点的有 12 个，结构稳定无单点社区。本轮无新增代码改动，仅作"已达成"状态回填，与 V22 P0 历史记录一致。
 - [ ] `log.md` 记录 V22 关键改动。
 
 ---

--- a/log.md
+++ b/log.md
@@ -1,5 +1,14 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-24] structural | docs/checklists/tech-stack-next-phase-checklist-v22.md — V22 DoD「community_quality_warning: false」回填打勾
+
+- 触发：[`docs/checklists/tech-stack-next-phase-checklist-v22.md`](docs/checklists/tech-stack-next-phase-checklist-v22.md) DoD 余 2 项中数值最直接可验项；按"每日推进一项"节奏继续顺次回填
+- 验证：`exports/graph-stats.json`（`generated_at: 2026-05-24`）实测 `community_count = 17`、`largest_community_ratio = 0.248`（最大社区 = "VLA（Vision-Language-Action） 社区" 105 / 423 = 24.8%，远低于 V22 ≤ 40% 阈值）、`community_quality_warning = false`、`singleton_communities = []`；最大社区占比相对 V21 基线 46.1% 累计下降 21.3 pp，结构稳定且 17 个社区中 ≥ 10 项节点的有 12 个
+- 归因：V22 P0「社区粒度二级拆分」（Girvan-Newman 一级 + Louvain `resolution=1.15` 二级对占比 > 40% 且节点数 ≥ 30 的巨型社区做二级拆分）持续生效，叠加 P1 / P2 / P3 累积新增页面（motion-retargeting × 5 / 抓取链 × 3 / 接触-操作交叉 / VLA-WAM / BifrostUMI / OpenLoong / WorldVLN / easy_quadruped 等）形成的多向回链让原 Locomotion 巨型社区进一步均匀化
+- 状态联动：V22 checklist DoD「community_quality_warning: false」由 `[ ]` 变 `[x]`；checklist 文件就地追加 2026-05-24 验证日期与数值快照
+- 后续：DoD 余 1 项（`log.md` 记录 V22 关键改动）按节奏继续回填，本日新增日志本身即对该项的部分兑现；DoD 全部清零后基于 llm-wiki 与最新 graph-stats / 事实库 / 站点状态新建 V23 清单
+- 本轮无代码改动，仅清单与日志状态回填
+
 ## [2026-05-24] ingest | sources/papers/worldvln_arxiv_2605_15964.md — 接入 WorldVLN 空中 VLN 自回归 WAM；沉淀 wiki/entities/paper-worldvln-aerial-vln-wam.md；交叉更新 vision-language-navigation、world-action-models
 
 - 原始资料：`sources/papers/worldvln_arxiv_2605_15964.md`（<https://arxiv.org/abs/2605.15964>）、`sources/sites/worldvln-embodiedcity.md`、 `sources/repos/worldvln_embodiedcity.md`；索引 `sources/README.md`


### PR DESCRIPTION
## 摘要

V22 技术栈清单「社区质量警告」目标已达成，本 PR 回填验证状态与数据快照。`exports/graph-stats.json` 实测 `community_quality_warning = false`、最大社区占比 24.8%（V21 基线 46.1% 下降 21.3 pp），17 个社区中 12 个 ≥ 10 节点，结构稳定无单点社区。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 变更详情

### `docs/checklists/tech-stack-next-phase-checklist-v22.md`
- 将「`community_quality_warning` 在 `exports/graph-stats.json` 中变为 `false`」从 `[ ]` 标记为 `[x]`
- 追加 2026-05-24 验证日期与数值快照：
  - `community_count = 17`
  - `largest_community_ratio = 0.248`（最大社区"VLA 社区" 105/423）
  - `community_quality_warning = false`
  - `singleton_communities = []`
  - 社区占比相对 V21 累计下降 21.3 pp，12/17 社区 ≥ 10 节点

### `log.md`
- 新增 2026-05-24 structural 日志条目，记录：
  - 触发条件与验证数据
  - 归因分析（V22 P0 二级拆分 + P1/P2/P3 新增页面的均匀化效果）
  - 状态联动与后续计划
  - 明确本轮无代码改动，仅清单与日志状态回填

## 验证

- [x] `make ci-preflight`（仅清单与日志改动，无 wiki 内容变更）
- [x] 数据来源：`exports/graph-stats.json`（`generated_at: 2026-05-24`）已验证
- [x] 与 V22 P0 历史记录一致，无新增代码改动

## 相关 Issue

无

https://claude.ai/code/session_019TagHGLQGJdaCiXVeRmcCw