### PR TITLE
fix(ux): 修复路线页互链枢纽副标题中文提前换行

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -357,7 +357,15 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   letter-spacing: -.01em;
   margin: 0;
 }
-.section-subtitle { color: var(--text-muted); font-size: .97rem; margin-bottom: 28px; max-width: 72ch; }
+.section-subtitle {
+  color: var(--text-muted);
+  font-size: .97rem;
+  margin-bottom: 28px;
+  max-width: 72ch;
+  /* CJK：避免「核心」等词在容器边缘被拆成两行 */
+  word-break: keep-all;
+  line-break: strict;
+}
 .detail-recent-ingest-timeline { display: grid; gap: 10px; }
 .detail-recent-ingest-item {
   display: flex;
@@ -651,6 +659,10 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   flex: 1;
   min-width: 0;
   max-width: var(--content-max-width);
+}
+/* 详情/路线主栏已由 flex 限宽，勿再叠 72ch 导致副标题提前换行 */
+.detail-content-main .section-subtitle {
+  max-width: none;
 }
 /* Detail page — 来源链接：超长 URL 单行省略，悬停 title 显示完整地址 */
 #detailSourceList > article.card {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 `roadmap.html`「全站互链枢纽 · Top 10」区块副标题在较窄主栏下提前换行，并把「核心」拆成「核 / 心页」的问题。
- 为 `.section-subtitle` 增加 `word-break: keep-all` 与 `line-break: strict`，使中文在标点处换行。
- 在 `.detail-content-main` 内取消 `72ch` 限宽，与 `.detail-summary` 一致，避免详情/路线主栏被二次收窄。

## 验证
- 本地 `docs/` 静态服务 + Puppeteer 检查：1280px 视口下副标题单行完整显示；700px 视口下换行点为「排序，」与「优先浏览…」，不再拆开「核心」。
- N/A：`make ci-preflight`（仅 CSS，无 wiki / 派生文件变更）

## 验证截图
![路线页互链枢纽区块副标题换行修复](https://cursor.com/artifacts/c/art-81bc8faa-3864-4aa3-b1d4-f84c13326bbd)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fba5418-bb2c-4e74-a91a-caaf93db8967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fba5418-bb2c-4e74-a91a-caaf93db8967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

