### PR TITLE
fix(ux): 子页 TOC 副标题去掉句末句号

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -88,7 +88,7 @@
       <div class="container detail-content-layout">
         <aside id="detailTocSection" class="detail-toc-panel" aria-labelledby="detail-toc" hidden>
           <h2 class="section-title" id="detail-toc">目录导航</h2>
-          <p class="section-subtitle">快速导航。</p>
+          <p class="section-subtitle">快速导航</p>
           <div style="margin-bottom: 1.2rem;">
             <a id="detailGraphLink" href="graph.html" class="btn-secondary" style="display:flex; align-items:center; gap:6px; justify-content:center; padding:8px; border-color:rgba(0,212,255,0.3); color:var(--text);">
               <span>🕸️</span> 关联图谱节点


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将详情页侧栏 TOC 区块副标题由「快速导航。」改为「快速导航」，与主标题「目录导航」的标点风格一致。

## 验证
- 仅修改 `docs/detail.html` 静态文案，无脚本或导出链路变更。
- 任意 `docs/detail.html?id=...` 详情页侧栏在正文含标题时会显示该副标题。

## 改动文件
- `docs/detail.html`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72c15d7b-8e30-4cca-98ee-f799311ec825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72c15d7b-8e30-4cca-98ee-f799311ec825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

