### PR TITLE
fix(ux): 筛选态悬停时不高亮连至灰色节点的边

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2425,6 +2425,19 @@
         || currentTopic !== 'all';
     }
 
+    function edgeNodeId(endpoint) {
+      return typeof endpoint === 'object' ? endpoint.id : endpoint;
+    }
+
+    /** 悬停/聚焦高亮：筛选态下与灰色节点相连的边不参与高亮 */
+    function edgeHighlightsWithNode(e, nodeId) {
+      const s = edgeNodeId(e.source);
+      const t = edgeNodeId(e.target);
+      if (s !== nodeId && t !== nodeId) return false;
+      if (!hasActiveGraphFilter()) return true;
+      return visibleNodeIds.has(s) && visibleNodeIds.has(t);
+    }
+
     node
       .on('mouseenter', (ev, d) => {
         // 时序动画进行中：禁用节点悬停，避免选中尚未显现的背景节点
@@ -2445,20 +2458,14 @@
           n.id === d.id ? 0.18 : 0);
         link
           .attr('stroke', e => {
-            const s = typeof e.source === 'object' ? e.source.id : e.source;
-            const t = typeof e.target === 'object' ? e.target.id : e.target;
             const dimColor = isDark() ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.06)';
-            return (s === d.id || t === d.id) ? nodeColor(d) : dimColor;
+            return edgeHighlightsWithNode(e, d.id) ? nodeColor(d) : dimColor;
           })
           .attr('stroke-width', e => {
-            const s = typeof e.source === 'object' ? e.source.id : e.source;
-            const t = typeof e.target === 'object' ? e.target.id : e.target;
-            return (s === d.id || t === d.id) ? linkWidthBase * 1.8 : linkWidthBase * 0.5;
+            return edgeHighlightsWithNode(e, d.id) ? linkWidthBase * 1.8 : linkWidthBase * 0.5;
           })
           .attr('stroke-opacity', e => {
-            const s = typeof e.source === 'object' ? e.source.id : e.source;
-            const t = typeof e.target === 'object' ? e.target.id : e.target;
-            return (s === d.id || t === d.id) ? 0.7 : 0.3;
+            return edgeHighlightsWithNode(e, d.id) ? 0.7 : 0.3;
           });
         showTooltip(ev, d);
       })
@@ -3382,17 +3389,15 @@
         .style('stroke-width', null)
         .attr('stroke', e => {
           const { sourceId: sId, targetId: tId } = edgeNodeIds(e);
-          return (sId === d.id || tId === d.id) ? nodeColor(d) : edgeBaseColor();
+          return edgeHighlightsWithNode(e, d.id) ? nodeColor(d) : edgeBaseColor();
         })
         .attr('stroke-opacity', e => {
           const { sourceId: sId, targetId: tId } = edgeNodeIds(e);
           if (!tlShown(sId) || !tlShown(tId)) return 0;   // 任一端未显现 → 连线隐藏
-          const involved = (sId === d.id || tId === d.id);
-          return involved ? 0.85 : 0.18;
+          return edgeHighlightsWithNode(e, d.id) ? 0.85 : 0.18;
         })
         .attr('stroke-width', e => {
-          const { sourceId: sId, targetId: tId } = edgeNodeIds(e);
-          return (sId === d.id || tId === d.id) ? linkWidthBase * 1.5 : linkWidthBase;
+          return edgeHighlightsWithNode(e, d.id) ? linkWidthBase * 1.5 : linkWidthBase;
         });
 
       const color = nodeColor(d);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 延续 PR #616：筛选态下悬停可见节点时，与灰色（未命中筛选）节点相连的边不再参与高亮
- 点击打开侧栏（`openSidebar`）时同样遵循该规则

## 实现
- 新增 `edgeHighlightsWithNode(e, nodeId)`：仅当边连接当前节点，且筛选态下两端均在 `visibleNodeIds` 内时才返回 true
- `mouseenter` 与 `openSidebar` 的连线 `stroke` / `stroke-width` / `stroke-opacity` 统一走该判断

## 验证
- Puppeteer 脚本：勾选社区筛选 → 悬停有灰色邻居的可见节点 → 连至灰色节点的边 `stroke-opacity` 保持低调（未 > 0.35）
- 清除筛选后悬停高亮行为与原先一致

## 验证截图
![筛选态悬停：仅高亮可见节点之间的连线](https://cursor.com/artifacts/c/art-ac14f581-6b2b-4e06-b760-ce4477863364)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21cf4ed0-006f-4431-81fc-14f8211fc78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21cf4ed0-006f-4431-81fc-14f8211fc78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

