### PR TITLE
Unify node radius calculation across graph views

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -193,6 +193,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
   <script defer src="graph-tooltip.js"></script>
+  <script defer src="graph-node-size.js"></script>
   <script defer src="main.js"></script>
 </body>
 </html>

--- a/docs/graph-node-size.js
+++ b/docs/graph-node-size.js
@@ -1,0 +1,45 @@
+(function () {
+  'use strict';
+
+  /**
+   * Graph view、首页知识图谱预览、详情页知识地图（1-hop 邻居）共用的节点尺寸标尺。
+   * 半径按 sqrt(degree) 在 [R_MIN, R_MAX] 间归一化插值：
+   * 度数 ≤1 的节点取 R_MIN（明显最小），全图最大度数的节点取 R_MAX（明显最大）。
+   */
+  var R_MIN = 4;
+  var R_MAX = 30;
+
+  /** 与 graph view 一致的度数统计：每条边给两端各计 1 度 */
+  function computeDegreeMap(edges) {
+    var map = {};
+    (edges || []).forEach(function (e) {
+      map[e.source] = (map[e.source] || 0) + 1;
+      map[e.target] = (map[e.target] || 0) + 1;
+    });
+    return map;
+  }
+
+  function maxDegreeOf(degreeMap) {
+    var max = 1;
+    for (var id in degreeMap) {
+      if (degreeMap[id] > max) max = degreeMap[id];
+    }
+    return max;
+  }
+
+  function radiusForDegree(degree, maxDegree) {
+    var span = Math.sqrt(Math.max(maxDegree || 1, 2)) - 1;
+    var t = (Math.sqrt(Math.max(degree || 0, 1)) - 1) / span;
+    if (t < 0) t = 0;
+    if (t > 1) t = 1;
+    return R_MIN + (R_MAX - R_MIN) * t;
+  }
+
+  window.RNGraphNodeSize = {
+    R_MIN: R_MIN,
+    R_MAX: R_MAX,
+    computeDegreeMap: computeDegreeMap,
+    maxDegreeOf: maxDegreeOf,
+    radiusForDegree: radiusForDegree
+  };
+})();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1555,6 +1555,7 @@
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
   <script src="main.js"></script>
   <script src="graph-tooltip.js"></script>
+  <script src="graph-node-size.js"></script>
   <script>
   (async function () {
     /* ── 颜色 & 类型标签 ── */
@@ -1862,7 +1863,10 @@
       }
       return TYPE_COLOR[d.type] || TYPE_COLOR[''];
     }
-    function baseRadius(d) { return Math.max(5, Math.min(18, 4 + Math.sqrt(d._degree || 0) * 2.2)); }
+    // 节点半径标尺与首页预览、详情页知识地图共用（graph-node-size.js）：
+    // 度数 1 → 最小半径，全图最大度数 → 最大半径
+    let graphMaxDegree = 1;
+    function baseRadius(d) { return window.RNGraphNodeSize.radiusForDegree(d._degree || 0, graphMaxDegree); }
     function scaledRadius(d) { return baseRadius(d) * nodeScale; }
     // 最终字号 = baseRadius × nodeScale × 0.4 × (fontSliderVal/10)
     // 0.4 让 baseRadius=10 的节点在 nodeScale=1, fontSliderVal=10 时字体≈10px
@@ -1956,11 +1960,8 @@
     renderLegend();
 
     /* ── 计算节点度数 ── */
