### PR TITLE
⚡ Bolt: Cache lowercased strings in document processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -72,3 +72,7 @@
 ## 2026-06-13 - Avoid Array Allocation in Stringification & Hoist Hot Loop Invariants
 **Learning:** In hot execution paths like `substringScore` and BM25 loops, repeatedly evaluating `Object.keys(obj).join()`, redundant multiplications (`k1 * lenNorm`), and property allocations degrades performance. Using `Object.keys` allocates an intermediate array, and doing mathematical operations inside a token loop multiplies CPU overhead.
 **Action:** Replace `Object.keys(obj).join()` with a `for...in` string concatenation loop to preserve fast substring match performance (`indexOf`) while completely eliminating array allocation overhead. Furthermore, always hoist constant mathematical operations and scale factors outside inner token loops.
+
+## 2026-06-14 - Python Loop Optimization: Cache String Operations
+**Learning:** In the python search ranking code (`scripts/search_wiki_core.py`), extracting and lowercasing document properties (`fm.get("summary").lower()`, `title.lower()`) inside the inner scoring loop `compute_score` creates unnecessary string allocation and lowercasing operations for every document on every query.
+**Action:** Always cache derived strings (like lowercased strings) on static `doc` instances during an initial pass, and pass them as arguments to scoring functions instead of repeatedly recalculating them inside the hot loop to reduce CPU cycles and GC thrashing.

