### PR TITLE
fix(ux): 赞助按钮尺寸对齐并移至顶栏最右侧

### DIFF
--- a/docs/sponsor.js
+++ b/docs/sponsor.js
@@ -32,12 +32,7 @@
     toggle.setAttribute('aria-haspopup', 'dialog');
     toggle.innerHTML = '<span class="sponsor-icon" aria-hidden="true">❤</span>';
 
-    var themeToggle = document.getElementById('themeToggle');
-    if (themeToggle) {
-      headerRight.insertBefore(toggle, themeToggle);
-    } else {
-      headerRight.appendChild(toggle);
-    }
+    headerRight.appendChild(toggle);
 
     var dialog = document.createElement('div');
     dialog.id = 'sponsorDialog';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将 `.sponsor-toggle` 与 `.theme-toggle` 共用同一套尺寸样式（`min-width: 44px`、`height: 30px`、`padding: 0 8px`、`font-size: 0.8rem` 等）
- 在 `@media (max-width: 860px)` 下为赞助按钮补齐与主题切换按钮相同的响应式规则，避免移动端两者高度/宽度不一致
- 赞助按钮图标字号从 `0.95rem` 调整为 `0.8rem`，与 ☀️/🌙 按钮视觉一致
- **赞助按钮移至顶栏最右侧**（`GitHub` → 白天黑夜 → ❤ 赞助）

## 验证
- N/A：`make ci-preflight`（仅 CSS / 前端脚本改动，未触及 wiki / 导出链路）
- 本地 `docs/index.html` 顶栏截图：赞助 ❤ 位于最右侧，与白天黑夜 ☀️ 按钮宽高一致

## 验证截图
![首页顶栏赞助按钮位于最右侧](https://cursor.com/artifacts/c/art-90afa61a-c900-4553-a3c3-8f2582da1402)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a5b3bba-4ced-4840-a4c7-dd1d2fad9977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a5b3bba-4ced-4840-a4c7-dd1d2fad9977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

