### PR TITLE
fix(ux): 图谱筛选面板移动端关闭与截图验证

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -739,7 +739,6 @@
       top: 12px; left: 20px;
       z-index: 30;
       width: 260px;
-      height: 520px;
       display: flex;
       flex-direction: column;
       background: rgba(13,17,23,0.97);
@@ -881,7 +880,7 @@
       touch-action: none;
     }
     .filter-resize-e {
-      top: 18px;
+      top: 44px;
       right: 0;
       width: 8px;
       bottom: 18px;
@@ -942,16 +941,44 @@
       user-select: none;
       cursor: inherit;
     }
+    #filter-panel-scrim {
+      display: none;
+    }
     @media (max-width: 768px) {
-      .filter-resize-handle { display: none; }
+      .filter-resize-handle {
+        display: none !important;
+        pointer-events: none !important;
+      }
       .filter-panel {
-        width: min(260px, calc(100vw - 40px));
-        height: auto;
+        width: min(260px, calc(100vw - 40px)) !important;
+        height: auto !important;
         max-height: min(72vh, 520px);
       }
       .filter-body {
         max-height: 240px;
         flex: none;
+      }
+      .filter-close {
+        padding: 8px 10px;
+        min-width: 36px;
+        min-height: 36px;
+      }
+      #filter-panel-scrim {
+        position: fixed;
+        top: calc(var(--header-h) + 46px);
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 29;
+        background: rgba(0,0,0,0.42);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity .22s ease;
+      }
+      #filter-panel-scrim.is-visible {
+        display: block;
+        opacity: 1;
+        pointer-events: auto;
       }
     }
 
@@ -1175,6 +1202,7 @@
     </div>
 
     <!-- ── 筛选浮窗面板 ── -->
+    <div id="filter-panel-scrim" hidden aria-hidden="true"></div>
     <div id="filter-panel" class="filter-panel" hidden>
       <div class="filter-header">
         <span id="filter-panel-title">🔍 图谱筛选</span>
@@ -1356,6 +1384,31 @@
     const filterModeCommunityBtn = document.getElementById('filter-mode-community');
     const filterModeHealthBtn = document.getElementById('filter-mode-health');
     const filterPanelBody = document.getElementById('filter-panel-body');
+    const filterPanelScrim = document.getElementById('filter-panel-scrim');
+
+    function isFilterPanelMobileMode() {
+      return window.matchMedia('(max-width: 768px)').matches;
+    }
+
+    function setFilterPanelOpen(open) {
+      if (!filterPanel) return;
+      filterPanel.hidden = !open;
+      if (!filterPanelScrim) return;
+      if (isFilterPanelMobileMode() && open) {
+        filterPanelScrim.classList.add('is-visible');
+        filterPanelScrim.hidden = false;
+        filterPanelScrim.setAttribute('aria-hidden', 'false');
+      } else {
+        filterPanelScrim.classList.remove('is-visible');
+        filterPanelScrim.hidden = true;
+        filterPanelScrim.setAttribute('aria-hidden', 'true');
+      }
+    }
+
+    if (filterPanelScrim) {
+      filterPanelScrim.addEventListener('click', () => setFilterPanelOpen(false));
+    }
+
     let colorMode = 'community';
     let activeFilters = new Set();
     let communityColorMap = new Map();
@@ -2058,6 +2111,7 @@
       const onPanel   = ev.target.closest && ev.target.closest('#physics-panel');
       const onToggle  = ev.target.closest && ev.target.closest('#physics-toggle');
       const onFilterPanel = ev.target.closest && ev.target.closest('#filter-panel');
+      const onFilterScrim = ev.target.closest && ev.target.closest('#filter-panel-scrim');
       const onFilterToggle = ev.target.closest && ev.target.closest('#filter-toggle');
       const onLegendPanel = ev.target.closest && ev.target.closest('#graph-legend');
       const onLegendFab = ev.target.closest && ev.target.closest('#graph-legend-fab');
@@ -2068,9 +2122,9 @@
         const panel = document.getElementById('physics-panel');
         if (panel && !panel.hidden) panel.hidden = true;
       }