-    const degreeMap = {};
-    for (const e of graphData.edges) {
-      degreeMap[e.source] = (degreeMap[e.source] || 0) + 1;
-      degreeMap[e.target] = (degreeMap[e.target] || 0) + 1;
-    }
+    const degreeMap = window.RNGraphNodeSize.computeDegreeMap(graphData.edges);
+    graphMaxDegree = window.RNGraphNodeSize.maxDegreeOf(degreeMap);
 
     /* ── 准备节点/边数据：title / summary / recency 都直接来自 link-graph.json ── */
     const nodes = graphData.nodes.map(n => ({

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,6 +103,7 @@
 
   <script src="main.js"></script>
   <script src="graph-tooltip.js"></script>
+  <script src="graph-node-size.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js" defer></script>
   <script src="mini-graph.js" defer></script>
   <script>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2557,6 +2557,10 @@
       var current = nodeMap[currentPath];
       if (!current) return; // 当前节点不在图谱里
 
+      // 节点半径继承 graph view 的标尺（graph-node-size.js），度数基准为全图
+      var degreeMap = window.RNGraphNodeSize.computeDegreeMap(gd.edges);
+      var maxDegree = window.RNGraphNodeSize.maxDegreeOf(degreeMap);
+
       var neighborSet = {};
       (gd.edges || []).forEach(function (e) {
         if (e.source === e.target) return;
@@ -2582,12 +2586,14 @@
         id: currentPath, label: current.label || currentPath,
         type: current.type || '', community: current.community || '',
         summary: current.summary || '', isCurrent: true,
+        _degree: degreeMap[currentPath] || 0,
         fx: W / 2, fy: H / 2
       }].concat(neighborIds.map(function (id) {
         var n = nodeMap[id];
         return {
           id: id, label: n.label || id, type: n.type || '', community: n.community || '',
-          summary: n.summary || '', isCurrent: false
+          summary: n.summary || '', isCurrent: false,
+          _degree: degreeMap[id] || 0
         };
       }));
       var edges = neighborIds.map(function (id) { return { source: currentPath, target: id }; });
@@ -2603,7 +2609,7 @@
       hoverTip.bindOutsideDismiss(svgEl, document.body);
 
       function detailMiniNodeRadius(d, scale) {
-        var base = d.isCurrent ? 8 : 6;
+        var base = window.RNGraphNodeSize.radiusForDegree(d._degree || 0, maxDegree);
         return base * (scale || 1);
       }
 
@@ -2631,7 +2637,7 @@
         .force('link', window.d3.forceLink(edges).id(function (d) { return d.id; }).distance(54).strength(0.5))
         .force('charge', window.d3.forceManyBody().strength(-160).distanceMax(220))
         .force('center', window.d3.forceCenter(W / 2, H / 2).strength(0.12))
-        .force('collision', window.d3.forceCollide().radius(14).strength(0.7))
+        .force('collision', window.d3.forceCollide().radius(function (d) { return detailMiniNodeRadius(d) + 8; }).strength(0.7))
         .alphaDecay(0.05);
 
       var line = lineLayer.selectAll('line').data(edges).join('line')
@@ -2681,7 +2687,7 @@
         .attr('fill-opacity', 0.9);
       nodeG.append('text')
         .text(function (d) { return d.label.length > 10 ? d.label.slice(0, 10) + '…' : d.label; })
-        .attr('dy', function (d) { return (d.isCurrent ? 8 : 6) + 11; })
+        .attr('dy', function (d) { return detailMiniNodeRadius(d) + 11; })
         .attr('text-anchor', 'middle')
         .attr('font-size', '10px')
         .style('fill', 'var(--text-muted)')

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -134,11 +134,12 @@
 
     fetch('exports/graph-stats.json').then(function(r){ return r.json(); }).then(function(stats) {
       var totalNodes = gd.nodes.length, totalEdges = gd.edges.length;
-      var degreeMap = {};
-      gd.edges.forEach(function(e) {
-        degreeMap[e.source] = (degreeMap[e.source]||0)+1;
-        degreeMap[e.target] = (degreeMap[e.target]||0)+1;
-      });
+      // 节点半径继承 graph view 的标尺（graph-node-size.js），度数基准为全图
+      var degreeMap = window.RNGraphNodeSize.computeDegreeMap(gd.edges);
+      var maxDegree = window.RNGraphNodeSize.maxDegreeOf(degreeMap);
+      function nodeRadius(d) {
+        return window.RNGraphNodeSize.radiusForDegree(d._degree, maxDegree);
+      }
 
       var topIds = new Set(
         gd.nodes.slice().sort(function(a,b){ return (degreeMap[b.id]||0)-(degreeMap[a.id]||0); })
@@ -190,7 +191,7 @@
         .force('link', d3.forceLink(edges).id(function(d){ return d.id; }).distance(60).strength(0.4))
         .force('charge', d3.forceManyBody().strength(-200).distanceMax(300))
         .force('center', d3.forceCenter(W/2, H/2).strength(0.08))
-        .force('collision', d3.forceCollide().radius(12).strength(0.6))
+        .force('collision', d3.forceCollide().radius(function(d){ return nodeRadius(d) + 4; }).strength(0.6))
         .alphaDecay(0.03);
 
       line = lineLayer.selectAll('line').data(edges).join('line')
@@ -214,9 +215,7 @@
         })
         .on('mouseenter', function(ev, d) {
           if (isMobile) return;
-          d3.select(this).select('circle').attr('fill-opacity', 1).attr('r', function(){
-            return Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2)) * 1.3;
-          });
+          d3.select(this).select('circle').attr('fill-opacity', 1).attr('r', nodeRadius(d) * 1.3);
           showTooltip(ev, d, nodeFill, communityLabelMap);
         })
         .on('mousemove', function(ev) {
@@ -225,19 +224,18 @@
         })
         .on('mouseleave', function(ev, d) {
           if (isMobile) return;
-          d3.select(this).select('circle').attr('fill-opacity', 0.9).attr('r',
-            Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2)));
+          d3.select(this).select('circle').attr('fill-opacity', 0.9).attr('r', nodeRadius(d));
           if (!isMobile || !pinnedNode) hideTooltip();
         });
 
       nodeG.append('circle')
