### PR TITLE
Validate exported layout positions before applying

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1798,9 +1798,22 @@
     function applyExportedLayout(data) {
       const layout = data && data.layout;
       if (!layout || !layout.positions) return false;
+      const positions = layout.positions;
+      // Reject the whole cache if any coordinate is non-finite or runaway —
+      // a divergent export (e.g. positions of 1e60+) will pin every node to
+      // the canvas corner instead of producing a usable layout.
+      const MAX_ABS = 1e6;
+      for (const n of nodes) {
+        const p = positions[n.id];
+        if (!p) continue;
+        if (!Number.isFinite(p.x) || !Number.isFinite(p.y) ||
+            Math.abs(p.x) > MAX_ABS || Math.abs(p.y) > MAX_ABS) {
+          return false;
+        }
+      }
       let applied = 0;
       for (const n of nodes) {
-        const p = layout.positions[n.id];
+        const p = positions[n.id];
         if (!p) continue;
         n.x = p.x;
         n.y = p.y;


### PR DESCRIPTION
## 摘要

添加对导出布局坐标的验证，拒绝包含非有限数值或超大值（如 1e60+）的缓存，防止发散导出导致所有节点被固定在画布角落。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 详情

在 `applyExportedLayout()` 函数中添加验证逻辑：
- 检查每个节点的坐标是否为有限数值（`Number.isFinite`）
- 检查坐标绝对值是否超过阈值 `MAX_ABS = 1e6`
- 若任何坐标不合法，整体拒绝该缓存并返回 `false`，避免应用损坏的布局

同时提取 `layout.positions` 为局部变量，减少重复访问。

## 验证

- N/A（纯前端防御性代码，无需测试命令）

https://claude.ai/code/session_01BGLzTJNaKvjGLbXpWrMj1u