### PR TITLE
feat(ux): 图谱预计算布局、刷新力模拟与移动端视口修复

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1713,11 +1713,38 @@
       searchList.innerHTML = nodes.map(n => '<option value="' + escapeHtml(n._info.title || n.label) + '"></option>').join('');
     }
 
-    /* ── SVG 尺寸 ── */
+    /* ── SVG 尺寸（移动端首屏 clientHeight 可能为 0，需延后 fit）── */
     const wrap = document.getElementById('graph-wrap');
     const svg = d3.select('#graph-canvas');
-    let W = wrap.clientWidth, H = wrap.clientHeight;
-    svg.attr('width', W).attr('height', H);
+    let W = 0;
+    let H = 0;
+
+    function updateGraphViewport() {
+      if (!wrap) return false;
+      const nextW = wrap.clientWidth;
+      const nextH = wrap.clientHeight;
+      if (nextW <= 0 || nextH <= 0) return false;
+      W = nextW;
+      H = nextH;
+      svg.attr('width', W).attr('height', H);
+      simulation.force('center', d3.forceCenter(W / 2, H / 2).strength(0.05));
+      return true;
+    }
+
+    function whenGraphViewportReady(callback, attempt) {
+      const n = attempt || 0;
+      if (updateGraphViewport()) {
+        callback();
+        return;
+      }
+      if (n < 80) {
+        requestAnimationFrame(() => whenGraphViewportReady(callback, n + 1));
+        return;
+      }
+      window.addEventListener('load', () => {
+        if (updateGraphViewport()) callback();
+      }, { once: true });
+    }
 
     /* ── Zoom ── */
     const gRoot = svg.append('g');
@@ -1951,7 +1978,7 @@
     function finishSimulationLoad() {
       document.getElementById('graph-loading').style.display = 'none';
       node.select('.node-label').transition().duration(400).style('opacity', 0.85);
-      setTimeout(() => fitToScreen(), 100);
+      whenGraphViewportReady(() => fitToScreen());
     }
 
     function startLiveForceSimulation() {
@@ -1976,6 +2003,7 @@
 
     if (usingPrecomputedLayout) {
       simulation.stop();
+      simulation.tick();
       syncGraphDomFromSimulation();
       finishSimulationLoad();
     } else {
@@ -2532,6 +2560,7 @@
     }
 
     function fitToVisibleNodes() {
+      if (!updateGraphViewport()) return;
       const visNodes = nodes.filter(n => visibleNodeIds.has(n.id) && n.x != null);
       if (visNodes.length === 0) return;
       const xs = visNodes.map(n => n.x), ys = visNodes.map(n => n.y);
@@ -2549,6 +2578,7 @@
 
     /* ── 适配屏幕到所有节点 ── */
     function fitToScreen() {
+      if (!updateGraphViewport()) return;
       const allNodes = nodes.filter(n => n.x != null);
       if (allNodes.length === 0) return;
       const xs = allNodes.map(n => n.x), ys = allNodes.map(n => n.y);
@@ -2581,15 +2611,21 @@
       );
     }
 
-    /* ── resize ── */
-    window.addEventListener('resize', () => {
-      W = wrap.clientWidth; H = wrap.clientHeight;
-      svg.attr('width', W).attr('height', H);
-      simulation.force('center', d3.forceCenter(W / 2, H / 2).strength(0.05));
+    /* ── resize（移动端地址栏收起会改变可视高度；预计算布局需重新 fit）── */
+    let resizeFitTimer = null;
+    function onGraphViewportResize() {
+      if (!updateGraphViewport()) return;
       if (!usingPrecomputedLayout) {
         simulation.alpha(0.1).restart();
+        return;
       }
-    });
+      clearTimeout(resizeFitTimer);
+      resizeFitTimer = setTimeout(() => fitToScreen(), 120);
+    }
+    window.addEventListener('resize', onGraphViewportResize);
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', onGraphViewportResize);
+    }
 
     /* ── 主题切换监听：同步更新 D3 SVG 元素颜色 ── */
     new MutationObserver(() => {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2596,6 +2596,7 @@
 
     /* ── 搜索飞行定位 ── */
     function flyToVisible() {
+      if (!updateGraphViewport()) return;
       const visNodes = nodes.filter(n => visibleNodeIds.has(n.id) && n.x != null);
       if (visNodes.length === 0 || visNodes.length > 15) return;
       const xs = visNodes.map(n => n.x), ys = visNodes.map(n => n.y);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- `make graph` 在 `link-graph.json` 导出预计算节点坐标（`layout.positions`），打开 `graph.html` 时直接落位，避免首屏全量力模拟卡顿。
- 工具栏新增 **「↻ 刷新布局」**：从随机初始位置 `alpha(1)` 重新跑力导向，行为与无缓存时首次打开一致。
- 修复移动端节点挤在左上角：首屏等待 `#graph-wrap` 有效尺寸后再 `fitToScreen`，并在 `resize` / `visualViewport` 变化时重新适配。

## 验证

- `make ci-preflight` 通过（合并 main 后已重算 582 节点 layout）
- `pytest tests/test_graph_layout.py` 通过

## 主要改动

| 区域 | 说明 |
|------|------|
| `scripts/graph_layout.py` | numpy 离线力模拟，参数对齐 `graph.html` 默认物理 |
| `scripts/generate_link_graph.py` | 导出 `layout` 字段 |
| `docs/graph.html` | 应用预计算布局、`restart-simulation`、移动端 `whenGraphViewportReady` |

## 验证截图

（建议在 `cd docs && python3 -m http.server 8765` 后用手机/窄屏打开 `graph.html` 确认首屏铺满画布）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b0f6d58-88bd-4687-97e1-3c9ec481e2b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b0f6d58-88bd-4687-97e1-3c9ec481e2b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

