### PR TITLE
fix(ux): sponsor.js 缓存破坏，避免 iOS 仍显示旧 ❤ emoji

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧩</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
-  <script id="sponsor-js" src="sponsor.js"></script>
+  <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
 </head>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕸️</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
-  <script id="sponsor-js" src="sponsor.js"></script>
+  <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── 图谱页专用样式（不影响其他页面）── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <title>Robotics Notebooks | 机器人技术栈地图</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗺️</text></svg>" />
   <script src="theme-init.js"></script>
-  <script id="sponsor-js" src="sponsor.js"></script>
+  <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="manifest" href="manifest.json" />
   <meta name="theme-color" content="#1c1c1e" />

--- a/docs/module.html
+++ b/docs/module.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧱</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
-  <script id="sponsor-js" src="sponsor.js"></script>
+  <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/docs/modules/imitation-learning.html
+++ b/docs/modules/imitation-learning.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎭</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/modules/motion-control.html
+++ b/docs/modules/motion-control.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦿</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/modules/reinforcement-learning.html
+++ b/docs/modules/reinforcement-learning.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/retargeting-pipeline.html
+++ b/docs/relations/retargeting-pipeline.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕺</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/rl-vs-il.html
+++ b/docs/relations/rl-vs-il.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧪</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/sim2real-pipeline.html
+++ b/docs/relations/sim2real-pipeline.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌉</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/relations/wbc-vs-rl.html
+++ b/docs/relations/wbc-vs-rl.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚖️</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="../theme-init.js"></script>
-  <script id="sponsor-js" src="../sponsor.js"></script>
+  <script id="sponsor-js" src="../sponsor.js?v=2"></script>
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
-  <script id="sponsor-js" src="sponsor.js"></script>
+  <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
 </head>

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Robotics Notebooks Service Worker — 离线缓存支持
-const CACHE_NAME = 'robotics-wiki-2026-06-15';
+const CACHE_NAME = 'robotics-wiki-2026-06-15-v2';
 const ASSETS_TO_CACHE = [
   '/Robotics_Notebooks/',
   '/Robotics_Notebooks/index.html',
@@ -42,6 +42,22 @@ self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
   const url = new URL(event.request.url);
   if (url.origin !== self.location.origin) return;
+
+  // sponsor.js 等小脚本优先走网络，避免 emoji/文案更新后仍显示旧缓存
+  if (url.pathname.endsWith('/sponsor.js')) {
+    event.respondWith(
+      fetch(event.request)
+        .then((resp) => {
+          if (resp && resp.status === 200) {
+            const clone = resp.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          }
+          return resp;
+        })
+        .catch(() => caches.match(event.request))
+    );
+    return;
+  }
 
   event.respondWith(
     caches.match(event.request).then((cached) => {

--- a/docs/tech-map.html
+++ b/docs/tech-map.html
@@ -13,7 +13,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧭</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
-  <script id="sponsor-js" src="sponsor.js"></script>
+  <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── 筛选浮窗（参照 physics-panel）── */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 线上 `sponsor.js` 已是 ☕，但 iPhone Safari / Service Worker 会长期缓存旧版 `sponsor.js`（仍含 ❤）
- 全站 `sponsor.js` 引用加 `?v=2` 缓存破坏参数
- `sw.js` 升级缓存版本，并对 `sponsor.js` 改为 network-first，避免 stale-while-revalidate 先返回旧脚本

## 验证
- 仅改 `docs/` 静态资源与 SW，不涉及 wiki / 导出链路
- N/A：`make ci-preflight`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-733b7ee9-3a3b-4341-b0b6-d03f3d352a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-733b7ee9-3a3b-4341-b0b6-d03f3d352a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

