### PR TITLE
feat(graph): Add "vision-backbone" topic filter with explicit node IDs

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v24.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v24.md
@@ -47,8 +47,8 @@
 
 ## P3: 交互层"专题与感知"增强 (UX/UI)
 
-- [ ] **图谱页"视觉感知骨干"专题视图**：
-    - [ ] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V23 13 项基础上新增「视觉感知骨干」专题；命中规则复用 community id + path 片段双路并集机制；同步在 `#filter-topic-chips` 增加对应 `data-topic` chip；新增视图配 Puppeteer 截图归档到 `.cursor-artifacts/screenshots/`。
+- [x] **图谱页"视觉感知骨干"专题视图**：
+    - [x] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V23 13 项基础上新增「视觉感知骨干」专题（`vision-backbone`）；命中规则复用 path 片段并集机制（`backbone/backbones/cnn/vit/resnet/yolo/detection`），因核心页同处 community-3（与动作重定向共享）不宜按社区命中，新增 `ids` 显式纳入 `visual-representation-for-policy` / `generative-vision-pretraining` 两页；同步在 `#filter-topic-chips` 增加 `data-topic="vision-backbone"`（👁️ 视觉骨干）chip；专题视图精准命中 9 个相关节点（cnn-vs-vit / vision-backbones / visual-representation-for-policy / perception-backbone-selection / object-detection / object-detection-model-selection / generative-vision-pretraining + ResNet/YOLO 实体）。Puppeteer 截图归档至 `.cursor-artifacts/screenshots/graph-topic-vision-backbone.png`。
 - [ ] **详情页"同专题相关页"提示（可选）**：
     - [ ] 评估在详情页对命中某专题的页面给出"属于 X 专题"轻量徽标 + 跳转图谱专题视图的链接（空态降级隐藏）。
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1448,6 +1448,7 @@
           <button class="filter-topic-chip" type="button" data-topic="wbt" title="全身运动跟踪（WBT）"><span>🕺</span><span>WBT</span></button>
           <button class="filter-topic-chip" type="button" data-topic="cross-embodiment" title="跨具身迁移"><span>🔀</span><span>跨具身</span></button>
           <button class="filter-topic-chip" type="button" data-topic="safe-fine-tuning" title="真机安全微调"><span>🛡️</span><span>安全微调</span></button>
+          <button class="filter-topic-chip" type="button" data-topic="vision-backbone" title="视觉感知骨干"><span>👁️</span><span>视觉骨干</span></button>
         </div>
       </details>
       <div class="filter-mode-tabs" id="filter-mode-tabs" aria-label="筛选维度">
@@ -1777,6 +1778,15 @@
         segments: new Set([
           'safe','safety','cbf','clf','barrier','lyapunov','slowrl','lora','cmdp'
         ])
+      },
+      'vision-backbone': {
+        segments: new Set([
+          'backbone','backbones','cnn','vit','resnet','yolo','detection'
+        ]),
+        ids: new Set([
+          'wiki/concepts/visual-representation-for-policy.md',
+          'wiki/concepts/generative-vision-pretraining.md'
+        ])
       }
     };
     let currentTopic = 'all';
@@ -1796,6 +1806,7 @@
       if (cfg.excludeSegments) {
         for (const ex of cfg.excludeSegments) if (segs.has(ex)) return false;
       }
+      if (cfg.ids && cfg.ids.has(d.id)) return true;
       if (cfg.communities && cfg.communities.has(d.community)) return true;
       if (cfg.segments) {
         for (const seg of cfg.segments) if (segs.has(seg)) return true;

--- a/log.md
+++ b/log.md
@@ -1,5 +1,12 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-14] structural | docs/graph.html — V24 P3 图谱新增「视觉感知骨干」专题视图（vision-backbone）
+
+- `TOPIC_FILTERS` 新增 `vision-backbone` 项：path 片段 `backbone/backbones/cnn/vit/resnet/yolo/detection` 并集命中；因核心页同处 community-3（与动作重定向共享）不宜按社区命中，`nodeMatchesTopic` 扩展支持 `ids` 显式纳入 `visual-representation-for-policy` / `generative-vision-pretraining` 两页
+- `#filter-topic-chips` 新增 `data-topic="vision-backbone"`（👁️ 视觉骨干）chip，专题视图精准命中 9 个相关节点（cnn-vs-vit / vision-backbones / visual-representation-for-policy / perception-backbone-selection / object-detection / object-detection-model-selection / generative-vision-pretraining + ResNet/YOLO 实体）
+- `docs/checklists/tech-stack-next-phase-checklist-v24.md` P3 首项打勾
+- 验证：`make lint` 退出码 0（仅 1 条信息型预警）；Puppeteer 截图归档 `.cursor-artifacts/screenshots/graph-topic-vision-backbone.png`
+
 ## [2026-06-14] ingest | sources/personal/amp_mjlab_policy_training_essence.md + perceptive_locomotion_representation_essence.md — 两条 ChatGPT 对话核心知识点：wiki/concepts/neural-feedback-controller.md、terrain-latent-representation.md；增补 privileged-training、amp-mjlab
 
 ## [2026-06-14] ingest | sources/papers/agi_to_asi_arxiv_2606_12683.md — DeepMind From AGI to ASI 技术报告；wiki/entities/paper-from-agi-to-asi.md；交叉 embodied-scaling-laws / data-flywheel / robot-learning-three-eras-narrative


### PR DESCRIPTION
## 摘要

在图谱页新增「视觉感知骨干」（vision-backbone）专题视图，通过 path 片段并集 + 显式节点 ID 机制精准命中 9 个相关节点，完成 V24 P3 checklist 首项。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他

## 详细说明

### `docs/graph.html`

1. **新增 topic filter chip**（第 1451 行）：
   - `data-topic="vision-backbone"`，标签「👁️ 视觉骨干」
   - 标题「视觉感知骨干」

2. **扩展 `TOPIC_FILTERS` 配置**（第 1780–1789 行）：
   - 新增 `vision-backbone` 项，包含：
     - `segments`：`backbone/backbones/cnn/vit/resnet/yolo/detection` 路径片段并集
     - `ids`：显式纳入 `visual-representation-for-policy.md` 和 `generative-vision-pretraining.md`（因两页同处 community-3，不宜按社区命中，需显式指定）
   
3. **增强 `nodeMatchesTopic` 逻辑**（第 1809 行）：
   - 新增 `if (cfg.ids && cfg.ids.has(d.id)) return true;` 分支
   - 在社区和路径片段检查之前执行，支持显式节点 ID 纳入

### `log.md`

记录本次 structural 改动的完整上下文：
- 新增 topic 项及其命中规则
- 精准命中的 9 个节点列表
- 验证命令与截图归档路径

### `docs/checklists/tech-stack-next-phase-checklist-v24.md`

将 P3 首项「图谱页'视觉感知骨干'专题视图」标记为完成（✓），并补充详细实现说明。

## 验证

- [x] `make lint` 退出码 0（仅 1 条信息型预警）
- [x] Puppeteer 截图验证：`.cursor-artifacts/screenshots/graph-topic-vision-backbone.png`
- [x] 图谱页加载正常，vision-backbone chip 可点击，精准命中 9 个相关节点

## 相关 Issue

无

https://claude.ai/code/session_016tMPj4BaFiU7R9WiEMJyxh