### PR TITLE
feat(ux): 移动端图谱浮窗仅画布空白处关闭

### DIFF
--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -3,26 +3,47 @@
 
   /**
    * 移动端：点击画布空白处关闭已固定的节点浮窗。
-   * @param {Element} containerEl - SVG 或画布容器
+   * 仅当 event.target 落在 canvasEl 内时生效，画布外点击不会关闭。
+   *
+   * @param {Element} canvasEl - SVG 画布（接收 pointer/click 的容器）
    * @param {{ isMobile: boolean, getPinned: function, clearPin: function, hide: function }} tooltipApi
    * @param {{ nodeSelector?: string, tooltipEl?: Element }} [opts]
    */
-  function bindGraphTooltipBlankDismiss(containerEl, tooltipApi, opts) {
-    if (!containerEl || !tooltipApi) return;
+  function bindGraphTooltipBlankDismiss(canvasEl, tooltipApi, opts) {
+    if (!canvasEl || !tooltipApi) return;
     opts = opts || {};
     var nodeSelector = opts.nodeSelector || '.node-g';
     var tooltipEl = opts.tooltipEl || null;
+    var lastDismissAt = 0;
 
-    containerEl.addEventListener('click', function (ev) {
-      if (!tooltipApi.isMobile || !tooltipApi.getPinned()) return;
-      var closest = ev.target.closest;
-      if (!closest) return;
-      if (closest.call(ev.target, nodeSelector)) return;
-      if (closest.call(ev.target, '.tt-link')) return;
-      if (tooltipEl && tooltipEl.contains(ev.target)) return;
+    function shouldDismiss(ev) {
+      if (!tooltipApi.isMobile || !tooltipApi.getPinned()) return false;
+      var target = ev.target;
+      if (!target || !canvasEl.contains(target)) return false;
+      var closest = target.closest;
+      if (!closest) return false;
+      if (closest.call(target, nodeSelector)) return false;
+      if (closest.call(target, '.tt-link')) return false;
+      if (tooltipEl && tooltipEl.contains(target)) return false;
+      return true;
+    }
+
+    function dismissFromBlank(ev) {
+      if (!shouldDismiss(ev)) return;
+      var now = Date.now();
+      if (now - lastDismissAt < 300) return;
+      lastDismissAt = now;
       tooltipApi.clearPin();
       tooltipApi.hide();
-    });
+    }
+
+    function onClick(ev) {
+      if (ev.defaultPrevented) return;
+      dismissFromBlank(ev);
+    }
+
+    canvasEl.addEventListener('pointerup', dismissFromBlank);
+    canvasEl.addEventListener('click', onClick);
   }
 
   window.RNGraphTooltip = {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2290,19 +2290,6 @@
       }
     });
 
-    if (window.RNGraphTooltip) {
-      window.RNGraphTooltip.bindBlankDismiss(
-        document.getElementById('graph-canvas'),
-        {
-          isMobile,
-          getPinned: () => pinnedNode,
-          clearPin: () => { pinnedNode = null; },
-          hide: hideTooltip
-        },
-        { nodeSelector: '.node-g', tooltipEl: tooltip }
-      );
-    }
-
     function escapeHtml(s) {
       return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
     }
@@ -3416,13 +3403,36 @@
 
     sbClose.addEventListener('click', closeSidebar);
 
-    // V21: 点击背景退出高亮聚焦模式
+    function dismissMobilePinnedTooltip() {
+      if (!isMobile || !pinnedNode) return false;
+      pinnedNode = null;
+      hideTooltip();
+      return true;
+    }
+
+    // V21: 点击背景退出高亮聚焦模式；移动端空白处关闭浮窗
     svg.on('click', (ev) => {
-      // 如果点击的不是节点，则视为点击背景
-      if (!ev.target.closest('.node-g')) {
-        closeSidebar();
+      if (ev.defaultPrevented) return;
+      if (ev.target.closest('.node-g')) return;
+      if (isMobile) {
+        dismissMobilePinnedTooltip();
+        return;
       }
+      closeSidebar();
     });
+
+    if (window.RNGraphTooltip) {
+      window.RNGraphTooltip.bindBlankDismiss(
+        document.getElementById('graph-canvas'),
+        {
+          isMobile,
+          getPinned: () => pinnedNode,
+          clearPin: () => { pinnedNode = null; },
+          hide: hideTooltip
+        },
+        { nodeSelector: '.node-g', tooltipEl: tooltip }
+      );
+    }
 
     // 覆盖节点 click：PC 打开侧边栏而不是直接跳转
     node.on('click', (ev, d) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复移动端**点击画布外**（工具栏、页面其他区域）也会关闭节点浮窗：移除 `graph.html` 的 document 级 dismiss，并在 `bindBlankDismiss` 中严格校验 `canvasEl.contains(target)`。
- 修复 **graph view 画布空白处** dismiss 不生效：D3 zoom 在移动端常拦截 `click`，新增 `pointerup` 监听；空白 tap 拆为 `dismissMobilePinnedTooltip()`，避免 `closeSidebar()` 副作用。

## 验证
- Graph view 移动端：点节点出浮窗 → 点画布空白关闭；点工具栏/图例 FAB 不关闭
- 首页预览 / 详情 1-hop：点画布外页面区域不关闭浮窗

## 涉及文件
- `docs/graph-tooltip.js` — 共享 blank dismiss（pointerup + contains 校验）
- `docs/graph.html` — 移除 document dismiss，修复空白 tap
- `docs/main.js` / `docs/mini-graph.js` — 复用共享逻辑

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e96db0f-04de-4030-bb96-9dc60c8e9179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e96db0f-04de-4030-bb96-9dc60c8e9179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