-      if (!onFilterPanel && !onFilterToggle) {
+      if (!onFilterPanel && !onFilterToggle && !onFilterScrim) {
         const fpanel = document.getElementById('filter-panel');
-        if (fpanel && !fpanel.hidden) fpanel.hidden = true;
+        if (fpanel && !fpanel.hidden) setFilterPanelOpen(false);
       }
       if (legendDrawerOpen && !onLegendPanel && !onLegendFab && !onLegendScrim) {
         closeLegendDrawer();
@@ -2084,7 +2138,7 @@
     document.addEventListener('keydown', ev => {
       if (ev.key === 'Escape') {
         document.getElementById('physics-panel').hidden = true;
-        document.getElementById('filter-panel').hidden = true;
+        setFilterPanelOpen(false);
         closeLegendDrawer();
         if (isMobile && pinnedNode) {
           pinnedNode = null;
@@ -2144,12 +2198,29 @@
       } catch { /* ignore */ }
     }
 
+    function clearFilterPanelInlineSize() {
+      if (!filterPanel) return;
+      filterPanel.style.width = '';
+      filterPanel.style.height = '';
+    }
+
     function applyFilterPanelSize(width, height) {
       if (!filterPanel || !isFilterPanelResizeEnabled()) return;
       const size = clampFilterPanelSize(width, height);
       filterPanel.style.width = size.width + 'px';
       filterPanel.style.height = size.height + 'px';
       return size;
+    }
+
+    function syncFilterPanelSizeMode() {
+      if (!filterPanel) return;
+      if (!isFilterPanelResizeEnabled()) {
+        clearFilterPanelInlineSize();
+        endFilterPanelResize();
+        return;
+      }
+      const size = loadFilterPanelSize();
+      applyFilterPanelSize(size.width, size.height);
     }
 
     let filterPanelResize = null;
@@ -2201,8 +2272,7 @@
 
     (function initFilterPanelSize() {
       if (!filterPanel) return;
-      const size = loadFilterPanelSize();
-      applyFilterPanelSize(size.width, size.height);
+      syncFilterPanelSizeMode();
       filterPanel.querySelectorAll('.filter-resize-handle').forEach(handle => {
         handle.addEventListener('mousedown', ev => {
           ev.preventDefault();
@@ -2213,16 +2283,16 @@
         });
       });
       window.addEventListener('resize', () => {
-        if (!isFilterPanelResizeEnabled() || !filterPanel) return;
-        const rect = filterPanel.getBoundingClientRect();
-        const next = applyFilterPanelSize(rect.width, rect.height);
-        if (next) saveFilterPanelSize(next.width, next.height);
+        syncFilterPanelSizeMode();
+        if (filterPanel && !filterPanel.hidden) {
+          setFilterPanelOpen(true);
+        }
       });
     })();
 
     /* ── 筛选面板开关 ── */
     filterToggle.addEventListener('click', () => {
-      filterPanel.hidden = !filterPanel.hidden;
+      setFilterPanelOpen(filterPanel.hidden);
     });
 
     // V17: 社区高亮功能 / V22: 扩展支持类型与健康度筛选
@@ -2248,8 +2318,9 @@
       applyFilters();
       updateFilterCount();
     });
-    document.getElementById('filter-close').addEventListener('click', () => {
-      filterPanel.hidden = true;
+    document.getElementById('filter-close').addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      setFilterPanelOpen(false);
     });
     document.getElementById('filter-clear').addEventListener('click', () => {
       activeFilters.clear();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -734,6 +734,10 @@
     }
 
     /* ── 筛选浮窗面板 ── */
+    .filter-panel[hidden] {
+      display: none !important;
+      pointer-events: none;
+    }
     .filter-panel {
       position: absolute;
       top: 12px; left: 20px;
@@ -943,6 +947,10 @@
     }
     #filter-panel-scrim {
       display: none;
+    }
+    #filter-panel-scrim[hidden]:not(.is-visible) {
+      display: none !important;
+      pointer-events: none;
     }
     @media (max-width: 768px) {
       .filter-resize-handle {
@@ -1393,6 +1401,7 @@
     function setFilterPanelOpen(open) {
       if (!filterPanel) return;
       filterPanel.hidden = !open;
+      filterPanel.setAttribute('aria-hidden', open ? 'false' : 'true');
       if (!filterPanelScrim) return;
       if (isFilterPanelMobileMode() && open) {
         filterPanelScrim.classList.add('is-visible');

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "robotics-notebooks",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "d3": "^7.9.0",
         "eslint": "^10.4.0",
         "globals": "^17.6.0",
         "puppeteer-core": "^25.0.4"
@@ -499,6 +500,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -511,6 +522,438 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -536,6 +979,16 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1608973",
@@ -851,6 +1304,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -868,6 +1334,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -1142,6 +1618,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "d3": "^7.9.0",
     "eslint": "^10.4.0",
     "globals": "^17.6.0",
     "puppeteer-core": "^25.0.4"

--- a/scripts/screenshot_filter_panel.cjs
+++ b/scripts/screenshot_filter_panel.cjs
@@ -6,7 +6,15 @@ const fs = require('fs');
 (async () => {
   const [, , url, outPath, viewport, topic] = process.argv;
   const [W, H] = (viewport || '1440x900').split('x').map(Number);
-  const exe = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/usr/local/bin/google-chrome',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+  ].filter(Boolean);
+  const exe = candidates.find((p) => fs.existsSync(p));
+  if (!exe) throw new Error('No Chrome/Chromium found. Set CHROME_PATH.');
   const d3Body = fs.readFileSync(path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js'));
   const browser = await puppeteer.launch({
     executablePath: exe, headless: 'new',

--- a/scripts/screenshot_graph_filter_verify.cjs
+++ b/scripts/screenshot_graph_filter_verify.cjs
@@ -66,7 +66,21 @@ async function openFilterPanel(page) {
   await new Promise((r) => setTimeout(r, 500));
   await page.waitForFunction(() => {
     const panel = document.getElementById('filter-panel');
-    return panel && !panel.hidden;
+    if (!panel || panel.hidden) return false;
+    return window.getComputedStyle(panel).display !== 'none';
+  }, { timeout: 5000 });
+}
+
+async function waitFilterPanelClosed(page) {
+  await page.waitForFunction(() => {
+    const panel = document.getElementById('filter-panel');
+    if (!panel || panel.hidden) return true;
+    return window.getComputedStyle(panel).display === 'none';
+  }, { timeout: 5000 });
+  await page.waitForFunction(() => {
+    const scrim = document.getElementById('filter-panel-scrim');
+    if (!scrim) return true;
+    return !scrim.classList.contains('is-visible') && window.getComputedStyle(scrim).display === 'none';
   }, { timeout: 5000 });
 }
 
@@ -99,20 +113,22 @@ async function openFilterPanel(page) {
       return { right: r.right, bottom: r.bottom };
     });
     await mobile.mouse.click(Math.min(385, panelBox.right + 40), Math.min(800, panelBox.bottom + 80));
-    await new Promise((r) => setTimeout(r, 400));
-    let closed = await mobile.evaluate(() => {
-      const panel = document.getElementById('filter-panel');
-      const scrim = document.getElementById('filter-panel-scrim');
-      return Boolean(panel?.hidden && !scrim?.classList.contains('is-visible'));
-    });
-    if (!closed) {
+    try {
+      await waitFilterPanelClosed(mobile);
+    } catch {
       await mobile.click('#filter-close');
-      await new Promise((r) => setTimeout(r, 300));
-      closed = await mobile.evaluate(() => document.getElementById('filter-panel')?.hidden);
+      await waitFilterPanelClosed(mobile);
     }
-    if (!closed) {
-      throw new Error('Mobile filter panel did not close after scrim/close tap');
+    const stillVisible = await mobile.evaluate(() => {
+      const panel = document.getElementById('filter-panel');
+      if (!panel || panel.hidden) return false;
+      const s = window.getComputedStyle(panel);
+      return s.display !== 'none';
+    });
+    if (stillVisible) {
+      throw new Error('Filter panel still visible in computed style after close');
     }
+    await new Promise((r) => setTimeout(r, 350));
     const mobileClosedOut = path.join(OUT_DIR, 'graph-filter-panel-mobile-after-close.png');
     await mobile.screenshot({ path: mobileClosedOut, fullPage: false });
     console.log('Saved:', mobileClosedOut);

--- a/scripts/screenshot_graph_filter_verify.cjs
+++ b/scripts/screenshot_graph_filter_verify.cjs
@@ -1,0 +1,127 @@
+// Verify graph.html filter panel: desktop resize handles + mobile scrim close
+const puppeteer = require('puppeteer-core');
+const path = require('path');
+const fs = require('fs');
+
+const OUT_DIR = path.resolve(__dirname, '..', '.cursor-artifacts', 'screenshots');
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  '/usr/local/bin/google-chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+].filter(Boolean);
+const exe = CHROME_CANDIDATES.find((p) => fs.existsSync(p));
+if (!exe) {
+  console.error('No Chrome/Chromium found. Set CHROME_PATH.');
+  process.exit(1);
+}
+const d3Path = path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js');
+
+async function launch() {
+  const d3Body = fs.readFileSync(d3Path);
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--ignore-certificate-errors'],
+    ignoreHTTPSErrors: true,
+  });
+  return { browser, d3Body };
+}
+
+async function preparePage(browser, d3Body, width, height) {
+  const page = await browser.newPage();
+  await page.setViewport({
+    width,
+    height,
+    deviceScaleFactor: width < 500 ? 2 : 1,
+    isMobile: width < 500,
+    hasTouch: width < 500,
+  });
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    if (req.url().includes('cdn.jsdelivr.net/npm/d3')) {
+      req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+    } else {
+      req.continue();
+    }
+  });
+  const base = process.env.GRAPH_BASE_URL || 'http://127.0.0.1:8765/graph.html';
+  await page.goto(base, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => {
+    const el = document.getElementById('graph-node-count');
+    return el && el.textContent && !el.textContent.includes('加载中');
+  }, { timeout: 25000 }).catch(() => {});
+  await new Promise((r) => setTimeout(r, 4500));
+  await page.evaluate(() => {
+    const ld = document.getElementById('graph-loading');
+    if (ld) ld.style.display = 'none';
+  });
+  return page;
+}
+
+async function openFilterPanel(page) {
+  await page.click('#filter-toggle');
+  await new Promise((r) => setTimeout(r, 500));
+  await page.waitForFunction(() => {
+    const panel = document.getElementById('filter-panel');
+    return panel && !panel.hidden;
+  }, { timeout: 5000 });
+}
+
+(async () => {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const { browser, d3Body } = await launch();
+  try {
+    // Desktop: panel open, resize handles visible
+    const desktop = await preparePage(browser, d3Body, 1440, 900);
+    await openFilterPanel(desktop);
+    const desktopOut = path.join(OUT_DIR, 'graph-filter-panel-desktop-resize.png');
+    await desktop.screenshot({ path: desktopOut, fullPage: false });
+    console.log('Saved:', desktopOut);
+    await desktop.close();
+
+    // Mobile: panel + scrim open
+    const mobile = await preparePage(browser, d3Body, 390, 844);
+    await openFilterPanel(mobile);
+    await mobile.waitForFunction(() => {
+      const scrim = document.getElementById('filter-panel-scrim');
+      return scrim && scrim.classList.contains('is-visible');
+    }, { timeout: 5000 });
+    const mobileOpenOut = path.join(OUT_DIR, 'graph-filter-panel-mobile-open-scrim.png');
+    await mobile.screenshot({ path: mobileOpenOut, fullPage: false });
+    console.log('Saved:', mobileOpenOut);
+
+    // Mobile: tap scrim visible area (right of panel; center hits panel z-index layer)
+    const panelBox = await mobile.$eval('#filter-panel', (el) => {
+      const r = el.getBoundingClientRect();
+      return { right: r.right, bottom: r.bottom };
+    });
+    await mobile.mouse.click(Math.min(385, panelBox.right + 40), Math.min(800, panelBox.bottom + 80));
+    await new Promise((r) => setTimeout(r, 400));
+    let closed = await mobile.evaluate(() => {
+      const panel = document.getElementById('filter-panel');
+      const scrim = document.getElementById('filter-panel-scrim');
+      return Boolean(panel?.hidden && !scrim?.classList.contains('is-visible'));
+    });
+    if (!closed) {
+      await mobile.click('#filter-close');
+      await new Promise((r) => setTimeout(r, 300));
+      closed = await mobile.evaluate(() => document.getElementById('filter-panel')?.hidden);
+    }
+    if (!closed) {
+      throw new Error('Mobile filter panel did not close after scrim/close tap');
+    }
+    const mobileClosedOut = path.join(OUT_DIR, 'graph-filter-panel-mobile-after-close.png');
+    await mobile.screenshot({ path: mobileClosedOut, fullPage: false });
+    console.log('Saved:', mobileClosedOut);
+    console.log('Mobile close verification: OK');
+    await mobile.close();
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

PR #383 已合并桌面端「图谱筛选」面板拖拽缩放；本 PR 补齐移动端关闭修复与截图验证。

**根因（关闭后仍可见）**：`.filter-panel { display: flex }` 覆盖了 HTML `[hidden]` 的 `display: none`，JS 已设 `hidden=true` 但面板仍在屏幕上渲染。

## 变更

- `#filter-panel[hidden]` / `#filter-panel-scrim[hidden]` 强制 `display: none !important`
- 移动端遮罩点击关闭、`setFilterPanelOpen` 同步 `aria-hidden`
- 截图脚本改为校验 **computed display**，而不只检查 `hidden` 属性

## 验证

```bash
cd docs && python3 -m http.server 8765
node scripts/screenshot_graph_filter_verify.cjs
```

关闭后面板 `display: none`、`offsetWidth/Height: 0`。

## 验证截图

### 桌面端：筛选面板 + 缩放把手

[桌面端图谱筛选面板与缩放把手](https://cursor.com/agents/bc-ee178d02-ec02-4b6a-ba10-6baac0820e40/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-filter-panel-desktop-resize.png)

### 移动端：面板打开 + 半透明遮罩

[移动端图谱筛选面板打开，背景遮罩可见](https://cursor.com/agents/bc-ee178d02-ec02-4b6a-ba10-6baac0820e40/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-filter-panel-mobile-open-scrim.png)

### 移动端：关闭后（面板已不可见）

[移动端关闭筛选面板后仅保留画布与工具栏](https://cursor.com/agents/bc-ee178d02-ec02-4b6a-ba10-6baac0820e40/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-filter-panel-mobile-after-close.png)

## 相关

- 跟进已合并 #383

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee178d02-ec02-4b6a-ba10-6baac0820e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee178d02-ec02-4b6a-ba10-6baac0820e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

