### PR TITLE
fix(graph): 时序动画期间彻底屏蔽节点指针事件（补 #424 未合入的两次修复）

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2374,7 +2374,6 @@
       })
       .on('click', (ev, d) => {
         ev.stopPropagation();
-        if (timelineAnimating) return;
         if (isMobile) {
           // 移动端：点击节点显示/关闭固定卡片
           if (pinnedNode === d) {
@@ -3401,6 +3400,8 @@
     // 覆盖节点 click：PC 打开侧边栏而不是直接跳转
     node.on('click', (ev, d) => {
       ev.stopPropagation();
+      // 时序动画进行中：禁用节点点击，避免打开背景节点详情侧栏
+      if (timelineAnimating) return;
       if (isMobile) {
         if (pinnedNode === d) {
           pinnedNode = null;

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3037,7 +3037,8 @@
         Math.floor(TIMELINE_TARGET_MS / Math.ceil(timelineTotal / timelineBatchSize))));
 
       // 隐藏全部，力模拟成员清空（从 0 个节点开始生长）
-      node.interrupt().style('opacity', 0);
+      // pointer-events: none 确保透明节点不捕获任何鼠标/触控事件（opacity:0 在 SVG 中不足以屏蔽指针事件）
+      node.interrupt().style('opacity', 0).style('pointer-events', 'none');
       node.select('.node-circle')
         .interrupt()
         .attr('fill-opacity', 0)
@@ -3061,7 +3062,7 @@
       timelineRevealedIds.clear();
       timelineIdx = 0;
       timelineTotal = 0;
-      node.interrupt();
+      node.interrupt().style('pointer-events', null);  // 恢复指针事件
       link.interrupt();
       svg.interrupt('tlfit');
       updateTimelineControls();


### PR DESCRIPTION
## 摘要

PR #424 在合并时只包含到 `1c2a7e7`，**漏掉了本分支随后推送的两个关键修复**。本 PR 补上这两次提交，彻底修复时序动画期间「点击/悬停仍能弹出背景全局节点」的问题：

- `e5bc0e2` — 修正点击守卫位置。节点上有两个 `click` 绑定，D3 中后绑定的 `node.on('click')`（line 3402，打开侧栏）会覆盖前面链式 `.on('click')`，导致先前加在被覆盖处理器上的 `timelineAnimating` 守卫为**死代码**。已移到生效的处理器上。
- `005db13` — **根本原因修复**。SVG 中 `opacity:0` 只隐藏视觉、**不屏蔽指针事件**，「点空白处」实际命中的是透明的背景节点 `<g.node-g>`，JS 守卫无法覆盖所有事件路径。改为进入时序模式时对全部节点 `pointer-events:none`，退出时恢复 —— 在浏览器渲染层把节点从命中测试中彻底剔除，覆盖播放 / 暂停 / 拖拽全程。

> 这也解释了上一次「合并后仍复现」：当时 `main` 只到 `1c2a7e7`（经测试确为 buggy 版本），并未包含这两个修复。

改动范围：仅 `docs/graph.html`（`+5 / -3`）。与当前 `main` 无冲突（`main` 自基点起未改动 `graph.html`）。

## 验证

- `node --check` 内嵌 JS 语法通过。
- **Headless（puppeteer-core + chromium）复现并对照测试**——进入时序动画→暂停→点击节点：

| 版本 | 时序模式 | 暂停 | 点击节点 → 侧栏 |
|------|---------|------|----------------|
| 本 PR（`005db13`） | ✕退出动画 ✓ | 播放(已暂停) ✓ | **保持关闭 ✅** |
| 合并前 `main`（`1c2a7e7`） | ✕退出动画 ✓ | 播放(已暂停) ✓ | **弹出 ❌（复现 bug）** |

```
FIXED (005db13):  verdict="OK: click ignored",         sidebarAfterClick=false
BUGGY (1c2a7e7):  verdict="BUG: sidebar OPENED on click", sidebarAfterClick=true
```

- `make ci-preflight`：N/A（仅 `graph.html` 交互式 JS 改动，不涉及 wiki/schema/派生数据）。

https://claude.ai/code/session_011yCKV2QZvCscbfjJtpuMdU

---
_Generated by [Claude Code](https://claude.ai/code/session_011yCKV2QZvCscbfjJtpuMdU)_