### PR TITLE
fix(ux): 修复运动控制路线页 L1–L7 章节在 L0 后消失

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -638,6 +638,13 @@
       .replace(/</g, '&lt;');
   }
 
+  /** 将 HTML 片段内的 ```mermaid 围栏转为可渲染的 .mermaid 节点（路线自测块等）。 */
+  function convertMermaidFencesInHtmlFragment(html) {
+    return String(html || '').replace(/```mermaid\s*\n([\s\S]*?)```/gi, function (_, code) {
+      return '<div class="mermaid">' + escapeMermaidForInnerHtml(String(code || '').trim()) + '</div>';
+    });
+  }
+
   function renderCodeBlock(code, lang) {
     const normalizedLang = normalizeCodeLang(lang);
     if (normalizedLang === 'mermaid') {
@@ -1743,7 +1750,8 @@
 
     function flushHtmlBlock() {
       if (!htmlBlockLines.length) return;
-      blocks.push(applyMathBlocksInHtmlFragment(htmlBlockLines.join('\n')));
+      var htmlFragment = convertMermaidFencesInHtmlFragment(htmlBlockLines.join('\n'));
+      blocks.push(applyMathBlocksInHtmlFragment(htmlFragment));
       htmlBlockLines = [];
       htmlBlockOpenTag = '';
     }
@@ -1759,6 +1767,10 @@
       const trimmed = line.trim();
 
       if (trimmed.startsWith('```')) {
+        if (htmlBlockOpenTag) {
+          htmlBlockLines.push(line);
+          return;
+        }
         if (inCodeBlock) {
           flushCodeBlock();
           inCodeBlock = false;

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-01] fix(ux) | docs/main.js — 修复运动控制路线页 L1–L7 章节被 L0 自测块吞没
+
+- 根因：`<details class="selftest-answers">` 内的 ` ```mermaid ` 会提前 `flushHtmlBlock()`，导致 `<details>` 未闭合，后续 L1–L7 的 h2 落入错误 DOM，`wrapRoadmapCollapsibleMajorHeadings` 只显示到 L0。
+- 变更：HTML 块解析中保留围栏行直至 `</details>`；`flushHtmlBlock` 时将块内 mermaid 转为 `.mermaid`。
+- 验证：`roadmap.html?id=roadmap-motion-control` 顶层折叠章节含 L0–L7；`make ci-preflight` 通过。
+
 ## [2026-05-31] query | wiki/queries/cross-embodiment-transfer-strategy.md — 跨具身策略迁移选型指南（V23 P1 WBT 知识链收官）
 
 - 新建 wiki：[cross-embodiment-transfer-strategy.md](wiki/queries/cross-embodiment-transfer-strategy.md)（单具身重训 + 重定向 / Any2Any 高效后训练 / 多具身联合训练三路径：9 维「算力 × 数据 × 泛化」对照表 + Mermaid 决策树 + 7 类典型故障模式 + 4 条推荐组合 pipeline；定位为 [WBT pipeline](wiki/concepts/whole-body-tracking-pipeline.md) 阶段 5 选型横切面）。

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -162,11 +162,15 @@ console.log('ok');
         expected_snippets = [
             "function renderMathBlocks(text)",
             "function applyMathBlocksInHtmlFragment(html)",
+            "function convertMermaidFencesInHtmlFragment(html)",
             'class="math-block"',
             'class="math-inline"',
             "expr.trim() +",
             "renderMathBlocks(renderInlineMarkdown(paragraphLines.join(",
-            "applyMathBlocksInHtmlFragment(htmlBlockLines.join",
+            "convertMermaidFencesInHtmlFragment(htmlBlockLines.join",
+            "applyMathBlocksInHtmlFragment(htmlFragment)",
+            "if (htmlBlockOpenTag) {",
+            "htmlBlockLines.push(line);",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 [运动控制技术路线](https://imchong.github.io/Robotics_Notebooks/roadmap.html?id=roadmap-motion-control) 在 L0 之后不再显示 L1–L7 折叠章节的问题。

**根因：** 路线正文 L0 自测参考答案使用 `<details class="selftest-answers">`，其中包含 ` ```mermaid ` 代码围栏。Markdown 解析器在遇到围栏时会提前 `flushHtmlBlock()`，导致 `<details>` 未闭合；后续 L1–L7 的 `h2` 被错误嵌套在该未闭合块内，`wrapRoadmapCollapsibleMajorHeadings` 只生成到 L0 的顶层折叠项。

**修复：** 在 HTML 块（`details` 等）打开期间，将 ` ``` ` 行保留在块内直至 `</details>`；在 `flushHtmlBlock` 时将块内 mermaid 围栏转为 `.mermaid` 节点，自测展开时仍可渲染。

## 验证

- `make ci-preflight` 通过
- Playwright 检查：`roadmap.html?id=roadmap-motion-control` 顶层 `details.roadmap-major-section` 共 15 项，含 L0–L7；L0 折叠体内不再嵌套 L1–L7 的 `h2`

## 验证截图

[运动控制路线页 L0–L7 章节均可见](https://cursor.com/agents/bc-e5848660-6eb1-4e6b-8902-2f41dc38cef3/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-motion-control-l-levels-fix.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5848660-6eb1-4e6b-8902-2f41dc38cef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5848660-6eb1-4e6b-8902-2f41dc38cef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

