### PR TITLE
feat: V23 P0 缩写/别名归一化检索 V2 收口

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v23.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v23.md
@@ -21,8 +21,8 @@
 
 ## P0: 自动化与工具链深度强化 (Engineering)
 
-- [ ] **缩写/别名归一化检索 V2**：
-    - [ ] `scripts/search_wiki_core.py` 的 `WIKI_ABBREVIATIONS` 在 V22 16 条基础上补 WBT / BFM / DAgger / RSI / RFC / RMA / EMA / LoRA / DoF 等 V22 期间新增的高频缩写，确保新热点直接可检；新增用例覆盖到 `tests/test_search_wiki_core.py`。
+- [x] **缩写/别名归一化检索 V2**：
+    - [x] `scripts/search_wiki_core.py` 的 `WIKI_ABBREVIATIONS` 在 V22 16 条基础上补 WBT / BFM / DAgger / RSI / RFC / RMA / EMA / LoRA / DoF 等 V22 期间新增的高频缩写，确保新热点直接可检；新增用例覆盖到 `tests/test_search_wiki_core.py`。（2026-05-26：补全 9 条至共 25 条；新增 `test_v22_abbreviations_expand_to_full` / `test_v22_full_phrases_expand_to_abbreviation` 两组子测试，`python -m unittest tests.test_search_wiki_core` 全 26 用例通过；ruff / mypy 同步绿）
 - [ ] **Entity-Paper 类页元数据 Lint**：
     - [ ] `scripts/lint_wiki.py` 新增 `entity_paper_metadata_check`：以 `wiki/entities/paper-*.md` 为目标，校验 frontmatter 至少包含 `arxiv` / `venue` / `code` 三类来源中之一，且正文存在「方法栈 / 评测 / 与其他工作对比」三段式（缺失给出 INFO 级提示，不阻塞 CI）。基线快照写入 lint 报告，作为后续 ingest 工作流自检入口。
 - [ ] **图谱 latest_wiki_nodes 时间窗口可配置**：

--- a/log.md
+++ b/log.md
@@ -1,5 +1,12 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-26] checklist-v23 | scripts/search_wiki_core.py、tests/test_search_wiki_core.py — V23 P0「缩写/别名归一化检索 V2」收口
+
+- 变更：`scripts/search_wiki_core.py` 的 `WIKI_ABBREVIATIONS` 在 V22 16 条基础上补齐 9 条 V22 期间高频缩写（**WBT** / **BFM** / **DAgger** / **RSI** / **RFC** / **RMA** / **EMA** / **LoRA** / **DoF**），共 25 条；映射均双向化（`_build_alias_indexes` 自动构造 forward + reverse）。
+- 测试：`tests/test_search_wiki_core.py` 新增两组 subTest——`test_v22_abbreviations_expand_to_full`（9 条缩写 → 全称展开）与 `test_v22_full_phrases_expand_to_abbreviation`（9 条全称 → 缩写大写化反向命中），`python -m unittest tests.test_search_wiki_core -v` 26/26 通过。
+- 门禁：`ruff check`、`ruff format --check`、`PYTHONPATH=scripts mypy scripts/search_wiki_core.py` 均绿。
+- 清单：[`docs/checklists/tech-stack-next-phase-checklist-v23.md`](docs/checklists/tech-stack-next-phase-checklist-v23.md) P0「缩写/别名归一化检索 V2」打勾。
+
 ## [2026-05-26] ingest | sources/blogs/wechat_embodied_ai_lab_humanoid_rl_motion_survey.md、sources/blogs/wechat_embodied_ai_lab_humanoid_amp_motion_prior_survey.md — Agent Reach 重抓两篇微信公众号长文；42+19 篇论文分别入库并升格 wiki 实体节点
 
 - 工具：已安装 [Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach) v1.4.0（`pip install` + `agent-reach install --channels=wechat`）；微信正文经 `~/.agent-reach/tools/wechat-article-for-ai`（Camoufox）

--- a/scripts/search_wiki_core.py
+++ b/scripts/search_wiki_core.py
@@ -53,6 +53,15 @@ WIKI_ABBREVIATIONS: dict[str, list[str]] = {
     "lip": ["linear inverted pendulum"],
     "zmp": ["zero moment point"],
     "tsid": ["task-space inverse dynamics"],
+    "wbt": ["whole-body tracking"],
+    "bfm": ["behavior foundation model"],
+    "dagger": ["dataset aggregation"],
+    "rsi": ["reference state initialization"],
+    "rfc": ["residual force control"],
+    "rma": ["rapid motor adaptation"],
+    "ema": ["exponential moving average"],
+    "lora": ["low-rank adaptation"],
+    "dof": ["degrees of freedom"],
 }
 
 

