### PR TITLE
feat(ux): 路线 L 阶段入口改为超链接下拉框

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1144,9 +1144,11 @@
     var sid = String(stage.id || '');
     var title = String(stage.title || '');
     var openAttr = opts.openByDefault ? ' open' : '';
+    var stageClass = 'roadmap-vtree-stage roadmap-vtree-stage-embed';
+    if (opts.atEntry) stageClass += ' roadmap-vtree-stage-at-entry';
     var parts = [];
     parts.push('<li class="roadmap-vtree-item">');
-    parts.push('<details class="roadmap-vtree-stage roadmap-vtree-stage-embed"' + openAttr + '>');
+    parts.push('<details class="' + stageClass + '"' + openAttr + '>');
     parts.push('<summary class="roadmap-vtree-summary">');
     parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(index + 1)) + '</span>');
     parts.push(
@@ -1193,7 +1195,7 @@
 
   /**
    * 路线正文：将 article 下每个顶层 h2 及其后内容包进默认收起的 <details>，首屏只保留章节标题行。
-   * 须在 embedRoadmapStagesIntoMarkdownBody 之后调用，使各 L 阶段嵌入块留在对应章节内。
+   * 须在 embedRoadmapStagesIntoMarkdownBody 之后调用，使各 L 阶段入口下拉块留在对应章节内。
    */
   function wrapRoadmapCollapsibleMajorHeadings(container) {
     if (!container) return;
@@ -1250,14 +1252,37 @@
     }, true);
   }
 
+  /** 在单个 L 章节（h2 与下一同级 h2 之间）定位「本阶段入口」段落；无则回退到首个 h3 前。 */
+  function findRoadmapStageEntryAnchor(h2) {
+    if (!h2) return null;
+    var node = h2.nextSibling;
+    var fallbackBefore = null;
+    while (node) {
+      if (node.nodeType === 1) {
+        var el = node;
+        if (el.tagName === 'H2' && el.id) break;
+        if (el.tagName === 'P' && (el.textContent || '').indexOf('本阶段入口') >= 0) {
+          return { mode: 'replace', element: el };
+        }
+        if (!fallbackBefore && el.tagName === 'H3') {
+          fallbackBefore = el;
+        }
+      }
+      node = node.nextSibling;
+    }
+    if (fallbackBefore) return { mode: 'insertBefore', element: fallbackBefore };
+    return null;
+  }
+
   /**
-   * When正文里已有对应的 L 章节标题（h2），把各阶段的「阶段速览」链接块插入到该标题下方，
-   * 避免单独占一整段 mini-map 区。若任一阶段找不到匹配标题则返回 false，保留顶部整块速览。
+   * 正文里已有对应 L 章节时，把各阶段相关链接下拉块放到「本阶段入口」处（替换原静态链接行），
+   * 不再插在 h2 标题下。若任一阶段找不到 h2 或入口锚点则返回 false，保留顶部整块速览。
    */
   function embedRoadmapStagesIntoMarkdownBody(contentEl, roadmapPage, roadmapId, detailPages) {
     var stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
     if (!contentEl || stages.length < 2) return false;
-    var targets = [];
+    var stageHeadings = [];
+    var entryAnchors = [];
     var i;
     for (i = 0; i < stages.length; i++) {
       var sid = String(stages[i].id || '').toLowerCase();
@@ -1266,20 +1291,31 @@
         return h.id === sid || h.id.indexOf(sid + '-') === 0;
       });
       if (!h2) return false;
-      targets.push(h2);
+      var anchor = findRoadmapStageEntryAnchor(h2);
+      if (!anchor) return false;
+      stageHeadings.push(h2);
+      entryAnchors.push(anchor);
     }
     var seen = new Set();
