### PR TITLE
feat(tooling): V24 P0 新增 scaffold_wiki_page.py 页面骨架脚手架与测试

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v24.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v24.md
@@ -28,8 +28,8 @@
     - [ ] `scripts/lint_wiki.py` 新增 `stale_claim_check`：扫描正文出现「SOTA / 最新 / 当前最强 / state-of-the-art」等绝对化措辞但 frontmatter `updated` 早于库内同主题更晚页面的情形，给出 INFO 级提示（不阻塞 CI），并写入 lint 报告基线快照；新增用例覆盖到 `tests/`。
 - [ ] **缺页概念巡检 V1**：
     - [ ] `scripts/lint_wiki.py` 新增 `missing_concept_page_check`：统计正文中以 `**术语**`/反引号高频出现（≥ N 页引用）但无独立 `wiki/concepts|methods|formalizations` 页的术语，输出"建议新建页"候选清单（INFO 级，不阻塞 CI），作为后续 ingest/query 选题入口。
-- [ ] **query → wiki 回填脚手架**：
-    - [ ] 新增 `scripts/scaffold_wiki_page.py`：给定 type（concept/comparison/query/...）与标题，按全库 frontmatter 规范生成骨架（含速查区块锚点、`related`/`sources` 占位、三段式正文骨架），降低把 query 答案沉淀回 wiki 的手工成本；自带 `--dry-run` 与 lint 自检。
+- [x] **query → wiki 回填脚手架**：
+    - [x] 新增 `scripts/scaffold_wiki_page.py`：给定 type（concept/comparison/query/...）与标题，按全库 frontmatter 规范生成骨架（含速查区块锚点、`related`/`sources` 占位、三段式正文骨架），降低把 query 答案沉淀回 wiki 的手工成本；自带 `--dry-run` 与 lint 自检。
 
 ## P1: 视觉感知骨干与机器人表征专题 (Quality)
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,13 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-11] tooling | scripts/scaffold_wiki_page.py、tests/test_scaffold_wiki_page.py — V24 P0「query → wiki 回填脚手架」：新增页面骨架生成脚本与测试
+
+- 新增 [`scripts/scaffold_wiki_page.py`](scripts/scaffold_wiki_page.py)：`type + 标题`（可选 `--slug`）按全库 frontmatter 规范生成骨架——含 `## 英文缩写速查` 落在规范位置（定义之后、为什么重要之前）、`related`/`sources` 占位、三段式正文；query 类型额外含 `**Query 产物**` / `## 参考来源` / `## 关联页面`
+- 复用 `lint_wiki.has_section` / `wiki_abbrev_section.is_abbrev_glossary_well_placed` 做生成后结构自检；`--dry-run` 只打印不落盘、`--force` 控制覆盖
+- 新增 [`tests/test_scaffold_wiki_page.py`](tests/test_scaffold_wiki_page.py) 7 例：结构自检、缩写区块位序、query 标记、frontmatter 键、slug 推断、dry-run 不落盘、写入与防覆盖
+- 验证：新增测试全绿（全量 149 passed）、ruff/format/mypy 通过、`lint_wiki` 基线 51 项不变
+- 勾选 checklist v24 P0「query → wiki 回填脚手架」
+
 ## [2026-06-10] structural | wiki/concepts/vision-backbones.md、wiki/methods/object-detection.md — V24 P1「视觉感知专题交叉补强」：明示「骨干特征 → 检测/分割头 → 策略输入」衔接链并与新页双向回链
 
 - 在 [`vision-backbones.md`](wiki/concepts/vision-backbones.md) 新增「骨干特征 → 检测/分割头 → 策略输入」小节，补回链 [`cnn-vs-vit-backbones.md`](wiki/comparisons/cnn-vs-vit-backbones.md)、[`perception-backbone-selection.md`](wiki/queries/perception-backbone-selection.md)（frontmatter `related` + 关联页面）

