### PR TITLE
feat(docs): V23 P3 详情页「最近相关 ingest」时间线

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v23.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v23.md
@@ -48,8 +48,8 @@
 
 ## P3: 交互层"时间维度"增强 (UX/UI)
 
-- [ ] **详情页"最近相关 ingest"时间线**：
-    - [ ] 在 `docs/detail.html` 的「关联页面」附近新增 `#detailRecentIngestTimeline` 容器：基于 `exports/link-graph.json` 的 `latest_wiki_nodes` 与当前节点 1-hop 邻居取交集，展示最近 30 天内入库的相关页面（最多 6 项，按 `recency` 倒序）；空态降级隐藏（不显示标题）。
+- [x] **详情页"最近相关 ingest"时间线**：
+    - [x] 在 `docs/detail.html` 的「关联页面」附近新增 `#detailRecentIngestTimeline` 容器：基于 `exports/link-graph.json` 的 `latest_wiki_nodes` 与当前节点 1-hop 邻居取交集，展示最近 30 天内入库的相关页面（最多 6 项，按 `recency` 倒序）；空态降级隐藏（不显示标题）。（2026-06-05：在 `detail-related` 与 `detail-recommended` 之间新增 `#detail-recent-ingest-section`（默认 `hidden`，空态整段含标题不渲染）；`docs/main.js` 新增 `renderDetailRecentIngestTimeline(detailPage)`，并发拉取 `link-graph.json`（算 1-hop 邻居）与 `graph-stats.json`（取 `latest_wiki_nodes`）取交集，窗口锚定到最新一条 ingest 回溯 30 天，避免静态站随时间陈化整段消失，按 `recency` 倒序、最多 6 项，复用 `WIKI_TYPE_LABEL_HOME` 类型标签；在 `renderDetailMiniMap` 调用后挂载。`docs/style.css` 新增 `.detail-recent-ingest-*` 轻量时间线样式（左缘强调条 + 日期徽标 + 类型/标题两行）。`node --check` + `eslint docs/main.js` 全绿、`make lint` 全部检查通过；BFM 详情页验证截图命中 5 项（Foundation Policy / SONIC / BFM 分类 02 / 选型指南 / WBT pipeline）。）
 - [ ] **图谱页"专题视图"扩充**：
     - [ ] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V22 10 项基础上新增「全身运动跟踪（WBT）」「跨具身迁移」「真机安全微调」三个专题；命中规则复用 V22 community id + path 片段双路并集机制；新增视图均配 Puppeteer 截图归档到 `.cursor-artifacts/screenshots/`。
 

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -122,6 +122,12 @@
             </div>
           </section>
 
+          <section class="section" id="detail-recent-ingest-section" style="padding: 40px 0;" hidden>
+            <h2 class="section-title">最近相关 ingest</h2>
+            <p class="section-subtitle">与本页相关、最近 30 天内入库的页面（按入库时间倒序，最多 6 项）。</p>
+            <div id="detailRecentIngestTimeline" class="detail-recent-ingest-timeline"></div>
+          </section>
+
           <section class="section" id="detail-recommended" style="padding: 40px 0;">
             <h2 class="section-title">相关推荐</h2>
             <div id="detailRecommendedList" class="card-grid data-loading">

--- a/docs/main.js
+++ b/docs/main.js
@@ -2386,6 +2386,69 @@
     return idx;
   }
 
