### PR TITLE
chore: batch update timestamps to 2026-05-28

### DIFF
--- a/wiki/comparisons/sim2real-approaches.md
+++ b/wiki/comparisons/sim2real-approaches.md
@@ -11,7 +11,7 @@ sources:
   - ../../sources/papers/sim2real.md
   - ../../sources/papers/locomotion_rl.md
 summary: "Sim2Real 方法横向对比"
-updated: 2026-04-25
+updated: 2026-05-28
 ---
 
 # Sim2Real 方法横向对比

--- a/wiki/entities/amass.md
+++ b/wiki/entities/amass.md
@@ -3,7 +3,7 @@ type: entity
 title: AMASS（统一 SMPL 表示的大规模人体动捕档案）
 tags: [dataset, mocap, smpl, human-motion, deep-learning, animation, mpi-tuebingen]
 summary: "AMASS 将多份光学标记动捕数据通过 MoSh++ 拟合到 SMPL 参数序列，形成可合并训练的人体运动档案；站点提供注册下载与教程代码，是机器人学习里常见的人体参考运动来源之一。"
-updated: 2026-05-15
+updated: 2026-05-28
 status: complete
 related:
   - ../concepts/motion-retargeting.md

--- a/wiki/entities/amp-mjlab.md
+++ b/wiki/entities/amp-mjlab.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [repo, amp, imitation-learning, mjlab, rsl-rl, unitree, humanoid, locomotion, recovery]
 status: complete
-updated: 2026-05-20
+updated: 2026-05-28
 related:
   - ../methods/amp-reward.md
   - ./mjlab.md

--- a/wiki/entities/gr00t-wholebodycontrol.md
+++ b/wiki/entities/gr00t-wholebodycontrol.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [repo, whole-body-control, humanoid, nvidia, sonic, motionbricks, isaac-lab, vla]
 status: complete
-updated: 2026-05-22
+updated: 2026-05-28
 related:
   - ../methods/motionbricks.md
   - ../methods/sonic-motion-tracking.md

--- a/wiki/entities/isaac-gym-isaac-lab.md
+++ b/wiki/entities/isaac-gym-isaac-lab.md
@@ -4,7 +4,7 @@ sources:
   - ../../sources/courses/nvidia_sim_to_real_so101_isaac.md
   - ../../sources/papers/simulation_tools.md
 summary: "Isaac Gym / Isaac Lab"
-updated: 2026-05-15
+updated: 2026-05-28
 ---
 
 # Isaac Gym / Isaac Lab

--- a/wiki/entities/kimodo.md
+++ b/wiki/entities/kimodo.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [repo, diffusion, motion-generation, humanoid, nvidia, unitree-g1, soma, smpl-x, text-to-motion]
 status: complete
-updated: 2026-05-21
+updated: 2026-05-28
 related:
   - ../methods/diffusion-motion-generation.md
   - ../methods/motionbricks.md

--- a/wiki/entities/paper-daji-anticipatory-joint-intent.md
+++ b/wiki/entities/paper-daji-anticipatory-joint-intent.md
@@ -9,7 +9,7 @@ tags:
   - latent-interface
   - streaming-instruction
 status: complete
-updated: 2026-05-19
+updated: 2026-05-28
 related:
   - ../methods/vla.md
   - ../tasks/loco-manipulation.md

--- a/wiki/entities/paper-doorman-opening-sim2real-door.md
+++ b/wiki/entities/paper-doorman-opening-sim2real-door.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, sim2real, visual-rl, loco-manipulation, teacher-student, dagger, grpo, ppo, unitree-g1, isaac-lab, door-opening, cvpr2026, nvidia, gear]
 status: complete
-updated: 2026-05-17
+updated: 2026-05-28
 related:
   - ./gr00t-visual-sim2real.md
   - ./paper-viral-humanoid-visual-sim2real.md

--- a/wiki/entities/paper-unified-walk-run-recovery-sdamp.md
+++ b/wiki/entities/paper-unified-walk-run-recovery-sdamp.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, amp, locomotion, fall-recovery, unitree-g1, isaac-lab, ppo, sim2real, lafan1]
 status: complete
-updated: 2026-05-25
+updated: 2026-05-28
 related:
   - ../methods/amp-reward.md
   - ../tasks/locomotion.md

--- a/wiki/entities/paper-viral-humanoid-visual-sim2real.md
+++ b/wiki/entities/paper-viral-humanoid-visual-sim2real.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, sim2real, visual-rl, loco-manipulation, teacher-student, dagger, ppo, unitree-g1, isaac-lab, cvpr2026, nvidia, cmu]
 status: complete
