### PR TITLE
fix(ux): 修复移动端图谱筛选面板底部裁切与清除按钮不可见

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -678,7 +678,10 @@
       color: rgba(0,0,0,0.35);
     }
     [data-theme="light"] .filter-item input[type=checkbox] { accent-color: #1659b4; }
-    [data-theme="light"] .filter-footer { border-top-color: rgba(0,0,0,0.07); }
+    [data-theme="light"] .filter-footer {
+      border-top-color: rgba(0,0,0,0.07);
+      background: rgba(250,249,246,0.98);
+    }
     [data-theme="light"] .filter-clear {
       border-color: rgba(0,0,0,0.1);
       color: rgba(0,0,0,0.4);
@@ -1157,13 +1160,32 @@
         pointer-events: none !important;
       }
       .filter-panel {
-        width: min(260px, calc(100vw - 40px)) !important;
-        height: auto !important;
-        max-height: min(72vh, 520px);
+        position: fixed;
+        top: calc(var(--header-h) + 46px + 8px);
+        left: 12px;
+        width: min(300px, calc(100vw - 24px)) !important;
+        height: min(520px, calc(100dvh - var(--header-h) - 46px - 20px)) !important;
+        max-height: min(520px, calc(100dvh - var(--header-h) - 46px - 20px));
+        z-index: 31;
+      }
+      .filter-topic-section[open] .filter-topic-chips {
+        max-height: 96px;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
       }
       .filter-body {
-        max-height: 240px;
-        flex: none;
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+      .filter-footer {
+        flex-shrink: 0;
+        position: sticky;
+        bottom: 0;
+        z-index: 2;
+        background: rgba(13,17,23,0.97);
       }
       .filter-close {
         padding: 8px 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 移动端 `graph.html` 筛选面板在展示 17 个社区后，因 `max-height` + `overflow: hidden` 导致底部「清除全部」被裁切、列表显示不全
- 改为 flex 列布局：面板占满可用视口高度，社区列表区域可滚动，页脚 sticky 固定；专题 chips 展开时限制高度并独立滚动

## 根因
筛选面板顶部区块（专题视图、维度切换、连接数滑块）在移动端占用较多高度，再叠加 `filter-body` 固定 `max-height: 240px` 与面板 `height: auto`，总高度超出 `max-height` 后 `overflow: hidden` 裁掉了 `.filter-footer` 中的清除按钮。

## 验证
- 390×844 移动端视口 Puppeteer 验证：`filter-clear` 在面板可视区域内（`clearVisible: true`）
- 社区列表 `scrollHeight` > `clientHeight`，可滚动浏览全部 17 项

## 验证截图
![移动端筛选面板 — 清除全部按钮可见](https://cursor.com/artifacts/c/art-f5aa04ea-e47e-4bae-a760-39ed45720548)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c019dc4-49a3-442b-b38d-3c011671a35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c019dc4-49a3-442b-b38d-3c011671a35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

