### PR TITLE
feat(ux): 首页与详情页知识图谱增加节点悬浮预览卡片

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -57,6 +57,7 @@
             <span id="detailMiniMapMeta" class="detail-mini-map-meta">正在读取邻居关系…</span>
           </div>
           <svg id="detailMiniMapSvg" class="detail-mini-map-svg" role="img" aria-label="当前节点 1-hop 邻居图"></svg>
+          <div id="detail-mini-map-tooltip" class="graph-hover-tooltip hidden" role="tooltip" aria-hidden="true"></div>
         </aside>
       </div>
     </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,6 +81,7 @@
           <div id="mini-graph-stats" style="position:absolute;bottom:12px;left:16px;font-size:.72rem;line-height:1.8;pointer-events:none"></div>
           <a href="graph.html" id="mini-graph-expand" style="position:absolute;bottom:12px;right:16px;font-size:.72rem;text-decoration:none;">打开完整图谱 →</a>
         </div>
+        <div id="mini-graph-tooltip" class="mini-graph-tooltip hidden" role="tooltip" aria-hidden="true"></div>
       </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,7 @@
           <div id="mini-graph-stats" style="position:absolute;bottom:12px;left:16px;font-size:.72rem;line-height:1.8;pointer-events:none"></div>
           <a href="graph.html" id="mini-graph-expand" style="position:absolute;bottom:12px;right:16px;font-size:.72rem;text-decoration:none;">打开完整图谱 →</a>
         </div>
-        <div id="mini-graph-tooltip" class="mini-graph-tooltip hidden" role="tooltip" aria-hidden="true"></div>
+        <div id="mini-graph-tooltip" class="graph-hover-tooltip hidden" role="tooltip" aria-hidden="true"></div>
       </div>
     </section>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -2194,6 +2194,109 @@
     formalization: '#fb923c', '': '#64748b'
   };
   var DETAIL_MINI_TABLEAU10 = ['#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f', '#edc948', '#b07aa1', '#ff9da7', '#9c755f', '#bab0ac'];
