### PR TITLE
fix(ux): 路线页 L 阶段下拉链接与标题文字左对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1600,16 +1600,23 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   margin-bottom: 0.5rem;
 }
 .roadmap-vtree-stage {
+  --roadmap-vtree-summary-pad-x: 0.85rem;
+  --roadmap-vtree-summary-gap: 0.5rem;
+  /* 与 summary 内序号/图标列同宽，供链接区与标题文字左对齐 */
+  --roadmap-vtree-step-width: 1.5rem;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--surface-strong, var(--bg-alt));
   overflow: hidden;
 }
+.roadmap-vtree-stage-at-entry {
+  --roadmap-vtree-step-width: 1.25rem;
+}
 .roadmap-vtree-summary {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.65rem 0.85rem;
+  gap: var(--roadmap-vtree-summary-gap);
+  padding: 0.65rem var(--roadmap-vtree-summary-pad-x);
   cursor: pointer;
   list-style: none;
   font-weight: 600;
@@ -1622,7 +1629,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 }
 .roadmap-vtree-step {
   flex-shrink: 0;
-  width: 1.5rem;
+  width: var(--roadmap-vtree-step-width);
   height: 1.5rem;
   border-radius: 999px;
   background: var(--accent);
@@ -1635,7 +1642,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .roadmap-vtree-step-icon {
   width: auto;
   height: auto;
-  min-width: 1.25rem;
+  min-width: var(--roadmap-vtree-step-width);
   padding: 0;
   border-radius: 0;
   background: transparent;
@@ -1660,8 +1667,19 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .roadmap-vtree-links {
   list-style: none;
   margin: 0;
-  padding: 0.35rem 0.85rem 0.65rem 2.45rem;
+  padding: 0.35rem var(--roadmap-vtree-summary-pad-x, 0.85rem) 0.65rem
+    calc(
+      var(--roadmap-vtree-summary-pad-x, 0.85rem) + var(--roadmap-vtree-step-width, 1.5rem) +
+        var(--roadmap-vtree-summary-gap, 0.5rem)
+    );
   border-top: 1px solid var(--border);
+}
+.detail-markdown-body ul.roadmap-vtree-links {
+  /* 覆盖正文区 ul 默认 1.4em，避免链接区与标题文字错位 */
+  padding-left: calc(
+    var(--roadmap-vtree-summary-pad-x, 0.85rem) + var(--roadmap-vtree-step-width, 1.5rem) +
+      var(--roadmap-vtree-summary-gap, 0.5rem)
+  );
 }
 .roadmap-vtree-link-row {
   padding: 0.45rem 0;
@@ -1675,9 +1693,19 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   word-break: break-word;
 }
 .roadmap-vtree-empty {
-  padding: 0.45rem 0.85rem 0.65rem 2.45rem;
+  padding: 0.45rem var(--roadmap-vtree-summary-pad-x, 0.85rem) 0.65rem
+    calc(
+      var(--roadmap-vtree-summary-pad-x, 0.85rem) + var(--roadmap-vtree-step-width, 1.5rem) +
+        var(--roadmap-vtree-summary-gap, 0.5rem)
+    );
   margin: 0;
   border-top: 1px solid var(--border);
+}
+.detail-markdown-body .roadmap-vtree-empty {
+  padding-left: calc(
+    var(--roadmap-vtree-summary-pad-x, 0.85rem) + var(--roadmap-vtree-step-width, 1.5rem) +
+      var(--roadmap-vtree-summary-gap, 0.5rem)
+  );
 }
 /* 嵌入正文各 L 章节下的单阶段「速览」块（与顶部整块二选一） */
 .roadmap-stage-embed-wrap {
@@ -1689,11 +1717,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 /* 替换「本阶段入口」静态链接行时的下拉块 */
 .roadmap-stage-entry-embed {
   margin: 10px 0 16px;
-}
-.roadmap-stage-entry-embed .roadmap-vtree-links,
-.roadmap-stage-entry-embed .roadmap-vtree-empty {
-  padding-left: 0.85rem;
-  padding-right: 0.85rem;
 }
 .roadmap-vtree-stage-at-entry .roadmap-vtree-summary {
   font-size: 0.92rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修正 `roadmap.html?id=roadmap-motion-control` 各 L 阶段「本阶段入口」下拉块中，站内链接列表与 summary 标题文字（如 `L3 · 控制基础与最优化`）的左缘错位问题。
- 用 CSS 变量统一 summary 内边距、图标/序号列宽与间距，链接区 `padding-left` 按 `pad + step + gap` 计算，与标题文字起始列对齐。
- 增加 `.detail-markdown-body ul.roadmap-vtree-links` 规则，避免正文区 `ul` 默认 `1.4em` 缩进覆盖专用样式；移除此前将链接贴齐容器左缘的 `0.85rem` 覆盖。

## 验证
- `make test` 通过（128 passed）
- Playwright 量测 L3 展开块：`headingLeft` 与 `linkLeft` 均为 `344.59px`，`delta = 0`

## 验证截图
[运动控制路线页](https://cursor.com/agents/bc-8bb9bcd2-6d1f-48ae-931c-e234f8d7ee9e/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-motion-control-align.png)
[L3 阶段入口链接与标题对齐](https://cursor.com/agents/bc-8bb9bcd2-6d1f-48ae-931c-e234f8d7ee9e/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Froadmap-l3-align.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bb9bcd2-6d1f-48ae-931c-e234f8d7ee9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bb9bcd2-6d1f-48ae-931c-e234f8d7ee9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

