### PR TITLE
feat(graph): 时序动画暂停时已显现节点可点击打开详情侧栏

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2842,6 +2842,7 @@
     function revealTimelineNode(d) {
       const sel = node.filter(n => n.id === d.id);
       sel.attr('transform', `translate(${d.x},${d.y})`);   // 从出生位置出现，随后由力模拟带动
+      sel.style('pointer-events', null);   // 恢复指针事件，使暂停时可点击
       sel.interrupt()
         .style('opacity', 1)
         .select('.node-glow')
@@ -2862,6 +2863,7 @@
         const shown = timelineRevealedIds.has(d.id);
         const g = d3.select(this);
         g.interrupt().style('opacity', shown ? 1 : 0);
+        g.style('pointer-events', shown ? null : 'none');   // 已显现节点可点击
         g.select('.node-glow').attr('fill-opacity', 0);
         g.select('.node-circle')
           .interrupt()
@@ -3401,8 +3403,8 @@
     // 覆盖节点 click：PC 打开侧边栏而不是直接跳转
     node.on('click', (ev, d) => {
       ev.stopPropagation();
-      // 时序动画进行中：禁用节点点击，避免打开背景节点详情侧栏
-      if (timelineAnimating) return;
+      // 播放中禁止点击；暂停时已显现节点（pointer-events 已恢复）可点击打开详情
+      if (timelinePlaying) return;
       if (isMobile) {
         if (pinnedNode === d) {
           pinnedNode = null;


### PR DESCRIPTION
## 摘要

延续 #426（时序动画期间彻底屏蔽透明背景节点指针事件）。#426 在播放 / 暂停 / 拖拽全程对**所有**节点 `pointer-events:none`，副作用是**暂停时也无法点击已显现的节点查看详情**。本 PR 让暂停状态下**已显现的节点可点击打开详情侧栏**，同时**未显现的背景节点仍然完全惰性**。

核心思路：把"是否惰性"从「整个时序模式」收窄到「计时器是否在推进」——

- `revealTimelineNode`（播放逐个 pop-in）：节点显现时 `style('pointer-events', null)` 恢复指针事件。
- `renderTimelineStatic`（拖拽 / 倒退批量渲染）：按 `shown` 状态 `style('pointer-events', shown ? null : 'none')`，已显现可点、未显现惰性。
- 节点 `click` 守卫：由 `if (timelineAnimating) return` 改为 `if (timelinePlaying) return`——仅在**计时器推进中（播放）**屏蔽点击；**暂停时**已显现节点（pointer-events 已恢复）可正常 `openSidebar`。未显现背景节点在渲染层即被 `pointer-events:none` 剔除出命中测试，双重保险。

改动范围：仅 `docs/graph.html`（`+4 / -2`）。与 `main` 无冲突（PR 仅 3-dot 引入 graph.html 改动；`main.js` 等其他文件不受影响）。

## 验证

`make ci-preflight`：N/A（仅 `graph.html` 交互式 JS 改动，不涉及 wiki / schema / 派生数据，与 #426 一致）。

**Headless（puppeteer-core + chromium）行为对照测试** —— 进入时序动画，分别在「暂停」与「播放中」点击已显现节点：

| 场景 | 计时器 | 点击已显现节点 → 侧栏 | 背景未显现节点 |
|------|--------|----------------------|----------------|
| **暂停** | 已暂停（按钮显示「播放」） | **打开 ✅**（pointer-events: `auto`） | 惰性 ✅（pointer-events: `none`） |
| **播放中** | 推进中（按钮显示「暂停」） | **保持关闭 ✅**（`timelinePlaying` 守卫拦截） | 惰性 ✅ |

```
暂停 + 点击已显现节点:  verdict="OK: revealed clickable on pause, background inert"
                       sidebarAfterRevealed=true,  revealed.pe="auto",  unrevealed.pe="none"
播放 + 点击已显现节点:  verdict="OK: click blocked during active playback"
                       sidebarOpen=false
```

控制台无 JS 报错（`pageerror` 捕获为空）。

https://claude.ai/code/session_011yCKV2QZvCscbfjJtpuMdU

---
_Generated by [Claude Code](https://claude.ai/code/session_011yCKV2QZvCscbfjJtpuMdU)_