### PR TITLE
Fix light theme colors for legend title, slider value, and filter empty

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -545,6 +545,7 @@
       background: rgba(255,255,255,0.94);
       border-color: rgba(0,0,0,0.08);
     }
+    [data-theme="light"] .legend-title { color: rgba(0,0,0,0.45); }
     [data-theme="light"] .legend-row { color: rgba(0,0,0,0.5); }
     [data-theme="light"] .legend-row:hover { background: rgba(0,0,0,0.04); }
     [data-theme="light"] .legend-row.active { background: #e6f7ff; color: #1659b4; }
@@ -574,6 +575,7 @@
     [data-theme="light"] .physics-close { color: rgba(0,0,0,0.3); }
     [data-theme="light"] .physics-close:hover { color: rgba(0,0,0,0.72); }
     [data-theme="light"] .slider-label { color: rgba(0,0,0,0.45); }
+    [data-theme="light"] .slider-val { color: #1659b4; }
     [data-theme="light"] .physics-toggle { color: rgba(0,0,0,0.45); }
     [data-theme="light"] .physics-toggle input[type=checkbox] { accent-color: #1659b4; }
     [data-theme="light"] .physics-section-title { color: rgba(0,0,0,0.4); }
@@ -650,6 +652,7 @@
       border-color: rgba(0,0,0,0.28);
       color: rgba(0,0,0,0.8);
     }
+    [data-theme="light"] .filter-empty { color: rgba(0,0,0,0.45); }
     [data-theme="light"] .filter-count {
       background: #1659b4;
       color: #fff;


### PR DESCRIPTION
## 摘要

添加三个缺失的浅色主题样式规则，修复图表界面中图例标题、滑块数值和空过滤器的文本颜色显示。

## 变更类型

- [x] 前端（`docs/`）

## 详情

在 `docs/graph.html` 中为浅色主题补充三条 CSS 规则：

1. `.legend-title` — 图例标题颜色设为 `rgba(0,0,0,0.45)`，与其他图例元素保持一致
2. `.slider-val` — 滑块数值颜色设为 `#1659b4`（品牌蓝），与其他交互元素对齐
3. `.filter-empty` — 空过滤器提示文本颜色设为 `rgba(0,0,0,0.45)`，保持视觉层级

这些样式补充了现有浅色主题的不完整部分，确保所有 UI 元素在浅色模式下有明确的颜色定义。

## 验证

- [x] 代码审查：三条规则均遵循现有浅色主题的颜色方案
- [x] 无需测试：纯样式补充，不涉及逻辑变更

## 相关 Issue

无

https://claude.ai/code/session_01MGF1bjFUNc3bcyRqR5JWjE