### PR TITLE
feat(ux): 详情页微图「查看全部 N 个邻居」跳转全图

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -57,6 +57,9 @@
             <span id="detailMiniMapMeta" class="detail-mini-map-meta">正在读取邻居关系…</span>
           </div>
           <svg id="detailMiniMapSvg" class="detail-mini-map-svg" role="img" aria-label="当前节点 1-hop 邻居图"></svg>
+          <div class="detail-mini-map-foot">
+            <a id="detailMiniMapAllNeighbors" class="detail-mini-map-all-link" href="graph.html" hidden>查看全部邻居 →</a>
+          </div>
           <div id="detail-mini-map-tooltip" class="graph-hover-tooltip hidden" role="tooltip" aria-hidden="true"></div>
         </aside>
       </div>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1275,6 +1275,8 @@
       text-transform: uppercase; letter-spacing: .06em; margin-bottom: 7px;
     }
     .sb-related-list { list-style: none; padding: 0; margin: 0 0 12px; display: flex; flex-direction: column; gap: 4px; }
+    .sb-neighbors-list { max-height: 220px; overflow-y: auto; }
+    .sb-neighbors-count { font-weight: 400; color: var(--text-muted, #94a3b8); }
     .sb-related-list li a {
       font-size: .76rem; color: rgba(0,212,255,0.75);
       text-decoration: none; display: block;
@@ -1530,6 +1532,10 @@
           <span class="sb-community-dot" id="sb-community-dot"></span>
           <span id="sb-community-label"></span>
         </div>
+      </div>
+      <div id="sb-neighbors-section" hidden>
+        <div class="sb-section-title">图邻居 <span id="sb-neighbors-count" class="sb-neighbors-count"></span></div>
+        <ul class="sb-related-list sb-neighbors-list" id="sb-neighbors-list"></ul>
       </div>
       <div id="sb-related-section" hidden>
         <div class="sb-section-title">关联页面</div>
@@ -3383,6 +3389,9 @@
     const sbCommunityBlock = document.getElementById('sb-community-block');
     const sbCommunityDot   = document.getElementById('sb-community-dot');
     const sbCommunityLabel = document.getElementById('sb-community-label');
+    const sbNeighborsSec  = document.getElementById('sb-neighbors-section');
+    const sbNeighborsList = document.getElementById('sb-neighbors-list');
+    const sbNeighborsCount = document.getElementById('sb-neighbors-count');
     const sbRelSec     = document.getElementById('sb-related-section');
     const sbRelList    = document.getElementById('sb-related-list');
     const sbPaperSec   = document.getElementById('sb-paper-section');
@@ -3463,6 +3472,26 @@
       const item = indexItems.find(it => it.path === d.id);
       const tags = item?.tags || [];
       sbTags.innerHTML = tags.map(t => `<span class="sb-tag">${escapeHtml(t)}</span>`).join('');
+
+      // 1-hop graph neighbors (full list)
+      const neighborIds = Array.from(direct).sort((a, b) => {
+        const na = nodes.find(n => n.id === a);
+        const nb = nodes.find(n => n.id === b);
+        return String(na?.label || na?._info?.title || a)
+          .localeCompare(String(nb?.label || nb?._info?.title || b), 'zh-CN');
+      });
+      if (neighborIds.length) {
+        if (sbNeighborsCount) sbNeighborsCount.textContent = '(' + neighborIds.length + ')';
+        sbNeighborsList.innerHTML = neighborIds.map(id => {
+          const n = nodes.find(nd => nd.id === id);
+          const label = n?.label || n?._info?.title || id.split('/').pop().replace('.md', '');
+          const detailId = toDetailId(id);
+          return `<li><a href="detail.html?id=${encodeURIComponent(detailId)}">${escapeHtml(label)}</a></li>`;
+        }).join('');
+        sbNeighborsSec.hidden = false;
+      } else {
+        sbNeighborsSec.hidden = true;
+      }
 
       // related from index
       const related = item?.related || [];

--- a/docs/main.js
+++ b/docs/main.js
@@ -2466,6 +2466,7 @@
     var wrap = document.getElementById('detailMiniMapWrap');
     var svgEl = document.getElementById('detailMiniMapSvg');
     var metaEl = document.getElementById('detailMiniMapMeta');
+    var allNeighborsLink = document.getElementById('detailMiniMapAllNeighbors');
     var tooltipEl = document.getElementById('detail-mini-map-tooltip');
     if (!wrap || !svgEl || typeof window.d3 === 'undefined') return;
     var currentPath = (detailPage && detailPage.path) || '';
@@ -2638,13 +2639,23 @@
           window.d3.zoomIdentity.translate(W / 2 - scale * cx, H / 2 - scale * cy).scale(scale));
       });
 
