### PR TITLE
fix(ux): 窄窗 TOC 改汉堡抽屉，≥1632px 才显示侧栏目录

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -20,6 +20,8 @@
   --header-h: 58px;
   /* 与 https://imchong.github.io/ 主栏 (.container / .header-inner) 一致 */
   --content-max-width: 960px;
+  /* 负边距 TOC 完整露出： (vw - content-max) / 2 + container-padding - (toc宽+gap) ≥ 0 → vw ≥ 1632 */
+  --detail-toc-desktop-min: 1632px;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
 }
@@ -787,7 +789,7 @@ body.sponsor-dialog-open {
   background: var(--surface);
   box-shadow: var(--shadow-sm);
 }
-@media (min-width: 1200px) {
+@media (min-width: 1632px) {
   .detail-toc-panel {
     /* width(320) + .detail-content-layout gap(40) — 与主栏对齐且不占横向滚动 */
     margin-left: -360px;
@@ -1452,7 +1454,7 @@ body.sponsor-dialog-open {
   opacity: 1;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1631px) {
   .detail-toc-panel {
     position: fixed;
     top: 16px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 修复 PC 新开 Chrome 窗口（约 1280–1440px）时详情/路线页 TOC 被 `overflow-x: clip` 裁切的问题。
- **方案**：视口 **&lt; 1632px** 时沿用汉堡按钮抽屉 TOC（与移动端一致），**≥ 1632px** 才启用桌面侧栏负边距布局。
- 主 column 仍为 960px，布局结构不变（已基于最新 `main` 重推）。

## 断点依据

负边距 TOC 左缘 = `(vw - 960) / 2 + 24 - 360`，需 ≥ 0 → `vw ≥ 1632`。低于此宽度侧栏必被裁切，故改抽屉。

## 验证

- `make ci-preflight` 通过
- Puppeteer：`1280 / 1440 / 1631px` → `position: fixed` + 汉堡可见；`1632 / 1680px` → 侧栏 TOC 100% 可见

## 验证截图

![1680px 视口下侧栏 TOC 完整显示](https://cursor.com/artifacts/c/art-b1c4d62d-96b5-472d-8b99-ce82ee178599)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba76dd7b-e267-474d-a433-d3e72d5e51af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba76dd7b-e267-474d-a433-d3e72d5e51af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