+  var GRAPH_NODE_TYPE_LABEL = {
+    concept: '概念', method: '方法', task: '任务',
+    entity: '工具', comparison: '对比', query: 'Query',
+    formalization: '形式化', '': 'Wiki'
+  };
+
+  function buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId) {
+    var color = nodeFill(d);
+    var typeLabel = GRAPH_NODE_TYPE_LABEL[d.type] || d.type || 'Wiki';
+    var summary = d.summary || '';
+    if (summary.length > 100) summary = summary.slice(0, 100) + '…';
+    var communityLabel = d.community && communityLabelMap[d.community];
+    var community = communityLabel
+      ? '<div class="tt-summary">社区：' + escapeHtml(String(communityLabel)) + '</div>'
+      : '';
+    var linkHtml;
+    if (d.isCurrent) {
+      linkHtml = '<div class="tt-summary">当前页面</div>';
+    } else {
+      var pid = pathToId[d.id];
+      var href = pid ? detailHref(pid) : ('graph.html?focus=' + encodeURIComponent(d.id));
+      var linkText = pid ? '打开详情页 →' : '在完整图谱中查看 →';
+      linkHtml = '<a class="tt-link" href="' + escapeHtml(href) + '">' + escapeHtml(linkText) + '</a>';
+    }
+    return '<span class="tt-type" style="background:' + escapeHtml(String(color)) + ';color:#0d1117">' +
+      escapeHtml(String(typeLabel)) + '</span>' +
+      '<div class="tt-title">' + escapeHtml(String(d.label || d.id)) + '</div>' +
+      (summary ? '<div class="tt-summary">' + escapeHtml(String(summary)) + '</div>' : '') +
+      community +
+      linkHtml;
+  }
+
+  function setupGraphHoverTooltip(tooltipEl) {
+    var pinnedNode = null;
+    var isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+
+    function moveTooltip(ev) {
+      if (!tooltipEl) return;
+      var x = ev.clientX + 14;
+      var y = ev.clientY - 10;
+      var tw = tooltipEl.offsetWidth;
+      var th = tooltipEl.offsetHeight;
+      tooltipEl.style.left = (x + tw > window.innerWidth - 20 ? x - tw - 28 : x) + 'px';
+      tooltipEl.style.top = (y + th > window.innerHeight - 20 ? y - th : y) + 'px';
+      tooltipEl.style.transform = '';
+    }
+
+    function hideTooltip() {
+      if (!tooltipEl) return;
+      tooltipEl.classList.add('hidden');
+      tooltipEl.setAttribute('aria-hidden', 'true');
+      tooltipEl.style.left = '';
+      tooltipEl.style.top = '';
+      tooltipEl.style.transform = '';
+      tooltipEl.style.right = '';
+      tooltipEl.style.bottom = '';
+    }
+
+    function showTooltip(ev, d, html) {
+      if (!tooltipEl) return;
+      tooltipEl.innerHTML = html;
+      tooltipEl.classList.remove('hidden');
+      tooltipEl.setAttribute('aria-hidden', 'false');
+      tooltipEl.style.left = '';
+      tooltipEl.style.top = '';
+      tooltipEl.style.width = '';
+      tooltipEl.style.transform = '';
+      if (isMobile) {
+        tooltipEl.classList.add('tt-pinned');
+        tooltipEl.style.right = '20px';
+        tooltipEl.style.bottom = '20px';
+        pinnedNode = d;
+      } else {
+        tooltipEl.classList.remove('tt-pinned');
+        moveTooltip(ev);
+      }
+    }
+
+    if (tooltipEl && !tooltipEl.dataset.hoverBound) {
+      tooltipEl.dataset.hoverBound = '1';
+      tooltipEl.addEventListener('click', function (ev) {
+        var link = ev.target.closest && ev.target.closest('.tt-link');
+        if (!link) return;
+        var href = link.getAttribute('href');
+        if (!href) return;
+        window.location.href = href;
+        setTimeout(function () {
+          pinnedNode = null;
+          hideTooltip();
+        }, 100);
+      });
+    }
+
+    return {
+      isMobile: isMobile,
+      show: showTooltip,
+      move: moveTooltip,
+      hide: hideTooltip,
+      getPinned: function () { return pinnedNode; },
+      clearPin: function () { pinnedNode = null; }
+    };
+  }
+
 
   function buildPathToDetailIdIndex(detailPages) {
     var idx = {};
@@ -2212,6 +2315,7 @@
     var wrap = document.getElementById('detailMiniMapWrap');
     var svgEl = document.getElementById('detailMiniMapSvg');
     var metaEl = document.getElementById('detailMiniMapMeta');
+    var tooltipEl = document.getElementById('detail-mini-map-tooltip');
     if (!wrap || !svgEl || typeof window.d3 === 'undefined') return;
     var currentPath = (detailPage && detailPage.path) || '';
     if (!currentPath) return;
@@ -2219,8 +2323,10 @@
     fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var palette = (window.d3 && window.d3.schemeTableau10) ? window.d3.schemeTableau10 : DETAIL_MINI_TABLEAU10;
       var communityColor = {};
+      var communityLabelMap = {};
       (gd.communities || []).forEach(function (c, i) {
         communityColor[c.id] = palette[i % palette.length];
+        communityLabelMap[c.id] = c.label || c.id;
       });
       var nodeMap = {};
       (gd.nodes || []).forEach(function (n) { nodeMap[n.id] = n; });
@@ -2240,12 +2346,24 @@
       var pathToId = buildPathToDetailIdIndex(detailPages);
       var nodes = [{
         id: currentPath, label: current.label || currentPath,
-        type: current.type || '', community: current.community || '', isCurrent: true
+        type: current.type || '', community: current.community || '',
+        summary: current.summary || '', isCurrent: true
       }].concat(neighborIds.map(function (id) {
         var n = nodeMap[id];
-        return { id: id, label: n.label || id, type: n.type || '', community: n.community || '', isCurrent: false };
+        return {
+          id: id, label: n.label || id, type: n.type || '', community: n.community || '',
+          summary: n.summary || '', isCurrent: false
+        };
       }));
       var edges = neighborIds.map(function (id) { return { source: currentPath, target: id }; });
+
+      function nodeFill(d) {
+        var cc = d.community && communityColor[d.community];
+        if (cc) return cc;
+        return TYPE_COLOR_DETAIL_MINI[d.type] || TYPE_COLOR_DETAIL_MINI[''];
+      }
+
+      var hoverTip = setupGraphHoverTooltip(tooltipEl);
 
       wrap.hidden = false;
       var W = wrap.clientWidth || 700;
@@ -2284,19 +2402,38 @@
         .attr('class', function (d) { return d.isCurrent ? 'mini-node-current' : 'mini-node'; })
         .style('cursor', function (d) { return d.isCurrent ? 'default' : 'pointer'; })
         .on('click', function (ev, d) {
+          if (hoverTip.isMobile && !d.isCurrent) {
+            ev.stopPropagation();
+            if (hoverTip.getPinned() === d) {
+              hoverTip.clearPin();
+              hoverTip.hide();
+            } else {
+              hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId));
+            }
+            return;
+          }
           if (d.isCurrent) return;
           var pid = pathToId[d.id];
           if (pid) window.location.href = detailHref(pid);
+        })
+        .on('mouseenter', function (ev, d) {
+          if (hoverTip.isMobile) return;
+          window.d3.select(this).select('circle').attr('fill-opacity', 1);
+          hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId));
+        })
+        .on('mousemove', function (ev) {
+          if (hoverTip.isMobile && hoverTip.getPinned()) return;
+          if (!hoverTip.isMobile || !hoverTip.getPinned()) hoverTip.move(ev);
+        })
+        .on('mouseleave', function () {
+          if (hoverTip.isMobile) return;
+          window.d3.select(this).select('circle').attr('fill-opacity', 0.9);
+          if (!hoverTip.isMobile || !hoverTip.getPinned()) hoverTip.hide();
         });
 
