### PR TITLE
V23: Add paper-* entity metadata lint checks (info-only)

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v23.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v23.md
@@ -23,8 +23,8 @@
 
 - [x] **缩写/别名归一化检索 V2**：
     - [x] `scripts/search_wiki_core.py` 的 `WIKI_ABBREVIATIONS` 在 V22 16 条基础上补 WBT / BFM / DAgger / RSI / RFC / RMA / EMA / LoRA / DoF 等 V22 期间新增的高频缩写，确保新热点直接可检；新增用例覆盖到 `tests/test_search_wiki_core.py`。（2026-05-26：补全 9 条至共 25 条；新增 `test_v22_abbreviations_expand_to_full` / `test_v22_full_phrases_expand_to_abbreviation` 两组子测试，`python -m unittest tests.test_search_wiki_core` 全 26 用例通过；ruff / mypy 同步绿）
-- [ ] **Entity-Paper 类页元数据 Lint**：
-    - [ ] `scripts/lint_wiki.py` 新增 `entity_paper_metadata_check`：以 `wiki/entities/paper-*.md` 为目标，校验 frontmatter 至少包含 `arxiv` / `venue` / `code` 三类来源中之一，且正文存在「方法栈 / 评测 / 与其他工作对比」三段式（缺失给出 INFO 级提示，不阻塞 CI）。基线快照写入 lint 报告，作为后续 ingest 工作流自检入口。
+- [x] **Entity-Paper 类页元数据 Lint**：
+    - [x] `scripts/lint_wiki.py` 新增 `entity_paper_metadata_check`：以 `wiki/entities/paper-*.md` 为目标，校验 frontmatter 至少包含 `arxiv` / `venue` / `code` 三类来源中之一，且正文存在「方法栈 / 评测 / 与其他工作对比」三段式（缺失给出 INFO 级提示，不阻塞 CI）。基线快照写入 lint 报告，作为后续 ingest 工作流自检入口。（2026-05-27：新增 `_check_paper_entity_metadata` 与两条 INFO key `paper_missing_source_meta` / `paper_missing_three_sections`；基线快照：131/131 缺来源键、130/131 缺三段式之一。`tests/test_lint_wiki_paper_metadata.py` 新增 6 用例覆盖来源命中、缺失定位、非论文实体豁免、信息型计数；`python -m pytest tests/ --ignore=test_graph_layout.py` 106 通过，ruff / mypy 同步绿）
 - [ ] **图谱 latest_wiki_nodes 时间窗口可配置**：
     - [ ] `scripts/generate_link_graph.py` 把 `latest_wiki_nodes` 的「最近 N 项」改为可通过 CLI flag / 环境变量配置（默认 10，上限 30）；前端 `docs/main.js` 在详情页底部新增「最近 30 天 ingest 时间线」轻量展示（仅在主入口/首页生效）。
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,12 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-05-27] checklist-v23 | scripts/lint_wiki.py、tests/test_lint_wiki_paper_metadata.py — V23 P0「Entity-Paper 类页元数据 Lint」收口
+
+- 变更：`scripts/lint_wiki.py` 新增 `_check_paper_entity_metadata`，针对 `wiki/entities/paper-*.md` 做两项信息型检查——frontmatter 是否含 `arxiv` / `venue` / `code` 任一来源键、正文是否覆盖「方法 / 评测 / 对比」三段式；两个新 result key `paper_missing_source_meta` 与 `paper_missing_three_sections` 加入 `INFO_ONLY_KEYS`，缺失不阻塞 CI 但写入 lint 报告作为 ingest 流水线基线。
+- 基线快照：当前 131 个 paper-* 实体全部缺 arxiv/venue/code 显式键（依赖 `sources:` 间接来源），130/131 缺三段式之一（多数缺「评测」段），将作为后续 ingest 模板对齐的目标。
+- 测试：`tests/test_lint_wiki_paper_metadata.py` 新增 6 用例（命中 arxiv/venue/code、缺失定位、三段式部分缺失、非 paper- 实体豁免、信息型计数）；`python -m pytest tests/ --ignore=tests/test_graph_layout.py --no-cov` 106 通过；`ruff check` 与 `mypy scripts/lint_wiki.py` 均绿。
+- 清单：[`docs/checklists/tech-stack-next-phase-checklist-v23.md`](docs/checklists/tech-stack-next-phase-checklist-v23.md) P0「Entity-Paper 类页元数据 Lint」打勾。
+
 ## [2026-05-27] ingest | sources/papers/smp.md — 扩写 arXiv:2512.03028 完整摘录（摘要、SDS/ESM/GSI、任务与 AMP 对比、G1 部署、wiki 映射）；同步 sources/README 论文索引
 
 ## [2026-05-27] ingest | sources/repos/smp_suz_tsinghua.md — 接入清华 SUZ-tsinghua/smp（G1 上 SMP + mjlab 复现）；沉淀 wiki/entities/smp-g1-mjlab.md；交叉更新 wiki/methods/smp.md、wiki/entities/mimickit.md、wiki/entities/mjlab.md、wiki/comparisons/amp-add-smp-motion-prior-variants.md

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -15,6 +15,9 @@ lint_wiki.py — 自动化 wiki 健康检查脚本
  11. concepts/methods/tasks 缺少 summary/description 字段（V10 新增）
  12. formalizations/ 公式变量在正文是否有物理含义解释（V21 新增）
  13. 高频引用的 methods/ 缺少 queries/ 操作指南或 comparisons/ 对比页（V22 新增，信息型）
