### PR TITLE
⚡ Bolt: [performance improvement] Hoist regex and avoid closures in markdown parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,3 +65,7 @@
 ## 2026-06-03 - Python Loop Optimization: Avoid Repeated Imports and Function Calls
 **Learning:** In the python search ranking code (`scripts/search_wiki_core.py`), repeatedly importing `date` from `datetime` and calling `date.today()` inside the inner scoring loop `compute_score` creates significant execution overhead and degrades overall search performance.
 **Action:** Always hoist invariant module imports and relatively static values (like `date.today()`) out of hot document processing loops to the global module scope to avoid unneeded CPU instruction execution and memory pressure.
+
+## 2026-06-09 - Avoid Closure and Array Methods in Hot Loops
+**Learning:** In frontend JavaScript processing large text bodies (like markdown rendering via `renderMarkdownContent` in `docs/main.js`), repeatedly calling array iteration methods like `.forEach()` allocates a new closure scope for every line. For large arrays or tight loops, this incurs measurable performance overhead compared to a standard `for` loop.
+**Action:** For optimal performance in JavaScript hot loops, such as array iteration and text parsing, always replace `.forEach()`, `.map()`, and `.filter()` with standard `for` loops to eliminate function closure allocation and invocation overhead.

--- a/docs/main.js
+++ b/docs/main.js
@@ -1709,6 +1709,15 @@
     target.scrollIntoView({ behavior: 'auto', block: 'start' });
   }
 
+  // ⚡ Bolt Optimization: Hoist regular expressions to avoid recompilation inside the hot markdown parsing loop
+  // Expected impact: Eliminates regex recompilation overhead per line in the main markdown render loop, improving text parsing speed.
+  const RE_HR = /^(-{3,}|\*{3,}|_{3,})$/;
+  const RE_HEADING = /^(#{1,6})\s+(.*)$/;
+  const RE_QUOTE = /^>\s?(.*)$/;
+  const RE_TASK = /^[-*]\s+\[([ xX])\]\s*(.*)$/;
+  const RE_UNORDERED = /^[-*]\s+(.*)$/;
+  const RE_ORDERED = /^\d+\.\s+(.*)$/;
+
   function renderMarkdownContent(markdown, headings, markdownContext) {
     let source = stripYamlFrontmatter(markdown);
     if (!source) {
@@ -1827,13 +1836,14 @@
       return HTML_BLOCK_TAGS.indexOf(tag) >= 0 ? tag : '';
     }
 
-    lines.forEach(function (line) {
+  for (let idx = 0; idx < lines.length; idx++) {
+    const line = lines[idx];
       const trimmed = line.trim();
 
       if (trimmed.startsWith('```')) {
         if (htmlBlockOpenTag) {
           htmlBlockLines.push(line);
-          return;
+        continue;
         }
         if (inCodeBlock) {
           flushCodeBlock();
@@ -1847,12 +1857,12 @@
           inCodeBlock = true;
           codeLang = normalizeCodeLang(trimmed.replace(/^```+/, '').trim().split(/\s+/)[0] || '');
         }
-        return;
+      continue;
       }
 
       if (inCodeBlock) {
         codeLines.push(line);
-        return;
+      continue;
       }
 
       if (htmlBlockOpenTag) {
@@ -1861,7 +1871,7 @@
         if (closeRe.test(line)) {
           flushHtmlBlock();
         }
-        return;
+      continue;
       }
 
       const htmlOpenTag = startsHtmlBlock(trimmed);
@@ -1877,7 +1887,7 @@
         if (selfClose) {
           flushHtmlBlock();
         }
-        return;
+      continue;
       }
 
       if (trimmed.startsWith('|') && trimmed.endsWith('|')) {
@@ -1885,7 +1895,7 @@
         flushList();
         flushQuote();
         tableLines.push(trimmed);
-        return;
+      continue;
       }
 
       if (tableLines.length) flushTable();
@@ -1894,19 +1904,19 @@
         flushParagraph();
         flushList();
         flushQuote();
-        return;
+      continue;
       }
 
-      if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
+    if (RE_HR.test(trimmed)) {
         flushParagraph();
         flushList();
         flushQuote();
         flushTable();
         blocks.push('<hr>');
-        return;
+      continue;
       }
 
-      const headingMatch = trimmed.match(/^(#{1,6})\s+(.*)$/);
+    const headingMatch = trimmed.match(RE_HEADING);
       if (headingMatch) {
         flushParagraph();
         flushList();
@@ -1916,18 +1926,18 @@
         const headingMeta = level >= 2 && headingQueue.length ? headingQueue.shift() : null;
         const headingId = headingMeta ? headingMeta.slug : slugifyHeading(text);
         blocks.push('<h' + level + ' id="' + escapeHtml(headingId) + '">' + renderMathBlocks(renderInlineMarkdown(text, context)) + '</h' + level + '>');
-        return;
+      continue;
       }
 
-      const quoteMatch = trimmed.match(/^>\s?(.*)$/);
+    const quoteMatch = trimmed.match(RE_QUOTE);
       if (quoteMatch) {
         flushParagraph();
         flushList();
         quoteLines.push(quoteMatch[1]);
-        return;
+      continue;
       }
 
-      const taskMatch = trimmed.match(/^[-*]\s+\[([ xX])\]\s*(.*)$/);
+    const taskMatch = trimmed.match(RE_TASK);
       if (taskMatch) {
         flushParagraph();
         flushQuote();
@@ -1938,27 +1948,27 @@
           checked: String(taskMatch[1] || '').trim().toLowerCase() === 'x',
           text: String(taskMatch[2] || '').trim()
         });
-        return;
+      continue;
       }
 
-      const unorderedMatch = trimmed.match(/^[-*]\s+(.*)$/);
+    const unorderedMatch = trimmed.match(RE_UNORDERED);
       if (unorderedMatch) {
         flushParagraph();
         flushQuote();
         if (listTag && listTag !== 'ul') flushList();
         listTag = 'ul';
         listItems.push({ task: false, checked: false, text: unorderedMatch[1] });
-        return;
+      continue;
       }
 
-      const orderedMatch = trimmed.match(/^\d+\.\s+(.*)$/);
+    const orderedMatch = trimmed.match(RE_ORDERED);
       if (orderedMatch) {
         flushParagraph();
         flushQuote();
         if (listTag && listTag !== 'ol') flushList();
         listTag = 'ol';
         listItems.push({ task: false, checked: false, text: orderedMatch[1] });
-        return;
+      continue;
       }
 
       flushList();
@@ -1967,10 +1977,10 @@
       if (bookmarkAnchorHtml) {
         flushParagraph();
         blocks.push(bookmarkAnchorHtml);
-        return;
+      continue;
       }
       paragraphLines.push(trimmed);
-    });
+  }
 
     if (inCodeBlock) flushCodeBlock();
     flushParagraph();


### PR DESCRIPTION
💡 What: Hoisted multiple regular expressions out of the markdown rendering loop and converted `lines.forEach` to a standard `for` loop.
🎯 Why: In the `renderMarkdownContent` hot loop, regex literals were recompiled and a function closure was allocated for every single line of text parsed, creating unnecessary CPU and GC overhead.
📊 Impact: Eliminates regex recompilation overhead and closure allocations per line, improving markdown text parsing performance during client-side rendering.
🔬 Measurement: Verified by linting (`npm run lint:js`), local benchmarks indicating `for` loops and hoisted regexes are faster, and the automated test suite (`make test`), ensuring no functional regressions.

---
*PR created automatically by Jules for task [1274370048579510786](https://jules.google.com/task/1274370048579510786) started by @ImChong*