-      nodeG.append('title').text(function (d) { return d.label; });
       nodeG.append('circle')
         .attr('r', function (d) { return d.isCurrent ? 8 : 6; })
-        .attr('fill', function (d) {
-          var cc = d.community && communityColor[d.community];
-          if (cc) return cc;
-          return TYPE_COLOR_DETAIL_MINI[d.type] || TYPE_COLOR_DETAIL_MINI[''];
-        })
+        .attr('fill', function (d) { return nodeFill(d); })
         .attr('fill-opacity', 0.9);
       nodeG.append('text')
         .text(function (d) { return d.label.length > 10 ? d.label.slice(0, 10) + '…' : d.label; })
@@ -2316,7 +2453,7 @@
       if (metaEl) {
         var totalDeg = Object.keys(neighborSet).length;
         var shown = neighborIds.length;
-        metaEl.textContent = shown + ' / ' + totalDeg + ' 个 1-hop 邻居 · 拖拽平移 · 点击跳转';
+        metaEl.textContent = shown + ' / ' + totalDeg + ' 个 1-hop 邻居 · 悬停预览 · 拖拽平移 · 点击跳转';
       }
     }).catch(function () {
       if (metaEl) metaEl.textContent = '邻居数据加载失败';

--- a/docs/main.js
+++ b/docs/main.js
@@ -2365,6 +2365,12 @@
 
       var hoverTip = setupGraphHoverTooltip(tooltipEl);
 
+      function detailMiniNodeRadius(d, scale) {
+        var base = d.isCurrent ? 8 : 6;
+        return base * (scale || 1);
+      }
+
+
       wrap.hidden = false;
       var W = wrap.clientWidth || 700;
       var H = 180;
@@ -2418,7 +2424,9 @@
         })
         .on('mouseenter', function (ev, d) {
           if (hoverTip.isMobile) return;
-          window.d3.select(this).select('circle').attr('fill-opacity', 1);
+          window.d3.select(this).select('circle')
+            .attr('fill-opacity', 1)
+            .attr('r', function (node) { return detailMiniNodeRadius(node, 1.3); });
           hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId));
         })
         .on('mousemove', function (ev) {
@@ -2427,12 +2435,14 @@
         })
         .on('mouseleave', function () {
           if (hoverTip.isMobile) return;
-          window.d3.select(this).select('circle').attr('fill-opacity', 0.9);
+          window.d3.select(this).select('circle')
+            .attr('fill-opacity', 0.9)
+            .attr('r', function (node) { return detailMiniNodeRadius(node); });
           if (!hoverTip.isMobile || !hoverTip.getPinned()) hoverTip.hide();
         });
 
       nodeG.append('circle')
