### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DOM-based XSS in template literals

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Unsanitized variables (`typeLabel` and `communityId`) were interpolated directly into HTML template strings returned by `tooltipHtml` and pushed to `renderLegend`'s `rows` array in `docs/graph.html`.
 **Learning:** Even when surrounding variables (like `label`, `summary`) use custom `escapeHtml()`, seemingly innocuous string properties mapped from backend values (like `d.type` or `communityId`) can be overlooked and become vectors for DOM-based XSS if the data source contains special characters.
 **Prevention:** Always consistently apply sanitization functions (like `escapeHtml()`) to ALL variables interpolated into strings that will be assigned to `.innerHTML` or HTML attributes, regardless of their perceived "safe" origin.
+
+## 2026-06-02 - [DOM-based XSS in Tooltips and Search Cards]
+**Vulnerability:** Dynamic properties mapped from node data (`detailUrl` and `graphUrl`) were concatenated directly into the `href` and `data-result-url` attributes of HTML template strings in `docs/mini-graph.js`, `docs/graph.html`, and `docs/main.js` without escaping.
+**Learning:** While `encodeURIComponent` mitigates some injection vectors, it does not escape single quotes, leaving the attribute vulnerable if the injected string is wrapped in single quotes, or if it breaks out in other ways. Additionally, standard codebase security practice demands explicit escaping for all interpolated variables destined for HTML insertion to ensure robust defense in depth.
+**Prevention:** Consistently apply `escapeHtml()` to all URL variables before interpolating them into HTML attributes like `href="..."`, even when they appear to just consist of IDs or paths.

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2237,7 +2237,7 @@
              `<div class="tt-title">${escapeHtml(String(info.title || d.label))}</div>` +
              (summary ? `<div class="tt-summary">${escapeHtml(String(summary))}</div>` : '') +
              community +
-             `<a class="tt-link" href="${detailUrl}" target="_self">打开详情页 →</a>`;
+             `<a class="tt-link" href="${escapeHtml(detailUrl)}" target="_self">打开详情页 →</a>`;
     }
 
     function showTooltip(ev, d) {

--- a/docs/main.js
+++ b/docs/main.js
@@ -3768,12 +3768,12 @@
         ? '<span style="font-size:.72rem;color:var(--text-muted);margin-left:6px">'
           + matchExplanation(item, queryTokens) + '</span>'
         : '';
-      var graphBtn = '<a href="' + graphUrl + '" onclick="event.stopPropagation()" '
+      var graphBtn = '<a href="' + escapeHtml(graphUrl) + '" onclick="event.stopPropagation()" '
         + 'style="font-size:.75rem;opacity:.6;margin-left:8px;text-decoration:none" '
         + 'title="查看图谱邻居" tabindex="-1">🔗图谱</a>';
-      return '<article class="card" data-result-url="' + detailUrl + '">'
+      return '<article class="card" data-result-url="' + escapeHtml(detailUrl) + '">'
         + '<p class="card-meta" style="font-size:.75rem;margin-bottom:.25rem">' + escapeHtml(typeLabel) + explain + '</p>'
-        + '<h3><a href="' + detailUrl + '">' + escapeHtml(item.title || item.id) + '</a>' + graphBtn + '</h3>'
+        + '<h3><a href="' + escapeHtml(detailUrl) + '">' + escapeHtml(item.title || item.id) + '</a>' + graphBtn + '</h3>'
         + '<p>' + escapeHtml((item.summary || '').slice(0, 120)) + '</p>'
         + (tagLine ? '<div class="chip-list">' + tagLine + '</div>' : '')
         + '</article>';

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -55,7 +55,7 @@
       '<div class="tt-title">' + escapeHtml(String(d.label || d.id)) + '</div>' +
       (summary ? '<div class="tt-summary">' + escapeHtml(String(summary)) + '</div>' : '') +
       community +
-      '<a class="tt-link" href="' + detailUrl + '">打开详情页 →</a>';
+      '<a class="tt-link" href="' + escapeHtml(detailUrl) + '">打开详情页 →</a>';
   }
 
   function showTooltip(ev, d, nodeFill, communityLabelMap) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unsanitized URLs (`detailUrl` and `graphUrl`) constructed from node data were directly interpolated into HTML attributes (`href`, `data-result-url`) in `docs/main.js`, `docs/graph.html`, and `docs/mini-graph.js` without explicit HTML escaping.
🎯 Impact: While `encodeURIComponent` was used to build these URLs, relying on it alone for HTML attribute safety is insufficient and risky (e.g., single quotes are not escaped), potentially allowing DOM-based XSS if the data source contains malicious payloads.
🔧 Fix: Wrapped all URL variables in `escapeHtml()` prior to template string interpolation, aligning with the codebase's strict defense-in-depth sanitization policy.
✅ Verification: Ran `make ci-test` and verified the visual functionality of tooltips and search cards via Playwright screenshot to confirm escaping did not break URL resolution.

---
*PR created automatically by Jules for task [1470542878884646158](https://jules.google.com/task/1470542878884646158) started by @ImChong*