### PR TITLE
fix(ux): 图谱参数面板仅保留排斥力滑块

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1389,39 +1389,6 @@
       <div class="slider-divider"></div>
 
       <div class="slider-row">
-        <div class="slider-label">
-          <span>节点大小</span>
-          <span class="slider-val" id="val-size">1.0×</span>
-        </div>
-        <input type="range" id="sl-size" min="40" max="280" value="100" step="5"
-               aria-label="节点大小" />
-      </div>
-
-      <div class="slider-divider"></div>
-
-      <div class="slider-row">
-        <div class="slider-label">
-          <span>连接线粗细</span>
-          <span class="slider-val" id="val-link">1.0px</span>
-        </div>
-        <input type="range" id="sl-link" min="2" max="60" value="10" step="1"
-               aria-label="连接线粗细" />
-      </div>
-
-      <div class="slider-divider"></div>
-
-      <div class="slider-row">
-        <div class="slider-label">
-          <span>节点字体大小</span>
-          <span class="slider-val" id="val-font">×1.5</span>
-        </div>
-        <input type="range" id="sl-font" min="6" max="22" value="15" step="1"
-               aria-label="节点字体大小" />
-      </div>
-
-      <div class="slider-divider"></div>
-
-      <div class="slider-row">
         <label class="physics-toggle" for="check-magnetic">
           <input type="checkbox" id="check-magnetic" />
           <span>🧲 磁吸模式</span>
@@ -1835,11 +1802,11 @@
       return false;
     }
 
-    /* ── 可变物理参数（由滑动块控制）── */
-    let chargeStrength = -800;   // 排斥力（负值）
-    let nodeScale      = 1.0;    // 节点大小倍数
-    let linkWidthBase  = 1.0;    // 连接线基础粗细（px）
-    let fontSliderVal  = 15;     // 字体滑块值（6-22），作为乘数作用在nodeScale上
+    /* ── 可变物理参数 ── */
+    let chargeStrength = -800;   // 排斥力（负值，由滑块控制）
+    const nodeScale      = 1.0;    // 节点大小倍数
+    const linkWidthBase  = 1.0;    // 连接线基础粗细（px）
+    const fontSliderVal  = 15;     // 字体缩放（相对 nodeScale）
     let isMagnetic     = false;
 
     /* ── 主题辅助（响应 data-theme 切换）── */
@@ -3343,39 +3310,10 @@
       updateForces();
     });
 
-    /* 4. 磁吸模式 checkbox */
+    /* 磁吸模式 checkbox */
     document.getElementById('check-magnetic').addEventListener('change', ev => {
       isMagnetic = ev.target.checked;
       updateForces();
-    });
-
-    /* 2. 节点大小 slider（min=40, max=280, value/100 = nodeScale） */
-    document.getElementById('sl-size').addEventListener('input', ev => {
-      nodeScale = Number(ev.target.value) / 100;
-      document.getElementById('val-size').textContent = nodeScale.toFixed(1) + '×';
-      // 更新圆半径 & 标签位置
-      node.select('.node-circle').attr('r', scaledRadius);
-      node.select('.node-glow').attr('r', d => scaledRadius(d) + 6);
-      label.attr('dy', d => scaledRadius(d) + 13);
-      // 更新碰撞半径并重新模拟
-      simulation
-        .force('collision', d3.forceCollide().radius(d => scaledRadius(d) + 5).strength(0.7))
-        .alpha(0.3).restart();
-    });
-
-    /* 3. 连接线粗细 slider（min=2, max=60, value/10 = linkWidthBase） */
-    document.getElementById('sl-link').addEventListener('input', ev => {
-      linkWidthBase = Number(ev.target.value) / 10;
-      document.getElementById('val-link').textContent = linkWidthBase.toFixed(1) + 'px';
-      // 立即更新，无需重启模拟
-      link.attr('stroke-width', linkWidthBase);
-    });
-
-    /* 4. 节点字体大小 slider（min=6, max=22, step=1）—— 在 nodeScale 基础上再缩放 */
-    document.getElementById('sl-font').addEventListener('input', ev => {
-      fontSliderVal = Number(ev.target.value);
-      document.getElementById('val-font').textContent = '×' + (fontSliderVal / 10).toFixed(1);
-      label.attr('font-size', d => scaledFontSize(d) + 'px');
     });
 
     /* ════════════════════════════════════════════


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 精简 `docs/graph.html` 中「⚙ 图谱参数」面板：仅保留**排斥力**滑块。
- 移除节点大小、连接线粗细、节点字体大小三个参数滑块及其事件监听。
- 磁吸模式开关、刷新布局、时序动画等布局与演示控件保持不变；节点/连线/字号的默认值仍由内部常量驱动。

## 验证
- 本地打开 `graph.html` → 点击工具栏「参数」→ 面板内仅显示排斥力滑块 + 磁吸模式 + 布局与演示区。
- 排斥力滑块拖动后布局仍会实时更新（`updateForces()`）。
- 本次仅改前端展示，未涉及 `wiki/` 或派生导出。

## 验证截图
![图谱参数面板仅保留排斥力滑块](https://cursor.com/artifacts/c/art-f046c562-2fab-42e0-877f-a51c0cdb62c0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c48763b2-b8ed-4cc6-a07a-4458fc7b4288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c48763b2-b8ed-4cc6-a07a-4458fc7b4288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

