### PR TITLE
fix(ux): 图谱加载不再全屏遮挡，首屏即可与节点交互

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -373,27 +373,10 @@
       }
     }
 
-    /* ── 加载状态 ── */
+    /* 加载状态仅由工具栏 #graph-node-count 提示，不遮挡画布 */
     #graph-loading {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-direction: column;
-      gap: 14px;
-      color: rgba(255,255,255,0.4);
-      font-size: .9rem;
-      z-index: 20;
+      display: none !important;
     }
-    .spinner {
-      width: 32px; height: 32px;
-      border: 2px solid rgba(255,255,255,0.08);
-      border-top-color: #00d4ff;
-      border-radius: 50%;
-      animation: spin .8s linear infinite;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
 
     /* ── 移动端优化 ── */
     @media (max-width: 768px) {
@@ -1215,10 +1198,7 @@
 
   <!-- ── 图谱容器 ── -->
   <div id="graph-wrap">
-    <div id="graph-loading">
-      <div class="spinner"></div>
-      <span>正在构建知识图谱…</span>
-    </div>
+    <div id="graph-loading" hidden aria-hidden="true"></div>
     <svg id="graph-canvas"></svg>
     <div id="graph-tooltip" class="hidden" role="tooltip"></div>
     <button id="graph-legend-fab" type="button" aria-label="打开图例" aria-expanded="false" aria-controls="graph-legend" title="图例">🎨</button>
@@ -1706,8 +1686,11 @@
     try {
       graphData = await fetch('exports/link-graph.json').then(r => r.json());
     } catch (e) {
-      document.getElementById('graph-loading').innerHTML =
-        '<span style="color:#f87171">数据加载失败：' + escapeHtml(e.message) + '</span>';
+      const countEl = document.getElementById('graph-node-count');
+      if (countEl) {
+        countEl.textContent = '数据加载失败';
+        countEl.title = e.message || '';
+      }
       return;
     }
     fetch('exports/index-v1.json')
@@ -2061,14 +2044,11 @@
     }
 
     function finishSimulationLoad() {
-      document.getElementById('graph-loading').style.display = 'none';
       node.select('.node-label').transition().duration(400).style('opacity', 0.85);
       whenGraphViewportReady(() => fitToScreen());
     }
 
     function restartForceSimulation() {
-      const loadingEl = document.getElementById('graph-loading');
-      if (loadingEl) loadingEl.style.display = '';
       node.select('.node-label').style('opacity', 0);
       updateGraphViewport();
       randomizeNodePositions();
@@ -2081,7 +2061,7 @@
       syncGraphDomFromSimulation();
     });
 
-    /* ── 隐藏加载 & 标签渐显 ── */
+    /* ── 布局稳定后标签渐显 ── */
     simulation.on('end', () => {
       finishSimulationLoad();
     });

--- a/scripts/screenshot_graph_layout_verify.cjs
+++ b/scripts/screenshot_graph_layout_verify.cjs
@@ -41,7 +41,9 @@ const path = require('path');
     await page.waitForFunction(() => {
       const loading = document.getElementById('graph-loading');
       const count = document.getElementById('graph-node-count');
-      const loadingHidden = !loading || loading.style.display === 'none';
+      const loadingHidden = !loading || loading.hidden
+        || loading.style.display === 'none'
+        || window.getComputedStyle(loading).display === 'none';
       const countReady = count && count.textContent && !count.textContent.includes('加载中');
       return loadingHidden && countReady;
     }, { timeout: 90000 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 移除 `graph.html` 全屏「正在构建知识图谱…」遮罩与 spinner，加载状态仅由工具栏 `#graph-node-count`（「加载中…」→ 节点/边统计）提示。
- 数据拉取失败时改为在工具栏显示「数据加载失败」，不再用遮罩挡住画布。
- 重启力导向布局时也不再弹出遮罩；布局计算过程中用户可继续拖拽、缩放与点击节点。
- 截图脚本 `screenshot_graph_layout_verify.cjs` 对 `#graph-loading` 的就绪判断兼容 `hidden` / CSS `display:none`。

## 验证

- 本地 `node scripts/screenshot_graph_layout_verify.cjs`：587 节点渲染正常，质心居中，空白点击后布局未塌到角落。
- 本次为纯前端 `docs/graph.html` 改动，未改 wiki；仓库既有 wiki lint 告警与本次无关。

## 验证截图

[图谱页加载后无全屏遮罩，节点可直接交互](https://cursor.com/agents/bc-c5109234-c0a1-42a7-af91-dda229d1acd3/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-layout-loaded.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5109234-c0a1-42a7-af91-dda229d1acd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5109234-c0a1-42a7-af91-dda229d1acd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

