### PR TITLE
fix(ux): 消除详情页 Mermaid 灯箱打开时的闪烁

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -56,6 +56,7 @@
 - [x] 技术路线页 `roadmap.html`：基于导出阶段数据渲染可折叠阶段树（垂直 `<details>` 列表）；已移除折叠 Mermaid 线框总图与路线页内 Mermaid CDN。
 - [x] 技术路线页 `roadmap.html`：favicon、顶栏统一为 🚀（与首页「技术路线指南」CTA 一致）；主题切换仍为 ☀️/🌙。
 - [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
+- [x] 详情页 Mermaid 灯箱：加载态文案 + `stage-pending` 在 `fit` 完成前隐藏，消除「空面板 / 先大后缩」闪烁。
 ---
 
 ## 验收标准 (DoD)

--- a/docs/main.js
+++ b/docs/main.js
@@ -902,15 +902,24 @@
     });
   }
 
+  function revealMermaidLightboxStage(stage, body) {
+    if (!stage || !body) return;
+    resetMermaidLightboxView(stage);
+    fitMermaidLightboxToView(stage, body);
+    stage.classList.remove('mermaid-lightbox-stage-pending');
+    if (mermaidLightboxEl) mermaidLightboxEl.classList.remove('mermaid-lightbox-loading');
+  }
+
   function mountMermaidLightboxSvg(stage, body, svgClone) {
     if (!stage || !body || !svgClone) return;
     body.innerHTML = '';
     stage.innerHTML = '';
+    stage.className = 'mermaid-lightbox-stage mermaid-lightbox-stage-pending';
     stage.appendChild(svgClone);
     body.appendChild(stage);
     requestAnimationFrame(function () {
       requestAnimationFrame(function () {
-        fitMermaidLightboxToView(stage, body);
+        revealMermaidLightboxStage(stage, body);
       });
     });
   }
@@ -920,10 +929,8 @@
     var box = ensureMermaidLightbox();
     var body = box.querySelector('.mermaid-lightbox-body');
     if (!body) return;
-    var stage = document.createElement('div');
-    stage.className = 'mermaid-lightbox-stage';
-    body.innerHTML = '';
-    body.appendChild(stage);
+    body.innerHTML = '<p class="mermaid-lightbox-status" role="status">正在生成高清预览…</p>';
+    box.classList.add('mermaid-lightbox-loading');
     box.hidden = false;
     box.setAttribute('aria-hidden', 'false');
     document.body.classList.add('mermaid-lightbox-open');
@@ -933,6 +940,7 @@
         closeMermaidLightbox();
         return;
       }
+      var stage = document.createElement('div');
       mountMermaidLightboxSvg(stage, body, svgClone);
     });
     var closeBtn = box.querySelector('.mermaid-lightbox-close');
@@ -943,6 +951,7 @@
     if (!mermaidLightboxEl || mermaidLightboxEl.hidden) return;
     mermaidLightboxEl.hidden = true;
     mermaidLightboxEl.setAttribute('aria-hidden', 'true');
+    mermaidLightboxEl.classList.remove('mermaid-lightbox-loading');
     var body = mermaidLightboxEl.querySelector('.mermaid-lightbox-body');
     if (body) {
       body.innerHTML = '';

--- a/docs/style.css
+++ b/docs/style.css
@@ -883,6 +883,21 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--text-muted) 48%, transparent) transparent;
 }
+.mermaid-lightbox-loading .mermaid-lightbox-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+}
+.mermaid-lightbox-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+.mermaid-lightbox-stage.mermaid-lightbox-stage-pending {
+  visibility: hidden;
+}
 .mermaid-lightbox-body::-webkit-scrollbar {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页点击放大 Mermaid 流程图时，原先会先露出空灯箱、再以 `scale(1)` 显示 1.75× 离屏重绘的大图，两帧后才 `fit` 到灯箱视口，造成明显「闪一下再缩小」。

本 PR 调整灯箱打开流程：

- 离屏 SVG 生成完成前，灯箱 body 仅显示「正在生成高清预览…」加载文案，不再提前挂载空 `stage`。
- SVG 挂载后添加 `mermaid-lightbox-stage-pending`，在 `fitMermaidLightboxToView` 完成前隐藏图形。
- `fit` 时调用 `resetMermaidLightboxView`，避免沿用上次的平移/缩放状态。
- 关闭灯箱时清除 `mermaid-lightbox-loading` 类。

仍保留 1.75× 离屏高清重绘策略，仅优化可见性时序。

## 验证

- `npm run lint:js` 通过
- `make ci-preflight` 通过
- 静态站详情页（含 Mermaid）渲染正常

## 验证截图

[GMR vs NMR vs ReActor 详情页（含 Mermaid）](https://cursor.com/agents/bc-445ba04d-0543-4ebb-ac18-9c42dea46489/artifacts?path=%2Fhome%2Fubuntu%2F.cursor-artifacts%2Fscreenshots%2Fwiki-comparisons-gmr-vs-nmr-vs-reactor.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-445ba04d-0543-4ebb-ac18-9c42dea46489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-445ba04d-0543-4ebb-ac18-9c42dea46489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