--- a/scripts/scaffold_wiki_page.py
+++ b/scripts/scaffold_wiki_page.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""scaffold_wiki_page.py — 按全库 frontmatter 规范生成 wiki 页面骨架。
+
+把 query 答案 / 选题候选沉淀回 wiki 时，手工拼 frontmatter、速查区块、三段式
+正文骨架成本不低。本脚本给定 type 与标题，输出符合 lint 结构要求的骨架：
+含「英文缩写速查」锚点（落在规范位置）、`related`/`sources` 占位与三段式正文。
+
+用法：
+    python3 scripts/scaffold_wiki_page.py concept "视觉伺服" --slug visual-servoing-intro
+    python3 scripts/scaffold_wiki_page.py query "机器人感知选型" --slug perception-pick --dry-run
+
+自带 `--dry-run`（只打印不落盘）与生成后结构自检（复用 lint_wiki 判据）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+from lint_wiki import has_section, word_count
+from wiki_abbrev_section import is_abbrev_glossary_well_placed
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# type → wiki 子目录
+TYPE_DIRS: dict[str, str] = {
+    "concept": "concepts",
+    "method": "methods",
+    "task": "tasks",
+    "comparison": "comparisons",
+    "query": "queries",
+    "formalization": "formalizations",
+    "entity": "entities",
+    "overview": "overview",
+}
+
+
+def slugify(title: str, override: str | None) -> str:
+    """从标题或 --slug 生成 kebab-case slug；纯中文标题需显式 --slug。"""
+    if override:
+        return override.strip().lower()
+    ascii_only = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return ascii_only
+
+
+def _frontmatter(page_type: str, title: str) -> str:
+    today = date.today().isoformat()
+    return (
+        "---\n"
+        f"type: {page_type}\n"
+        "tags:\n"
+        "  - TODO\n"
+        "status: draft\n"
+        f"updated: {today}\n"
+        f'summary: "TODO：一句话概括「{title}」是什么、为什么重要。"\n'
+        "related:\n"
+        "  - ../TODO/related-page.md\n"
+        "sources:\n"
+        "  - ../../sources/TODO/source.md\n"
+        "---\n"
+    )
+
+
+_ABBREV_BLOCK = (
+    "## 英文缩写速查\n\n"
+    "| 缩写 | 英文全称 | 简要说明 |\n"
+    "|------|----------|----------|\n"
+    "| TODO | TODO Full Name | TODO 待补全 |\n"
+)
+
+_TAIL_BLOCK = (
+    "## 关联页面\n\n"
+    "- [TODO 相关页面标题](../TODO/related-page.md)\n\n"
+    "## 参考来源\n\n"
+    "- [TODO 来源标题](../../sources/TODO/source.md)\n\n"
+    "## 推荐继续阅读\n\n"
+    "- [TODO 外部资料标题](https://example.com)\n"
+)
+
+
+def _body_standard(title: str) -> str:
+    return (
+        f"# {title}\n\n"
+        "## 一句话定义\n\n"
+        f"**{title}**：TODO 一句话核心定义（在机器人语境下它解决什么问题）。\n\n"
+        f"{_ABBREV_BLOCK}\n"
+        "## 为什么重要\n\n"
+        "- **TODO 要点一：** 待补全。\n"
+        "- **TODO 要点二：** 待补全。\n\n"
+        "## 核心内容\n\n"
+        "TODO 三段式骨架：**是什么 → 怎么做 → 取舍与边界**，逐段补全。\n\n"
+        "## 常见误区或局限\n\n"
+        "- **误区：「TODO」** TODO 纠正。\n"
+        "- **局限：** TODO 待补全。\n\n"
+        f"{_TAIL_BLOCK}"
+    )
+
+
+def _body_query(title: str) -> str:
+    return (
+        f"# Query：{title}\n\n"
+        "> **Query 产物**：本页由以下问题触发：「TODO 触发问题」\n"
+        "> 综合来源：[TODO 页面](../TODO/related-page.md)\n\n"
+        f"{_ABBREV_BLOCK}\n"
+        "## TL;DR 决策结论\n\n"
+        "- TODO 第一刀砍在哪。\n"
+        "- TODO 第二刀砍在哪。\n\n"
+        "## 详细分析\n\n"
+        "TODO 分类对比 / 决策树 / 推荐组合，逐段补全。\n\n"
+        "## 关联页面\n\n"
+        "- [TODO 相关页面标题](../TODO/related-page.md)\n\n"
+        "## 参考来源\n\n"
+        "- [TODO 来源标题](../../sources/TODO/source.md)\n"
+    )
+
+
+def build_skeleton(page_type: str, title: str) -> str:
+    body = _body_query(title) if page_type == "query" else _body_standard(title)
+    return _frontmatter(page_type, title) + "\n" + body
+
+
+def self_check(content: str, page_type: str) -> list[str]:
+    """复用 lint_wiki 判据对骨架做结构自检；返回问题列表（空=通过）。"""
+    problems: list[str] = []
+    fm = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not fm:
+        problems.append("缺 frontmatter 区块")
+    else:
+        for key in ("type", "updated", "summary", "related", "sources"):
+            if not re.search(rf"^{key}\s*:", fm.group(1), re.MULTILINE):
+                problems.append(f"frontmatter 缺 {key}")
+
+    if not has_section(content, ["英文缩写速查"]):
+        problems.append("缺「英文缩写速查」区块")
+    elif not is_abbrev_glossary_well_placed(content):
+        problems.append("「英文缩写速查」位置不规范")
+    if not has_section(content, ["关联", "related"]):
+        problems.append("缺「关联页面」区块")
+    if not has_section(content, ["参考来源", "sources"]):
+        problems.append("缺「参考来源」区块")
+
+    if page_type == "query":
+        for needle, label in (
+            ("**Query 产物**", "Query 产物说明"),
+            ("## 参考来源", "## 参考来源"),
+            ("## 关联页面", "## 关联页面"),
+        ):
+            if needle not in content:
+                problems.append(f"query 页缺 {label}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="生成符合 lint 规范的 wiki 页面骨架")
+    parser.add_argument("type", choices=sorted(TYPE_DIRS), help="页面类型")
+    parser.add_argument("title", help="页面标题（h1 与 summary 中使用）")
+    parser.add_argument("--slug", help="文件名 slug（纯中文标题必填）")
+    parser.add_argument("--dry-run", action="store_true", help="只打印骨架，不落盘")
+    parser.add_argument("--force", action="store_true", help="允许覆盖已存在文件")
+    args = parser.parse_args(argv)
+
+    slug = slugify(args.title, args.slug)
+    if not slug:
+        print("✗ 无法从标题推断 slug（纯中文？请用 --slug 指定）", file=sys.stderr)
+        return 2
+
+    content = build_skeleton(args.type, args.title)
+
+    problems = self_check(content, args.type)
+    wc = word_count(content)
+
+    target = REPO_ROOT / "wiki" / TYPE_DIRS[args.type] / f"{slug}.md"
+
+    if args.dry_run:
+        print(content)
+        print(f"--- 自检：{'通过' if not problems else '发现问题'} ---", file=sys.stderr)
+    if problems:
+        for p in problems:
+            print(f"✗ 结构自检：{p}", file=sys.stderr)
+        return 1
+
+    print(
+        f"✓ 结构自检通过（骨架 {wc} 字，待补全正文以超过 200 字下限）",
+        file=sys.stderr,
+    )
+
+    if args.dry_run:
+        print(f"（--dry-run：未写入 {target.relative_to(REPO_ROOT)}）", file=sys.stderr)
+        return 0
+
+    if target.exists() and not args.force:
+        print(f"✗ 已存在 {target.relative_to(REPO_ROOT)}（--force 可覆盖）", file=sys.stderr)
+        return 1
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    print(f"✓ 已生成 {target.relative_to(REPO_ROOT)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scaffold_wiki_page.py
+++ b/tests/test_scaffold_wiki_page.py
@@ -1,0 +1,63 @@
+"""Unit tests for scripts/scaffold_wiki_page.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import scaffold_wiki_page as scaf
+
+
+def test_standard_skeleton_passes_self_check() -> None:
+    content = scaf.build_skeleton("concept", "视觉伺服")
+    assert scaf.self_check(content, "concept") == []
+    # 关键结构锚点
+    assert "## 一句话定义" in content
+    assert "## 英文缩写速查" in content
+    assert "## 关联页面" in content
+    assert "## 参考来源" in content
+
+
+def test_abbrev_after_definition_before_why() -> None:
+    content = scaf.build_skeleton("method", "示例方法")
+    pos_def = content.find("## 一句话定义")
+    pos_abbrev = content.find("## 英文缩写速查")
+    pos_why = content.find("## 为什么重要")
+    assert pos_def < pos_abbrev < pos_why
+
+
+def test_query_skeleton_has_query_markers() -> None:
+    content = scaf.build_skeleton("query", "感知选型")
+    assert scaf.self_check(content, "query") == []
+    assert "**Query 产物**" in content
+    assert content.startswith("---")
+    assert "# Query：感知选型" in content
+
+
+def test_frontmatter_has_required_keys() -> None:
+    content = scaf.build_skeleton("concept", "X")
+    for key in ("type:", "updated:", "summary:", "related:", "sources:"):
+        assert key in content
+
+
+def test_slugify_derives_from_ascii_title() -> None:
+    assert scaf.slugify("Visual Servoing Intro", None) == "visual-servoing-intro"
+    assert scaf.slugify("anything", "explicit-slug") == "explicit-slug"
+    # 纯中文标题无 override → 空 slug，交由 CLI 报错
+    assert scaf.slugify("视觉伺服", None) == ""
+
+
+def test_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(scaf, "REPO_ROOT", tmp_path)
+    rc = scaf.main(["concept", "Demo Page", "--dry-run"])
+    assert rc == 0
+    assert not (tmp_path / "wiki" / "concepts" / "demo-page.md").exists()
+
+
+def test_write_creates_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(scaf, "REPO_ROOT", tmp_path)
+    rc = scaf.main(["concept", "Demo Page", "--slug", "demo-page"])
+    assert rc == 0
+    out = tmp_path / "wiki" / "concepts" / "demo-page.md"
+    assert out.exists()
+    # 不允许无 --force 覆盖
+    assert scaf.main(["concept", "Demo Page", "--slug", "demo-page"]) == 1


### PR DESCRIPTION
## 摘要

- 落地执行清单 v24 P0「query → wiki 回填脚手架」：新增 `scripts/scaffold_wiki_page.py`，给定 `type + 标题`（可选 `--slug`）按全库 frontmatter 规范生成页面骨架，降低把 query 答案沉淀回 wiki 的手工成本。
- 背景：PR #598 合并时仅含本分支当时的第一个提交（V24 P1 视觉感知交叉补强），本 scaffold 提交是在其合并后才推送的，故未进 `main`；本 PR 把它单独并入。

## 改动内容

- **`scripts/scaffold_wiki_page.py`**
  - 生成的骨架满足 lint 结构要求：`## 英文缩写速查` 落在规范位置（一句话定义之后、为什么重要之前）、`related`/`sources` 占位、三段式正文。
  - `query` 类型额外含 `**Query 产物**` / `## 参考来源` / `## 关联页面`。
  - 复用 `lint_wiki.has_section` 与 `wiki_abbrev_section.is_abbrev_glossary_well_placed` 做**生成后结构自检**；`--dry-run` 只打印不落盘、`--force` 控制覆盖；纯中文标题无 `--slug` 时明确报错退出。
- **`tests/test_scaffold_wiki_page.py`** — 7 例覆盖：结构自检、缩写区块位序、query 标记、frontmatter 键、slug 推断、dry-run 不落盘、写入与防覆盖。
- 勾选 checklist v24 P0 对应项并补 `log.md`。

## 验证

- 新增测试全绿，全量 **149 passed**（`PYTHONPATH="$PWD:$PWD/scripts" pytest -o addopts=""`，本环境 pytest 为 uv-tool 隔离环境缺 pytest-cov）。
- `ruff check` / `ruff format --check` / `mypy` 均通过。
- `lint_wiki` 基线 **51 项不变**（纯工具脚本，无 wiki 内容改动，无需图谱/导出重生）。
- N/A：非 wiki 渲染类改动，按 CLAUDE.md §5 表格不强制截图。

https://claude.ai/code/session_01TWnjiBV9Kb3pM9oJRL8cZv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWnjiBV9Kb3pM9oJRL8cZv)_