### PR TITLE
fix(ux): 详情页 TOC 改用 1320px 网格布局，修复 PC 窄窗被 clip

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -20,6 +20,11 @@
   --header-h: 58px;
   /* 与 https://imchong.github.io/ 主栏 (.container / .header-inner) 一致 */
   --content-max-width: 960px;
+  --detail-toc-width: 320px;
+  --detail-layout-gap: 40px;
+  /* TOC + gap；详情/路线正文区外层宽于主栏，主栏仍保持 --content-max-width */
+  --detail-layout-toc-offset: calc(var(--detail-toc-width) + var(--detail-layout-gap));
+  --detail-layout-max-width: calc(var(--content-max-width) + var(--detail-layout-toc-offset));
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
 }
@@ -731,10 +736,7 @@ body.sponsor-dialog-open {
   display: none;
 }
 .detail-content-layout {
-  display: flex;
-  gap: 40px;
   align-items: start;
-  justify-content: center;
 }
 #detail-content-section {
   padding-top: 12px;
@@ -777,7 +779,7 @@ body.sponsor-dialog-open {
   box-sizing: border-box;
 }
 .detail-toc-panel {
-  width: 320px;
+  width: var(--detail-toc-width);
   flex-shrink: 0;
   position: sticky;
   top: 92px;
@@ -787,10 +789,26 @@ body.sponsor-dialog-open {
   background: var(--surface);
   box-shadow: var(--shadow-sm);
 }
-@media (min-width: 1200px) {
+@media (min-width: 1201px) {
+  /* 外层 grid 容纳 TOC + 主栏；主栏左缘与上方 hero / subnav 对齐，避免负边距被 overflow-x:clip 裁切 */
+  .container.detail-content-layout,
+  .detail-hero > .container.detail-hero-stack {
+    max-width: var(--detail-layout-max-width);
+    margin-inline: auto;
+    display: grid;
+    grid-template-columns: var(--detail-toc-width) minmax(0, 1fr);
+    gap: var(--detail-layout-gap);
+    align-items: start;
+  }
+  .detail-hero > .container.detail-hero-stack > * {
+    grid-column: 2;
+  }
+  .page-subnav-wrap > .container.page-subnav {
+    max-width: var(--detail-layout-max-width);
+    margin-inline: auto;
+    padding-left: calc(24px + var(--detail-layout-toc-offset));
+  }
   .detail-toc-panel {
-    /* width(320) + .detail-content-layout gap(40) — 与主栏对齐且不占横向滚动 */
-    margin-left: -360px;
     display: flex;
     flex-direction: column;
     /* 长目录超出视口时：卡片高度封顶，仅目录列表区域滚动 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 修复 PC 端新开 Chrome 窗口（约 1280–1440px）时详情/路线页 TOC 左侧被 `overflow-x: clip` 裁切、只能看到一半的问题。
- **主 column 仍为 960px**（`--content-max-width` 未改）；仅将带 TOC 的正文区外层扩为 `1320px = 320 + 40 + 960` 的 CSS Grid，去掉 `margin-left: -360px` 负边距 hack。
- 同步让 `detail-hero` 与 `page-subnav` 使用相同列对齐，保证标题、子导航与正文主栏左缘一致。

## 改动要点

- 新增 CSS 变量：`--detail-toc-width`、`--detail-layout-gap`、`--detail-layout-max-width`
- 桌面断点从重叠的 `1200px` 拆为 `1201px+` 启用 grid（`≤1200px` 仍走抽屉 TOC）
- 影响页面：`detail.html`、`roadmap.html`、`module.html`（共用 `detail-content-layout` 样式）

## 验证

- `make ci-preflight` 通过
- Puppeteer 实测：`1280 / 1366 / 1440px` 视口 TOC 可见 100%，hero / subnav / 主栏 `delta = 0`

## 验证截图

![1280px 视口下 TOC 与正文并排完整显示](https://cursor.com/artifacts/c/art-6eafcdf3-8a60-4b81-bef2-c0c69cfe39ed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba76dd7b-e267-474d-a433-d3e72d5e51af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba76dd7b-e267-474d-a433-d3e72d5e51af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

