### PR TITLE
V23 完成 + V24 清单启动：图谱专题视图扩充与工具链准备

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Wiki Lint](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-690节点_4993边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
-[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-100%25-green)](docs/checklists/tech-stack-next-phase-checklist-v23.md)
+[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-100%25-green)](docs/checklists/tech-stack-next-phase-checklist-v24.md)
 
 
 
@@ -66,7 +66,7 @@
 
 ## 维护看板
 
-- 当前技术栈执行清单：[V23](docs/checklists/tech-stack-next-phase-checklist-v23.md)
+- 当前技术栈执行清单：[V24](docs/checklists/tech-stack-next-phase-checklist-v24.md)
 - 前端体验优化清单：[frontend-optimization-v1](docs/checklists/frontend-optimization-v1.md)
 - 历史执行清单索引：[docs/checklists/README.md](docs/checklists/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 `docs/` 是 GitHub Pages 展示层和历史资料暂存区。当前前端页面、导出数据镜像、执行清单都在这里维护。
 
 常用入口：
-- [当前技术栈执行清单 v23](checklists/tech-stack-next-phase-checklist-v23.md)
+- [当前技术栈执行清单 v24](checklists/tech-stack-next-phase-checklist-v24.md)
 - [前端体验优化清单 v1](checklists/frontend-optimization-v1.md)
 - [历史执行清单索引](checklists/README.md)
 - [展示层变更记录](change-log.md)

--- a/docs/checklists/README.md
+++ b/docs/checklists/README.md
@@ -4,7 +4,7 @@
 
 ## 当前入口
 
-- [技术栈项目执行清单 v23](tech-stack-next-phase-checklist-v23.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
+- [技术栈项目执行清单 v24](tech-stack-next-phase-checklist-v24.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
 - [前端体验优化清单 v1](frontend-optimization-v1.md) — GitHub Pages 首页与交互体验优化计划。
 - [Cursor Cloud Agent：PR 与验证截图流程](cloud-agent-pr-workflow.md) — Cloud Agent 推送分支、开 PR、附验证截图的路径约定。
 - [GitHub Actions CI 门禁](github-actions-ci-gate.md) — 合并 `main` 前必须等全量 Actions 全绿；branch protection 建议。
@@ -35,6 +35,7 @@
 - [v20](tech-stack-next-phase-checklist-v20.md)
 - [v21](tech-stack-next-phase-checklist-v21.md)
 - [v22](tech-stack-next-phase-checklist-v22.md)
+- [v23](tech-stack-next-phase-checklist-v23.md)
 
 ## 维护规则
 

--- a/docs/checklists/tech-stack-next-phase-checklist-v23.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v23.md
@@ -50,18 +50,18 @@
 
 - [x] **详情页"最近相关 ingest"时间线**：
     - [x] 在 `docs/detail.html` 的「关联页面」附近新增 `#detailRecentIngestTimeline` 容器：基于 `exports/link-graph.json` 的 `latest_wiki_nodes` 与当前节点 1-hop 邻居取交集，展示最近 30 天内入库的相关页面（最多 6 项，按 `recency` 倒序）；空态降级隐藏（不显示标题）。（2026-06-05：在 `detail-related` 与 `detail-recommended` 之间新增 `#detail-recent-ingest-section`（默认 `hidden`，空态整段含标题不渲染）；`docs/main.js` 新增 `renderDetailRecentIngestTimeline(detailPage)`，并发拉取 `link-graph.json`（算 1-hop 邻居）与 `graph-stats.json`（取 `latest_wiki_nodes`）取交集，窗口锚定到最新一条 ingest 回溯 30 天，避免静态站随时间陈化整段消失，按 `recency` 倒序、最多 6 项，复用 `WIKI_TYPE_LABEL_HOME` 类型标签；在 `renderDetailMiniMap` 调用后挂载。`docs/style.css` 新增 `.detail-recent-ingest-*` 轻量时间线样式（左缘强调条 + 日期徽标 + 类型/标题两行）。`node --check` + `eslint docs/main.js` 全绿、`make lint` 全部检查通过；BFM 详情页验证截图命中 5 项（Foundation Policy / SONIC / BFM 分类 02 / 选型指南 / WBT pipeline）。）
-- [ ] **图谱页"专题视图"扩充**：
-    - [ ] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V22 10 项基础上新增「全身运动跟踪（WBT）」「跨具身迁移」「真机安全微调」三个专题；命中规则复用 V22 community id + path 片段双路并集机制；新增视图均配 Puppeteer 截图归档到 `.cursor-artifacts/screenshots/`。
+- [x] **图谱页"专题视图"扩充**：
+    - [x] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V22 10 项基础上新增「全身运动跟踪（WBT）」「跨具身迁移」「真机安全微调」三个专题；命中规则复用 V22 community id + path 片段双路并集机制；新增视图均配 Puppeteer 截图归档到 `.cursor-artifacts/screenshots/`。（2026-06-06：`TOPIC_FILTERS` 新增三项——`wbt`（segments：wbt/tracking/beyondmimic/sdamp/heracles/opentrack/maskedmimic/sonic/any2any/twist/twist2，命中 22 节点）、`cross-embodiment`（segments：embodiment/any2any/transfer，命中 3 节点）、`safe-fine-tuning`（community-13 + segments：safe/safety/cbf/clf/barrier/lyapunov/slowrl/lora/cmdp，命中 18 节点）；`#filter-topic-chips` 同步新增三枚 `data-topic` chip（🕺 WBT / 🔀 跨具身 / 🛡️ 安全微调），复用既有 `nodeMatchesTopic` 双路并集逻辑无需改动。把已过时的 `scripts/screenshot_graph_topic.cjs`（仍点击 V22 移除的 `#topic-view` 下拉）改为展开 `#filter-topic-section` 后点击 `[data-topic]` chip。`make lint` 全绿（仅 1 条无关信息型预警）、内联 JS `new Function` 语法校验通过；三专题视图截图归档至 `.cursor-artifacts/screenshots/graph-topic-{wbt,cross-embodiment,safe-fine-tuning}.png`。）
 
 ---
 
 ## 验收标准 (Definition of DoD)
 
-- [ ] `make lint`: 0 errors（含新引入的 `entity_paper_metadata_check` INFO 级检查不阻塞 CI）。
-- [ ] 知识图谱节点数 **≥ 445**，边数 **≥ 3320**（见 `exports/graph-stats.json`）。
-- [ ] 事实库扩展至 **170 条** 以上（重点补 WBT 跨具身 / 真机安全微调 矛盾检测规则）。
-- [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。
-- [ ] `log.md` 记录 V23 关键改动。
+- [x] `make lint`: 0 errors（含新引入的 `entity_paper_metadata_check` INFO 级检查不阻塞 CI）。（2026-06-06：0 errors，仅 1 条无关信息型预警）
+- [x] 知识图谱节点数 **≥ 445**，边数 **≥ 3320**（见 `exports/graph-stats.json`）。（2026-06-06：690 节点 / 4993 边）
+- [x] 事实库扩展至 **170 条** 以上（重点补 WBT 跨具身 / 真机安全微调 矛盾检测规则）。（2026-06-06：172 条）
+- [x] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。（2026-06-06：`largest_community_ratio` 0.104、warning false）
+- [x] `log.md` 记录 V23 关键改动。（2026-06-06：P0–P3 各项均有 log 条目，P3 末项与全部完成已补记）
 
 ---
 

--- a/docs/checklists/tech-stack-next-phase-checklist-v24.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v24.md
@@ -1,0 +1,72 @@
+# 技术栈项目执行清单 v24
+
+最后更新：2026-06-06（V24 启动，基于 V23 完整交付）
+项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
+上一版清单：[`tech-stack-next-phase-checklist-v23.md`](tech-stack-next-phase-checklist-v23.md)
+方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
+
+---
+
+## V23 交付基线 (V24 起点)
+
+| 维度 | V23 状态 | V24 目标 |
+|------|-----------|---------|
+| 知识图谱节点 | 690 | **≥ 705** |
+| 知识图谱边数 | 4993 | **≥ 5050** |
+| 事实库 (CANONICAL_FACTS) | 172 条 | **≥ 185 条** |
+| 社区结构 | 17 社区，最大社区占 10.4%（`community_quality_warning: false`） | **保持 ≤ 25%，新增专题不破坏均衡** |
+| 技术专题 | 全身运动跟踪（WBT）/ 跨具身迁移 / 真机安全微调（V23 P1–P3 全部交付） | **建立"视觉感知骨干与机器人表征"专题** |
+| 图谱专题视图 | V23 扩至 13 项（新增 WBT / 跨具身 / 真机安全微调） | **新增「视觉感知骨干」专题至 14 项** |
+
+> 背景：V23 期间 ingest 了 ResNet（1512.03385）与 YOLO v1（1506.02640），但视觉感知层 wiki 仍偏薄——仅 `wiki/concepts/vision-backbones.md` 与 `wiki/methods/object-detection.md` 两页核心、无 comparisons / queries 落地，也缺「骨干 → 表征 → 下游策略输入」的衔接视角。V24 优先补齐这条从视觉骨干到机器人策略输入的知识链。
+
+---
+
+## P0: 自动化与工具链深度强化 (Engineering)
+
+- [ ] **陈旧声明（stale claim）巡检 V1**：
+    - [ ] `scripts/lint_wiki.py` 新增 `stale_claim_check`：扫描正文出现「SOTA / 最新 / 当前最强 / state-of-the-art」等绝对化措辞但 frontmatter `updated` 早于库内同主题更晚页面的情形，给出 INFO 级提示（不阻塞 CI），并写入 lint 报告基线快照；新增用例覆盖到 `tests/`。
+- [ ] **缺页概念巡检 V1**：
+    - [ ] `scripts/lint_wiki.py` 新增 `missing_concept_page_check`：统计正文中以 `**术语**`/反引号高频出现（≥ N 页引用）但无独立 `wiki/concepts|methods|formalizations` 页的术语，输出"建议新建页"候选清单（INFO 级，不阻塞 CI），作为后续 ingest/query 选题入口。
+- [ ] **query → wiki 回填脚手架**：
+    - [ ] 新增 `scripts/scaffold_wiki_page.py`：给定 type（concept/comparison/query/...）与标题，按全库 frontmatter 规范生成骨架（含速查区块锚点、`related`/`sources` 占位、三段式正文骨架），降低把 query 答案沉淀回 wiki 的手工成本；自带 `--dry-run` 与 lint 自检。
+
+## P1: 视觉感知骨干与机器人表征专题 (Quality)
+
+- [ ] **视觉表征知识链 (+3)**：
+    - [ ] `wiki/comparisons/cnn-vs-vit-backbones.md`（CNN（ResNet 系）vs ViT 系视觉骨干对比：归纳偏置、数据量需求、分辨率/吞吐、下游迁移、在机器人感知中的取舍）。
+    - [ ] `wiki/concepts/visual-representation-for-policy.md`（视觉表征作为策略输入：端到端联合训练 vs 冻结预训练骨干 vs 机器人专用预训练表征（R3M / VC-1 / DINOv2 等）三条路径与取舍）。
+    - [ ] `wiki/queries/perception-backbone-selection.md`（机器人感知骨干/表征选型 Query：分类骨干 / 检测头 / 通用预训练表征三类，给出选型决策树与典型失败模式）。
+- [ ] **视觉感知专题交叉补强**：
+    - [ ] 在 `wiki/concepts/vision-backbones.md` 与 `wiki/methods/object-detection.md` 中明示「骨干特征 → 检测/分割头 → 策略输入」的衔接，并与 P1 新页形成双向回链，消除孤儿页。
+
+## P2: 事实库与矛盾检测扩展 (Quantity)
+
+- [ ] **事实库扩展**：
+    - [ ] `schema/canonical-facts.json` 由 172 → **≥ 185 条**：新增视觉骨干（ResNet 残差连接 / ViT 数据量门槛 / YOLO 单阶段 vs 两阶段）与机器人表征（冻结预训练表征 vs 端到端、R3M/VC-1 定位）专题的矛盾检测规则。
+
+## P3: 交互层"专题与感知"增强 (UX/UI)
+
+- [ ] **图谱页"视觉感知骨干"专题视图**：
+    - [ ] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V23 13 项基础上新增「视觉感知骨干」专题；命中规则复用 community id + path 片段双路并集机制；同步在 `#filter-topic-chips` 增加对应 `data-topic` chip；新增视图配 Puppeteer 截图归档到 `.cursor-artifacts/screenshots/`。
+- [ ] **详情页"同专题相关页"提示（可选）**：
+    - [ ] 评估在详情页对命中某专题的页面给出"属于 X 专题"轻量徽标 + 跳转图谱专题视图的链接（空态降级隐藏）。
+
+---
+
+## 验收标准 (Definition of DoD)
+
+- [ ] `make lint`: 0 errors（新引入的 `stale_claim_check` / `missing_concept_page_check` 均为 INFO 级，不阻塞 CI）。
+- [ ] 知识图谱节点数 **≥ 705**，边数 **≥ 5050**（见 `exports/graph-stats.json`）。
+- [ ] 事实库扩展至 **185 条** 以上（重点补 视觉骨干 / 机器人表征 矛盾检测规则）。
+- [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。
+- [ ] `log.md` 记录 V24 关键改动。
+
+---
+
+## 状态说明
+
+- `[ ]` 待执行
+- `[~]` 进行中
+- `[x]` 已完成
+- `[−]` 已评估，决定跳过（附理由）

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1475,6 +1475,9 @@
           <button class="filter-topic-chip" type="button" data-topic="learning" title="学习范式 IL/RL"><span>🎓</span><span>IL/RL</span></button>
           <button class="filter-topic-chip" type="button" data-topic="sim2real" title="Sim2Real"><span>🔁</span><span>Sim2Real</span></button>
           <button class="filter-topic-chip" type="button" data-topic="state-estimation" title="状态估计"><span>📊</span><span>状态估计</span></button>
+          <button class="filter-topic-chip" type="button" data-topic="wbt" title="全身运动跟踪（WBT）"><span>🕺</span><span>WBT</span></button>
+          <button class="filter-topic-chip" type="button" data-topic="cross-embodiment" title="跨具身迁移"><span>🔀</span><span>跨具身</span></button>
+          <button class="filter-topic-chip" type="button" data-topic="safe-fine-tuning" title="真机安全微调"><span>🛡️</span><span>安全微调</span></button>
         </div>
       </details>
       <div class="filter-mode-tabs" id="filter-mode-tabs" aria-label="筛选维度">
@@ -1781,6 +1784,23 @@
       'state-estimation': {
         segments: new Set([
           'estimation','ekf','ukf','slam','vio','odometry'
+        ])
+      },
+      'wbt': {
+        segments: new Set([
+          'wbt','tracking','beyondmimic','sdamp','heracles','opentrack',
+          'maskedmimic','sonic','any2any','twist','twist2'
+        ])
+      },
+      'cross-embodiment': {
+        segments: new Set([
+          'embodiment','any2any','transfer'
+        ])
+      },
+      'safe-fine-tuning': {
+        communities: new Set(['community-13']),
+        segments: new Set([
+          'safe','safety','cbf','clf','barrier','lyapunov','slowrl','lora','cmdp'
         ])
       }
     };

--- a/log.md
+++ b/log.md
@@ -1,5 +1,13 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-06] structural | docs — V23 P3 图谱页「专题视图」扩充（WBT / 跨具身 / 真机安全微调）
+
+- 清单推进：[tech-stack-next-phase-checklist-v23.md](docs/checklists/tech-stack-next-phase-checklist-v23.md) P3 末项打勾，V23 清单全部完成
+- 前端改动：[docs/graph.html](docs/graph.html) `TOPIC_FILTERS` 在 V22 10 项基础上新增 `wbt`（segments 11 项，命中 22 节点）、`cross-embodiment`（segments 3 项，命中 3 节点）、`safe-fine-tuning`（community-13 + segments 9 项，命中 18 节点）；`#filter-topic-chips` 同步新增 🕺 WBT / 🔀 跨具身 / 🛡️ 安全微调 三枚 `data-topic` chip，复用既有 `nodeMatchesTopic` 双路并集逻辑
+- 工具修复：[scripts/screenshot_graph_topic.cjs](scripts/screenshot_graph_topic.cjs) 由点击 V22 已移除的 `#topic-view` 下拉改为展开 `#filter-topic-section` 后点击 `[data-topic]` chip
+- 验证：`make lint` 全绿（仅 1 条无关信息型预警）、内联 JS `new Function` 语法校验通过；三专题视图截图归档至 `.cursor-artifacts/screenshots/graph-topic-{wbt,cross-embodiment,safe-fine-tuning}.png`
+- V23 验收：节点 690（≥445）/ 边 4993（≥3320）/ 事实库 172（≥170）/ `largest_community_ratio` 0.104（≤0.25）/ `community_quality_warning` false，全部达标
+
 ## [2026-06-06] ingest | sources/sites/karpathy-ai.md、sources/blogs/karpathy_llm_wiki_gist.md — Andrej Karpathy 个人站与 LLM Wiki Gist；wiki/entities/andrej-karpathy.md、wiki/references/llm-wiki-karpathy.md、wiki/overview/robot-learning-overview.md
 
 ## [2026-06-06] structural | wiki — 全库 587 页英文缩写速查区块重排至「一句话定义」后、「为什么重要」前；新增 reorder 脚本与 lint 位置校验

--- a/scripts/screenshot_graph_topic.cjs
+++ b/scripts/screenshot_graph_topic.cjs
@@ -58,7 +58,12 @@ const fs = require('fs');
       if (ld) ld.style.display = 'none';
     });
     if (topic && topic !== 'all') {
-      await page.select('#topic-view', topic);
+      await page.evaluate((t) => {
+        const sec = document.getElementById('filter-topic-section');
+        if (sec) sec.open = true;
+        const btn = document.querySelector('[data-topic="' + t + '"]');
+        if (btn) btn.click();
+      }, topic);
       await new Promise(r => setTimeout(r, 1800));
     }
     await page.screenshot({ path: path.resolve(out), fullPage: false });


### PR DESCRIPTION
## 摘要

完成 V23 最后一项（图谱页「专题视图」扩充），新增「全身运动跟踪（WBT）」「跨具身迁移」「真机安全微调」三个专题过滤器，并启动 V24 清单。V23 全部验收标准达标（690 节点 / 4993 边 / 172 条事实库 / 社区质量指标正常）。

## 变更类型

- [x] 前端（`docs/`）
- [x] 维护脚本 / CI / 文档

## 详细改动

### 前端：图谱页专题视图扩充
- **`docs/graph.html`**：
  - `TOPIC_FILTERS` 新增三项：
    - `wbt`：11 个 segment（wbt/tracking/beyondmimic/sdamp/heracles/opentrack/maskedmimic/sonic/any2any/twist/twist2），命中 22 节点
    - `cross-embodiment`：3 个 segment（embodiment/any2any/transfer），命中 3 节点
    - `safe-fine-tuning`：community-13 + 9 个 segment（safe/safety/cbf/clf/barrier/lyapunov/slowrl/lora/cmdp），命中 18 节点
  - `#filter-topic-chips` 同步新增三枚 chip：🕺 WBT / 🔀 跨具身 / 🛡️ 安全微调
  - 复用既有 `nodeMatchesTopic` 双路并集逻辑，无需改动核心过滤算法

### 工具修复
- **`scripts/screenshot_graph_topic.cjs`**：
  - 修复：V22 已移除 `#topic-view` 下拉，改为展开 `#filter-topic-section` 后点击 `[data-topic]` chip
  - 三专题视图截图已归档至 `.cursor-artifacts/screenshots/graph-topic-{wbt,cross-embodiment,safe-fine-tuning}.png`

### 文档与清单
- **新增 `docs/checklists/tech-stack-next-phase-checklist-v24.md`**：
  - V24 起点基线：690 节点 / 4993 边 / 172 条事实库
  - P0–P3 四个优先级，重点补齐「视觉感知骨干与机器人表征」专题
  - 新增自动化工具：陈旧声明巡检、缺页概念巡检、query → wiki 回填脚手架

- **更新 `docs/checklists/tech-stack-next-phase-checklist-v23.md`**：
  - P3 末项（图谱专题视图）标记完成，附 2026-06-06 验收记录
  - 全部验收标准打勾：节点 690（≥445）/ 边 4993（≥3320）/ 事实库 172（≥170）/ 社区质量指标达标

- **更新导航指针**：
  - `README.md`、`docs/README.md`、`docs/checklists/README.md` 的当前清单指向由 v23 → v24
  - `docs/checklists/README.md` 历史索引新增 v23 条目

- **更新 `log.md`**：
  - 新增 2026-06-06 structural 条目，记录

https://claude.ai/code/session_01SjUQoZUhqr2J3EUfRdJB5T