### PR TITLE
fix(ux): 修复详情页 TOC 十位数序号被裁切

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -652,11 +652,16 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 }
 .detail-toc-list ol {
   margin: 0;
-  padding-left: 1.1em;
+  padding-left: 2.5em;
+  list-style-position: outside;
 }
 .detail-toc-list ol ol {
   margin-top: .35em;
   margin-bottom: 0;
+  padding-left: 2.15em;
+}
+.detail-toc-list li {
+  list-style-position: outside;
 }
 .detail-toc-list li + li {
   margin-top: .5em;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 子页左侧目录（`detail.html` / `roadmap.html` 等共用的 `.detail-toc-list`）在条目达到第 10 项及以上时，有序列表 marker 的十位数字会被侧栏 `overflow-x: hidden` 与过小的 `padding-left: 1.1em` 一起裁切。
- 将顶层与嵌套 `<ol>` 的左内边距加大到 `2.5em` / `2.15em`，并显式设置 `list-style-position: outside`，为两位数序号留出空间。

## 验证
- `python3 -m pytest tests/test_content_sync.py -q -p no:cov` 通过
- 本地 `docs` 静态服务可正常打开 `detail.html?id=wiki-concepts-floating-base-dynamics`（该页 TOC 条目 ≥10）

## 验证截图
N/A（Cloud 环境未安装 Puppeteer/Chrome 截图依赖；改动仅为 CSS 缩进，可在合并后于任意长文详情页左侧 TOC 目视确认第 10 项序号完整显示）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c23e79dc-4b6c-4a15-a3d4-6b33d2e4c69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c23e79dc-4b6c-4a15-a3d4-6b33d2e4c69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