+      var totalDeg = Object.keys(neighborSet).length;
+      var shown = neighborIds.length;
       if (metaEl) {
-        var totalDeg = Object.keys(neighborSet).length;
-        var shown = neighborIds.length;
         metaEl.textContent = shown + ' / ' + totalDeg + ' 个 1-hop 邻居 · 悬停预览 · 拖拽平移 · 点击跳转';
+      }
+      if (allNeighborsLink) {
+        if (totalDeg > 0) {
+          allNeighborsLink.hidden = false;
+          allNeighborsLink.textContent = '查看全部 ' + totalDeg + ' 个邻居 →';
+          allNeighborsLink.href = 'graph.html?focus=' + encodeURIComponent(currentPath);
+        } else {
+          allNeighborsLink.hidden = true;
+        }
       }
     }).catch(function () {
       if (metaEl) metaEl.textContent = '邻居数据加载失败';
+      if (allNeighborsLink) allNeighborsLink.hidden = true;
     });
   }
 
@@ -2713,7 +2724,7 @@
 
     const graphLink = document.getElementById('detailGraphLink');
     if (graphLink) {
-      graphLink.href = 'graph.html?focus=' + encodeURIComponent(detailPage.id || detailId);
+      graphLink.href = 'graph.html?focus=' + encodeURIComponent(detailPage.path || detailPage.id || detailId);
     }
     var ogTitle = document.getElementById('ogTitleMeta');
     var ogDesc = document.getElementById('ogDescMeta');

--- a/docs/style.css
+++ b/docs/style.css
@@ -592,6 +592,20 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   font-size: .78rem;
   color: var(--text-muted);
 }
+.detail-mini-map-foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+  padding-bottom: 4px;
+}
+.detail-mini-map-all-link {
+  font-size: .78rem;
+  color: var(--accent);
+  text-decoration: none;
+}
+.detail-mini-map-all-link:hover {
+  text-decoration: underline;
+}
 .detail-mini-map-svg {
   display: block;
   width: 100%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页知识地图微图底部新增 **「查看全部 N 个邻居 →」** 链接，跳转到 `graph.html?focus=<wiki-path>` 并在全图侧栏列出完整 1-hop 邻居
- 修复目录栏「关联图谱节点」的 `focus` 参数：由 detail page id 改为 wiki `path`，与 `link-graph.json` 节点 id 对齐

## 改动
| 文件 | 说明 |
|------|------|
| `docs/detail.html` | 微图底部 `#detailMiniMapAllNeighbors` 链接容器 |
| `docs/main.js` | `renderDetailMiniMap` 写入邻居数与跳转 URL；`detailGraphLink` 使用 `detailPage.path` |
| `docs/style.css` | `.detail-mini-map-foot` / `.detail-mini-map-all-link` 样式 |
| `docs/graph.html` | 侧栏新增「图邻居 (N)」可滚动列表，点击节点或 `?focus=` 进入时展示全部 1-hop |

## 验证
- `make lint-js` 通过
- `make lint` 通过
- 本地静态站截图（WBC 详情页）：微图显示「查看全部 99 个邻居 →」

## 验证截图
![详情页微图查看全部邻居链接](https://cursor.com/artifacts/c/art-2cb0b9c0-a4f0-4763-96db-2bab5e176d2b)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15f9aa44-97c5-4108-8649-c3d57b0aaadf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15f9aa44-97c5-4108-8649-c3d57b0aaadf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