+ 14. wiki/entities/paper-* 元数据基线（V23 新增，信息型）：
+     - frontmatter 至少含 arxiv/venue/code 三类来源键之一；
+     - 正文至少含「方法栈 / 评测 / 与其他工作对比」三段式。
 
 用法：
   python3 scripts/lint_wiki.py
@@ -42,6 +45,8 @@ METHOD_PRACTITIONER_INBOUND_THRESHOLD = 3
 INFO_ONLY_KEYS: set[str] = {
     "missing_pages",
     "methods_without_practitioner_query",
+    "paper_missing_source_meta",
+    "paper_missing_three_sections",
 }
 
 
@@ -189,6 +194,8 @@ def _empty_results() -> dict[str, Any]:
         "entity_missing_outgoing": [],
         "wikilink_syntax": [],
         "methods_without_practitioner_query": [],
+        "paper_missing_source_meta": [],
+        "paper_missing_three_sections": [],
         "_ingest_covered": 0,
         "_ingest_total": 0,
     }
@@ -641,6 +648,50 @@ def _check_methods_without_practitioner_query(
             )
 
 
+def _check_paper_entity_metadata(pages: list[Path], results: dict[str, Any]) -> None:
+    """V23: paper-* 实体页元数据基线检查（信息型，不阻塞 CI）。
+
+    针对 ``wiki/entities/paper-*.md``：
+      - frontmatter 至少包含 ``arxiv`` / ``venue`` / ``code`` 三类来源键之一；
+      - 正文至少存在「方法栈 / 评测 / 与其他工作对比」三段式。
+
+    用于 ingest 工作流自检入口，缺失项作为基线快照写入 lint 报告。
+    """
+    method_patterns = ["方法栈", "流程总览", "流程", "核心机制", "核心信息", "pipeline", "方法"]
+    eval_patterns = ["评测", "实验", "量化", "结果", "benchmark"]
+    compare_patterns = ["与其他工作", "与其他页面", "对比", "比较"]
+    source_keys = ("arxiv", "venue", "code")
+
+    for page in pages:
+        rel = page.relative_to(REPO_ROOT)
+        parts = rel.parts
+        if len(parts) < 3 or parts[0] != "wiki" or parts[1] != "entities":
+            continue
+        if not page.name.startswith("paper-"):
+            continue
+
+        content = page.read_text(encoding="utf-8")
+        fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+        fm_block = fm_match.group(1) if fm_match else ""
+        has_source = any(
+            re.search(rf"^{key}\s*:", fm_block, re.MULTILINE) for key in source_keys
+        )
+        if not has_source:
+            results["paper_missing_source_meta"].append(str(rel))
+
+        missing_sections = []
+        if not has_section(content, method_patterns):
+            missing_sections.append("方法")
+        if not has_section(content, eval_patterns):
+            missing_sections.append("评测")
+        if not has_section(content, compare_patterns):
+            missing_sections.append("对比")
+        if missing_sections:
+            results["paper_missing_three_sections"].append(
+                f"{rel}（缺 {' / '.join(missing_sections)}）"
+            )
+
+
 def _check_methods_entities(pages: list[Path], results: dict[str, Any]) -> None:
     """methods/ 页面结构检查 + entities/ 出边检查。
 
@@ -683,6 +734,7 @@ def lint() -> dict[str, Any]:
     _check_graph_orphans(results)
     _check_methods_entities(pages, results)
     _check_methods_without_practitioner_query(pages, inbound, results)
+    _check_paper_entity_metadata(pages, results)
 
     return results
 
@@ -735,6 +787,16 @@ def format_report(results: dict[str, Any]) -> str:
         (
             "methods_without_practitioner_query",
             "高频引用 methods/ 缺 queries/ 或 comparisons/ 落地（信息型，不阻塞 CI）",
+            "💡",
+        ),
+        (
+            "paper_missing_source_meta",
+            "paper-* 实体 frontmatter 缺 arxiv/venue/code 来源键（信息型，不阻塞 CI）",
+            "💡",
+        ),
+        (
+            "paper_missing_three_sections",
+            "paper-* 实体正文缺「方法/评测/对比」三段式（信息型，不阻塞 CI）",
             "💡",
         ),
     ]

--- a/tests/test_lint_wiki_paper_metadata.py
+++ b/tests/test_lint_wiki_paper_metadata.py
@@ -1,0 +1,94 @@
+"""Tests for V23 lint check: paper-* 实体页元数据基线（信息型）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import lint_wiki as lw
+
+
+def _setup_wiki(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(lw, "REPO_ROOT", tmp_path)
+    wiki = tmp_path / "wiki"
+    (wiki / "entities").mkdir(parents=True)
+    return wiki
+
+
+def _run(pages: list[Path]) -> dict:
+    results = lw._empty_results()
+    lw._check_paper_entity_metadata(pages, results)
+    return results
+
+
+def test_complete_paper_passes_both_checks(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "entities" / "paper-foo.md"
+    page.write_text(
+        "---\n"
+        "type: entity\n"
+        "arxiv: 2401.00000\n"
+        "---\n"
+        "\n"
+        "## 方法栈\n正文\n\n## 评测\n正文\n\n## 与其他工作对比\n正文\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["paper_missing_source_meta"] == []
+    assert results["paper_missing_three_sections"] == []
+
+
+def test_venue_or_code_satisfies_source_check(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    for key in ("venue", "code"):
+        page = wiki / "entities" / f"paper-{key}.md"
+        page.write_text(
+            f"---\ntype: entity\n{key}: https://example.org\n---\n"
+            "## 方法\n## 实验\n## 对比\n",
+            encoding="utf-8",
+        )
+        results = _run([page])
+        assert results["paper_missing_source_meta"] == [], f"{key} should satisfy"
+
+
+def test_missing_source_key_is_flagged(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "entities" / "paper-bar.md"
+    page.write_text(
+        "---\ntype: entity\nsources:\n  - ../../sources/papers/bar.md\n---\n"
+        "## 方法栈\n## 评测\n## 对比\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["paper_missing_source_meta"] == ["wiki/entities/paper-bar.md"]
+    assert results["paper_missing_three_sections"] == []
+
+
+def test_partial_three_sections_records_missing(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "entities" / "paper-baz.md"
+    page.write_text(
+        "---\narxiv: 2402.99999\n---\n## 方法栈\n仅有方法段\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["paper_missing_source_meta"] == []
+    assert len(results["paper_missing_three_sections"]) == 1
+    record = results["paper_missing_three_sections"][0]
+    assert "评测" in record and "对比" in record and "方法" not in record
+
+
+def test_non_paper_entity_is_ignored(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "entities" / "unitree-g1.md"
+    page.write_text("---\ntype: entity\n---\n# 普通实体\n", encoding="utf-8")
+    results = _run([page])
+    assert results["paper_missing_source_meta"] == []
+    assert results["paper_missing_three_sections"] == []
+
+
+def test_info_only_keys_do_not_count_toward_failing_total() -> None:
+    results = lw._empty_results()
+    results["paper_missing_source_meta"].append("wiki/entities/paper-x.md")
+    results["paper_missing_three_sections"].append("wiki/entities/paper-x.md（缺 评测）")
+    assert lw._failing_total(results) == 0
+    assert lw._info_total(results) == 2


### PR DESCRIPTION
## 摘要

新增 V23 lint 检查，针对 `wiki/entities/paper-*.md` 实体页的元数据基线进行两项信息型校验：
1. frontmatter 是否包含 `arxiv` / `venue` / `code` 任一来源键
2. 正文是否覆盖「方法 / 评测 / 对比」三段式

缺失项作为基线快照写入 lint 报告，不阻塞 CI，用于后续 ingest 工作流自检。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### scripts/lint_wiki.py
- 新增 `_check_paper_entity_metadata()` 函数，遍历 `wiki/entities/paper-*.md` 页面
- 检查 frontmatter 中是否存在 `arxiv`、`venue`、`code` 任一键（通过正则匹配）
- 检查正文是否包含方法、评测、对比三类段落（支持多种别名如「流程」「实验」「比较」等）
- 新增两个 result key：`paper_missing_source_meta` 和 `paper_missing_three_sections`，加入 `INFO_ONLY_KEYS` 集合
- 在 `lint()` 主函数中调用该检查
- 在 `format_report()` 中添加对应的报告输出段落

### tests/test_lint_wiki_paper_metadata.py
新增 6 个测试用例：
- `test_complete_paper_passes_both_checks`：完整元数据通过两项检查
- `test_venue_or_code_satisfies_source_check`：`venue` 或 `code` 键满足来源检查
- `test_missing_source_key_is_flagged`：缺失来源键被正确标记
- `test_partial_three_sections_records_missing`：部分缺失三段式被记录
- `test_non_paper_entity_is_ignored`：非 paper- 实体被豁免
- `test_info_only_keys_do_not_count_toward_failing_total`：信息型键不计入失败总数

### docs/checklists/tech-stack-next-phase-checklist-v23.md
标记「Entity-Paper 类页元数据 Lint」为已完成。

### log.md
记录本次变更的基线快照：131 个 paper-* 实体全部缺显式来源键，130/131 缺三段式之一。

## 验证

- [x] `python -m pytest tests/ --ignore=tests/test_graph_layout.py --no-cov` — 106 用例通过（含新增 6 个）
- [x] `ruff check` — 无风格问题
- [x] `mypy scripts/lint_wiki.py` — 类型检查通过

## 相关 Issue

无

https://claude.ai/code/session_01XCkakoFbZrYjxNfUBedVW9