### PR TITLE
feat(ux): 赞助按钮与文案 emoji 改为 ☕

### DIFF
--- a/docs/sponsor.js
+++ b/docs/sponsor.js
@@ -30,7 +30,7 @@
     toggle.setAttribute('aria-label', '赞助我');
     toggle.setAttribute('title', '赞助我');
     toggle.setAttribute('aria-haspopup', 'dialog');
-    toggle.innerHTML = '<span class="sponsor-icon" aria-hidden="true">❤</span>';
+    toggle.innerHTML = '<span class="sponsor-icon" aria-hidden="true">🧋</span>';
 
     headerRight.appendChild(toggle);
 

--- a/docs/sponsor.js
+++ b/docs/sponsor.js
@@ -30,7 +30,7 @@
     toggle.setAttribute('aria-label', '赞助我');
     toggle.setAttribute('title', '赞助我');
     toggle.setAttribute('aria-haspopup', 'dialog');
-    toggle.innerHTML = '<span class="sponsor-icon" aria-hidden="true">🧋</span>';
+    toggle.innerHTML = '<span class="sponsor-icon" aria-hidden="true">☕</span>';
 
     headerRight.appendChild(toggle);
 
@@ -46,7 +46,7 @@
       '<div class="sponsor-dialog-card">' +
         '<div class="sponsor-dialog-header">' +
           '<h2 id="sponsorDialogTitle" class="sponsor-dialog-title">赞助我</h2>' +
-          '<p class="sponsor-dialog-hint">微信扫一扫，赞助支持作者 ❤</p>' +
+          '<p class="sponsor-dialog-hint">微信扫一扫，赞助支持作者 ☕</p>' +
         '</div>' +
         '<div class="sponsor-dialog-body">' +
           '<img class="sponsor-qr" src="' + assetBase + 'sponsor/wechat-pay.png" alt="微信收款码" width="260" height="352" />' +

--- a/docs/sponsor/README.md
+++ b/docs/sponsor/README.md
@@ -1,6 +1,6 @@
 # Sponsor QR · 赞助收款码
 
-站点顶栏「❤」按钮会弹出本目录下的 `wechat-pay.png` 微信收款码。
+站点顶栏「☕」按钮会弹出本目录下的 `wechat-pay.png` 微信收款码。
 
 图像与 [Robot_Retarget_Online](https://github.com/ImChong/Robot_Retarget_Online) 共用同一份文件；如需更换，直接覆盖此路径即可，无需改代码：
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将站点头部赞助按钮图标改为 ☕
- 弹窗提示文案「微信扫一扫，赞助支持作者」同步使用 ☕
- 更新 `docs/sponsor/README.md` 中的按钮说明

## 验证
- 仅修改 `docs/sponsor.js` 与 `docs/sponsor/README.md`，不涉及 wiki / 导出链路
- N/A：`make ci-preflight`（非 wiki 改动）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-733b7ee9-3a3b-4341-b0b6-d03f3d352a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-733b7ee9-3a3b-4341-b0b6-d03f3d352a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

