### PR TITLE
fix(ux): detail 正文支持角括号自动链接，修复推荐继续阅读 URL 显示

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -402,8 +402,17 @@
       return token;
     });
 
+    // 2c. Angle-bracket autolinks: <https://...>（wiki 推荐继续阅读等常用）
+    const withAutolinks = withRefLinks.replace(/<(https?:\/\/[^>\s]+)>/gi, function (match, url) {
+      if (!isSafeUrl(url)) return match;
+      const html = '<a href="' + escapeHtml(url) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(url) + '</a>';
+      const token = linkPrefix + linkTokens.length + '@@';
+      linkTokens.push({ token: token, html: html });
+      return token;
+    });
+
     // 3. Apply standard escapes and basic Markdown styles
-    let rendered = escapeHtml(withRefLinks)
+    let rendered = escapeHtml(withAutolinks)
       .replace(/`([^`]+)`/g, '<code>$1</code>')
       .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
       .replace(/\*([^*]+)\*/g, '<em>$1</em>');

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -328,6 +328,8 @@ console.log('ok');
             "function normalizeInternalMarkdownTarget(target, currentPath)",
             "function resolveInternalMarkdownHref(target, currentPath, routeIndex)",
             "function renderInlineMarkdown(text, markdownContext)",
+            "Angle-bracket autolinks: <https://...>",
+            "/<(https?:\\/\\/[^>\\s]+)>/gi",
             "function renderLinkLabel(label)",
             "renderLinkLabel(label)",
             "resolveInternalMarkdownHref(target, markdownContext.currentPath, markdownContext.routeIndex)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

`detail.html` 自定义 Markdown 渲染器 `renderInlineMarkdown` 此前只解析 `[text](url)`，未处理 wiki 中常见的角括号自动链接 `<https://...>`。在 OmniRetarget、PHP 等页的「推荐继续阅读」中，URL 经 `escapeHtml` 后以纯文本显示（如 `&lt;https://arxiv.org/...&gt;`）。本 PR 在链接保护阶段增加 **2c 角括号 autolink** 解析，使外链正常渲染为可点击超链接。

## 变更类型

- [x] 前端（`docs/main.js`）
- [x] 测试（`tests/test_content_sync.py` 结构断言）

## 验证

- `make test`：123 passed
- 本地 `cd docs && python3 -m http.server 8765` + `./scripts/screenshot_site_detail.sh entity-paper-hrl-stack-03-omniretarget` 生成详情页截图

## 验证截图

[OmniRetarget 详情页推荐继续阅读](https://cursor.com/agents/bc-aa7e2777-e339-45f5-a828-f47fac1f4610/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fomniretarget-autolink.png)

## 相关 Issue

无（用户反馈线上两页推荐继续阅读链接未渲染）

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa7e2777-e339-45f5-a828-f47fac1f4610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa7e2777-e339-45f5-a828-f47fac1f4610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

