### PR TITLE
feat(ux): 知识图谱悬浮预览卡片与移开鼠标闪烁修复

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2231,7 +2231,7 @@
     var isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
 
     function moveTooltip(ev) {
-      if (!tooltipEl) return;
+      if (!tooltipEl || tooltipEl.classList.contains('hidden')) return;
       var x = ev.clientX + 14;
       var y = ev.clientY - 10;
       var tw = tooltipEl.offsetWidth;
@@ -2245,30 +2245,28 @@
       if (!tooltipEl) return;
       tooltipEl.classList.add('hidden');
       tooltipEl.setAttribute('aria-hidden', 'true');
-      tooltipEl.style.left = '';
-      tooltipEl.style.top = '';
-      tooltipEl.style.transform = '';
-      tooltipEl.style.right = '';
-      tooltipEl.style.bottom = '';
     }
 
     function showTooltip(ev, d, html) {
       if (!tooltipEl) return;
       tooltipEl.innerHTML = html;
-      tooltipEl.classList.remove('hidden');
       tooltipEl.setAttribute('aria-hidden', 'false');
-      tooltipEl.style.left = '';
-      tooltipEl.style.top = '';
       tooltipEl.style.width = '';
       tooltipEl.style.transform = '';
       if (isMobile) {
         tooltipEl.classList.add('tt-pinned');
+        tooltipEl.style.left = '';
+        tooltipEl.style.top = '';
         tooltipEl.style.right = '20px';
         tooltipEl.style.bottom = '20px';
         pinnedNode = d;
+        tooltipEl.classList.remove('hidden');
       } else {
         tooltipEl.classList.remove('tt-pinned');
+        tooltipEl.style.right = '';
+        tooltipEl.style.bottom = '';
         moveTooltip(ev);
+        tooltipEl.classList.remove('hidden');
       }
     }
 

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -61,25 +61,28 @@
   function showTooltip(ev, d, nodeFill, communityLabelMap) {
     if (!tooltip) return;
     tooltip.innerHTML = tooltipHtml(d, nodeFill, communityLabelMap);
-    tooltip.classList.remove('hidden');
     tooltip.setAttribute('aria-hidden', 'false');
-    tooltip.style.left = '';
-    tooltip.style.top = '';
     tooltip.style.width = '';
     tooltip.style.transform = '';
     if (isMobile) {
       tooltip.classList.add('tt-pinned');
+      tooltip.style.left = '';
+      tooltip.style.top = '';
       tooltip.style.right = '20px';
       tooltip.style.bottom = '20px';
       pinnedNode = d;
+      tooltip.classList.remove('hidden');
     } else {
       tooltip.classList.remove('tt-pinned');
+      tooltip.style.right = '';
+      tooltip.style.bottom = '';
       moveTooltip(ev);
+      tooltip.classList.remove('hidden');
     }
   }
 
   function moveTooltip(ev) {
-    if (!tooltip) return;
+    if (!tooltip || tooltip.classList.contains('hidden')) return;
     var x = ev.clientX + 14;
     var y = ev.clientY - 10;
     var tw = tooltip.offsetWidth;
@@ -93,11 +96,6 @@
     if (!tooltip) return;
     tooltip.classList.add('hidden');
     tooltip.setAttribute('aria-hidden', 'true');
-    tooltip.style.left = '';
-    tooltip.style.top = '';
-    tooltip.style.transform = '';
-    tooltip.style.right = '';
-    tooltip.style.bottom = '';
   }
 
   if (tooltip) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1967,8 +1967,12 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   pointer-events: none;
   transition: opacity 0.12s;
 }
+.graph-hover-tooltip:not(.hidden) {
+  visibility: visible;
+}
 .graph-hover-tooltip.hidden {
   opacity: 0;
+  visibility: hidden;
   pointer-events: none !important;
 }
 .graph-hover-tooltip.tt-pinned {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

为首页「知识图谱预览」与详情页「知识地图（1-hop 邻居）」增加节点悬浮预览卡片，并修复移开鼠标时卡片在画布角落闪烁的问题。

## 修复说明（闪烁）

`hideTooltip` 原先会清空 `left/top`，导致 `position: fixed` 的 tooltip 回退到 DOM 静态位置。详情页 tooltip 位于画布容器底部，因此在 opacity 淡出期间会在左下角闪一下。

- 隐藏时保留上次坐标，不再清空定位
- 显示前先 `moveTooltip`，再移除 `.hidden`
- `.hidden` 增加 `visibility: hidden`
- `moveTooltip` 在隐藏状态下不更新位置

## 验证

- `npm run lint:js` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3734dc2f-b8ea-4705-887a-b5cf7c88ef2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3734dc2f-b8ea-4705-887a-b5cf7c88ef2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

