### PR TITLE
fix(ux): 统一图谱筛选面板「清除全部」按钮左下内边距

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -857,7 +857,7 @@
       flex-shrink: 0;
     }
     .filter-footer {
-      padding: 8px 14px 10px;
+      padding: 10px 14px 14px;
       border-top: 1px solid rgba(255,255,255,0.06);
     }
     .filter-clear {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

图谱视图（`docs/graph.html`）筛选浮窗底部「清除全部」按钮与面板边框的间距不一致：`.filter-footer` 原先为 `padding: 8px 14px 10px`，左侧内边距 14px、下侧仅 10px，视觉上左下不对齐。

本次将 footer 内边距调整为 `10px 14px 14px`，使按钮距面板左缘与下缘均为 14px，与面板内其他区块（如 `filter-header`、`filter-item`）的水平内边距保持一致。

## 验证

- 仅修改 `docs/graph.html` 内联样式，未触及 wiki / 导出派生文件，无需 `make ci-preflight`。
- 本地 `cd docs && python3 -m http.server 8765`，Puppeteer 打开 `graph.html` 并展开筛选面板。
- 计算样式：`filter-footer` 的 `padding-left` 与 `padding-bottom` 均为 **14px**；按钮相对 `#filter-panel` 边框的内缩距左/下均为 **15px**（含 1px 面板边框）。

## 验证截图

**筛选面板全貌（含底部「清除全部」）**

[图谱筛选面板全貌，底部清除全部按钮左下间距一致](https://cursor.com/agents/bc-5aaaf4bd-ab59-450d-8793-d8a57cf0cba5/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-filter-panel-with-clear-btn.png)

**底部区域特写（左 / 下内边距对齐）**

[清除全部按钮与面板左、下边框等距 14px 特写](https://cursor.com/agents/bc-5aaaf4bd-ab59-450d-8793-d8a57cf0cba5/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-filter-clear-spacing-verify.png)

## 风险

- 无功能逻辑变更，仅 footer 垂直留白 +2px（下侧），对布局影响可忽略。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aaaf4bd-ab59-450d-8793-d8a57cf0cba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aaaf4bd-ab59-450d-8793-d8a57cf0cba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

