### PR TITLE
Add sim2real alias to wiki search index

### DIFF
--- a/scripts/search_wiki_core.py
+++ b/scripts/search_wiki_core.py
@@ -86,6 +86,7 @@ CANONICAL_TOPIC_PAGES: dict[str, str] = {
     "control barrier function": "wiki/concepts/control-barrier-function.md",
     "vla": "wiki/methods/vla.md",
     "vision-language-action": "wiki/methods/vla.md",
+    "sim2real": "wiki/concepts/sim2real.md",
 }
 
 COMPARISON_INTENT_MARKERS = frozenset(


### PR DESCRIPTION
## 摘要

为 wiki 搜索索引添加 "sim2real" 别名，指向 `wiki/concepts/sim2real.md` 页面，便于用户通过该术语快速查找相关内容。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`
- [ ] 其他：无需额外测试，仅为别名映射添加

## 相关 Issue

无

https://claude.ai/code/session_012CCEJ1EKsQ5sWXxExMhuSa