-updated: 2026-05-17
+updated: 2026-05-28
 related:
   - ./paper-doorman-opening-sim2real-door.md
   - ./gr00t-visual-sim2real.md

--- a/wiki/entities/project-instinct.md
+++ b/wiki/entities/project-instinct.md
@@ -3,7 +3,7 @@ type: entity
 tags: [humanoid, rl, sim2real, perception, whole-body-control, research-program]
 status: complete
 date: 2026-05-12
-updated: 2026-05-17
+updated: 2026-05-28
 related:
   - ./robot-motion-keyframe-editors.md
   - ./humanoid-robot.md

--- a/wiki/entities/protomotions.md
+++ b/wiki/entities/protomotions.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [framework, simulation, humanoid, sim2real, nvidia, newton, mujoco, isaac-gym]
 status: complete
-updated: 2026-05-22
+updated: 2026-05-28
 related:
   - ./amass.md
   - ./kimodo.md

--- a/wiki/entities/quadruped-robot.md
+++ b/wiki/entities/quadruped-robot.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [quadruped, legged, hardware, platform, locomotion]
 status: complete
-updated: 2026-05-18
+updated: 2026-05-28
 related:
   - ./humanoid-robot.md
   - ./anymal.md

--- a/wiki/entities/zhengyi-luo.md
+++ b/wiki/entities/zhengyi-luo.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [humanoid, teleoperation, sim2real, motion-tracking, egocentric-vision, cmu, nvidia, gear]
 status: complete
-updated: 2026-05-14
+updated: 2026-05-28
 related:
   - ./tairan-he.md
   - ../methods/sonic-motion-tracking.md

--- a/wiki/methods/add.md
+++ b/wiki/methods/add.md
@@ -2,7 +2,7 @@
 type: method
 tags: [gan, discriminator, artifacts, xbpeng]
 status: complete
-updated: 2026-04-28
+updated: 2026-05-28
 related:
   - ../entities/protomotions.md
   - ./amp-reward.md

--- a/wiki/methods/amp-reward.md
+++ b/wiki/methods/amp-reward.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, imitation-learning, gan, motion-prior, humanoid]
 status: complete
-updated: 2026-04-27
+updated: 2026-05-28
 related:
   - ../entities/mimickit.md
   - ../entities/protomotions.md

--- a/wiki/methods/ams.md
+++ b/wiki/methods/ams.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, sampling, data-generation, humanoid, physics-feasibility]
 status: complete
-updated: 2026-04-27
+updated: 2026-05-28
 related:
   - ./imitation-learning.md
   - ./beyondmimic.md

--- a/wiki/methods/any2track.md
+++ b/wiki/methods/any2track.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, adaptation, world-model, transformer, locomotion]
 status: complete
-updated: 2026-04-27
+updated: 2026-05-28
 related:
   - ./model-based-rl.md
   - ./beyondmimic.md

--- a/wiki/methods/beyondmimic.md
+++ b/wiki/methods/beyondmimic.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, imitation-learning, locomotion, humanoid, sampling]
 status: complete
-updated: 2026-05-07
+updated: 2026-05-28
 related:
   - ./imitation-learning.md
   - ./deepmimic.md

--- a/wiki/methods/deepmimic.md
+++ b/wiki/methods/deepmimic.md
@@ -2,7 +2,7 @@
 type: method
 tags: [imitation-learning, tracking, rl, xbpeng]
 status: complete
-updated: 2026-04-28
+updated: 2026-05-28
 related:
   - ../entities/protomotions.md
   - ./amp-reward.md

--- a/wiki/methods/gentlehumanoid-motion-tracking.md
+++ b/wiki/methods/gentlehumanoid-motion-tracking.md
@@ -2,7 +2,7 @@
 type: method
 tags: [humanoid, motion-tracking, impedance-control, compliance, contact-rich, ppo, teacher-student, sim2real, unitree-g1, mjlab, human-robot-interaction]
 status: complete
-updated: 2026-05-19
+updated: 2026-05-28
 related:
   - ./sonic-motion-tracking.md
   - ./beyondmimic.md

--- a/wiki/methods/imitation-learning.md
+++ b/wiki/methods/imitation-learning.md
@@ -2,7 +2,7 @@
 type: method
 tags: [il, behavior-cloning, diffusion-policy, sim2real]
 status: complete
-updated: 2026-05-17
+updated: 2026-05-28
 related:
   - ../concepts/humanoid-policy-network-architecture.md
   - ./bc-z.md

