### PR TITLE
fix(ux): 修复路线图页移动端副标题文字溢出列宽

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1508,6 +1508,15 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   .cta-row a { width: 100%; }
   .page-hero h1 { font-size: 2rem; }
   .container { padding: 0 18px; }
+  /* 窄屏：keep-all 会让长中文副标题整段不换行溢出列宽 */
+  .section-subtitle,
+  .detail-content-main .section-subtitle {
+    min-width: 0;
+    max-width: 100%;
+    word-break: normal;
+    line-break: auto;
+    overflow-wrap: break-word;
+  }
   /* 首页 Wiki 搜索：移动端收紧内边距与字号 */
   .search-bar-wrap input[type="search"] {
     padding: 12px 12px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 路线图页「全站互链枢纽 · Top 10」下的 `.section-subtitle` 在移动端因 `word-break: keep-all` 导致长中文说明不换行、超出列宽。
- 在 `@media (max-width: 860px)` 下为 `.section-subtitle` 放宽换行规则（`word-break: normal`、`overflow-wrap: break-word`），并限制 `max-width: 100%`。

## 验证
- `make ci-preflight` 通过
- 390×844 视口下 `#roadmap-related .section-subtitle` 的 `scrollWidth === clientWidth`，文字在容器内正常换行

## 验证截图
![路线图互链枢纽区块移动端换行正常](https://cursor.com/artifacts/c/art-78b669f0-49ff-453e-87e1-71c963b4fd47)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0305f84c-c43c-4e64-a4ad-9d1706dbae11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0305f84c-c43c-4e64-a4ad-9d1706dbae11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

