### PR TITLE
refactor: extract wiki cache to shared utility module

### DIFF
--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List
 from build_search_index import generate_search_index
 from search_indexing import parse_frontmatter, strip_frontmatter
 from utils.paths import path_to_id
+from utils.wiki_cache import wiki_stem_to_path
 
 ROOT = Path(__file__).resolve().parents[1]
 OUTPUT = ROOT / "exports" / "index-v1.json"
@@ -341,8 +342,7 @@ def collect_markdown_links(text: str, current_path: Path) -> List[str]:
             continue
         general.append(path_to_id(resolved, ROOT))
     if current_path.parts and "wiki" in current_path.parts:
-        wiki_dir = ROOT / "wiki"
-        stem_to_path = {p.stem: p for p in wiki_dir.rglob("*.md")}
+        stem_to_path = wiki_stem_to_path()
         for target in re.findall(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]", text):
             linked_path = stem_to_path.get(target.strip())
             if linked_path:

--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -185,6 +185,7 @@ LATEST_NODES_CAP = 30
 LATEST_NODES_WINDOW_DAYS = 30
 LATEST_NODES_ENV_VAR = "GRAPH_LATEST_NODES_MAX"
 
+
 def wiki_recency_date(content: str, page: Path) -> date:
     """用于「最近更新」排序：取 frontmatter 的 updated / created 与文件 mtime 中的最大值。"""
     candidates: list[date] = []

--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any
 
 from export_minimal import extract_summary
+from utils.wiki_cache import wiki_stem_to_path
 
 REPO_ROOT = Path(__file__).parent.parent
 WIKI_DIR = REPO_ROOT / "wiki"
@@ -183,17 +184,6 @@ LATEST_NODES_DEFAULT = 20
 LATEST_NODES_CAP = 30
 LATEST_NODES_WINDOW_DAYS = 30
 LATEST_NODES_ENV_VAR = "GRAPH_LATEST_NODES_MAX"
-
-# Wikilink [[stem]] 解析缓存（wiki 文件集合不变时可复用）
-_STEM_TO_PATH: dict[str, Path] | None = None
-
-
-def _wiki_stem_index() -> dict[str, Path]:
-    global _STEM_TO_PATH
-    if _STEM_TO_PATH is None:
-        _STEM_TO_PATH = {p.stem: p for p in WIKI_DIR.rglob("*.md")}
-    return _STEM_TO_PATH
-
 
 def wiki_recency_date(content: str, page: Path) -> date:
     """用于「最近更新」排序：取 frontmatter 的 updated / created 与文件 mtime 中的最大值。"""
@@ -476,7 +466,7 @@ def extract_internal_links(content: str, source_path: Path) -> list[Path]:
                             targets.append(resolved)
 
     # 3. Wikilinks [[name]]
-    stem_map = _wiki_stem_index()
+    stem_map = wiki_stem_to_path()
     for match in re.finditer(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]", content):
         stem = match.group(1).strip()
         if stem in stem_map:

--- a/scripts/utils/wiki_cache.py
+++ b/scripts/utils/wiki_cache.py
@@ -1,0 +1,25 @@
+"""共享的 wiki 页面扫描缓存。
+
+`wiki/*.md` 在一次脚本运行内通常被多处重复 `rglob`，对 1000+ 文件的目录树
+这会带来可观的重复 I/O。本模块用进程级缓存把扫描摊销到一次。
+
+⚠️ 缓存有效期为整个进程生命周期，**仅在 wiki 文件集合不变时可复用**。
+只读导出脚本（export_minimal、generate_link_graph 等）可放心使用；
+会在运行中新增/删除 wiki .md 的脚本不要用本缓存，否则会读到过期结果。
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+WIKI_DIR = Path(__file__).resolve().parents[2] / "wiki"
+
+
+@lru_cache(maxsize=1)
+def wiki_stem_to_path() -> dict[str, Path]:
+    """返回 {文件名(stem) -> 路径} 索引，用于解析 [[stem]] wikilink。
+
+    返回的 dict 被缓存复用，调用方只读、不要原地修改。
+    """
+    return {p.stem: p for p in WIKI_DIR.rglob("*.md")}


### PR DESCRIPTION
## 摘要

将 wiki 文件扫描缓存从 `generate_link_graph.py` 中提取为独立的 `utils/wiki_cache.py` 模块，供多个只读导出脚本复用。避免对 1000+ 文件目录树的重复 I/O 扫描。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [ ] 知识入库（ingest / wiki 内容）
- [ ] 前端（`docs/`）
- [ ] 其他

## 详情

### 新增
- `scripts/utils/wiki_cache.py`：进程级缓存模块，导出 `wiki_stem_to_path()` 函数
  - 使用 `@lru_cache(maxsize=1)` 确保单次扫描结果复用
  - 包含详细文档说明缓存有效期限制（仅适用于只读脚本）

### 改动
- `scripts/generate_link_graph.py`：移除本地缓存实现 `_wiki_stem_index()`，改用共享模块
- `scripts/export_minimal.py`：移除本地缓存实现，改用共享模块

## 验证

- [x] `make ci-preflight`（脚本改动，无 wiki 内容变更）
- [x] 导入路径正确，缓存逻辑等价

## 相关 Issue

无

https://claude.ai/code/session_019G2U7w3opLofVqRV1iP6Q6