### PR TITLE
⚡ Bolt: [performance improvement] avoid array mapping in search tag iteration loops

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -3942,13 +3942,14 @@
       if (!queryTokens || !queryTokens.length) return '';
       var title = (item.title || '').toLowerCase();
       var summary = (item.summary || '').toLowerCase();
-      var tags = (item.tags || []).map(function(t) { return t.toLowerCase(); });
+      var itemTags = item.tags || [];
 
       // 检查标签命中 (V20 增强)
-      for (var k = 0; k < tags.length; k++) {
+      for (var k = 0; k < itemTags.length; k++) {
+        var tagLower = String(itemTags[k] || '').toLowerCase();
         for (var l = 0; l < queryTokens.length; l++) {
-          if (tags[k].indexOf(queryTokens[l]) >= 0) {
-            return escapeHtml('核心标签命中: ' + tags[k]);
+          if (tagLower.indexOf(queryTokens[l]) >= 0) {
+            return escapeHtml('核心标签命中: ' + itemTags[k]);
           }
         }
       }
@@ -3969,10 +3970,11 @@
       if (!queryTokens || !queryTokens.length) return 'exact';
       var title = String(item.title || '').toLowerCase();
       var path = String(item.path || '').toLowerCase();
-      var tags = (item.tags || []).map(function(t) { return String(t || '').toLowerCase(); });
-      for (var k = 0; k < tags.length; k++) {
+      var itemTags = item.tags || [];
+      for (var k = 0; k < itemTags.length; k++) {
+        var tagLower = String(itemTags[k] || '').toLowerCase();
         for (var l = 0; l < queryTokens.length; l++) {
-          if (tags[k].indexOf(queryTokens[l]) >= 0) return 'exact';
+          if (tagLower.indexOf(queryTokens[l]) >= 0) return 'exact';
         }
       }
       for (var i = 0; i < queryTokens.length; i++) {

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -406,7 +406,7 @@ console.log('ok');
 
     def test_main_js_search_match_explanation_escapes_user_facing_strings(self):
         content = MAIN_JS.read_text(encoding="utf-8")
-        self.assertIn("return escapeHtml('核心标签命中: ' + tags[k]);", content)
+        self.assertIn("return escapeHtml('核心标签命中: ' + itemTags[k]);", content)
         self.assertIn("return escapeHtml('标题命中: ' + t);", content)
 
     def test_main_js_defines_escape_html_once(self):


### PR DESCRIPTION
💡 What: Replaced `.map()` calls that converted strings to lowercase inside `matchExplanation` and `classifyTier` functions with standard `for` loops that use lazy string conversion.

🎯 Why: In `docs/main.js`, creating intermediate arrays and function closures via `.map()` inside the search query hot iteration loops introduces unnecessary memory allocations and garbage collection overhead, decreasing rendering performance during active searching.

📊 Impact: Eliminates redundant array creations, reducing closure execution overhead in the search ranking rendering path. Expected to reduce micro-stutters during fast typing.

🔬 Measurement: Verified that tests pass via `make ci-test` and `.map` allocations are eliminated from `matchExplanation` and `classifyTier` loops via grep inspection.

---
*PR created automatically by Jules for task [16514352528597703263](https://jules.google.com/task/16514352528597703263) started by @ImChong*