-    for (i = 0; i < targets.length; i++) {
-      if (seen.has(targets[i])) return false;
-      seen.add(targets[i]);
+    for (i = 0; i < stageHeadings.length; i++) {
+      if (seen.has(stageHeadings[i])) return false;
+      seen.add(stageHeadings[i]);
     }
     for (i = 0; i < stages.length; i++) {
-      var row = buildRoadmapStageRowHTML(stages[i], i, roadmapId, detailPages, { openByDefault: i === 0 });
+      var row = buildRoadmapStageRowHTML(stages[i], i, roadmapId, detailPages, {
+        openByDefault: false,
+        atEntry: true
+      });
       var wrap = document.createElement('div');
-      wrap.className = 'roadmap-stage-embed-wrap';
+      wrap.className = 'roadmap-stage-embed-wrap roadmap-stage-entry-embed';
       wrap.setAttribute('data-roadmap-stage-embed', String(stages[i].id || '').toLowerCase());
       wrap.innerHTML = '<ol class="roadmap-vtree">' + row + '</ol>';
-      targets[i].insertAdjacentElement('afterend', wrap);
+      var anchor = entryAnchors[i];
+      if (anchor.mode === 'replace') {
+        anchor.element.replaceWith(wrap);
+      } else {
+        anchor.element.parentNode.insertBefore(wrap, anchor.element);
+      }
     }
     return true;
   }

--- a/docs/main.js
+++ b/docs/main.js
@@ -1310,11 +1310,11 @@
       wrap.className = 'roadmap-stage-embed-wrap roadmap-stage-entry-embed';
       wrap.setAttribute('data-roadmap-stage-embed', String(stages[i].id || '').toLowerCase());
       wrap.innerHTML = '<ol class="roadmap-vtree">' + row + '</ol>';
-      var anchor = entryAnchors[i];
-      if (anchor.mode === 'replace') {
-        anchor.element.replaceWith(wrap);
+      var placement = entryAnchors[i];
+      if (placement.mode === 'replace') {
+        placement.element.replaceWith(wrap);
       } else {
-        anchor.element.parentNode.insertBefore(wrap, anchor.element);
+        placement.element.parentNode.insertBefore(wrap, placement.element);
       }
     }
     return true;

--- a/docs/style.css
+++ b/docs/style.css
@@ -1661,6 +1661,13 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .roadmap-stage-embed-wrap .roadmap-vtree-item {
   margin-bottom: 0;
 }
+/* 替换「本阶段入口」静态链接行时的下拉块 */
+.roadmap-stage-entry-embed {
+  margin: 10px 0 16px;
+}
+.roadmap-vtree-stage-at-entry .roadmap-vtree-summary {
+  font-size: 0.92rem;
+}
 /* 路线正文：顶层 h2 章节默认折叠（wrapRoadmapCollapsibleMajorHeadings） */
 .roadmap-major-section {
   margin: 0 0 1rem;

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -30,6 +30,8 @@ class RoadmapPageTests(unittest.TestCase):
             "roadmap_pages",
             "graph-stats.json",
             "renderRoadmapMarkdownBody",
+            "findRoadmapStageEntryAnchor",
+            "roadmap-stage-entry-embed",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 将 `roadmap-motion-control` 各 L 章节中原本插在 **h2 标题下方** 的阶段相关链接下拉框，移动到 **「本阶段入口」** 行位置。
- 运行时 **替换** 原 Markdown 中的静态「本阶段入口」链接段落；h2 下不再出现重复下拉块。
- L7 正文无「本阶段入口」行时，在首个 `h3`（英文缩写速查）前插入下拉块作为回退。

## 验证

- `npm run lint:js` 通过（修复 `no-redeclare`：`anchor` 在 `embedRoadmapStagesIntoMarkdownBody` 内重复声明）
- `PYTHONPATH=scripts python3 -m pytest` 通过

## 验证截图

[L1 本阶段入口下拉框（移动端视口）](https://cursor.com/agents/bc-4b3ed2db-365a-47f7-a9df-d3d8e357dfdb/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-motion-control-l1-entry.png)

## 改动文件

- `docs/main.js`：`findRoadmapStageEntryAnchor`、`embedRoadmapStagesIntoMarkdownBody`
- `docs/style.css`：`.roadmap-stage-entry-embed` 等
- `tests/test_roadmap_page.py`：断言新符号存在


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b3ed2db-365a-47f7-a9df-d3d8e357dfdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b3ed2db-365a-47f7-a9df-d3d8e357dfdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

