### PR TITLE
fix(ux): 路线 L 阶段相关链接仅显示标题超链接

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1173,7 +1173,6 @@
         var href = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
         parts.push('<li class="roadmap-vtree-link-row">');
         parts.push('<a class="roadmap-vtree-link-a" href="' + escapeHtml(href) + '">' + escapeHtml(page.title || rid) + '</a>');
-        parts.push('<code class="roadmap-vtree-link-id">' + escapeHtml(rid) + '</code>');
         parts.push('</li>');
       }
       parts.push('</ul>');

--- a/docs/style.css
+++ b/docs/style.css
@@ -1631,9 +1631,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   border-top: 1px solid var(--border);
 }
 .roadmap-vtree-link-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
   padding: 0.45rem 0;
   border-bottom: 1px dashed var(--border);
 }
@@ -1643,11 +1640,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .roadmap-vtree-link-a {
   font-weight: 500;
   word-break: break-word;
-}
-.roadmap-vtree-link-id {
-  font-size: 0.72rem;
-  opacity: 0.8;
-  word-break: break-all;
 }
 .roadmap-vtree-empty {
   padding: 0.45rem 0.85rem 0.65rem 2.45rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 技术路线页（如 `roadmap-motion-control`）各 L 章节内「本阶段入口」下拉模块中，相关项原先在蓝色标题链接下方还会显示灰色 `wiki-...` id 标签。
- 现改为**仅保留可点击的标题超链接**，与移动端阅读预期一致。

## 改动
- `docs/main.js`：`buildRoadmapStageRowHTML` 不再输出 `<code class="roadmap-vtree-link-id">`。
- `docs/style.css`：移除对应样式，并简化链接行布局。

## 验证
- 本地 `docs/` 静态服务打开 `roadmap.html?id=roadmap-motion-control`，L4 等阶段展开后相关项仅显示标题链接。
- 本次为纯前端展示调整，未改 wiki / 导出数据，无需 `make ci-preflight`。

## 验证截图
[运动控制路线页（移动端视口）](https://cursor.com/agents/bc-2b99f9ac-99a4-41df-ab4c-211356a93468/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-motion-control-mobile.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b99f9ac-99a4-41df-ab4c-211356a93468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b99f9ac-99a4-41df-ab4c-211356a93468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

