### PR TITLE
Disable node interactions during timeline animation

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1613,7 +1613,7 @@
     const TIMELINE_TARGET_MS = 12000;
 
     function areFiltersLocked() {
-      return timelineAnimating && timelinePlaying;
+      return timelineAnimating;
     }
 
     let communityColorMap = new Map();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2318,6 +2318,8 @@
 
     node
       .on('mouseenter', (ev, d) => {
+        // 时序动画进行中：禁用节点悬停，避免选中尚未显现的背景节点
+        if (timelineAnimating) return;
         // V21 修复：如果当前已经点击聚焦了某个节点（侧边栏打开），跳过 hover 高亮逻辑
         if (sidebar.classList.contains('open')) return;
         
@@ -2351,12 +2353,14 @@
         showTooltip(ev, d);
       })
       .on('mousemove', ev => {
+        if (timelineAnimating) return;
         // 移动端固定卡片后，mousemove 不移动 tooltip
         if (!isMobile || !pinnedNode) {
           moveTooltip(ev);
         }
       })
       .on('mouseleave', () => {
+        if (timelineAnimating) return;
         // V21 修复：如果当前已经点击聚焦了某个节点（侧边栏打开），不执行 mouseleave 的样式重置逻辑
         if (sidebar.classList.contains('open')) return;
 
@@ -2370,6 +2374,7 @@
       })
       .on('click', (ev, d) => {
         ev.stopPropagation();
+        if (timelineAnimating) return;
         if (isMobile) {
           // 移动端：点击节点显示/关闭固定卡片
           if (pinnedNode === d) {


### PR DESCRIPTION
## 摘要

禁用时序动画进行中的节点交互（hover、click 等），避免用户与尚未显现的背景节点交互。同时简化过滤器锁定逻辑，仅依赖 `timelineAnimating` 状态。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 问题
时序动画播放时，用户可能与尚未在视图中显现的背景节点进行交互（hover、click），导致意外的 UI 行为。

### 解决方案
1. **简化过滤器锁定逻辑**（第 1616 行）：
   - 从 `timelineAnimating && timelinePlaying` 改为仅 `timelineAnimating`
   - 移除冗余的 `timelinePlaying` 条件

2. **在节点事件处理中添加动画状态检查**：
   - `mouseenter`（第 2321-2322 行）：动画进行中跳过 hover 高亮
   - `mousemove`（第 2355-2356 行）：动画进行中跳过 tooltip 移动
   - `mouseleave`（第 2362-2363 行）：动画进行中跳过样式重置
   - `click`（第 2377-2378 行）：动画进行中跳过点击处理

所有检查均在现有逻辑之前执行，确保动画期间完全禁用交互。

## 验证

- 无需自动化测试（前端交互逻辑）
- 手动验证：启动时序动画，确认节点 hover/click 无响应；动画停止后恢复正常交互

## 相关 Issue

无

https://claude.ai/code/session_011yCKV2QZvCscbfjJtpuMdU