### PR TITLE
fix(ux): 图谱节点浮窗不再重复显示 type 摘要行

### DIFF
--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -93,8 +93,24 @@
     document.addEventListener('click', onClick);
   }
 
+  /** 与详情页一致：仅含 type 元数据的摘要不在浮窗正文重复展示 */
+  function isMetadataOnlySummary(summary) {
+    return /^type:\s*[\w-]+[。.]?$/i.test(String(summary || '').trim());
+  }
+
+  /** 浮窗摘要：过滤 type 占位行，并按 maxLen 截断 */
+  function formatTooltipSummary(raw, maxLen) {
+    var s = String(raw || '').trim();
+    if (!s || isMetadataOnlySummary(s)) return '';
+    maxLen = maxLen == null ? 100 : maxLen;
+    if (s.length > maxLen) return s.slice(0, maxLen) + '…';
+    return s;
+  }
+
   window.RNGraphTooltip = {
     bindBlankDismiss: bindGraphTooltipBlankDismiss,
-    bindOutsideDismiss: bindGraphTooltipOutsideDismiss
+    bindOutsideDismiss: bindGraphTooltipOutsideDismiss,
+    isMetadataOnlySummary: isMetadataOnlySummary,
+    formatTooltipSummary: formatTooltipSummary
   };
 })();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2223,11 +2223,17 @@
     /* ── 固定卡片状态（仅移动端使用）── */
     let pinnedNode = null;
 
+    function tooltipSummary(raw) {
+      return window.RNGraphTooltip?.formatTooltipSummary
+        ? window.RNGraphTooltip.formatTooltipSummary(raw, 100)
+        : (raw || '');
+    }
+
     function tooltipHtml(d) {
       const color = nodeColor(d);
       const info = d._info;
       const typeLabel = TYPE_LABEL[d.type] || d.type || 'Wiki';
-      const summary = (info.summary || '').slice(0, 100) + (info.summary?.length > 100 ? '…' : '');
+      const summary = tooltipSummary(info.summary);
       const detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
       const communityLabel = communityLabelMap.get(d.community);
       const community = communityLabel

--- a/docs/main.js
+++ b/docs/main.js
@@ -2200,11 +2200,17 @@
     formalization: '形式化', '': 'Wiki'
   };
 
+  function formatGraphTooltipSummary(raw) {
+    if (window.RNGraphTooltip && window.RNGraphTooltip.formatTooltipSummary) {
+      return window.RNGraphTooltip.formatTooltipSummary(raw, 100);
+    }
+    return raw || '';
+  }
+
   function buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId) {
     var color = nodeFill(d);
     var typeLabel = GRAPH_NODE_TYPE_LABEL[d.type] || d.type || 'Wiki';
-    var summary = d.summary || '';
-    if (summary.length > 100) summary = summary.slice(0, 100) + '…';
+    var summary = formatGraphTooltipSummary(d.summary);
     var communityLabel = d.community && communityLabelMap[d.community];
     var community = communityLabel
       ? '<div class="tt-summary">社区：' + escapeHtml(String(communityLabel)) + '</div>'
@@ -2597,6 +2603,9 @@
     }
 
     function isMetadataOnlySummary(summary) {
+      if (window.RNGraphTooltip && window.RNGraphTooltip.isMetadataOnlySummary) {
+        return window.RNGraphTooltip.isMetadataOnlySummary(summary);
+      }
       return /^type:\s*[\w-]+[。.]?$/i.test(String(summary || '').trim());
     }
 

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -40,11 +40,16 @@
     };
   }
 
+  function tooltipSummary(raw) {
+    return window.RNGraphTooltip && window.RNGraphTooltip.formatTooltipSummary
+      ? window.RNGraphTooltip.formatTooltipSummary(raw, 100)
+      : (raw || '');
+  }
+
   function tooltipHtml(d, nodeFill, communityLabelMap) {
     var color = nodeFill(d);
     var typeLabel = TYPE_LABEL[d.type] || d.type || 'Wiki';
-    var summary = d.summary || '';
-    if (summary.length > 100) summary = summary.slice(0, 100) + '…';
+    var summary = tooltipSummary(d.summary);
     var detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
     var communityLabel = d.community && communityLabelMap[d.community];
     var community = communityLabel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 节点悬浮/固定浮窗顶部已有中文类型标签（如「方法」）时，不再在标题下方重复展示 `type: method。` 等仅占位用的摘要行。
- 在 `docs/graph-tooltip.js` 新增共享的 `formatTooltipSummary` / `isMetadataOnlySummary`，与详情页摘要隐藏逻辑对齐。
- 覆盖首页迷你图谱（`mini-graph.js`）、完整图谱（`graph.html`）与详情页迷你图（`main.js`）三处 tooltip 渲染。

## 验证
- `npm run lint:js` 通过
- 逻辑：当 `summary` 全文匹配 `^type:\s*[\w-]+[。.]?$` 时，浮窗正文不渲染摘要区块，仅保留类型标签、标题、社区（若有）与详情链接
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-445a9208-8caa-42a8-98ee-660cd7571bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-445a9208-8caa-42a8-98ee-660cd7571bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

