### PR TITLE
fix(ux): 赞助按钮尺寸与白天黑夜切换按钮保持一致

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -118,7 +118,8 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   color: var(--accent);
   text-decoration: none;
 }
-.theme-toggle {
+.theme-toggle,
+.sponsor-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -133,6 +134,7 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
   line-height: 1;
   text-align: center;
   color: var(--text);
+  flex-shrink: 0;
 }
 .theme-toggle:hover {
   border-color: var(--accent);
@@ -143,21 +145,6 @@ a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 [data-theme="light"] .icon-sun { display: none; }
 [data-theme="light"] .icon-moon { display: inline; }
 
-.sponsor-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 44px;
-  height: 30px;
-  padding: 0 8px;
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.95rem;
-  line-height: 1;
-  color: var(--text);
-}
 .sponsor-toggle:hover {
   border-color: #e2566a;
 }
@@ -1543,7 +1530,8 @@ body.sponsor-dialog-open {
     font-size: 0.82rem;
     white-space: nowrap;
   }
-  .theme-toggle {
+  .theme-toggle,
+  .sponsor-toggle {
     min-width: 36px;
     padding: 0.3rem 0.6rem;
     border-radius: 6px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将 `.sponsor-toggle` 与 `.theme-toggle` 共用同一套尺寸样式（`min-width: 44px`、`height: 30px`、`padding: 0 8px`、`font-size: 0.8rem` 等）
- 在 `@media (max-width: 860px)` 下为赞助按钮补齐与主题切换按钮相同的响应式规则，避免移动端两者高度/宽度不一致
- 赞助按钮图标字号从 `0.95rem` 调整为 `0.8rem`，与 ☀️/🌙 按钮视觉一致

## 验证
- N/A：`make ci-preflight`（仅 CSS 改动，未触及 wiki / 导出链路）
- 本地 `docs/index.html` 顶栏截图：赞助 ❤ 与白天黑夜 ☀️ 按钮宽高一致

## 验证截图
![首页顶栏赞助按钮与主题切换按钮尺寸一致](https://cursor.com/artifacts/c/art-423f7f35-afc7-4252-89db-7f1c21cc22a9)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a5b3bba-4ced-4840-a4c7-dd1d2fad9977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a5b3bba-4ced-4840-a4c7-dd1d2fad9977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