--- a/tests/test_search_wiki_core.py
+++ b/tests/test_search_wiki_core.py
@@ -198,6 +198,45 @@ class TestExpandQueryAliases(unittest.TestCase):
         _, expansions = expand_query_aliases(["wbc"])
         self.assertTrue(any("whole-body control" == dst for _, dst in expansions))
 
+    def test_v22_abbreviations_expand_to_full(self):
+        """V23 P0：V22 期间新增的高频缩写必须可双向展开。"""
+        cases = [
+            ("WBT", "whole-body tracking"),
+            ("BFM", "behavior foundation model"),
+            ("DAgger", "dataset aggregation"),
+            ("RSI", "reference state initialization"),
+            ("RFC", "residual force control"),
+            ("RMA", "rapid motor adaptation"),
+            ("EMA", "exponential moving average"),
+            ("LoRA", "low-rank adaptation"),
+            ("DoF", "degrees of freedom"),
+        ]
+        for abbrev, full in cases:
+            with self.subTest(abbrev=abbrev):
+                expanded, expansions = expand_query_aliases([abbrev])
+                self.assertIn(abbrev, expanded)
+                self.assertIn(full, expanded)
+                self.assertTrue(any(dst == full for _, dst in expansions))
+
+    def test_v22_full_phrases_expand_to_abbreviation(self):
+        """V23 P0：V22 缩写的反向展开（全称 → 缩写）必须命中规范缩写（大写化形式）。"""
+        cases = [
+            (["whole-body", "tracking"], "WBT"),
+            (["behavior", "foundation", "model"], "BFM"),
+            (["dataset", "aggregation"], "DAGGER"),
+            (["reference", "state", "initialization"], "RSI"),
+            (["residual", "force", "control"], "RFC"),
+            (["rapid", "motor", "adaptation"], "RMA"),
+            (["exponential", "moving", "average"], "EMA"),
+            (["low-rank", "adaptation"], "LORA"),
+            (["degrees", "of", "freedom"], "DOF"),
+        ]
+        for tokens, expected_abbrev in cases:
+            with self.subTest(tokens=tokens):
+                expanded, expansions = expand_query_aliases(tokens)
+                self.assertIn(expected_abbrev, expanded)
+                self.assertTrue(any(dst == expected_abbrev for _, dst in expansions))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

补全 `WIKI_ABBREVIATIONS` 中 V22 期间新增的 9 条高频缩写（WBT / BFM / DAgger / RSI / RFC / RMA / EMA / LoRA / DoF），使其从 16 条扩展至 25 条；新增两组双向展开测试用例，验证缩写↔全称的完整映射。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细变更

### `scripts/search_wiki_core.py`
- 在 `WIKI_ABBREVIATIONS` 字典中新增 9 条缩写映射：
  - `wbt` → `whole-body tracking`
  - `bfm` → `behavior foundation model`
  - `dagger` → `dataset aggregation`
  - `rsi` → `reference state initialization`
  - `rfc` → `residual force control`
  - `rma` → `rapid motor adaptation`
  - `ema` → `exponential moving average`
  - `lora` → `low-rank adaptation`
  - `dof` → `degrees of freedom`
- 现有 `_build_alias_indexes` 机制自动构造双向映射（forward + reverse）

### `tests/test_search_wiki_core.py`
- 新增 `test_v22_abbreviations_expand_to_full`：验证 9 条缩写可展开至完整全称
- 新增 `test_v22_full_phrases_expand_to_abbreviation`：验证全称分词可反向命中规范缩写（大写化形式）
- 两组测试均采用 `subTest` 便于逐条诊断

### `log.md` 与 `docs/checklists/tech-stack-next-phase-checklist-v23.md`
- 记录本次变更的完成时间、测试覆盖情况及门禁通过状态
- 在 checklist 中标记「缩写/别名归一化检索 V2」P0 项为已完成

## 验证

- [x] `python -m unittest tests.test_search_wiki_core -v` — 26/26 用例通过（含新增 2 组 subTest）
- [x] `ruff check` — 通过
- [x] `ruff format --check` — 通过
- [x] `PYTHONPATH=scripts mypy scripts/search_wiki_core.py` — 通过

## 相关 Issue

无

https://claude.ai/code/session_01Pvr38TYedkdJ5kZvmG7WVv