-        .attr('r', function (d) { return d.isCurrent ? 8 : 6; })
+        .attr('r', function (d) { return detailMiniNodeRadius(d); })
         .attr('fill', function (d) { return nodeFill(d); })
         .attr('fill-opacity', 0.9);
       nodeG.append('text')

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -3,18 +3,115 @@
   var miniSvg  = document.getElementById('mini-graph-svg');
   var statsEl  = document.getElementById('mini-graph-stats');
   var expandEl = document.getElementById('mini-graph-expand');
+  var tooltip  = document.getElementById('mini-graph-tooltip');
   if (!miniWrap || !miniSvg) return;
+
+  var TYPE_LABEL = {
+    concept: '概念', method: '方法', task: '任务',
+    entity: '工具', comparison: '对比', query: 'Query',
+    formalization: '形式化', '': 'Wiki'
+  };
+
+  var isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+  var pinnedNode = null;
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function toDetailId(path) {
+    return String(path).replace(/\//g, '-').replace('.md', '');
+  }
 
   function miniGraphTheme() {
     var dark = document.documentElement.getAttribute('data-theme') !== 'light';
     return {
       background: dark ? '#0d1117' : '#eef2f7',
       edge: dark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.10)',
-      label: dark ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.70)', // 提高对比度
+      label: dark ? 'rgba(255,255,255,0.75)' : 'rgba(0,0,0,0.70)',
       stats: dark ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.62)',
-      link: dark ? '#60a5fa' : '#2563eb', // 使用更标准的蓝色
+      link: dark ? '#60a5fa' : '#2563eb',
       linkBorder: dark ? 'rgba(96,165,250,0.30)' : 'rgba(37,99,235,0.30)'
     };
+  }
+
+  function tooltipHtml(d, nodeFill, communityLabelMap) {
+    var color = nodeFill(d);
+    var typeLabel = TYPE_LABEL[d.type] || d.type || 'Wiki';
+    var summary = d.summary || '';
+    if (summary.length > 100) summary = summary.slice(0, 100) + '…';
+    var detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
+    var communityLabel = d.community && communityLabelMap[d.community];
+    var community = communityLabel
+      ? '<div class="tt-summary">社区：' + escapeHtml(String(communityLabel)) + '</div>'
+      : '';
+    return '<span class="tt-type" style="background:' + escapeHtml(String(color)) + ';color:#0d1117">' +
+      escapeHtml(String(typeLabel)) + '</span>' +
+      '<div class="tt-title">' + escapeHtml(String(d.label || d.id)) + '</div>' +
+      (summary ? '<div class="tt-summary">' + escapeHtml(String(summary)) + '</div>' : '') +
+      community +
+      '<a class="tt-link" href="' + detailUrl + '">打开详情页 →</a>';
+  }
+
+  function showTooltip(ev, d, nodeFill, communityLabelMap) {
+    if (!tooltip) return;
+    tooltip.innerHTML = tooltipHtml(d, nodeFill, communityLabelMap);
+    tooltip.classList.remove('hidden');
+    tooltip.setAttribute('aria-hidden', 'false');
+    tooltip.style.left = '';
+    tooltip.style.top = '';
+    tooltip.style.width = '';
+    tooltip.style.transform = '';
+    if (isMobile) {
+      tooltip.classList.add('tt-pinned');
+      tooltip.style.right = '20px';
+      tooltip.style.bottom = '20px';
+      pinnedNode = d;
+    } else {
+      tooltip.classList.remove('tt-pinned');
+      moveTooltip(ev);
+    }
+  }
+
+  function moveTooltip(ev) {
+    if (!tooltip) return;
+    var x = ev.clientX + 14;
+    var y = ev.clientY - 10;
+    var tw = tooltip.offsetWidth;
+    var th = tooltip.offsetHeight;
+    tooltip.style.left = (x + tw > window.innerWidth - 20 ? x - tw - 28 : x) + 'px';
+    tooltip.style.top = (y + th > window.innerHeight - 20 ? y - th : y) + 'px';
+    tooltip.style.transform = '';
+  }
+
+  function hideTooltip() {
+    if (!tooltip) return;
+    tooltip.classList.add('hidden');
+    tooltip.setAttribute('aria-hidden', 'true');
+    tooltip.style.left = '';
+    tooltip.style.top = '';
+    tooltip.style.transform = '';
+    tooltip.style.right = '';
+    tooltip.style.bottom = '';
+  }
+
+  if (tooltip) {
+    tooltip.addEventListener('click', function(ev) {
+      var link = ev.target.closest && ev.target.closest('.tt-link');
+      if (!link) return;
+      var href = link.getAttribute('href');
+      if (!href) return;
+      window.location.href = href;
+      setTimeout(function() {
+        pinnedNode = null;
+        hideTooltip();
+      }, 100);
+    });
   }
 
   var TABLEAU10 = ['#4e79a7','#f28e2b','#e15759','#76b7b2','#59a14f','#edc948','#b07aa1','#ff9da7','#9c755f','#bab0ac'];
