### PR TITLE
Add search aliases for CBF and VLA concepts

### DIFF
--- a/scripts/search_wiki_core.py
+++ b/scripts/search_wiki_core.py
@@ -73,6 +73,10 @@ CANONICAL_TOPIC_PAGES: dict[str, str] = {
     "whole-body control": "wiki/concepts/whole-body-control.md",
     "mpc": "wiki/methods/model-predictive-control.md",
     "model predictive control": "wiki/methods/model-predictive-control.md",
+    "cbf": "wiki/concepts/control-barrier-function.md",
+    "control barrier function": "wiki/concepts/control-barrier-function.md",
+    "vla": "wiki/methods/vla.md",
+    "vision-language-action": "wiki/methods/vla.md",
 }
 
 COMPARISON_INTENT_MARKERS = frozenset(


### PR DESCRIPTION
## 摘要

为搜索索引添加 4 个新的别名映射，支持用户通过缩写或全称搜索"控制屏障函数"（CBF）和"视觉语言动作"（VLA）两个概念。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`（改动 wiki 导出链）
- [ ] 其他：无需额外测试，仅为搜索别名配置

## 相关 Issue

无

https://claude.ai/code/session_015xSyksJccmLAVRJsyPrit2