### PR TITLE
fix(ux): 移除首页知识图谱预览「仅绘子图内连边」说明小字

### DIFF
--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -291,7 +291,7 @@
       var orphans = (stats.orphan_nodes||[]).length;
       statsEl.textContent =
         '全站 ' + totalNodes + ' 节点 · ' + totalEdges + ' 条边 · 孤儿 ' + orphans +
-        ' 个 | 预览：按连接度 Top-' + PREVIEW_TOP_N + ' 枢纽（仅绘子图内连边）';
+        ' 个 | 预览：按连接度 Top-' + PREVIEW_TOP_N + ' 枢纽';
     }).catch(function(){});
   }).catch(function(){});
 })();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 移除首页「知识图谱预览」区块左下角统计文案中的「（仅绘子图内连边）」说明，避免底部小字过于冗长。
- 修改文件：`docs/mini-graph.js`（`statsEl.textContent` 拼接字符串）。

## 验证
- 本地 `docs/index.html#mini-graph-section` 渲染正常；统计行现为「全站 N 节点 · M 条边 · 孤儿 K 个 | 预览：按连接度 Top-40 枢纽」。
- 本次仅改前端展示文案，未涉及 `wiki/` 或派生导出，无需 `make ci-preflight`。

## 验证截图
![首页知识图谱预览区块（已去掉仅绘子图内连边说明）](https://cursor.com/artifacts/c/art-3d6af7bb-0689-418a-8b9e-31be1654006a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c48763b2-b8ed-4cc6-a07a-4458fc7b4288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c48763b2-b8ed-4cc6-a07a-4458fc7b4288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

