### PR TITLE
fix(ux): 增加详情页 TOC 高亮项左右内边距

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -826,6 +826,8 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--accent);
   background: rgba(45,116,218,.10);
   font-weight: 700;
+  /* 高亮态单独加左右留白，避免背景贴字；默认项仍无水平 padding 以保持序号对齐 */
+  padding: 2px 8px;
 }
 .detail-toc-list .toc-entry.active a {
   font-weight: inherit;

--- a/scripts/screenshot_detail_toc_viewport.cjs
+++ b/scripts/screenshot_detail_toc_viewport.cjs
@@ -1,0 +1,87 @@
+'use strict';
+/**
+ * 截取详情页「目录导航 + 正文主栏」并排区域，用于验证 TOC 高亮样式。
+ *
+ * 用法:
+ *   node scripts/screenshot_detail_toc_viewport.cjs <pageUrl> <outPng> [viewportWidth] [viewportHeight]
+ */
+const puppeteer = require('puppeteer-core');
+
+const pageUrl = process.argv[2];
+const outPath = process.argv[3];
+const viewportWidth = parseInt(process.argv[4] || '1680', 10);
+const viewportHeight = parseInt(process.argv[5] || '900', 10);
+
+const executablePath =
+  process.env.PUPPETEER_EXECUTABLE_PATH ||
+  process.env.CHROME ||
+  '/usr/local/bin/google-chrome';
+
+(async function main() {
+  if (!pageUrl || !outPath) {
+    console.error(
+      '用法: node screenshot_detail_toc_viewport.cjs <url> <out.png> [width] [height]'
+    );
+    process.exit(2);
+  }
+
+  const browser = await puppeteer.launch({
+    executablePath,
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({
+      width: viewportWidth,
+      height: viewportHeight,
+      deviceScaleFactor: 1,
+    });
+    await page.goto(pageUrl, { waitUntil: 'networkidle2', timeout: 120000 });
+    await page.waitForSelector('#detailTocList:not(.data-loading)', { timeout: 90000 });
+    await page.waitForSelector('#detailContent:not(.data-loading)', { timeout: 90000 });
+    await page.waitForSelector('.detail-toc-list a.active, .detail-toc-list .toc-entry.active', {
+      timeout: 30000,
+    });
+
+    const scrollY = await page.evaluate(function () {
+      const section = document.getElementById('detailContentSection');
+      if (!section) return 0;
+      const headerOffset = 96;
+      const target = section.getBoundingClientRect().top + window.scrollY - headerOffset;
+      const y = Math.max(0, target);
+      window.scrollTo(0, y);
+      return y;
+    });
+    await page.waitForFunction(
+      function (expected) {
+        return Math.abs(window.scrollY - expected) < 2;
+      },
+      { timeout: 5000 },
+      scrollY
+    );
+    await new Promise(function (resolve) {
+      setTimeout(resolve, 300);
+    });
+
+    const layoutOk = await page.evaluate(function () {
+      const toc = document.getElementById('detailTocSection');
+      const main = document.querySelector('.detail-content-main');
+      if (!toc || !main) return false;
+      const tocTop = toc.getBoundingClientRect().top;
+      return window.scrollY > 100 && tocTop > 40 && tocTop < 220;
+    });
+    if (!layoutOk) {
+      throw new Error('screenshot_detail_toc_viewport: TOC 未滚入视口，请检查 viewport 宽度（建议 ≥1680）');
+    }
+
+    await page.screenshot({ path: outPath, fullPage: false });
+    console.log(outPath);
+  } finally {
+    await browser.close();
+  }
+})().catch(function (err) {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页 / 路线页 / 模块页共用的 `.detail-toc-list` 中，当前章节高亮背景与文字左右贴边，观感拥挤。
- 仅在 `.active` 状态增加 `padding: 2px 8px`，默认目录项仍保持 `padding: 2px 0`，避免破坏嵌套序号与父级文字左缘对齐。
- 新增 `scripts/screenshot_detail_toc_viewport.cjs`：滚动至正文区后截取「目录导航 + 正文主栏」并排视口，供 TOC 样式类 PR 验证。

## 验证
- `pytest tests/test_content_sync.py::DetailContentSyncTests::test_style_css_contains_heading_anchor_active_toc_and_hash_target_styles --no-cov` 通过
- 本地 headless 截图（`entity-legged-gym`，1680×900，滚动至 `#detailContentSection`）确认 TOC 高亮项留白正常

## 验证截图
![TOC 目录导航与正文并排，高亮项 1. 一句话定义 左右留白正常](https://cursor.com/artifacts/c/art-4db4ecee-f7ae-46ce-abe3-7db19d3f2903)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d7b8fe6-1f7d-4334-afdf-95d46e27d0fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d7b8fe6-1f7d-4334-afdf-95d46e27d0fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

