### PR TITLE
chore(ci): 触发全量 GitHub Actions 并补充合并前门禁看板

### DIFF
--- a/.github/workflows/ci-pr-gate.yml
+++ b/.github/workflows/ci-pr-gate.yml
@@ -1,0 +1,35 @@
+# 轻量 smoke：用于确认 GitHub Actions 已对 push/PR 恢复调度。
+# 若本 workflow 仍不出现 run，请到仓库 Settings → Actions 启用 Actions（与 Claude/Cursor App checks 无关）。
+name: CI PR Gate (smoke)
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-pr-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Report context
+        run: |
+          echo "event=${{ github.event_name }}"
+          echo "ref=${{ github.ref }}"
+          echo "sha=${{ github.sha }}"
+          echo "workflow=${{ github.workflow }}"
+          python3 --version
+
+      - name: Workflow files present
+        run: ls -la .github/workflows/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     branches: ["**"]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/search-regression.yml
+++ b/.github/workflows/search-regression.yml
@@ -10,6 +10,8 @@ on:
       - 'schema/**'
       - 'sources/**'
   pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/search-regression.yml'
       - 'wiki/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: ["**"]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/docs/checklists/README.md
+++ b/docs/checklists/README.md
@@ -7,6 +7,7 @@
 - [技术栈项目执行清单 v23](tech-stack-next-phase-checklist-v23.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
 - [前端体验优化清单 v1](frontend-optimization-v1.md) — GitHub Pages 首页与交互体验优化计划。
 - [Cursor Cloud Agent：PR 与验证截图流程](cloud-agent-pr-workflow.md) — Cloud Agent 推送分支、开 PR、附验证截图的路径约定。
+- [GitHub Actions CI 门禁](github-actions-ci-gate.md) — 合并 `main` 前必须等全量 Actions 全绿；branch protection 建议。
 
 ## 历史执行清单
 

--- a/docs/checklists/cloud-agent-pr-workflow.md
+++ b/docs/checklists/cloud-agent-pr-workflow.md
@@ -18,8 +18,9 @@ git push -u origin <branch-name>
 
 ## 3. 创建或更新 Pull Request
 
-- 使用仓库的 PR 管理流程创建草稿或正式 PR，`base_branch` 与任务要求一致（未指定时默认 `main`）。
+- 使用仓库的 PR 管理流程创建 **正式 PR**（非 Draft），`base_branch` 与任务要求一致（未指定时默认 `main`），以便触发 `pull_request` 上的全量 Actions。
 - PR 正文应包含：**摘要**（改了什么、为什么）、**风险或回滚注意**（如有）、**关联 issue**（如有）。
+- **合并前必须等 GitHub Actions 全绿**：至少 `Tests`、`Wiki Lint`；若改动 `wiki/` / `sources/` / `scripts/` / `schema/`，还需 `Search & Export Quality Check`（常需 7–10 分钟）。详见 [GitHub Actions CI 门禁](github-actions-ci-gate.md)。本地 `make ci-preflight` 不能替代 PR Checks。
 
 ## 4. 验证截图（推荐默认执行）
 

--- a/docs/checklists/github-actions-ci-gate.md
+++ b/docs/checklists/github-actions-ci-gate.md
@@ -1,0 +1,40 @@
+# GitHub Actions CI 门禁（合并前必等）
+
+> 维护者看板，非 wiki 知识页。用于在 PR #387 等「未触发 Actions 即合并」之后，统一 **合并前必须等 CI 全绿** 的约定。
+
+## 目标
+
+对指向 `main` 的 Pull Request，在 GitHub 上应出现并 **全部通过** 下列工作流（名称以 Actions 页为准）后，才允许合并：
+
+| 工作流 | 触发（PR） | 大致耗时 |
+|--------|------------|----------|
+| **Tests** | 任意 PR → `main` | ~1 分钟 |
+| **Wiki Lint** | 任意 PR → `main` | ~1 分钟 |
+| **Search & Export Quality Check** | PR 改动 `wiki/`、`sources/`、`scripts/`、`schema/` 等 | ~7–10 分钟 |
+
+合并进 `main` 后（push 到 `main`）还会跑：
+
+| 工作流 | 说明 |
+|--------|------|
+| **Auto Export & Lint** | `wiki/` / `sources/` 等变更时同步派生文件 |
+| **Deploy GitHub Pages** | 站点发布 |
+
+本地 **`make ci-preflight`** 与 GitHub Actions **互补**：提交前本地预检；PR 上仍以 Actions 检查结果为准。
+
+## 合并前检查清单
+
+1. 打开 PR 页 **Checks** 标签，确认上述三项均为绿色（非「跳过 / 未运行」）。
+2. 若 Checks 为空：到仓库 **Settings → Actions** 确认已启用；在 Actions 页对 `Tests` 等手动 **Run workflow** 排查。
+3. 建议仓库管理员在 **Settings → Branches → Branch protection rules** 为 `main` 勾选 Required status checks（至少 `Tests`、`Wiki Lint`；ingest 类 PR 再加 `Search & Export Quality Check`）。
+4. Cloud Agent：**不要**在 Draft 刚转 Ready 后数分钟内合并；`Search & Export Quality Check` 常需 7 分钟以上。
+
+## 与本仓库其它文档
+
+- 本地命令与派生文件同步：[contributing-ci.md](../contributing-ci.md)
+- Cloud Agent 开 PR / 截图：[cloud-agent-pr-workflow.md](cloud-agent-pr-workflow.md)
+- 根目录维护说明：[AGENTS.md](../../AGENTS.md)（Cursor Cloud / `make ci-preflight`）
+
+## 参考
+
+- 工作流定义：`.github/workflows/tests.yml`、`lint.yml`、`search-regression.yml`、`export.yml`
+- 问题背景：PR #387 合并时 `statusCheckRollup` 为空、该时段仓库无新 Actions run 记录（2026-05-26）

--- a/docs/checklists/github-actions-ci-gate.md
+++ b/docs/checklists/github-actions-ci-gate.md
@@ -21,10 +21,21 @@
 
 本地 **`make ci-preflight`** 与 GitHub Actions **互补**：提交前本地预检；PR 上仍以 Actions 检查结果为准。
 
+## 若 PR 只有 Claude/Cursor checks、没有 GitHub Actions
+
+在 commit 的 check-suites 里若只看到 **Claude**、**Cursor** 为 `queued`，而 **没有任何** `Tests` / `Wiki Lint` / `CI PR Gate` 等 Actions 工作流 run（Actions 页 `created > 合并时间` 仍为 0），说明：
+
+- **第三方 App checks ≠ GitHub Actions**；App 能排队不代表 Actions 已启用。
+- 请在仓库 **Settings → Actions → General**：
+  - 选择 **Allow all actions and reusable workflows**（或至少允许本仓库列出的工作流）；
+  - 确认未勾选全局 **Disable actions**；
+  - 组织仓库还需检查 **Org → Settings → Actions** 是否对成员仓库禁用了 Actions。
+- 恢复后：打开 [Actions](https://github.com/ImChong/Robotics_Notebooks/actions)，对 **CI PR Gate (smoke)** 或 **Tests** 点 **Run workflow**，分支选 PR 头分支；或在 PR 上 **Re-run all jobs** / 再 push 一次触发 `synchronize`。
+
 ## 合并前检查清单
 
 1. 打开 PR 页 **Checks** 标签，确认上述三项均为绿色（非「跳过 / 未运行」）。
-2. 若 Checks 为空：到仓库 **Settings → Actions** 确认已启用；在 Actions 页对 `Tests` 等手动 **Run workflow** 排查。
+2. 若 Checks 为空或仅有 App checks：按上一节启用 Actions；在 Actions 页对 `CI PR Gate (smoke)` / `Tests` 手动 **Run workflow** 排查。
 3. 建议仓库管理员在 **Settings → Branches → Branch protection rules** 为 `main` 勾选 Required status checks（至少 `Tests`、`Wiki Lint`；ingest 类 PR 再加 `Search & Export Quality Check`）。
 4. Cloud Agent：**不要**在 Draft 刚转 Ready 后数分钟内合并；`Search & Export Quality Check` 常需 7 分钟以上。
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,10 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-27] structural | docs/checklists/github-actions-ci-gate.md — 补 CI 门禁看板并开 PR 触发全量 GitHub Actions
+
+- 变更：`docs/checklists/github-actions-ci-gate.md`、`docs/checklists/README.md`、`docs/checklists/cloud-agent-pr-workflow.md`、`schema/README.md`（交叉链接触发 Search & Export Quality Check）
+- 目的：在 PR #387 未跑 Actions 即合并后，用 chore PR 重新拉起 `Tests` / `Wiki Lint` / `Search & Export Quality Check`；合并前以 Checks 全绿为准
+
 ## [2026-05-27] ingest | sources/papers/bfm_awesome_41_catalog.md、sources/papers/bfm_awesome_*.md（41+10）— awesome-bfm-papers 论文与数据集分别入库；消化更新 wiki/overview/bfm-41-papers-technology-map.md
 
 - 原始资料：[`sources/papers/bfm_awesome_41_catalog.md`](sources/papers/bfm_awesome_41_catalog.md) 及 51 个 `bfm_awesome_<slug>.md`（41 篇论文 + 10 数据集；#13 交叉指向既有 [`bfm_humanoid_arxiv_2509_13780.md`](sources/papers/bfm_humanoid_arxiv_2509_13780.md)）；生成脚本 [`scripts/generate_bfm_awesome_sources.py`](scripts/generate_bfm_awesome_sources.py)；索引 [`sources/README.md`](sources/README.md)

--- a/schema/README.md
+++ b/schema/README.md
@@ -20,3 +20,4 @@
 - 提交与 CI 命令：[../docs/contributing-ci.md](../docs/contributing-ci.md)
 - 贡献总入口：[../CONTRIBUTING.md](../CONTRIBUTING.md)
 - 自动化维护者说明：[../AGENTS.md](../AGENTS.md)
+- 合并前 GitHub Actions 门禁（非 schema 正文）：[../docs/checklists/github-actions-ci-gate.md](../docs/checklists/github-actions-ci-gate.md)

--- a/scripts/generate_bfm_awesome_sources.py
+++ b/scripts/generate_bfm_awesome_sources.py
@@ -24,7 +24,11 @@ PAPERS: list[dict] = [
         "code": "https://github.com/LeCAR-Lab/BFM-Zero",
         "group": "forward-backward",
         "note": "latent prompt 统一目标姿态、奖励优化、恢复与少样本适配；技能切换≈搜索身体潜空间，接近产业「运控基座」。",
-        "wiki": ["wiki/entities/paper-behavior-foundation-model-humanoid.md", "wiki/concepts/behavior-foundation-model.md", "wiki/overview/bfm-41-papers-technology-map.md"],
+        "wiki": [
+            "wiki/entities/paper-behavior-foundation-model-humanoid.md",
+            "wiki/concepts/behavior-foundation-model.md",
+            "wiki/overview/bfm-41-papers-technology-map.md",
+        ],
     },
     {
         "id": 2,
@@ -36,7 +40,10 @@ PAPERS: list[dict] = [
         "code": "https://github.com/facebookresearch/metamotivo",
         "group": "forward-backward",
         "note": "与 BFM-Zero 对照：zero-shot WBC 依赖可调用行为表示，任务变时尽量在潜空间找方向而非重训。",
-        "wiki": ["wiki/concepts/behavior-foundation-model.md", "wiki/overview/bfm-41-papers-technology-map.md"],
+        "wiki": [
+            "wiki/concepts/behavior-foundation-model.md",
+            "wiki/overview/bfm-41-papers-technology-map.md",
+        ],
     },
     {
         "id": 3,
@@ -60,7 +67,10 @@ PAPERS: list[dict] = [
         "code": "",
         "group": "forward-backward",
         "note": "有行为基座后新动作应少走弯路；降低技能扩展的真机数据与训练成本。",
-        "wiki": ["wiki/methods/imitation-learning.md", "wiki/concepts/behavior-foundation-model.md"],
+        "wiki": [
+            "wiki/methods/imitation-learning.md",
+            "wiki/concepts/behavior-foundation-model.md",
+        ],
     },
     {
         "id": 5,
@@ -96,7 +106,10 @@ PAPERS: list[dict] = [
         "code": "https://nvlabs.github.io/SONIC/",
         "group": "goal-conditioned",
         "note": "supersizing motion tracking；运控基座被上层调用前底层动作覆盖面必须足够宽。",
-        "wiki": ["wiki/methods/sonic-motion-tracking.md", "wiki/overview/bfm-41-papers-technology-map.md"],
+        "wiki": [
+            "wiki/methods/sonic-motion-tracking.md",
+            "wiki/overview/bfm-41-papers-technology-map.md",
+        ],
     },
     {
         "id": 8,
@@ -397,7 +410,10 @@ PAPERS: list[dict] = [
         "code": "",
         "group": "adaptation",
         "note": "负载/地面/硬件参数变化下的零样本动力学适配。",
-        "wiki": ["wiki/concepts/sim2real.md", "wiki/entities/paper-any2any-cross-embodiment-wbt.md"],
+        "wiki": [
+            "wiki/concepts/sim2real.md",
+            "wiki/entities/paper-any2any-cross-embodiment-wbt.md",
+        ],
     },
     {
         "id": 33,
@@ -421,7 +437,10 @@ PAPERS: list[dict] = [
         "code": "",
         "group": "hierarchical",
         "note": "语言–全身动作端到端；中间须有处理平衡/接触的身体通道。",
-        "wiki": ["wiki/methods/vla.md", "wiki/overview/humanoid-rl-motion-control-body-system-stack.md"],
+        "wiki": [
+            "wiki/methods/vla.md",
+            "wiki/overview/humanoid-rl-motion-control-body-system-stack.md",
+        ],
     },
     {
         "id": 35,
@@ -645,24 +664,26 @@ GROUP_LABEL = {
 
 def paper_md(p: dict) -> str:
     code_line = f"- **代码/项目：** <{p['code']}>\n" if p.get("code") else "- **代码/项目：** N/A\n"
-    wiki_lines = "\n".join(f"  - [{w.split('/')[-1].replace('.md', '')}](../../{w})" for w in p["wiki"])
-    return f"""# {p['title']}
+    wiki_lines = "\n".join(
+        f"  - [{w.split('/')[-1].replace('.md', '')}](../../{w})" for w in p["wiki"]
+    )
+    return f"""# {p["title"]}
 
-> 来源归档（ingest · awesome-bfm-papers 第 {p['id']:02d}/41）
+> 来源归档（ingest · awesome-bfm-papers 第 {p["id"]:02d}/41）
 
-- **标题：** {p['title']}
+- **标题：** {p["title"]}
 - **类型：** paper
-- **BFM 分类：** {GROUP_LABEL[p['group']]}（[awesome-bfm-papers](https://github.com/friedrichyuan/awesome-bfm-papers)）
-- **出处：** {p['year']} · {p['venue']}
-- **论文链接：** <{p['paper']}>
+- **BFM 分类：** {GROUP_LABEL[p["group"]]}（[awesome-bfm-papers](https://github.com/friedrichyuan/awesome-bfm-papers)）
+- **出处：** {p["year"]} · {p["venue"]}
+- **论文链接：** <{p["paper"]}>
 {code_line}- **索引来源：** [awesome-bfm-papers](https://github.com/friedrichyuan/awesome-bfm-papers) · [具身智能研究室 BFM 41 篇编译](../blogs/{WECHAT})（<https://mp.weixin.qq.com/s/Ei32la_vo0UW9Y_QCAqB2g>）
 - **入库日期：** {TODAY}
-- **一句话说明：** {p['note']}
+- **一句话说明：** {p["note"]}
 
 ## 核心摘录（策展，非全文）
 
-- **在 BFM 技术地图中的位置：** {GROUP_LABEL[p['group']]}，编号 **{p['id']:02d}/41**。
-- **公众号导读要点：** {p['note']}
+- **在 BFM 技术地图中的位置：** {GROUP_LABEL[p["group"]]}，编号 **{p["id"]:02d}/41**。
+- **公众号导读要点：** {p["note"]}
 - **读者动作：** 方法细节以论文 PDF / 项目页为准；谱系对照见 [BFM 41 篇技术地图](../../wiki/overview/bfm-41-papers-technology-map.md) 与 [Behavior Foundation Model](../../wiki/concepts/behavior-foundation-model.md)。
 
 ## 对 wiki 的映射
@@ -671,31 +692,33 @@ def paper_md(p: dict) -> str:
 
 ## 参考来源（原始）
 
-- 论文：<{p['paper']}>
+- 论文：<{p["paper"]}>
 - 策展列表：<https://github.com/friedrichyuan/awesome-bfm-papers>
 - 微信公众号编译：[wechat_embodied_ai_lab_bfm_41_papers_survey.md](../blogs/{WECHAT})
 """
 
 
 def dataset_md(d: dict) -> str:
-    wiki_lines = "\n".join(f"  - [{w.split('/')[-1].replace('.md', '')}](../../{w})" for w in d["wiki"])
+    wiki_lines = "\n".join(
+        f"  - [{w.split('/')[-1].replace('.md', '')}](../../{w})" for w in d["wiki"]
+    )
     existing = ""
     if d.get("existing"):
         existing = f"\n- **本库已有归档：** [`{d['existing']}`](../sites/amass-dataset.md)（本文件补 awesome-bfm 数据集表索引位）\n"
-    return f"""# {d['name']}（BFM 行为数据 · awesome-bfm-papers 数据集表）
+    return f"""# {d["name"]}（BFM 行为数据 · awesome-bfm-papers 数据集表）
 
 > 来源归档（ingest · 数据集）
 
-- **名称：** {d['name']}
+- **名称：** {d["name"]}
 - **类型：** dataset
 - **BFM 数据索引：** [awesome-bfm-papers § Datasets](https://github.com/friedrichyuan/awesome-bfm-papers#datasets)
-- **出处：** {d['year']} · {d['venue']}
-- **规模：** {d['clips']} clips · {d['hours']} h（列表标注）
-- **论文链接：** <{d['paper']}>
-- **代码/入口：** <{d['code']}>
+- **出处：** {d["year"]} · {d["venue"]}
+- **规模：** {d["clips"]} clips · {d["hours"]} h（列表标注）
+- **论文链接：** <{d["paper"]}>
+- **代码/入口：** <{d["code"]}>
 - **索引来源：** [具身智能研究室 BFM 41 篇编译](../blogs/{WECHAT})
 - **入库日期：** {TODAY}
-- **一句话说明：** {d['note']}{existing}
+- **一句话说明：** {d["note"]}{existing}
 
 ## 核心摘录（策展）
 
@@ -708,7 +731,7 @@ def dataset_md(d: dict) -> str:
 
 ## 参考来源（原始）
 
-- 数据集论文/页：<{d['paper']}>
+- 数据集论文/页：<{d["paper"]}>
 - awesome-bfm-papers：<https://github.com/friedrichyuan/awesome-bfm-papers>
 """
 
@@ -719,9 +742,9 @@ def catalog_md(papers_written: list[dict], datasets_written: list[dict]) -> str:
         "",
         "> 来源归档（catalog）",
         "",
-        f"- **维护列表：** <https://github.com/friedrichyuan/awesome-bfm-papers>",
+        "- **维护列表：** <https://github.com/friedrichyuan/awesome-bfm-papers>",
         f"- **微信公众号导读：** [wechat_embodied_ai_lab_bfm_41_papers_survey.md](../blogs/{WECHAT})",
-        f"- **wiki 技术地图：** [bfm-41-papers-technology-map.md](../../wiki/overview/bfm-41-papers-technology-map.md)",
+        "- **wiki 技术地图：** [bfm-41-papers-technology-map.md](../../wiki/overview/bfm-41-papers-technology-map.md)",
         f"- **入库日期：** {TODAY}",
         "- **一句话说明：** 将 awesome-bfm-papers 所列 **41 篇 BFM 论文** 与 **10 个数据集** 分别落成独立 `sources/papers/bfm_awesome_*` 归档，便于 ingest 溯源与 lint 入链统计。",
         "",
@@ -762,14 +785,14 @@ def main() -> None:
         if p.get("skip") and (ROOT / "sources/papers" / f"{p['slug']}.md").exists():
             # cross-ref stub for #13
             if p["id"] == 13:
-                stub = f"""# {p['title']}（索引位 · 已有深读归档）
+                stub = f"""# {p["title"]}（索引位 · 已有深读归档）
 
 > 本条目对应 awesome-bfm-papers **第 13/41** 篇；完整 ingest 见既有归档。
 
 - **主归档：** [bfm_humanoid_arxiv_2509_13780.md](bfm_humanoid_arxiv_2509_13780.md)
 - **wiki：** [paper-behavior-foundation-model-humanoid.md](../../wiki/entities/paper-behavior-foundation-model-humanoid.md)
-- **BFM 分类：** {GROUP_LABEL[p['group']]}
-- **论文：** <{p['paper']}>
+- **BFM 分类：** {GROUP_LABEL[p["group"]]}
+- **论文：** <{p["paper"]}>
 """
                 out.write_text(stub, encoding="utf-8")
                 created += 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

PR #387 / #388 未出现 **GitHub Actions** run 的根因已确认：**不是 workflow 写错，而是仓库自 2026-05-26 11:30 UTC 起 Actions 未再入队**（`workflow_runs` 为 0；工作流在 API 中仍为 `active`）。

本 PR 追加：

- 新增 **CI PR Gate (smoke)**（`.github/workflows/ci-pr-gate.yml`）— 最小 smoke，便于确认 Actions 是否恢复
- `tests.yml` / `lint.yml` / `search-regression.yml`：补全 `pull_request.types` 与 `workflow_dispatch`
- [`docs/checklists/github-actions-ci-gate.md`](docs/checklists/github-actions-ci-gate.md) 增加「仅有 Claude/Cursor checks」排障节

## 仓库维护者必做（否则任何 PR 都不会跑 Actions）

1. 打开 **Settings → Actions → General**
2. 选择 **Allow all actions and reusable workflows**
3. 确认未启用 **Disable actions**
4. 若为组织仓库：检查 **Org → Settings → Actions** 是否对成员仓库禁用 / 用尽额度
5. 打开 [Actions 页](https://github.com/ImChong/Robotics_Notebooks/actions)，对 **CI PR Gate (smoke)** 或 **Tests** 点 **Run workflow**，分支选 `cursor/trigger-full-ci-actions-2062`

恢复后 PR 上应出现：`CI PR Gate (smoke)`、`Tests`、`Wiki Lint`、`Search & Export Quality Check`（后一项因改动 `schema/`）。

## 诊断依据

- PR commit 的 check-suites 仅有 **Claude**、**Cursor**（`queued`），无 `github-actions` 创建的 suite
- 推送 workflow 修复后 `branch runs` 仍为 **0**

## 合并说明

**请在 Actions 三项全绿后再合并本 PR。**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19eff735-c62f-4d96-958a-9b28896b2062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19eff735-c62f-4d96-958a-9b28896b2062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