@@ -22,13 +119,16 @@
   fetch('exports/link-graph.json').then(function(r){ return r.json(); }).then(function(gd) {
     var palette = (typeof d3 !== 'undefined' && d3.schemeTableau10) ? d3.schemeTableau10 : TABLEAU10;
     var communityFill = {};
+    var communityLabelMap = {};
     (gd.communities || []).forEach(function(c, idx) {
       communityFill[c.id] = palette[idx % palette.length];
+      communityLabelMap[c.id] = c.label || c.id;
     });
     function nodeFill(d) {
       if (d.community && communityFill[d.community]) return communityFill[d.community];
       return palette[palette.length - 1];
     }
+
     fetch('exports/graph-stats.json').then(function(r){ return r.json(); }).then(function(stats) {
       var totalNodes = gd.nodes.length, totalEdges = gd.edges.length;
       var degreeMap = {};
@@ -37,14 +137,20 @@
         degreeMap[e.target] = (degreeMap[e.target]||0)+1;
       });
 
-      // Top-40 by degree
       var topIds = new Set(
         gd.nodes.slice().sort(function(a,b){ return (degreeMap[b.id]||0)-(degreeMap[a.id]||0); })
         .slice(0,40).map(function(n){ return n.id; })
       );
 
       var nodes = gd.nodes.filter(function(n){ return topIds.has(n.id); }).map(function(n){
-        return { id:n.id, label:n.label||n.id, type:n.type||'', community:n.community||'', _degree:degreeMap[n.id]||0 };
+        return {
+          id: n.id,
+          label: n.label || n.id,
+          type: n.type || '',
+          community: n.community || '',
+          summary: n.summary || '',
+          _degree: degreeMap[n.id] || 0
+        };
       });
       var nodeIdSet = new Set(nodes.map(function(n){ return n.id; }));
       var edges = gd.edges.filter(function(e){
@@ -58,6 +164,9 @@
       var g = svg.append('g');
       var lineLayer = g.append('g');
       var nodeLayer = g.append('g');
+
+      var line;
+      var label;
 
       function applyMiniGraphTheme() {
         var theme = miniGraphTheme();
@@ -81,22 +190,40 @@
         .force('collision', d3.forceCollide().radius(12).strength(0.6))
         .alphaDecay(0.03);
 
-      var line = lineLayer.selectAll('line').data(edges).join('line')
+      line = lineLayer.selectAll('line').data(edges).join('line')
         .attr('stroke-width',1);
 
       var nodeG = nodeLayer.selectAll('g').data(nodes).join('g')
         .style('cursor','pointer')
         .on('click', function(ev, d) {
+          if (isMobile) {
+            ev.stopPropagation();
+            if (pinnedNode === d) {
+              pinnedNode = null;
+              hideTooltip();
+            } else {
+              showTooltip(ev, d, nodeFill, communityLabelMap);
+            }
+            return;
+          }
           window.location.href = 'graph.html?focus=' + encodeURIComponent(d.id);
         })
         .on('mouseenter', function(ev, d) {
+          if (isMobile) return;
           d3.select(this).select('circle').attr('fill-opacity', 1).attr('r', function(){
             return Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2)) * 1.3;
           });
+          showTooltip(ev, d, nodeFill, communityLabelMap);
+        })
+        .on('mousemove', function(ev) {
+          if (isMobile && pinnedNode) return;
+          if (!isMobile || !pinnedNode) moveTooltip(ev);
         })
         .on('mouseleave', function(ev, d) {
+          if (isMobile) return;
           d3.select(this).select('circle').attr('fill-opacity', 0.9).attr('r',
             Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2)));
+          if (!isMobile || !pinnedNode) hideTooltip();
         });
 
       nodeG.append('circle')
@@ -104,15 +231,15 @@
         .attr('fill', function(d){ return nodeFill(d); })
         .attr('fill-opacity', 0.9);
 
-      var label = nodeG.append('text')
+      label = nodeG.append('text')
         .text(function(d){ return d.label.length>12 ? d.label.slice(0,12)+'…' : d.label; })
         .attr('dy', function(d){ return Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2))+11; })
         .attr('text-anchor','middle')
