### PR TITLE
fix(ux): 路线 L 阶段入口仅显示超链接，并与缩写速查表左缘对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1574,6 +1574,10 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   padding: 0;
   margin: 0;
 }
+.detail-markdown-body ol.roadmap-vtree {
+  padding-left: 0;
+  margin-bottom: 0;
+}
 .roadmap-vtree-item {
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 技术路线页各 L 章节「本阶段入口」下拉模块：相关项**仅保留标题超链接**，不再显示 `wiki-...` id 标签。
- 修复该模块相对下方「英文缩写速查」表**整体右缩约 22px** 的问题：正文全局 `ol { padding-left: 1.4em }` 误作用于 `ol.roadmap-vtree`，现已归零，模块外框与速查表左缘对齐。

## 改动
- `docs/main.js`：移除 `roadmap-vtree-link-id` 渲染。
- `docs/style.css`：新增 `.detail-markdown-body ol.roadmap-vtree { padding-left: 0; margin-bottom: 0; }`。

## 验证
- 本地 `roadmap.html?id=roadmap-motion-control`，L4 展开后测量：`embedStage.left === table.left`（390px 视口下均为 56px）。
- 纯前端展示调整，未改 wiki / 导出数据。

## 验证截图
[L4 入口模块与英文缩写速查表左缘对齐](https://cursor.com/agents/bc-2b99f9ac-99a4-41df-ab4c-211356a93468/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-l4-align.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b99f9ac-99a4-41df-ab4c-211356a93468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b99f9ac-99a4-41df-ab4c-211356a93468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

