### PR TITLE
fix(ux): 本阶段入口下拉用统一 🔗 替代全路线序号

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1157,7 +1157,11 @@
     parts.push('<li class="roadmap-vtree-item">');
     parts.push('<details class="' + stageClass + '"' + openAttr + '>');
     parts.push('<summary class="roadmap-vtree-summary">');
-    parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(index + 1)) + '</span>');
+    if (opts.atEntry) {
+      parts.push('<span class="roadmap-vtree-step roadmap-vtree-step-icon" aria-hidden="true">🔗</span>');
+    } else {
+      parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(index + 1)) + '</span>');
+    }
     parts.push(
       '<span class="roadmap-vtree-heading">' + escapeHtml(sid.toUpperCase() + ' · ' + title) + '</span>'
     );

--- a/docs/style.css
+++ b/docs/style.css
@@ -1614,6 +1614,17 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   align-items: center;
   justify-content: center;
 }
+.roadmap-vtree-step-icon {
+  width: auto;
+  height: auto;
+  min-width: 1.25rem;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1;
+}
 .roadmap-vtree-heading {
   flex: 1;
   min-width: 0;
@@ -1660,6 +1671,11 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 /* 替换「本阶段入口」静态链接行时的下拉块 */
 .roadmap-stage-entry-embed {
   margin: 10px 0 16px;
+}
+.roadmap-stage-entry-embed .roadmap-vtree-links,
+.roadmap-stage-entry-embed .roadmap-vtree-empty {
+  padding-left: 0.85rem;
+  padding-right: 0.85rem;
 }
 .roadmap-vtree-stage-at-entry .roadmap-vtree-summary {
   font-size: 0.92rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
PR #466 已合并「仅显示超链接」与「与英文缩写速查表左缘对齐」。本 PR 补上后续 UX：**各 L 章节「本阶段入口」下拉标题前不再显示全路线序号**（例如在 L4 处误显示「5」），改为统一 **🔗**，表示站内相关链接入口；标题文案仍为 `L4 · …`。

## 改动
- `docs/main.js`：`atEntry` 时用 `🔗` + `.roadmap-vtree-step-icon`；顶部阶段速览树（若启用）仍保留数字序号。
- `docs/style.css`：入口 emoji 无蓝色圆底；入口内链接列表水平内边距与 summary 一致。

## 验证
- 本地 `roadmap.html?id=roadmap-motion-control`，展开 L4：summary 为 🔗 + `L4 · 人形运动控制主干`，无数字圆标。
- 纯前端展示，未改 wiki / 导出数据。

## 验证截图
[L4 本阶段入口使用 🔗 图标](https://cursor.com/agents/bc-2b99f9ac-99a4-41df-ab4c-211356a93468/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-entry-link-icon.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b99f9ac-99a4-41df-ab4c-211356a93468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b99f9ac-99a4-41df-ab4c-211356a93468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

