### PR TITLE
test(wiki): 社区命名测试改读 link-graph 快照，加速 CI

### DIFF
--- a/tests/test_community_naming.py
+++ b/tests/test_community_naming.py
@@ -21,9 +21,7 @@ def _load_exported_communities() -> list[dict[str, Any]]:
     data = json.loads(LINK_GRAPH_SNAPSHOT.read_text(encoding="utf-8"))
     communities = data.get("communities")
     if not isinstance(communities, list) or not communities:
-        raise ValueError(
-            f"{LINK_GRAPH_SNAPSHOT.name} 缺少非空 communities 数组；请重新 make graph"
-        )
+        raise ValueError(f"{LINK_GRAPH_SNAPSHOT.name} 缺少非空 communities 数组；请重新 make graph")
     return communities
 
 

--- a/tests/test_community_naming.py
+++ b/tests/test_community_naming.py
@@ -1,10 +1,30 @@
-"""图谱社区命名：中文（English） 社区 格式校验与 override 覆盖。"""
+"""图谱社区命名：中文（English） 社区 格式校验（读 exports/link-graph.json 快照）。"""
 
 from __future__ import annotations
 
+import json
 import unittest
+from typing import Any
 
 import generate_link_graph as glg
+
+LINK_GRAPH_SNAPSHOT = glg.OUT_PATH
+
+
+def _load_exported_communities() -> list[dict[str, Any]]:
+    """读取 make graph 产出的 link-graph.json，避免在 pytest 中重跑全库社区检测。"""
+    if not LINK_GRAPH_SNAPSHOT.is_file():
+        raise FileNotFoundError(
+            f"缺少 {LINK_GRAPH_SNAPSHOT.relative_to(glg.REPO_ROOT)}；"
+            "请先运行 make graph 或 make ci-preflight"
+        )
+    data = json.loads(LINK_GRAPH_SNAPSHOT.read_text(encoding="utf-8"))
+    communities = data.get("communities")
+    if not isinstance(communities, list) or not communities:
+        raise ValueError(
+            f"{LINK_GRAPH_SNAPSHOT.name} 缺少非空 communities 数组；请重新 make graph"
+        )
+    return communities
 
 
 class CommunityHubNamePatternTest(unittest.TestCase):
@@ -32,20 +52,28 @@ class CommunityHubNamePatternTest(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertIsNone(glg.COMMUNITY_HUB_NAME_RE.fullmatch(name))
 
-    def test_overrides_cover_current_hubs(self) -> None:
-        """当前图谱全部命名社区（除「其他社区」）均应有 conforming override。"""
-        nodes, edges = glg._build_graph_data()
-        _communities, community_meta = glg.assign_communities(nodes, edges)
-        for meta in community_meta.values():
-            if meta["id"] == glg.OTHER_COMMUNITY_ID:
+    def test_community_name_overrides_match_pattern(self) -> None:
+        """COMMUNITY_NAME_OVERRIDES 中每条基名应符合命名规范。"""
+        for hub_id, hub_name in glg.COMMUNITY_NAME_OVERRIDES.items():
+            with self.subTest(hub_id=hub_id):
+                self.assertIsNotNone(
+                    glg.COMMUNITY_HUB_NAME_RE.fullmatch(hub_name),
+                    f"override {hub_id!r} name={hub_name!r}",
+                )
+
+    def test_exported_community_labels_conform_to_pattern(self) -> None:
+        """快照里全部命名社区（除「其他社区」）的 label 应符合 中文（English） 社区。"""
+        for meta in _load_exported_communities():
+            if meta.get("id") == glg.OTHER_COMMUNITY_ID:
                 continue
-            label = str(meta["label"])
-            self.assertTrue(label.endswith(" 社区"), label)
-            hub_name = label[: -len(" 社区")]
-            self.assertIsNotNone(
-                glg.COMMUNITY_HUB_NAME_RE.fullmatch(hub_name),
-                f"community {meta['id']!r} label={label!r} hub={meta.get('hub_id')!r}",
-            )
+            label = str(meta.get("label", ""))
+            with self.subTest(community_id=meta.get("id"), label=label):
+                self.assertTrue(label.endswith(" 社区"), label)
+                hub_name = label[: -len(" 社区")]
+                self.assertIsNotNone(
+                    glg.COMMUNITY_HUB_NAME_RE.fullmatch(hub_name),
+                    f"community {meta.get('id')!r} label={label!r} hub={meta.get('hub_id')!r}",
+                )
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

PR #517 已合并 HoST ingest 等内容；本 PR 单独承接此前留在 `cursor/host-standingup-ingest-26a2` 上的测试优化：社区命名校验改为读取 `exports/link-graph.json` 快照，不再在 pytest 内调用全库 Girvan-Newman/Louvain 社区检测。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make test` — 136 passed，约 3.5s（原 `test_overrides_cover_current_hubs` 单次约 7 分钟）
- [ ] `make ci-preflight`（仅改测试，未动 wiki/导出链）

## 技术说明

| 原行为 | 新行为 |
|--------|--------|
| `test_overrides_cover_current_hubs` 每次 pytest 调用 `_build_graph_data()` + `assign_communities()` | `test_exported_community_labels_conform_to_pattern` 读取 `glg.OUT_PATH`（`exports/link-graph.json`） |
| — | 新增 `test_community_name_overrides_match_pattern` 校验 `COMMUNITY_NAME_OVERRIDES` 格式 |

社区划分正确性仍由 `make graph` / CI 导出链路保证；本测试只校验已导出快照的 label 是否符合 `中文（English） 社区` 规范。

## 相关 Issue

无（承接 PR #517 合并后的遗留测试改动）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39bf61cf-4fef-4d99-8437-59c7e2dd26a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39bf61cf-4fef-4d99-8437-59c7e2dd26a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

