### PR TITLE
fix(ux): TOC 子序号左缘与父文字左缘精确对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -702,7 +702,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
-/* 子级：序号左缘与父项文字左缘对齐（不用与父序号列对齐） */
+/* 子级：序号左缘与父项文字左缘对齐（嵌套 ol 仍在文字列内） */
 .detail-toc-list ol ol > li {
   grid-template-columns: auto minmax(0, 1fr);
 }
@@ -731,7 +731,8 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .detail-toc-list .toc-entry {
   color: var(--text);
   border-radius: 8px;
-  padding: 2px 6px;
+  /* 无左右 padding，避免子序号列与父文字左缘错位 */
+  padding: 2px 0;
   margin: 0;
   transition: color var(--transition), background var(--transition);
   overflow-wrap: anywhere;

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -387,6 +387,7 @@ console.log('ok');
             "grid-template-columns: var(--toc-marker-width)",
             ".detail-toc-list ol ol > li::before",
             "text-align: left",
+            "padding: 2px 0",
             ".detail-hash-target",
             ".detail-markdown-body hr",
         ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- #525 合并后仍遗留 TOC 链接 `padding: 2px 6px`，导致子序号相对父文字视觉偏移（像序号中心对准文字）
- 改为 `padding: 2px 0`，使**子序号左缘**与父项**文字左缘**对齐

## 验证
- `make test` 通过
- `roadmap.html?id=roadmap-motion-control`：L4 子项 `markerLeft - parentTextLeft === 0`，侧栏 `panelLeft: 144`（左侧序号列完整可见）

## 验证截图
![路线页全页截图（含完整 TOC）](https://cursor.com/artifacts/c/art-94c561a2-91ef-4f70-b0d6-be804ff0c839)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39700b51-5ba6-4091-9873-1a8a7fb10064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39700b51-5ba6-4091-9873-1a8a7fb10064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