-        .attr('r', function(d){ return Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2)); })
+        .attr('r', nodeRadius)
         .attr('fill', function(d){ return nodeFill(d); })
         .attr('fill-opacity', 0.9);
 
       label = nodeG.append('text')
         .text(function(d){ return d.label.length>12 ? d.label.slice(0,12)+'…' : d.label; })
-        .attr('dy', function(d){ return Math.max(5, Math.min(14, 3+Math.sqrt(d._degree)*2))+11; })
+        .attr('dy', function(d){ return nodeRadius(d)+11; })
         .attr('text-anchor','middle')
         .attr('font-size','10px')
         .attr('pointer-events','none');


### PR DESCRIPTION
## 摘要

提取节点半径计算逻辑为独立模块 `graph-node-size.js`，在首页知识图谱预览、详情页知识地图和完整图谱视图中共用统一的度数-半径映射标尺。节点半径现基于 sqrt(degree) 在 [4, 30] 范围内归一化：**度数 1 锚定最小 4px，全图最大度数（当前 199）锚定最大 30px**，确保互联度最高的节点明显最大、度数 1 的节点明显最小，且三个视图的节点大小表示一致。

> 旧公式 `4 + √degree × 2.2` 在 18px 封顶，度数 ≥41 的节点全部一样大；知识地图原为固定 6/8px，与 Graph view 无关。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 新增模块
- **`docs/graph-node-size.js`**：提供节点半径计算的共用工具函数
  - `computeDegreeMap(edges)`：从边列表计算节点度数
  - `maxDegreeOf(degreeMap)`：获取最大度数
  - `radiusForDegree(degree, maxDegree)`：根据度数和全图最大度数计算半径
  - 半径范围：`R_MIN=4`（度数≤1）到 `R_MAX=30`（最大度数）

### 改动范围
1. **`docs/mini-graph.js`**（首页预览）
   - 使用 `RNGraphNodeSize.computeDegreeMap()` 替代内联度数计算
   - 碰撞检测半径改为动态计算：`nodeRadius(d) + 4`
   - 节点圆形和标签位置统一使用 `nodeRadius()` 函数

2. **`docs/main.js`**（详情页知识地图）
   - 在 1-hop 邻居图中添加 `_degree` 属性
   - 使用 `RNGraphNodeSize.radiusForDegree()` 替代硬编码的 `d.isCurrent ? 8 : 6` 逻辑
   - 碰撞检测半径改为 `detailMiniNodeRadius(d) + 8`

3. **`docs/graph.html`**（完整图谱视图）
   - 使用 `RNGraphNodeSize.radiusForDegree()` 替代原有的 `Math.max(5, Math.min(18, 4 + Math.sqrt(d._degree || 0) * 2.2))` 公式
   - 计算全图最大度数用于标尺基准

4. **HTML 文件**（`index.html`, `detail.html`, `graph.html`）
   - 添加 `<script src="graph-node-size.js">` 引入

## 验证

- `npx eslint docs/main.js`（仓库 JS 门禁 `make lint-js`）通过
- `node --check` 三个改动 JS 文件语法通过
- 标尺抽样：度数 1 → 4px，3 → 5.5px，10 → 8.3px，50 → 16px，100 → 21.9px，199 → 30px
- 三个视图的节点度数计算逻辑一致（均为每条边给两端各计 1 度），同一节点在三处图中大小一致
- `make ci-preflight`：N/A（仅 docs 前端 JS/HTML 改动，不涉及 wiki/schema/exports）

## 验证截图

Graph view（sim2real 度数 199 → 最大；边缘低度数节点为小点）：
`&lt;img alt="Graph view 新标尺" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/graph-view-new-scale.png" /&gt;`

首页知识图谱预览（Top-40，继承同一标尺）：
`&lt;img alt="首页知识图谱预览" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/index-mini-graph-new-scale.png" /&gt;`

详情页知识地图（sim2real，中心节点最大、邻居按各自全图度数分级）：
`&lt;img alt="知识地图 sim2real" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-mini-map-sim2real.png" /&gt;`

详情页知识地图（低度数页 BABEL，度数 3：当前节点很小，高互联度邻居明显更大）：
`&lt;img alt="知识地图低度数页" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-mini-map-low-degree.png" /&gt;`

## 相关 Issue

无

https://claude.ai/code/session_01P8fFNJkPiq2uGH1dcmGWZt