### PR TITLE
fix(ux): 首页图谱预览统计文案写明 Top-40 抽样规则

### DIFF
--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -12,6 +12,7 @@
     formalization: '形式化', '': 'Wiki'
   };
 
+  var PREVIEW_TOP_N = 40;
   var isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
   var pinnedNode = null;
 
@@ -143,7 +144,7 @@
 
       var topIds = new Set(
         gd.nodes.slice().sort(function(a,b){ return (degreeMap[b.id]||0)-(degreeMap[a.id]||0); })
-        .slice(0,40).map(function(n){ return n.id; })
+        .slice(0, PREVIEW_TOP_N).map(function(n){ return n.id; })
       );
 
       var nodes = gd.nodes.filter(function(n){ return topIds.has(n.id); }).map(function(n){
@@ -288,7 +289,9 @@
       }
 
       var orphans = (stats.orphan_nodes||[]).length;
-      statsEl.textContent = totalNodes + ' 节点 · ' + totalEdges + ' 条边 · 孤儿 ' + orphans + ' 个 | 显示 Top-40';
+      statsEl.textContent =
+        '全站 ' + totalNodes + ' 节点 · ' + totalEdges + ' 条边 · 孤儿 ' + orphans +
+        ' 个 | 预览：按连接度 Top-' + PREVIEW_TOP_N + ' 枢纽（仅绘子图内连边）';
     }).catch(function(){});
   }).catch(function(){});
 })();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 保持首页知识图谱预览 **Top-40** 抽样不变
- 左下角统计文案区分「全站规模」与「预览抽样规则」，避免用户误以为预览区即全图

## 变更
- `docs/mini-graph.js`：抽取 `PREVIEW_TOP_N = 40` 常量，统计文案改为：
  - `全站 {N} 节点 · {E} 条边 · 孤儿 {O} 个 | 预览：按连接度 Top-40 枢纽（仅绘子图内连边）`

## 验证
- 仅改前端文案与常量，无 wiki / 派生文件变更
- `make ci-preflight`：N/A（未触及 wiki 或导出链路）

## 验证截图
首页 `#mini-graph-stats` 左下角应显示含「全站」「预览：按连接度 Top-40」的新文案。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d53f81f9-cebb-4f66-ac0f-7066f0cb4111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d53f81f9-cebb-4f66-ac0f-7066f0cb4111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

