### PR TITLE
fix(ux): 详情页 TOC 标题内链显示为可点击超链接

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1314,7 +1314,15 @@
     }).filter(Boolean);
   }
 
-  function renderDetailToc(container, headings) {
+  function renderTocHeadingLabel(text, markdownContext) {
+    return renderInlineMarkdown(String(text || ''), markdownContext || {});
+  }
+
+  function tocHeadingLabelHasInnerLink(labelHtml) {
+    return /<a\s/i.test(String(labelHtml || ''));
+  }
+
+  function renderDetailToc(container, headings, markdownContext) {
     if (!container) return;
     if (!Array.isArray(headings) || !headings.length) {
       container.innerHTML = '<p class="data-meta">当前正文较短，暂不生成目录。</p>';
@@ -1322,10 +1330,48 @@
       return;
     }
 
+    const context = markdownContext || {};
     container.innerHTML = '<ol>' + headings.map(function (heading) {
-      return '<li class="toc-level-' + escapeHtml(heading.level) + '"><a href="#' + escapeHtml(heading.slug) + '">' + escapeHtml(heading.text) + '</a></li>';
+      const labelHtml = renderTocHeadingLabel(heading.text, context);
+      const slugAttr = escapeHtml(heading.slug);
+      const levelClass = 'toc-level-' + escapeHtml(heading.level);
+      if (tocHeadingLabelHasInnerLink(labelHtml)) {
+        return '<li class="' + levelClass + '"><span class="toc-entry" data-href="#' + slugAttr + '" role="link" tabindex="0">' + labelHtml + '</span></li>';
+      }
+      return '<li class="' + levelClass + '"><a href="#' + slugAttr + '">' + labelHtml + '</a></li>';
     }).join('') + '</ol>';
     removeLoadingState(container);
+  }
+
+  function bindDetailTocEntryNavigation(tocContainer) {
+    if (!tocContainer || tocContainer.dataset.tocEntryNavBound === '1') return;
+    tocContainer.dataset.tocEntryNavBound = '1';
+    tocContainer.addEventListener('click', function (event) {
+      const innerLink = event.target.closest('a[href]');
+      if (innerLink) {
+        const href = innerLink.getAttribute('href') || '';
+        if (href && href.charAt(0) !== '#') return;
+      }
+      const entry = event.target.closest('.toc-entry[data-href]');
+      if (!entry) return;
+      const sectionHref = entry.getAttribute('data-href') || '';
+      if (!sectionHref || sectionHref.charAt(0) !== '#') return;
+      event.preventDefault();
+      const targetId = sectionHref.slice(1);
+      const target = document.getElementById(targetId);
+      if (target && typeof target.scrollIntoView === 'function') {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+      history.replaceState({}, '', sectionHref);
+      notifyTocSpyScrollSync();
+    });
+    tocContainer.addEventListener('keydown', function (event) {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const entry = event.target.closest('.toc-entry[data-href]');
+      if (!entry || event.target.closest('a[href]')) return;
+      event.preventDefault();
+      entry.click();
+    });
   }
 
   function enhanceDetailHeadings(container) {
@@ -1359,16 +1405,17 @@
 
   function bindDetailTocSpy(container, tocContainer) {
     if (!container || !tocContainer) return;
+    bindDetailTocEntryNavigation(tocContainer);
     const headings = Array.from(container.querySelectorAll('h2[id], h3[id], h4[id]'));
-    const links = Array.from(tocContainer.querySelectorAll('a[href^="#"]'));
-    if (!headings.length || !links.length) return;
+    const navItems = Array.from(tocContainer.querySelectorAll('a[href^="#"], .toc-entry[data-href]'));
+    if (!headings.length || !navItems.length) return;
 
     let lastActiveHref = '';
 
     function scrollTocActiveIntoView() {
-      const activeLink = tocContainer.querySelector('a.active');
-      if (!activeLink || typeof activeLink.scrollIntoView !== 'function') return;
-      activeLink.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' });
+      const activeItem = tocContainer.querySelector('a.active, .toc-entry.active');
+      if (!activeItem || typeof activeItem.scrollIntoView !== 'function') return;
+      activeItem.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'auto' });
     }
 
     function updateActiveTocLink() {
@@ -1377,8 +1424,9 @@
         if (heading.getBoundingClientRect().top <= 140) activeId = heading.id;
       });
       const activeHref = '#' + activeId;
-      links.forEach(function (link) {
-        link.classList.toggle('active', link.getAttribute('href') === activeHref);
+      navItems.forEach(function (item) {
+        const itemHref = item.getAttribute('href') || item.getAttribute('data-href') || '';
+        item.classList.toggle('active', itemHref === activeHref);
       });
       if (activeHref !== lastActiveHref) {
         lastActiveHref = activeHref;
@@ -2243,17 +2291,18 @@
     if (tocSectionEl) {
       tocSectionEl.hidden = !detailHeadings.length;
     }
+    const detailMarkdownContext = {
+      currentPath: detailPage.path || '',
+      routeIndex: markdownRouteIndex
+    };
     if (tocEl) {
-      renderDetailToc(tocEl, collectMarkdownHeadings(contentMarkdown));
+      renderDetailToc(tocEl, detailHeadings, detailMarkdownContext);
     }
     if (contentSectionEl) {
       contentSectionEl.hidden = !contentMarkdown;
     }
     if (contentEl) {
-      contentEl.innerHTML = contentMarkdown ? renderMarkdownContent(contentMarkdown, detailHeadings, {
-        currentPath: detailPage.path || '',
-        routeIndex: markdownRouteIndex
-      }) : '<p>当前 detail page 暂无可同步正文。</p>';
+      contentEl.innerHTML = contentMarkdown ? renderMarkdownContent(contentMarkdown, detailHeadings, detailMarkdownContext) : '<p>当前 detail page 暂无可同步正文。</p>';
       renderDetailMath(contentEl);
       detailMermaidPromise = renderDetailMermaid(contentEl);
       enhanceDetailHeadings(contentEl);
@@ -2561,15 +2610,16 @@
     if (subnavContent) subnavContent.hidden = false;
 
     var headings = collectMarkdownHeadings(contentMarkdown);
+    var markdownRouteIndex = buildMarkdownRouteIndex(siteData);
+    var roadmapMarkdownContext = {
+      currentPath: detail.path || roadmapPage.path || '',
+      routeIndex: markdownRouteIndex
+    };
     if (tocEl) {
-      renderDetailToc(tocEl, headings);
+      renderDetailToc(tocEl, headings, roadmapMarkdownContext);
     }
     if (contentEl) {
-      var markdownRouteIndex = buildMarkdownRouteIndex(siteData);
-      contentEl.innerHTML = renderMarkdownContent(contentMarkdown, headings, {
-        currentPath: detail.path || roadmapPage.path || '',
-        routeIndex: markdownRouteIndex
-      });
+      contentEl.innerHTML = renderMarkdownContent(contentMarkdown, headings, roadmapMarkdownContext);
       renderDetailMath(contentEl);
       renderDetailMermaid(contentEl);
       enhanceDetailHeadings(contentEl);

--- a/docs/style.css
+++ b/docs/style.css
@@ -663,7 +663,8 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .detail-toc-list .toc-level-4 {
   margin-left: 1.6em;
 }
-.detail-toc-list a {
+.detail-toc-list a,
+.detail-toc-list .toc-entry {
   color: var(--text);
   border-radius: 8px;
   padding: 2px 6px;
@@ -671,10 +672,29 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   transition: color var(--transition), background var(--transition);
   overflow-wrap: anywhere;
 }
-.detail-toc-list a.active {
+.detail-toc-list .toc-entry {
+  display: inline;
+  cursor: pointer;
+}
+.detail-toc-list .toc-entry a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  padding: 0;
+  margin: 0;
+  font-weight: inherit;
+}
+.detail-toc-list .toc-entry a:hover {
+  text-decoration-thickness: 2px;
+}
+.detail-toc-list a.active,
+.detail-toc-list .toc-entry.active {
   color: var(--accent);
   background: rgba(45,116,218,.10);
   font-weight: 700;
+}
+.detail-toc-list .toc-entry.active a {
+  font-weight: inherit;
 }
 .detail-markdown-body {
   padding: 18px 20px;
@@ -1114,6 +1134,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   background: rgba(105,163,255,.06);
 }
 :root:not([data-theme="light"]) .detail-toc-list a.active,
+:root:not([data-theme="light"]) .detail-toc-list .toc-entry.active,
 :root:not([data-theme="light"]) .heading-anchor-link:hover,
 :root:not([data-theme="light"]) .heading-anchor-link:focus-visible,
 :root:not([data-theme="light"]) .heading-anchor-link.copied {

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -219,7 +219,7 @@ console.log('ok');
             "heading-anchor-link",
             "navigator.clipboard.writeText",
             "function bindDetailTocSpy(container, tocContainer)",
-            "tocContainer.querySelectorAll('a[href^=\"#\"]')",
+            "tocContainer.querySelectorAll('a[href^=\"#\"], .toc-entry[data-href]')",
             "item.classList.toggle('active',",
             "enhanceDetailHeadings(contentEl);",
             "bindDetailTocSpy(contentEl, tocEl);",

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -82,12 +82,20 @@ class DetailContentSyncTests(unittest.TestCase):
         expected_snippets = [
             "function slugifyHeading(text)",
             "function collectMarkdownHeadings(markdown)",
-            "function renderDetailToc(container, headings)",
+            "function renderTocHeadingLabel(text, markdownContext)",
+            "function renderDetailToc(container, headings, markdownContext)",
+            "function bindDetailTocEntryNavigation(tocContainer)",
+            "renderTocHeadingLabel(heading.text, context)",
+            'class="toc-entry"',
             "document.getElementById('detailTocList')",
-            "renderDetailToc(tocEl, collectMarkdownHeadings(contentMarkdown));",
+            "renderDetailToc(tocEl, detailHeadings, detailMarkdownContext)",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
+        render_detail_toc = content[
+            content.find("function renderDetailToc") : content.find("function bindDetailTocEntryNavigation")
+        ]
+        self.assertNotIn("escapeHtml(heading.text)", render_detail_toc)
 
     def test_main_js_contains_math_rendering_hooks_for_detail_content(self):
         content = MAIN_JS.read_text(encoding="utf-8")
@@ -265,6 +273,8 @@ console.log('ok');
             ".heading-anchor-link",
             ".detail-markdown-body h2:hover .heading-anchor-link",
             ".detail-toc-list a.active",
+            ".detail-toc-list .toc-entry.active",
+            ".detail-toc-list .toc-entry a",
             ".detail-hash-target",
             ".detail-markdown-body hr",
         ]

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -38,7 +38,7 @@ class DetailContentSyncTests(unittest.TestCase):
         expected_snippets = [
             "function stripYamlFrontmatter(markdown)",
             "function renderMarkdownContent(markdown, headings, markdownContext)",
-            "contentEl.innerHTML = contentMarkdown ? renderMarkdownContent(contentMarkdown, detailHeadings, {",
+            "contentEl.innerHTML = contentMarkdown ? renderMarkdownContent(contentMarkdown, detailHeadings, detailMarkdownContext)",
             "blocks.push('<hr>');",
             "function renderCodeBlock(code, lang)",
             "function escapeMermaidForInnerHtml(text)",
@@ -93,7 +93,9 @@ class DetailContentSyncTests(unittest.TestCase):
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
         render_detail_toc = content[
-            content.find("function renderDetailToc") : content.find("function bindDetailTocEntryNavigation")
+            content.find("function renderDetailToc") : content.find(
+                "function bindDetailTocEntryNavigation"
+            )
         ]
         self.assertNotIn("escapeHtml(heading.text)", render_detail_toc)
 
@@ -218,7 +220,7 @@ console.log('ok');
             "navigator.clipboard.writeText",
             "function bindDetailTocSpy(container, tocContainer)",
             "tocContainer.querySelectorAll('a[href^=\"#\"]')",
-            "link.classList.toggle('active',",
+            "item.classList.toggle('active',",
             "enhanceDetailHeadings(contentEl);",
             "bindDetailTocSpy(contentEl, tocEl);",
         ]
@@ -233,9 +235,10 @@ console.log('ok');
             "function resolveInternalMarkdownHref(target, currentPath, routeIndex)",
             "function renderInlineMarkdown(text, markdownContext)",
             "resolveInternalMarkdownHref(target, markdownContext.currentPath, markdownContext.routeIndex)",
-            "renderMarkdownContent(contentMarkdown, detailHeadings, {",
+            "const detailMarkdownContext = {",
             "currentPath: detailPage.path || ''",
             "routeIndex: markdownRouteIndex",
+            "renderMarkdownContent(contentMarkdown, detailHeadings, detailMarkdownContext)",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 PR #435 的 GitHub Actions 失败项：

- **Ruff format**：`tests/test_content_sync.py` 中 `render_detail_toc` 切片表达式换行不符合格式要求。
- **pytest**：同步 TOC 重构后的 `main.js` 实现，更新内容同步测试中的字符串断言（`detailMarkdownContext`、`navItems` / `.toc-entry` 等）。

## 验证

- `ruff format --check scripts tests` 通过
- `PYTHONPATH=scripts python3 -m pytest tests/ -q --no-cov` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6795e1e0-35d8-4139-a474-54d49d14e810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6795e1e0-35d8-4139-a474-54d49d14e810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

