### PR TITLE
fix(ux): 修复详情页表格内 LaTeX 竖线被误当作列分隔符

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -385,6 +385,80 @@
       });
   }
 
+  /** Split a markdown table row on column pipes, respecting $...$, \\(...\\), and \\| escapes. */
+  function splitMarkdownTableCells(row) {
+    const cells = [];
+    let current = '';
+    let inInlineMath = false;
+    let inDisplayMath = false;
+    let inParenMath = false;
+    let inCode = false;
+    const source = String(row || '');
+    let i = 0;
+
+    while (i < source.length) {
+      const ch = source[i];
+      const next = source[i + 1];
+
+      if (!inCode && !inInlineMath && !inDisplayMath && !inParenMath && ch === '\\' && next === '|') {
+        current += '\\|';
+        i += 2;
+        continue;
+      }
+
+      if (!inInlineMath && !inDisplayMath && !inParenMath && ch === '`') {
+        inCode = !inCode;
+        current += ch;
+        i++;
+        continue;
+      }
+
+      if (!inCode && !inInlineMath && !inParenMath && ch === '$' && next === '$') {
+        inDisplayMath = !inDisplayMath;
+        current += '$$';
+        i += 2;
+        continue;
+      }
+
+      if (!inCode && !inDisplayMath && ch === '$' && !inParenMath) {
+        inInlineMath = !inInlineMath;
+        current += ch;
+        i++;
+        continue;
+      }
+
+      if (!inCode && !inInlineMath && !inDisplayMath && ch === '\\' && next === '(') {
+        inParenMath = true;
+        current += '\\(';
+        i += 2;
+        continue;
+      }
+
+      if (inParenMath && ch === '\\' && next === ')') {
+        inParenMath = false;
+        current += '\\)';
+        i += 2;
+        continue;
+      }
+
+      if (!inCode && !inInlineMath && !inDisplayMath && !inParenMath && ch === '|') {
+        cells.push(current);
+        current = '';
+        i++;
+        continue;
+      }
+
+      current += ch;
+      i++;
+    }
+    cells.push(current);
+
+    const trimmed = cells.map(function (c) { return c.trim(); });
+    if (trimmed.length > 0 && trimmed[0] === '') trimmed.shift();
+    if (trimmed.length > 0 && trimmed[trimmed.length - 1] === '') trimmed.pop();
+    return trimmed;
+  }
+
   function normalizeCodeLang(lang) {
     const value = String(lang || '').trim().toLowerCase();
     if (!value) return 'text';
@@ -1433,9 +1507,7 @@
         const isHeader = i === 0;
         const isSeparator = row.replace(/\|/g, '').replace(/-/g, '').replace(/:/g, '').trim().length === 0;
         if (isSeparator) return '';
-        let cells = row.split('|').map(function (c) { return c.trim(); });
-        if (cells.length > 0 && cells[0] === '') cells.shift();
-        if (cells.length > 0 && cells[cells.length - 1] === '') cells.pop();
+        const cells = splitMarkdownTableCells(row);
         const tag = isHeader ? 'th' : 'td';
         return '<tr>' + cells.map(function (c) { return '<' + tag + '>' + renderMathBlocks(renderInlineMarkdown(c, context)) + '</' + tag + '>'; }).join('') + '</tr>';
       }).join('');

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -1,3 +1,4 @@
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -99,6 +100,82 @@ class DetailContentSyncTests(unittest.TestCase):
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
+
+    def test_main_js_splits_table_cells_inside_inline_math(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("function splitMarkdownTableCells(row)", content)
+        self.assertIn("const cells = splitMarkdownTableCells(row);", content)
+
+        node_script = r"""
+function splitMarkdownTableCells(row) {
+  const cells = [];
+  let current = '';
+  let inInlineMath = false;
+  let inDisplayMath = false;
+  let inParenMath = false;
+  let inCode = false;
+  const source = String(row || '');
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (!inCode && !inInlineMath && !inDisplayMath && !inParenMath && ch === '\\' && next === '|') {
+      current += '\\|'; i += 2; continue;
+    }
+    if (!inInlineMath && !inDisplayMath && !inParenMath && ch === '`') {
+      inCode = !inCode; current += ch; i++; continue;
+    }
+    if (!inCode && !inInlineMath && !inParenMath && ch === '$' && next === '$') {
+      inDisplayMath = !inDisplayMath; current += '$$'; i += 2; continue;
+    }
+    if (!inCode && !inDisplayMath && ch === '$' && !inParenMath) {
+      inInlineMath = !inInlineMath; current += ch; i++; continue;
+    }
+    if (!inCode && !inInlineMath && !inDisplayMath && ch === '\\' && next === '(') {
+      inParenMath = true; current += '\\('; i += 2; continue;
+    }
+    if (inParenMath && ch === '\\' && next === ')') {
+      inParenMath = false; current += '\\)'; i += 2; continue;
+    }
+    if (!inCode && !inInlineMath && !inDisplayMath && !inParenMath && ch === '|') {
+      cells.push(current); current = ''; i++; continue;
+    }
+    current += ch; i++;
+  }
+  cells.push(current);
+  const trimmed = cells.map(function (c) { return c.trim(); });
+  if (trimmed.length > 0 && trimmed[0] === '') trimmed.shift();
+  if (trimmed.length > 0 && trimmed[trimmed.length - 1] === '') trimmed.pop();
+  return trimmed;
+}
+const cases = [
+  [
+    '| M3 | 3 | + 负载相关 $K_l\\|\\tau_m-\\tau_e\\|$ | eRob80:50 |',
+    ['M3', '3', '+ 负载相关 $K_l\\|\\tau_m-\\tau_e\\|$', 'eRob80:50']
+  ],
+  [
+    '| 摩擦锥 | $|f_x|, |f_y| \\leq \\mu f_z$，$f_z \\geq 0$ |',
+    ['摩擦锥', '$|f_x|, |f_y| \\leq \\mu f_z$，$f_z \\geq 0$']
+  ]
+];
+for (const [row, expected] of cases) {
+  const got = splitMarkdownTableCells(row);
+  if (JSON.stringify(got) !== JSON.stringify(expected)) {
+    console.error(JSON.stringify({ row, expected, got }));
+    process.exit(1);
+  }
+}
+console.log('ok');
+"""
+        result = subprocess.run(
+            ["node", "-e", node_script],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
 
     def test_detail_page_loads_katex_assets(self):
         content = DETAIL_HTML.read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页 Markdown 表格按 `|` 分列时，未保护单元格内的行内公式（如 BAM 论文页 M3 行的 `$K_l\|\tau_m-\tau_e\|$`），导致 LaTeX 中的 `\|` 与绝对值符号 `|` 被当成列边界，表格错位、公式破碎。

## 改动

- 在 `docs/main.js` 新增 `splitMarkdownTableCells()`：分列时识别 `$...$`、`$$...$$`、`\(...\)`、反引号代码与 `\|` 转义。
- `flushTable()` 改用该函数解析单元格。
- 增加 `tests/test_content_sync.py` 回归用例（含 BAM M3 行与摩擦锥约束行）。

## 验证

- `npm run lint:js` 通过
- `pytest tests/test_content_sync.py::DetailContentSyncTests::test_main_js_splits_table_cells_inside_inline_math` 通过
- 本地静态站详情页 M3 行公式渲染正常（见截图）

## 验证截图

[BAM 摩擦模型族表格 M3 行公式渲染](https://cursor.com/agents/bc-f7deb939-f534-4e90-b394-f5ddb9ae956a/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fbam-table-m3.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7deb939-f534-4e90-b394-f5ddb9ae956a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7deb939-f534-4e90-b394-f5ddb9ae956a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

