### PR TITLE
fix(ux): 自测参考答案折叠箭头收进边框内

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1758,15 +1758,37 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   background: var(--surface-strong, var(--bg-alt));
 }
 .selftest-answers > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
   cursor: pointer;
   font-weight: 600;
   font-size: 0.95rem;
   color: var(--accent);
-  list-style-position: outside;
+  list-style: none;
   padding: 0.15rem 0;
 }
 .selftest-answers > summary::-webkit-details-marker {
-  color: var(--accent);
+  display: none;
+}
+.selftest-answers > summary::marker {
+  content: "";
+}
+.selftest-answers > summary::before {
+  content: "";
+  flex-shrink: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-right: 2px solid var(--accent);
+  border-bottom: 2px solid var(--accent);
+  transform: rotate(-45deg);
+  margin-top: -0.2rem;
+  opacity: 0.85;
+  transition: transform 0.15s ease, opacity var(--transition);
+}
+.selftest-answers[open] > summary::before {
+  transform: rotate(45deg);
+  margin-top: -0.35rem;
 }
 .selftest-answers[open] > summary {
   margin-bottom: 0.4rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 `roadmap.html` 路线正文中「参考答案（点击展开）」折叠块：原生 `<details>` 三角因 `list-style-position: outside` 落在边框外。改为与章节折叠 `.roadmap-major-section-summary` 一致的内置 `::before` 箭头，使指示符完全落在 `.selftest-answers` 边框与背景内。

## 变更类型

- [x] 前端（`docs/style.css`）

## 验证

- 仅 CSS，未改 wiki/导出链；`make ci-preflight` N/A
- 本地 `cd docs && python3 -m http.server 8765` 后打开 `roadmap.html?id=roadmap-motion-control`，`.selftest-answers` 箭头在边框内

## 验证截图

[参考答案折叠块：箭头在边框内](https://cursor.com/agents/bc-c38790ba-7af5-4053-b5cc-2df8bf6e42e6/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-selftest-answers.png)

## 相关 Issue

无

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c38790ba-7af5-4053-b5cc-2df8bf6e42e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c38790ba-7af5-4053-b5cc-2df8bf6e42e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