-        .attr('font-size','10px') // 稍大一点以提高清晰度
+        .attr('font-size','10px')
         .attr('pointer-events','none');
 
       applyMiniGraphTheme();
-      
+
       var observer = new MutationObserver(function() {
         applyMiniGraphTheme();
       });

--- a/docs/style.css
+++ b/docs/style.css
@@ -1951,3 +1951,86 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
     font-size: .78rem;
   }
 }
+
+/* 首页 mini-graph 节点悬浮预览卡片（对齐 graph.html tooltip） */
+.mini-graph-tooltip {
+  position: fixed;
+  z-index: 200;
+  padding: 12px 15px;
+  border-radius: 10px;
+  background: rgba(22, 27, 34, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  max-width: 280px;
+  max-height: 70vh;
+  overflow-y: auto;
+  pointer-events: none;
+  transition: opacity 0.12s;
+}
+.mini-graph-tooltip.hidden {
+  opacity: 0;
+  pointer-events: none !important;
+}
+.mini-graph-tooltip.tt-pinned {
+  pointer-events: auto;
+  border-color: rgba(0, 212, 255, 0.35);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(0, 212, 255, 0.15);
+}
+.mini-graph-tooltip .tt-type {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 4px;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mini-graph-tooltip .tt-title {
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #e6edf3;
+  margin-bottom: 5px;
+  line-height: 1.3;
+}
+.mini-graph-tooltip .tt-summary {
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.45);
+  line-height: 1.5;
+}
+.mini-graph-tooltip .tt-link {
+  display: inline-block;
+  font-size: 0.72rem;
+  color: rgba(0, 212, 255, 0.8);
+  margin-top: 9px;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(0, 212, 255, 0.3);
+  transition: color 0.12s, border-color 0.12s;
+}
+.mini-graph-tooltip .tt-link:hover {
+  color: #00d4ff;
+  border-color: rgba(0, 212, 255, 0.7);
+}
+[data-theme="light"] .mini-graph-tooltip {
+  background: rgba(255, 255, 255, 0.98);
+  border-color: rgba(0, 0, 0, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+[data-theme="light"] .mini-graph-tooltip .tt-title {
+  color: #1a1a1a;
+}
+[data-theme="light"] .mini-graph-tooltip .tt-summary {
+  color: rgba(0, 0, 0, 0.5);
+}
+[data-theme="light"] .mini-graph-tooltip .tt-link {
+  color: rgba(22, 90, 180, 0.85);
+  border-color: rgba(22, 90, 180, 0.3);
+}
+[data-theme="light"] .mini-graph-tooltip .tt-link:hover {
+  color: #1659b4;
+  border-color: rgba(22, 90, 180, 0.7);
+}
+[data-theme="light"] .mini-graph-tooltip.tt-pinned {
+  border-color: rgba(22, 90, 180, 0.35);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(22, 90, 180, 0.15);
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -1953,7 +1953,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 }
 
 /* 首页 mini-graph 节点悬浮预览卡片（对齐 graph.html tooltip） */
-.mini-graph-tooltip {
+.graph-hover-tooltip {
   position: fixed;
   z-index: 200;
   padding: 12px 15px;
@@ -1967,16 +1967,16 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   pointer-events: none;
   transition: opacity 0.12s;
 }
-.mini-graph-tooltip.hidden {
+.graph-hover-tooltip.hidden {
   opacity: 0;
   pointer-events: none !important;
 }
-.mini-graph-tooltip.tt-pinned {
+.graph-hover-tooltip.tt-pinned {
   pointer-events: auto;
   border-color: rgba(0, 212, 255, 0.35);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(0, 212, 255, 0.15);
 }
-.mini-graph-tooltip .tt-type {
+.graph-hover-tooltip .tt-type {
   display: inline-block;
   font-size: 0.7rem;
   font-weight: 700;
@@ -1986,19 +1986,19 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.mini-graph-tooltip .tt-title {
+.graph-hover-tooltip .tt-title {
   font-size: 0.92rem;
   font-weight: 700;
   color: #e6edf3;
   margin-bottom: 5px;
   line-height: 1.3;
 }
-.mini-graph-tooltip .tt-summary {
+.graph-hover-tooltip .tt-summary {
   font-size: 0.78rem;
   color: rgba(255, 255, 255, 0.45);
   line-height: 1.5;
 }
-.mini-graph-tooltip .tt-link {
+.graph-hover-tooltip .tt-link {
   display: inline-block;
   font-size: 0.72rem;
   color: rgba(0, 212, 255, 0.8);
@@ -2007,30 +2007,30 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   border-bottom: 1px solid rgba(0, 212, 255, 0.3);
   transition: color 0.12s, border-color 0.12s;
 }
-.mini-graph-tooltip .tt-link:hover {
+.graph-hover-tooltip .tt-link:hover {
   color: #00d4ff;
   border-color: rgba(0, 212, 255, 0.7);
 }
-[data-theme="light"] .mini-graph-tooltip {
+[data-theme="light"] .graph-hover-tooltip {
   background: rgba(255, 255, 255, 0.98);
   border-color: rgba(0, 0, 0, 0.1);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
 }
-[data-theme="light"] .mini-graph-tooltip .tt-title {
+[data-theme="light"] .graph-hover-tooltip .tt-title {
   color: #1a1a1a;
 }
-[data-theme="light"] .mini-graph-tooltip .tt-summary {
+[data-theme="light"] .graph-hover-tooltip .tt-summary {
   color: rgba(0, 0, 0, 0.5);
 }
-[data-theme="light"] .mini-graph-tooltip .tt-link {
+[data-theme="light"] .graph-hover-tooltip .tt-link {
   color: rgba(22, 90, 180, 0.85);
   border-color: rgba(22, 90, 180, 0.3);
 }
-[data-theme="light"] .mini-graph-tooltip .tt-link:hover {
+[data-theme="light"] .graph-hover-tooltip .tt-link:hover {
   color: #1659b4;
   border-color: rgba(22, 90, 180, 0.7);
 }
-[data-theme="light"] .mini-graph-tooltip.tt-pinned {
+[data-theme="light"] .graph-hover-tooltip.tt-pinned {
   border-color: rgba(22, 90, 180, 0.35);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(22, 90, 180, 0.15);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

为站点内两处局部知识图谱补齐与 `graph.html` 一致的节点悬浮预览卡片：

1. **首页**「知识图谱预览」（Top-40 mini-graph）
2. **详情页**「知识地图（1-hop 邻居）」

悬停时展示类型、标题、摘要、社区与跳转链接；**节点圆圈轻微膨胀（×1.3）**；移动端点击邻居节点固定卡片。

## 改动说明

- 抽取共享样式类 `.graph-hover-tooltip`（首页 `#mini-graph-tooltip` + 详情页 `#detail-mini-map-tooltip`）
- `docs/main.js`：新增 `buildGraphNodeTooltipHtml` / `setupGraphHoverTooltip`，接入 `renderDetailMiniMap`；详情页悬停时 `detailMiniNodeRadius(d, 1.3)` 对齐首页 mini-graph
- `docs/detail.html`：新增 tooltip 容器

## 验证

- `make lint` 与 `npm run lint:js` 通过
- 本地静态站悬停详情页邻居节点可显示预览卡片且圆圈膨胀

## 验证截图

[首页知识图谱预览悬浮卡片](https://cursor.com/agents/bc-3734dc2f-b8ea-4705-887a-b5cf7c88ef2d/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmini-graph-hover-preview.png)

[详情页 1-hop 知识地图悬浮卡片](https://cursor.com/agents/bc-3734dc2f-b8ea-4705-887a-b5cf7c88ef2d/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fdetail-mini-map-hover-preview.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3734dc2f-b8ea-4705-887a-b5cf7c88ef2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3734dc2f-b8ea-4705-887a-b5cf7c88ef2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