--- a/scripts/search_wiki_core.py
+++ b/scripts/search_wiki_core.py
@@ -182,7 +182,7 @@ def compute_avgdl(docs: list[dict]) -> float:
 def compute_score(
     token_counts: dict[str, int],
     query_tokens: list[str],
-    title: str = "",
+    title_l: str = "",
     avgdl: float = 0.0,
     k1: float = 1.5,
     b: float = 0.75,
@@ -191,14 +191,13 @@ def compute_score(
     dl: int = 1,
     doc_path: str = "",
     today_date: date | None = None,
+    summary_l: str = "",
 ) -> float:
     if not query_tokens:
         return 0.0
     score = 0.0
     fm = fm or {}
     avgdl = avgdl or dl
-    summary = str(fm.get("summary", fm.get("description", ""))).lower()
-    title_l = (title or "").lower()
 
     # Pre-compute document-level constants outside the loop
     len_norm = 1 - b + b * dl / avgdl
@@ -217,7 +216,7 @@ def compute_score(
         term_score = tf * idf_numerator_factor / denominator
         if token in title_l:
             term_score *= 5.0
-        elif summary and token in summary:
+        elif summary_l and token in summary_l:
             term_score *= 2.0
         score += term_score
 
@@ -413,14 +412,16 @@ def search(
     )  # tokenizer is normalized; keep CLI flag for output highlighting compatibility
     docs = iter_wiki_documents()
 
-    # ⚡ Bolt Optimization: Cache token counts to avoid redundant tokenization
-    # Tokenizing the body text is expensive. Doing it twice (once for avgdl, once for scoring)
-    # doubles the search latency. We cache it here on the doc objects.
+    # ⚡ Bolt Optimization: Cache token counts and lowercased fields to avoid redundant allocations
+    # Tokenizing and lowercasing per-document properties on every query is expensive. We cache them here.
     for doc in docs:
         if "token_counts" not in doc:
             counts = Counter(tokenize_text(doc["body"]))
             doc["token_counts"] = counts
             doc["dl"] = max(sum(counts.values()), 1)
+            doc["title_l"] = (doc.get("title") or "").lower()
+            fm = doc.get("frontmatter") or {}
+            doc["summary_l"] = str(fm.get("summary", fm.get("description", ""))).lower()
 
     avgdl = compute_avgdl(docs)
 
@@ -461,13 +462,14 @@ def search(
         score = compute_score(
             token_counts=token_counts,
             query_tokens=query_tokens,
-            title=doc["title"],
+            title_l=doc["title_l"],
             avgdl=avgdl,
             fm=fm,
             page_type=doc["page_type"],
             dl=doc.get("dl", 1),
             doc_path=doc["path"],
             today_date=today_date,
+            summary_l=doc["summary_l"],
         )
         if query_tokens and not semantic and score <= 0:
             continue

--- a/tests/test_search_wiki_core.py
+++ b/tests/test_search_wiki_core.py
@@ -52,40 +52,46 @@ class TestNormalizeScores(unittest.TestCase):
 class TestComputeScore(unittest.TestCase):
     def test_no_query_tokens(self):
         self.assertEqual(
-            compute_score({"a": 1}, [], title="t", avgdl=5.0, fm={}, page_type="concept"),
+            compute_score({"a": 1}, [], title_l="t", avgdl=5.0, fm={}, page_type="concept"),
             0.0,
         )
 
     def test_title_boost(self):
         tc = {"mpc": 2}
         s_title = compute_score(
-            tc, ["mpc"], title="MPC intro", avgdl=10.0, fm={}, page_type="method"
+            tc, ["mpc"], title_l="mpc intro", avgdl=10.0, fm={}, page_type="method"
         )
-        s_not = compute_score(tc, ["mpc"], title="other", avgdl=10.0, fm={}, page_type="method")
+        s_not = compute_score(tc, ["mpc"], title_l="other", avgdl=10.0, fm={}, page_type="method")
         self.assertGreater(s_title, s_not)
 
     def test_summary_boost(self):
         tc = {"foo": 1}
         fm = {"summary": "Contains foo term"}
         with_summary = compute_score(
-            tc, ["foo"], title="none", avgdl=5.0, fm=fm, page_type="concept"
+            tc,
+            ["foo"],
+            title_l="none",
+            avgdl=5.0,
+            fm=fm,
+            summary_l="contains foo term",
+            page_type="concept",
         )
-        without = compute_score(tc, ["foo"], title="none", avgdl=5.0, fm={}, page_type="concept")
+        without = compute_score(tc, ["foo"], title_l="none", avgdl=5.0, fm={}, page_type="concept")
         self.assertGreater(with_summary, without)
 
     def test_page_type_multipliers(self):
         tc = {"x": 1}
-        base = compute_score(tc, ["x"], title="", avgdl=5.0, fm={}, page_type="concept")
-        q = compute_score(tc, ["x"], title="", avgdl=5.0, fm={}, page_type="query")
-        c = compute_score(tc, ["x"], title="", avgdl=5.0, fm={}, page_type="comparison")
+        base = compute_score(tc, ["x"], title_l="", avgdl=5.0, fm={}, page_type="concept")
+        q = compute_score(tc, ["x"], title_l="", avgdl=5.0, fm={}, page_type="query")
+        c = compute_score(tc, ["x"], title_l="", avgdl=5.0, fm={}, page_type="comparison")
         self.assertLess(q, base)
         self.assertEqual(c, base)
 
     def test_comparison_boost_only_with_intent(self):
         tc = {"对比": 1}
-        plain = compute_score(tc, ["mpc"], title="", avgdl=5.0, fm={}, page_type="comparison")
+        plain = compute_score(tc, ["mpc"], title_l="", avgdl=5.0, fm={}, page_type="comparison")
         intent = compute_score(
-            tc, ["mpc", "对比"], title="", avgdl=5.0, fm={}, page_type="comparison"
+            tc, ["mpc", "对比"], title_l="", avgdl=5.0, fm={}, page_type="comparison"
         )
         self.assertGreater(intent, plain)
 
@@ -101,18 +107,20 @@ class TestComputeScore(unittest.TestCase):
         boosted = compute_score(
             tc,
             ["wbc", "全身控制"],
-            title="Whole-Body Control (WBC，全身控制)",
+            title_l="whole-body control (wbc，全身控制)",
             avgdl=10.0,
             fm={"summary": "WBC 全身控制 QP"},
+            summary_l="wbc 全身控制 qp",
             page_type="concept",
             doc_path="wiki/concepts/whole-body-control.md",
         )
         entity = compute_score(
             tc,
             ["wbc", "全身控制"],
-            title="wbc_fsm",
+            title_l="wbc_fsm",
             avgdl=10.0,
             fm={"summary": "全身控制部署"},
+            summary_l="全身控制部署",
             page_type="entity",
             doc_path="wiki/entities/wbc-fsm.md",
         )
@@ -122,12 +130,12 @@ class TestComputeScore(unittest.TestCase):
         tc = {"z": 1}
         today = date.today().isoformat()
         recent = compute_score(
-            tc, ["z"], title="", avgdl=3.0, fm={"updated": today}, page_type="concept"
+            tc, ["z"], title_l="", avgdl=3.0, fm={"updated": today}, page_type="concept"
         )
         old = compute_score(
             tc,
             ["z"],
-            title="",
+            title_l="",
             avgdl=3.0,
             fm={"updated": "1990-01-01"},
             page_type="concept",


### PR DESCRIPTION
💡 **What:** Caches lowercased versions of the document's `title` and `summary` frontmatter fields on the initial processing pass, avoiding the need to extract and call `.lower()` on them inside the hot inner scoring loop (`compute_score`).

🎯 **Why:** Previously, evaluating BM25 matches for document title and summary resulted in redundant lowercasing and dictionary lookups on *every document* for *every search request*, degrading python CPU performance and generating unnecessary GC pressure.

📊 **Impact:** Reduces redundant string processing and allocations down to zero within the core `compute_score` calculation loop, dramatically cutting constant execution overhead for multi-keyword queries.

🔬 **Measurement:** All search accuracy regression tests and unit tests run successfully, ensuring no logic divergence. The `make ci-test` pipeline fully clears without regression. Learning recorded to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [11426190497220627742](https://jules.google.com/task/11426190497220627742) started by @ImChong*