### PR TITLE
fix(ux): 统一 TOC 网格布局，子序号左缘与父文字对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -679,33 +679,45 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .detail-toc-panel[hidden] {
   display: none;
 }
+.detail-toc-list {
+  --toc-marker-width: 2.25em;
+}
 .detail-toc-list ol {
+  list-style: none;
   margin: 0;
-  padding-left: 2.5em;
-  list-style-position: outside;
-}
-.detail-toc-list ol ol {
-  margin-top: .35em;
-  margin-bottom: 0;
-  padding-left: 0;
-  margin-left: 0;
-}
-.detail-toc-list ol ol > li {
-  list-style-position: inside;
-}
-.detail-toc-list ol ol ol {
-  padding-left: 2em;
-}
-.detail-toc-list ol ol ol > li {
-  list-style-position: inside;
+  padding: 0;
+  counter-reset: toc;
 }
 .detail-toc-list li {
-  list-style-position: outside;
+  counter-increment: toc;
+  display: grid;
+  grid-template-columns: var(--toc-marker-width) minmax(0, 1fr);
+  column-gap: .35em;
+  align-items: start;
 }
-.detail-toc-list li + li {
+.detail-toc-list li::before {
+  content: counter(toc) ".";
+  grid-column: 1;
+  grid-row: 1;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.detail-toc-list li > a,
+.detail-toc-list li > .toc-entry {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+}
+.detail-toc-list li > ol {
+  grid-column: 2;
+  grid-row: 2;
+  margin-top: .35em;
+  counter-reset: toc;
+}
+.detail-toc-list ol > li + li {
   margin-top: .5em;
 }
-.detail-toc-list ol ol li + li {
+.detail-toc-list ol ol > li + li {
   margin-top: .35em;
 }
 .detail-toc-list a,
@@ -713,12 +725,12 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--text);
   border-radius: 8px;
   padding: 2px 6px;
-  margin-left: -6px;
+  margin: 0;
   transition: color var(--transition), background var(--transition);
   overflow-wrap: anywhere;
 }
 .detail-toc-list .toc-entry {
-  display: inline;
+  display: block;
   cursor: pointer;
 }
 .detail-toc-list .toc-entry a {

--- a/docs/style.css
+++ b/docs/style.css
@@ -702,6 +702,13 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
+/* 子级：序号左缘与父项文字左缘对齐（不用与父序号列对齐） */
+.detail-toc-list ol ol > li {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+.detail-toc-list ol ol > li::before {
+  text-align: left;
+}
 .detail-toc-list li > a,
 .detail-toc-list li > .toc-entry {
   grid-column: 2;

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -385,6 +385,8 @@ console.log('ok');
             ".detail-toc-list .toc-entry a",
             "--toc-marker-width",
             "grid-template-columns: var(--toc-marker-width)",
+            ".detail-toc-list ol ol > li::before",
+            "text-align: left",
             ".detail-hash-target",
             ".detail-markdown-body hr",
         ]

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -383,7 +383,8 @@ console.log('ok');
             ".detail-toc-list a.active",
             ".detail-toc-list .toc-entry.active",
             ".detail-toc-list .toc-entry a",
-            ".detail-toc-list ol ol > li",
+            "--toc-marker-width",
+            "grid-template-columns: var(--toc-marker-width)",
             ".detail-hash-target",
             ".detail-markdown-body hr",
         ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 侧栏 TOC 使用统一 **grid + CSS counter** 布局
- **子序号左缘**与父项**文字左缘**对齐（不是序号中心对准文字）
- 嵌套层序号列 `auto` + 左对齐；嵌套 `ol` 仍在父文字列内（支持 h4 等多层）
- 去掉 TOC 链接左右 `padding`，避免子序号相对父文字视觉偏移
- 标题换行时后续行与首行文字同列对齐

## 验证
- `make test` 通过
- 实测 L−1 / L4 / L4.0 下子项：`markerLeft - parentTextLeft === 0`

## 验证截图
![子序号左缘与父文字左缘对齐](https://cursor.com/artifacts/c/art-0ed2a409-bab2-430e-b3ac-767a7d2feff7)

![路线页全页截图](https://cursor.com/artifacts/c/art-94c561a2-91ef-4f70-b0d6-be804ff0c839)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39700b51-5ba6-4091-9873-1a8a7fb10064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39700b51-5ba6-4091-9873-1a8a7fb10064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

