### PR TITLE
fix(ux): 筛选态下灰色节点不触发图谱浮窗

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2419,16 +2419,23 @@
       }
     }
 
+    function hasActiveGraphFilter() {
+      return topDegreeIds !== null || activeFilters.size > 0 || searchQuery.length > 0
+        || focusedCommunityId || focusedType || focusedHealth !== null
+        || currentTopic !== 'all';
+    }
+
     node
       .on('mouseenter', (ev, d) => {
         // 时序动画进行中：禁用节点悬停，避免选中尚未显现的背景节点
         if (timelineAnimating) return;
         // V21 修复：如果当前已经点击聚焦了某个节点（侧边栏打开），跳过 hover 高亮逻辑
         if (sidebar.classList.contains('open')) return;
-        
+        // 筛选态下灰色节点不响应悬停（pointer-events 已关，此处作兜底）
+        if (hasActiveGraphFilter() && !visibleNodeIds.has(d.id)) return;
+
         buildNeighborSet(d);
-        const hasFilter = topDegreeIds !== null || activeFilters.size > 0 || searchQuery.length > 0
-          || focusedCommunityId || focusedType || focusedHealth !== null;
+        const hasFilter = hasActiveGraphFilter();
         node.select('.node-circle').attr('fill-opacity', n => {
           // 过滤后被隐藏的节点保持原始低透明度，不被 hover 恢复
           if (hasFilter && !visibleNodeIds.has(n.id)) return 0.06;
@@ -2809,9 +2816,7 @@
 
     function applyFilters() {
       if (timelineAnimating) return;
-      const hasFilter = topDegreeIds !== null || activeFilters.size > 0 || searchQuery.length > 0
-        || focusedCommunityId || focusedType || focusedHealth !== null
-        || currentTopic !== 'all';
+      const hasFilter = hasActiveGraphFilter();
       visibleNodeIds.clear();
       let visible = 0;
 
@@ -2821,7 +2826,10 @@
         if (ok) { visible++; visibleNodeIds.add(d.id); }
 
         // V21 修复：显式重置节点整体 opacity (移除 openSidebar 可能留下的残留)
-        d3.select(this).style('opacity', hasFilter ? (ok ? 1 : 0.08) : 1);
+        const g = d3.select(this);
+        g.style('opacity', hasFilter ? (ok ? 1 : 0.08) : 1);
+        // 灰色节点不捕获指针，避免触发浮窗/点击；解除筛选后恢复
+        g.style('pointer-events', hasFilter && !ok ? 'none' : null);
 
         d3.select(this).select('.node-circle')
           .attr('fill-opacity', ok ? 1 : 0.06)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 图谱筛选后，被置灰的未命中节点不再响应鼠标悬停/点击，因此不会弹出节点浮窗
- 仅保留筛选命中的节点可触发浮窗；清除筛选后恢复全部节点的指针事件

## 实现
- `applyFilters()`：对未命中节点设置 `pointer-events: none`，解除筛选时恢复为 `null`
- `mouseenter`：增加 `visibleNodeIds` 兜底判断，避免灰色节点误触发高亮与浮窗

## 验证
- 本地 Puppeteer 脚本验证：筛选前悬停可见 tooltip → 勾选筛选后灰色节点 `pointer-events:none` 且不显示 tooltip → 清除筛选后 tooltip 恢复
- 筛选态截图见下方

## 验证截图
![图谱筛选态：灰色节点不响应悬停](https://cursor.com/artifacts/c/art-311bdf12-7def-4cc1-8d4e-8e64fd25861c)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21cf4ed0-006f-4431-81fc-14f8211fc78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21cf4ed0-006f-4431-81fc-14f8211fc78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