+  // V23 P3：详情页「最近相关 ingest」时间线。
+  // 取 graph-stats.json 的 latest_wiki_nodes 与当前节点的 1-hop 邻居（来自 link-graph.json）的交集，
+  // 仅保留最近 30 天内入库的页面（窗口锚定到最新一条 ingest，避免静态站随时间陈化后整段消失），
+  // 最多 6 项，按 recency 倒序。空态时整段（含标题）隐藏。
+  function renderDetailRecentIngestTimeline(detailPage) {
+    var section = document.getElementById('detail-recent-ingest-section');
+    var listEl = document.getElementById('detailRecentIngestTimeline');
+    if (!section || !listEl) return;
+    var currentPath = (detailPage && detailPage.path) || '';
+    if (!currentPath) { section.hidden = true; return; }
+
+    Promise.all([
+      fetch('exports/link-graph.json').then(function (r) { return r.json(); }),
+      fetch('exports/graph-stats.json').then(function (r) { return r.json(); })
+    ]).then(function (res) {
+      var gd = res[0];
+      var stats = res[1];
+      var neighborSet = {};
+      (gd.edges || []).forEach(function (e) {
+        if (e.source === e.target) return;
+        if (e.source === currentPath) neighborSet[e.target] = true;
+        else if (e.target === currentPath) neighborSet[e.source] = true;
+      });
+
+      var latest = Array.isArray(stats.latest_wiki_nodes) ? stats.latest_wiki_nodes : [];
+      var dated = latest.filter(function (n) {
+        return n && n.path && n.detail_id && !isNaN(Date.parse(n.recency));
+      });
+      if (!dated.length) { section.hidden = true; return; }
+
+      // 以最新一条 ingest 作为窗口锚点，30 天回溯。
+      var anchor = dated.reduce(function (mx, n) {
+        var t = Date.parse(n.recency);
+        return t > mx ? t : mx;
+      }, 0);
+      var WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+      var MAX_ITEMS = 6;
+
+      var items = dated.filter(function (n) {
+        if (n.path === currentPath || !neighborSet[n.path]) return false;
+        return (anchor - Date.parse(n.recency)) <= WINDOW_MS;
+      });
+      items.sort(function (a, b) { return String(b.recency).localeCompare(String(a.recency)); });
+      if (items.length > MAX_ITEMS) items = items.slice(0, MAX_ITEMS);
+
+      if (!items.length) { section.hidden = true; return; }
+      section.hidden = false;
+      listEl.innerHTML = items.map(function (n) {
+        var typeLabel = WIKI_TYPE_LABEL_HOME[n.type] || (n.type ? String(n.type) : 'Wiki');
+        return (
+          '<a class="detail-recent-ingest-item" href="' + escapeHtml(detailHref(n.detail_id)) + '">' +
+          '<span class="detail-recent-ingest-date">' + escapeHtml(String(n.recency)) + '</span>' +
+          '<span class="detail-recent-ingest-body">' +
+          '<span class="detail-recent-ingest-type">' + escapeHtml(typeLabel) + '</span>' +
+          '<span class="detail-recent-ingest-label">' + escapeHtml(n.label || n.detail_id) + '</span>' +
+          '</span></a>'
+        );
+      }).join('');
+    }).catch(function () {
+      section.hidden = true;
+    });
+  }
+
   function renderDetailMiniMap(detailPage, detailPages) {
     var wrap = document.getElementById('detailMiniMapWrap');
     var svgEl = document.getElementById('detailMiniMapSvg');
@@ -2763,6 +2826,7 @@
     renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。');
 
     renderDetailMiniMap(detailPage, detailPages);
+    renderDetailRecentIngestTimeline(detailPage);
 
     var hashForLayoutScroll = window.location.hash.replace(/^#/, '');
     var emergencyLayoutScrollTimer = null;

--- a/docs/style.css
+++ b/docs/style.css
@@ -343,6 +343,34 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   margin: 0;
 }
 .section-subtitle { color: var(--text-muted); font-size: .97rem; margin-bottom: 28px; max-width: 72ch; }
+.detail-recent-ingest-timeline { display: grid; gap: 10px; }
+.detail-recent-ingest-item {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  border-left: 3px solid rgba(45,116,218,.45);
+  border-radius: 10px;
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color var(--transition), background var(--transition), transform var(--transition);
+}
+.detail-recent-ingest-item:hover {
+  border-color: rgba(45,116,218,.5);
+  background: rgba(45,116,218,.06);
+  transform: translateX(2px);
+}
+.detail-recent-ingest-date {
+  flex: 0 0 auto;
+  font-size: .82rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.detail-recent-ingest-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.detail-recent-ingest-type { font-size: .76rem; color: var(--text-muted); }
+.detail-recent-ingest-label { font-weight: 650; letter-spacing: -.01em; }
 .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
 .card {
   padding: 20px;

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-05] structural | docs — V23 P3 详情页「最近相关 ingest」时间线
+
+- 清单推进：[tech-stack-next-phase-checklist-v23.md](docs/checklists/tech-stack-next-phase-checklist-v23.md) P3 首项打勾
+- 前端改动：[docs/detail.html](docs/detail.html) 在 `detail-related` 与 `detail-recommended` 之间新增 `#detail-recent-ingest-section`（默认 `hidden`，空态整段含标题不渲染）；[docs/main.js](docs/main.js) 新增 `renderDetailRecentIngestTimeline`，并发取 `link-graph.json`（1-hop 邻居）与 `graph-stats.json`（`latest_wiki_nodes`）求交，窗口锚定最新一条 ingest 回溯 30 天，按 `recency` 倒序、最多 6 项；[docs/style.css](docs/style.css) 新增 `.detail-recent-ingest-*` 时间线样式
+- 验证：`node --check` + `eslint docs/main.js` 全绿、`make lint` 全部检查通过；BFM 详情页截图命中 5 项
+
 ## [2026-06-05] structural | wiki — 连接度前 50 hub 页补齐英文缩写速查（第 11–50 名，40 页）
 
 - 依据 `exports/link-graph.json` 总度排序：第 1–10 名已在 main，本次为第 11–50 名共 40 页新增 `## 英文缩写速查`；批量工具 `scripts/batch_insert_abbrev_glossary.py`


### PR DESCRIPTION
## 摘要

在详情页「关联项」与「相关推荐」之间新增「最近相关 ingest」时间线模块，展示与当前页面相关、最近 30 天内入库的页面（最多 6 项，按入库时间倒序）。基于 `link-graph.json` 的 1-hop 邻居与 `graph-stats.json` 的 `latest_wiki_nodes` 求交，窗口锚定到最新一条 ingest 回溯 30 天，避免静态站随时间陈化后整段消失。空态时整段含标题隐藏。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他

## 详细改动

### `docs/detail.html`
- 在 `#detail-related` 与 `#detail-recommended` 之间新增 `#detail-recent-ingest-section`（默认 `hidden`）
- 包含标题「最近相关 ingest」、说明文案及 `#detailRecentIngestTimeline` 容器

### `docs/main.js`
- 新增 `renderDetailRecentIngestTimeline(detailPage)` 函数
- 并发拉取 `link-graph.json`（计算当前节点 1-hop 邻居）与 `graph-stats.json`（取 `latest_wiki_nodes`）
- 求交集，过滤出最近 30 天内入库的相关页面（窗口锚定到最新一条 ingest）
- 按 `recency` 倒序，最多 6 项；复用 `WIKI_TYPE_LABEL_HOME` 类型标签
- 空态时隐藏整个 section；在 `renderDetailMiniMap` 调用后挂载

### `docs/style.css`
- 新增 `.detail-recent-ingest-timeline`：grid 布局，10px 间距
- 新增 `.detail-recent-ingest-item`：卡片样式，左缘 3px 蓝色强调条，hover 时背景变浅、向右平移 2px
- 新增 `.detail-recent-ingest-date`：日期徽标，等宽数字、浅灰色
- 新增 `.detail-recent-ingest-body`：flex 列布局，容纳类型与标题
- 新增 `.detail-recent-ingest-type`：浅灰色小字
- 新增 `.detail-recent-ingest-label`：加粗标题

### `log.md` 与 `docs/checklists/tech-stack-next-phase-checklist-v23.md`
- 记录本次改动日期、内容及验证结果
- 将 P3 首项「详情页&#39;最近相关 ingest&#39;时间线」标记为完成

## 验证

- [x] `node --check docs/main.js` 通过
- [x] `eslint docs/main.js` 通过
- [x] `make lint` 全部检查通过
- [x] BFM 详情页（`wiki-concepts-behavior-foundation-model`）验证截图命中 5 项：Foundation Policy / SONIC / BFM 分类 02 / 选型指南 / WBT pipeline

## 验证截图

`&lt;img alt="详情页「最近相关 ingest」时间线截图（BFM 详情页命中 5 项）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-recent-ingest.png" /&gt;`
