### PR TITLE
fix(ux): 路线图互链枢纽卡片复用关联项布局

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2112,6 +2112,7 @@
       const href = page.type === 'roadmap_page' ? roadmapHref(id) : detailHref(id);
       const buttonText = page.type === 'roadmap_page' ? '打开路线页' : '打开详情页';
       const summaryFallback = (options && options.summaryFallback) || '当前关联项暂无摘要';
+      const chipExtra = options && typeof options.chipExtra === 'function' ? options.chipExtra(id, page) : '';
       return [
         '<article class="card data-card">',
         '  <div>',
@@ -2120,6 +2121,7 @@
         '    <p>' + escapeHtml(page.summary || summaryFallback) + '</p>',
         '  </div>',
         '  <div class="chip-list">',
+        chipExtra,
         '    <a class="btn-secondary btn-inline" href="' + escapeHtml(href) + '">' + buttonText + '</a>',
         '  </div>',
         '</article>'
@@ -2164,9 +2166,10 @@
         var meta = hubMeta[id] || {};
         return (page && page.title) || meta.label || id;
       },
-      metaExtra: function (id) {
+      chipExtra: function (id) {
         var meta = hubMeta[id] || {};
-        return meta.degree != null ? '互链度 ' + meta.degree : '';
+        if (meta.degree == null) return '';
+        return '    <span class="data-chip" title="无向边总数（入链+出链）">互链度 ' + escapeHtml(String(meta.degree)) + '</span>\n';
       }
     });
   }

--- a/docs/main.js
+++ b/docs/main.js
@@ -2085,6 +2085,19 @@
     });
   }
 
+  function buildInternalLinkCardMeta(page, id, options) {
+    var typeLabel = (page && page.type) || (options && options.defaultType) || 'detail_page';
+    var extra = options && typeof options.metaExtra === 'function' ? options.metaExtra(id, page) : '';
+    return extra ? typeLabel + ' · ' + extra : typeLabel;
+  }
+
+  function buildInternalLinkTitle(id, page, options) {
+    if (options && typeof options.getTitle === 'function') {
+      return options.getTitle(id, page) || id;
+    }
+    return (page && page.title) || id;
+  }
+
   function renderInternalLinks(container, ids, detailPages, options) {
     if (!container) return;
     const emptyText = (options && options.emptyText) || '暂无内部关联项';
@@ -2098,12 +2111,13 @@
       const page = detailPages[id] || {};
       const href = page.type === 'roadmap_page' ? roadmapHref(id) : detailHref(id);
       const buttonText = page.type === 'roadmap_page' ? '打开路线页' : '打开详情页';
+      const summaryFallback = (options && options.summaryFallback) || '当前关联项暂无摘要';
       return [
         '<article class="card data-card">',
         '  <div>',
-        '    <h3><a href="' + escapeHtml(href) + '">' + escapeHtml(page.title || id) + '</a></h3>',
-        '    <p class="card-meta">' + escapeHtml(page.type || 'detail_page') + '</p>',
-        '    <p>' + escapeHtml(page.summary || '当前关联项暂无摘要') + '</p>',
+        '    <h3><a href="' + escapeHtml(href) + '">' + escapeHtml(buildInternalLinkTitle(id, page, options)) + '</a></h3>',
+        '    <p class="card-meta">' + escapeHtml(buildInternalLinkCardMeta(page, id, options)) + '</p>',
+        '    <p>' + escapeHtml(page.summary || summaryFallback) + '</p>',
         '  </div>',
         '  <div class="chip-list">',
         '    <a class="btn-secondary btn-inline" href="' + escapeHtml(href) + '">' + buttonText + '</a>',
@@ -2119,33 +2133,21 @@
     if (!container) return;
     var pathToId = buildPathToDetailIdIndex(detailPages);
     var hubs = Array.isArray(topHubs) ? topHubs : [];
-    var parts = [];
+    var ids = [];
+    var hubMeta = {};
     for (var i = 0; i < hubs.length; i++) {
       var hub = hubs[i];
       var path = hub && hub.id;
       if (!path) continue;
       var detailId = pathToId[path];
       if (!detailId) continue;
-      var page = resolveDetailPage(detailId, detailPages) || detailPages[detailId] || {};
-      var degree = hub.degree != null ? Number(hub.degree) : 0;
-      var title = page.title || hub.label || detailId;
-      var href = page.type === 'roadmap_page' ? roadmapHref(detailId) : detailHref(detailId);
-      var buttonText = page.type === 'roadmap_page' ? '打开路线页' : '打开详情页';
-      parts.push([
-        '<article class="card data-card">',
-        '  <div>',
-        '    <h3><a href="' + escapeHtml(href) + '">' + escapeHtml(title) + '</a></h3>',
-        '    <p class="card-meta">' + escapeHtml(page.type || 'wiki_page') + '</p>',
-        '    <p>' + escapeHtml(page.summary || '当前页面暂无摘要') + '</p>',
-        '  </div>',
-        '  <div class="chip-list">',
-        '    <span class="data-chip" title="无向边总数（入链+出链）">互链度 ' + escapeHtml(String(degree)) + '</span>',
-        '    <a class="btn-secondary btn-inline" href="' + escapeHtml(href) + '">' + buttonText + '</a>',
-        '  </div>',
-        '</article>'
-      ].join(''));
+      ids.push(detailId);
+      hubMeta[detailId] = {
+        label: hub.label || '',
+        degree: hub.degree != null ? Number(hub.degree) : 0
+      };
     }
-    if (!parts.length) {
+    if (!ids.length) {
       container.innerHTML = [
         '<article class="card"><p>',
         '无法从链接图统计中匹配到详情页条目。请稍后再试，或前往 ',
@@ -2155,8 +2157,18 @@
       removeLoadingState(container);
       return;
     }
-    container.innerHTML = parts.join('');
-    removeLoadingState(container);
+    renderInternalLinks(container, ids, detailPages, {
+      defaultType: 'wiki_page',
+      summaryFallback: '当前页面暂无摘要',
+      getTitle: function (id, page) {
+        var meta = hubMeta[id] || {};
+        return (page && page.title) || meta.label || id;
+      },
+      metaExtra: function (id) {
+        var meta = hubMeta[id] || {};
+        return meta.degree != null ? '互链度 ' + meta.degree : '';
+      }
+    });
   }
 
   function renderSourceCards(container, links, emptyText) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 路线图页「全站互链枢纽 · Top 10」复用 `renderInternalLinks` 卡片结构，与详情页关联项保持一致的贴底布局。
- **互链度**恢复为底部独立 `data-chip` 标签（如 `互链度 155`），不再写入 `card-meta` 行。
- 底部操作区仍通过 `card-grid` flex 贴底对齐，`打开详情页` 按钮 `min-height: 36px` 保持同排高度一致。
- 不显示内部页面 ID slug（延续 #550）。

## 验证
- `npm run lint:js` 通过
- `node --check docs/main.js` 通过

## 验证截图
![路线图互链枢纽：互链度独立标签 + 按钮贴底对齐](https://cursor.com/artifacts/c/art-953d7361-f63b-4c4c-9604-f45eedf837f0)

## 风险
- 纯前端展示层改动，不影响 wiki 导出数据。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41244956-49df-4a48-b109-5c1a05bdf8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41244956-49df-4a48-b109-5c1a05bdf8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

