### PR TITLE
docs: Add AWR algorithm guide and paper metadata

### DIFF
--- a/wiki/entities/paper-notebook-control-operators-for-interactive-character-anim.md
+++ b/wiki/entities/paper-notebook-control-operators-for-interactive-character-anim.md
@@ -3,6 +3,8 @@ type: entity
 tags: [paper, humanoid-paper-notebooks, paper-notebook-stub]
 status: stub
 updated: 2026-06-07
+venue: "SIGGRAPH Asia 2025"
+code: https://github.com/gouruiyu/ControlOperators
 related:
   - ../overview/paper-notebook-category-14-human-motion.md
   - ../overview/humanoid-paper-notebooks-index.md

--- a/wiki/entities/paper-notebook-learning-quadrupedal-locomotion-over-challenging.md
+++ b/wiki/entities/paper-notebook-learning-quadrupedal-locomotion-over-challenging.md
@@ -3,6 +3,8 @@ type: entity
 tags: [paper, humanoid-paper-notebooks, paper-notebook-stub]
 status: stub
 updated: 2026-06-07
+arxiv: "2010.11251"
+venue: "Science Robotics 2020"
 related:
   - ../overview/paper-notebook-category-03-high-impact-selection.md
   - ../overview/humanoid-paper-notebooks-index.md

--- a/wiki/entities/paper-notebook-unitree-h1-whitepaper.md
+++ b/wiki/entities/paper-notebook-unitree-h1-whitepaper.md
@@ -3,6 +3,8 @@ type: entity
 tags: [paper, humanoid-paper-notebooks, paper-notebook-stub]
 status: stub
 updated: 2026-06-07
+venue: "Unitree Robotics (whitepaper)"
+code: https://github.com/unitreerobotics/unitree_sdk2
 related:
   - ../overview/paper-notebook-category-12-hardware-design.md
   - ../overview/humanoid-paper-notebooks-index.md

--- a/wiki/queries/rl-algorithm-selection.md
+++ b/wiki/queries/rl-algorithm-selection.md
@@ -43,7 +43,8 @@ sources:
 | 确定性连续控制、操作任务 | **TD3** | SAC |
 | 模仿人类运动风格 | **AMP（PPO 变体）** | SAC+GAIL |
 | 需要最高渐近性能 | **SAC** | TD3 |
-| 调参时间有限，要稳定收敛 | **PPO** | AWR |
+| 调参时间有限，要稳定收敛 | **PPO** | [AWR](../methods/awr.md) |
+| 含人类演示 / 离线缓冲区数据 | **[AWR](../methods/awr.md)** | SAC |
 
 ---
 
@@ -142,6 +143,25 @@ $$\tilde{a} = \pi_{\theta'}(s') + \text{clip}(\epsilon, -c, c), \quad y = r + \g
 
 ---
 
+### AWR（Advantage-Weighted Regression）
+
+**类型**：Off-policy，回归式策略优化
+
+**原理**：不直接计算策略梯度，而是用优势函数的指数权重 $\exp(A/\beta)$ 对动作做加权监督回归，把策略优化转成监督学习。
+
+**适合足式机器人的原因**：
+- 实现极简，不需要信赖域 / clip，调参负担小
+- 离策兼容，可无缝吃人类演示或历史回放缓冲区数据
+- 作为"调参时间有限"或"有离线/演示数据"场景的备选路径
+
+**缺点**：
+- 渐近性能通常不及 SAC / PPO，对大规模并行仿真没有专门优化
+- 价值基准网络质量直接决定优势估计的可靠性
+
+详见 [AWR 方法页](../methods/awr.md)。
+
+---
+
 ## 足式机器人 RL 实践要点
 
 ### 1. 大规模并行仿真 → 用 PPO
@@ -176,6 +196,7 @@ PPO 更容易调试：reward 曲线平滑，超参数不敏感，失败原因更
 ## 关联页面
 
 - [Policy Optimization](../methods/policy-optimization.md) — PPO/SAC/TD3 算法详细说明
+- [AWR](../methods/awr.md) — 优势加权回归，离策/演示数据场景的回归式备选
 - [Reinforcement Learning](../methods/reinforcement-learning.md) — RL 方法全景
 - [Reward Design](../concepts/reward-design.md) — reward 设计是算法选型之后的核心问题
 - [Sim2Real](../concepts/sim2real.md) — 仿真训练后如何迁移到真实机器人


### PR DESCRIPTION
## 摘要

补充 AWR（Advantage-Weighted Regression）算法的详细说明，并为三篇论文补充 venue/arxiv/code 元数据。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）

## 具体改动

### wiki/queries/rl-algorithm-selection.md
- 为 AWR 链接添加内部引用 `[AWR](../methods/awr.md)`
- 新增表格行：「含人类演示 / 离线缓冲区数据」场景推荐 AWR 作为首选
- 新增 AWR 算法详解小节，包括：
  - 类型与原理（Off-policy 回归式策略优化）
  - 足式机器人适配原因（实现简洁、离策兼容、调参负担小）
  - 缺点说明（渐近性能、价值基准网络依赖）
- 在「关联页面」补充 AWR 方法页链接

### 论文元数据补充
- `paper-notebook-control-operators-for-interactive-character-anim.md`：添加 venue（SIGGRAPH Asia 2025）和 code 链接
- `paper-notebook-learning-quadrupedal-locomotion-over-challenging.md`：添加 arxiv（2010.11251）和 venue（Science Robotics 2020）
- `paper-notebook-unitree-h1-whitepaper.md`：添加 venue（Unitree Robotics whitepaper）和 code 链接

## 验证

- [x] `make ci-preflight` — 链接有效性检查通过
- [x] 内部引用 `../methods/awr.md` 格式正确
- [x] 表格格式保持一致
- [x] 论文元数据字段符合 schema

## 相关 Issue

无

https://claude.ai/code/session_01GPi1TVpRv6bbnbN7KVJwpC