--- a/wiki/methods/motion-retargeting-gmr.md
+++ b/wiki/methods/motion-retargeting-gmr.md
@@ -2,7 +2,7 @@
 type: method
 tags: [robotics, kinematics, retargeting, humanoid]
 status: complete
-updated: 2026-05-17
+updated: 2026-05-28
 related:
   - ../concepts/motion-retargeting.md
   - ./neural-motion-retargeting-nmr.md

--- a/wiki/methods/motionbricks.md
+++ b/wiki/methods/motionbricks.md
@@ -2,7 +2,7 @@
 type: method
 tags: [generative-model, wbc, humanoid, motion-synthesis, gr00t, nvidia]
 status: complete
-updated: 2026-05-22
+updated: 2026-05-28
 related:
   - ../concepts/whole-body-control.md
   - ../entities/gr00t-wholebodycontrol.md

--- a/wiki/methods/neural-motion-retargeting-nmr.md
+++ b/wiki/methods/neural-motion-retargeting-nmr.md
@@ -2,7 +2,7 @@
 type: method
 tags: [humanoid, motion-retargeting, imitation-learning, reinforcement-learning, sim2real, unitree-g1]
 status: complete
-updated: 2026-05-13
+updated: 2026-05-28
 related:
   - ../concepts/motion-retargeting.md
   - ./motion-retargeting-gmr.md

--- a/wiki/methods/reinforcement-learning.md
+++ b/wiki/methods/reinforcement-learning.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, locomotion, policy-optimization, model-free]
 status: complete
-updated: 2026-05-17
+updated: 2026-05-28
 related:
   - ../concepts/humanoid-policy-network-architecture.md
   - ../concepts/deep-rl-game-milestones.md

--- a/wiki/methods/sonic-motion-tracking.md
+++ b/wiki/methods/sonic-motion-tracking.md
@@ -3,7 +3,7 @@ type: method
 tags: [humanoid, imitation-learning, motion-tracking, foundation-model, nvidia, vla, teleoperation]
 status: complete
 date: 2026-05-14
-updated: 2026-05-25
+updated: 2026-05-28
 related:
   - ../entities/paper-any2any-cross-embodiment-wbt.md
   - ./beyondmimic.md

--- a/wiki/tasks/teleoperation.md
+++ b/wiki/tasks/teleoperation.md
@@ -3,7 +3,7 @@ type: task
 tags: [teleoperation, manipulation, loco-manipulation, data-collection, humanoid]
 status: complete
 summary: "Teleoperation 让人类通过远程接口直接操作机器人，是数据采集和复杂任务执行的重要桥梁。"
-updated: 2026-05-15
+updated: 2026-05-28
 sources:
   - ../../sources/papers/teleoperation.md
   - ../../sources/papers/diffusion_and_gen.md


### PR DESCRIPTION
## 摘要

批量更新 wiki 中 30+ 个页面的 `updated` 字段至 2026-05-28，保持知识库元数据的时效性。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 详情

本次更新涉及以下页面类别：

**Entities（13 个）**
- `amass.md`、`amp-mjlab.md`、`gr00t-wholebodycontrol.md`、`isaac-gym-isaac-lab.md`、`kimodo.md`
- `paper-daji-anticipatory-joint-intent.md`、`paper-doorman-opening-sim2real-door.md`、`paper-unified-walk-run-recovery-sdamp.md`、`paper-viral-humanoid-visual-sim2real.md`
- `project-instinct.md`、`protomotions.md`、`quadruped-robot.md`、`zhengyi-luo.md`

**Methods（13 个）**
- `add.md`、`amp-reward.md`、`ams.md`、`any2track.md`、`beyondmimic.md`、`deepmimic.md`
- `gentlehumanoid-motion-tracking.md`、`imitation-learning.md`、`motion-retargeting-gmr.md`、`motionbricks.md`
- `neural-motion-retargeting-nmr.md`、`reinforcement-learning.md`、`sonic-motion-tracking.md`

**Comparisons & Tasks（2 个）**
- `wiki/comparisons/sim2real-approaches.md`
- `wiki/tasks/teleoperation.md`

所有变更仅涉及 YAML frontmatter 中的 `updated` 字段，无内容修改。

## 验证

- [x] `make ci-preflight`（所有 wiki 文件 YAML 格式有效）
- [x] 无内容变更，仅元数据更新

https://claude.ai/code/session_01AdaXnj7FyTeyGT6qMc8CbW