### PR TITLE
fix(ux): 详情页知识地图移动端浮窗支持页内区外点击关闭

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2398,6 +2398,7 @@
 
       var hoverTip = setupGraphHoverTooltip(tooltipEl);
       hoverTip.bindBlankDismiss(svgEl, '.mini-node, .mini-node-current');
+      hoverTip.bindOutsideDismiss(svgEl, document.body);
 
       function detailMiniNodeRadius(d, scale) {
         var base = d.isCurrent ? 8 : 6;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「知识地图（1-hop 邻居）」微地图在移动端点击节点后会固定节点详情漂浮窗；此前仅绑定了画布空白处关闭（`bindBlankDismiss`），点击正文、导航栏等画布外区域无法关闭。
- 对齐首页 mini-graph 行为，补充 `bindOutsideDismiss(svgEl, document.body)`，使移动端在点击画布空白或页内任意非画布/非浮窗区域时关闭漂浮窗。

## 验证
- `npm run lint:js` 通过
- 逻辑与 `docs/mini-graph.js`、`docs/graph-tooltip.js` 中已有 `RNGraphTooltip` API 一致

## 风险
- 无；仅影响 `(hover: none) and (pointer: coarse)` 移动端且浮窗已固定时的点击行为
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aa82730-4dd7-4dc5-a2bd-61256092785d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aa82730-4dd7-4dc5-a2bd-61256092785d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

