### PR TITLE
feat(ux): 详情页"所属专题"轻量徽标，专题命中规则抽共享模块（V24 收口）

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v24.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v24.md
@@ -1,6 +1,6 @@
 # 技术栈项目执行清单 v24
 
-最后更新：2026-06-13（P2 事实库扩展至 186 条完成）
+最后更新：2026-06-15（P3 详情页专题徽标交付，V24 全部条目收口）
 项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
 上一版清单：[`tech-stack-next-phase-checklist-v23.md`](archive/tech-stack-next-phase-checklist-v23.md)
 方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
@@ -49,18 +49,18 @@
 
 - [x] **图谱页"视觉感知骨干"专题视图**：
     - [x] `docs/graph.html` 的 `TOPIC_FILTERS` 在 V23 13 项基础上新增「视觉感知骨干」专题（`vision-backbone`）；命中规则复用 path 片段并集机制（`backbone/backbones/cnn/vit/resnet/yolo/detection`），因核心页同处 community-3（与动作重定向共享）不宜按社区命中，新增 `ids` 显式纳入 `visual-representation-for-policy` / `generative-vision-pretraining` 两页；同步在 `#filter-topic-chips` 增加 `data-topic="vision-backbone"`（👁️ 视觉骨干）chip；专题视图精准命中 9 个相关节点（cnn-vs-vit / vision-backbones / visual-representation-for-policy / perception-backbone-selection / object-detection / object-detection-model-selection / generative-vision-pretraining + ResNet/YOLO 实体）。Puppeteer 截图归档至 `.cursor-artifacts/screenshots/graph-topic-vision-backbone.png`。
-- [ ] **详情页"同专题相关页"提示（可选）**：
-    - [ ] 评估在详情页对命中某专题的页面给出"属于 X 专题"轻量徽标 + 跳转图谱专题视图的链接（空态降级隐藏）。
+- [x] **详情页"同专题相关页"提示（可选）**：
+    - [x] 在详情页对命中某专题的页面给出"属于 X 专题"轻量徽标 + 跳转图谱专题视图的链接（空态降级隐藏）。专题命中规则抽到共享模块 `docs/topic-filters.js`（单一事实源，graph.html 与 detail.html 同源消费），详情页 `renderDetailTopicBadges` 复用 `link-graph.json` 现成社区数据计算命中并渲染徽标 → `graph.html?topic=<key>`；graph.html 新增 `?topic=` URL 参数自动激活对应专题视图。端到端验证：`vision-backbones` 详情页渲染「👁️ 视觉骨干」徽标，点击跳转后 graph 自动激活 `vision-backbone` 专题（截图归档 `.cursor-artifacts/screenshots/detail-topic-badge.png`、`graph-topic-from-url.png`）。
 
 ---
 
 ## 验收标准 (Definition of DoD)
 
-- [ ] `make lint`: 0 errors（新引入的 `stale_claim_check` / `missing_concept_page_check` 均为 INFO 级，不阻塞 CI）。
-- [ ] 知识图谱节点数 **≥ 705**，边数 **≥ 5050**（见 `exports/graph-stats.json`）。
+- [x] `make lint`: 0 errors（新引入的 `stale_claim_check` / `missing_concept_page_check` 均为 INFO 级，不阻塞 CI）。（2026-06-15 复核：`make lint` 通过，「✅ 所有检查通过！」）
+- [x] 知识图谱节点数 **≥ 705**，边数 **≥ 5050**（见 `exports/graph-stats.json`）。（2026-06-15：节点 1183 / 边 7292，远超目标）
 - [x] 事实库扩展至 **185 条** 以上（已达 186 条；重点补 视觉骨干 / 机器人表征 矛盾检测规则）。
-- [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。
-- [ ] `log.md` 记录 V24 关键改动。
+- [x] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。（2026-06-15：`false`，最大社区占比 0.179）
+- [x] `log.md` 记录 V24 关键改动。
 
 ---
 

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -44,6 +44,7 @@
           <div>
             <h1 id="detailTitle">正在读取详情页…</h1>
             <p id="detailSummary" class="detail-summary data-loading">当前页面直接消费 <code>exports/site-data-v1.json</code>，展示 detail page 元信息、正文与站内跳转。</p>
+            <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
           </div>
           <aside class="hero-panel detail-meta-panel">
             <h3>页面元信息</h3>
@@ -195,6 +196,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
   <script defer src="graph-tooltip.js"></script>
   <script defer src="graph-node-size.js"></script>
+  <script defer src="topic-filters.js"></script>
   <script defer src="main.js"></script>
 </body>
 </html>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1525,6 +1525,7 @@
   <script src="main.js"></script>
   <script src="graph-tooltip.js"></script>
   <script src="graph-node-size.js"></script>
+  <script src="topic-filters.js"></script>
   <script>
   (async function () {
     /* ── 颜色 & 类型标签 ── */
@@ -1701,117 +1702,12 @@
 
     /* ── 专题视图（V22 P3）：复用 link-graph.json 的 path / community 元数据 ── */
     // 每个专题给一组路径片段或 community id，命中即视为属于该专题（叠加关系，任一命中即可）。
-    const TOPIC_FILTERS = {
-      'motion-retargeting': {
-        communities: new Set(['community-3']),
-        segments: new Set([
-          'retargeting','retarget','gmr','nmr','reactor','sonic','exoactor',
-          'spider','wilor','mocap','teleoperation','deepmimic','amp',
-          'character','animation','keyframe','pipeline'
-        ])
-      },
-      'grasp': {
-        segments: new Set([
-          'grasp','graspnet','anygrasp','dexterous','manipulation',
-          'pick','place','bimanual','curobo'
-        ])
-      },
-      'tactile': {
-        segments: new Set([
-          'tactile','haptic','impedance','force','contact','visuo'
-        ]),
-        excludeSegments: new Set(['reinforcement'])
-      },
-      'communication': {
-        segments: new Set([
-          'ethercat','can','uart','dds','foxglove','rs485','rs232',
-          'serial','communication','protocol','bus','protocols','firmware'
-        ])
-      },
-      'wbc': {
-        communities: new Set(['community-0']),
-        segments: new Set([
-          'wbc','tsid','hqp','cbf','clf','whole','body','balance','hierarchical'
-        ])
-      },
-      'locomotion': {
-        communities: new Set(['community-11', 'community-9']),
-        segments: new Set([
-          'locomotion','gait','mpc','zmp','lip','walking','swing','stance','capture'
-        ])
-      },
-      'vla': {
-        communities: new Set(['community-5']),
-        segments: new Set([
-          'vla','foundation','octo','openvla','rt','pi0','gr00t'
-        ])
-      },
-      'learning': {
-        communities: new Set(['community-4', 'community-6']),
-        segments: new Set([
-          'imitation','reinforcement','ppo','sac','behavior','cloning','dreamer'
-        ])
-      },
-      'sim2real': {
-        segments: new Set([
-          'sim2real', 'randomization', 'domain'
-        ])
-      },
-      'state-estimation': {
-        segments: new Set([
-          'estimation','ekf','ukf','slam','vio','odometry'
-        ])
-      },
-      'wbt': {
-        segments: new Set([
-          'wbt','tracking','beyondmimic','sdamp','heracles','opentrack',
-          'maskedmimic','sonic','any2any','twist','twist2'
-        ])
-      },
-      'cross-embodiment': {
-        segments: new Set([
-          'embodiment','any2any','transfer'
-        ])
-      },
-      'safe-fine-tuning': {
-        communities: new Set(['community-13']),
-        segments: new Set([
-          'safe','safety','cbf','clf','barrier','lyapunov','slowrl','lora','cmdp'
-        ])
-      },
-      'vision-backbone': {
-        segments: new Set([
-          'backbone','backbones','cnn','vit','resnet','yolo','detection'
-        ]),
-        ids: new Set([
-          'wiki/concepts/visual-representation-for-policy.md',
-          'wiki/concepts/generative-vision-pretraining.md'
-        ])
-      }
-    };
+    // 专题命中规则迁移至共享模块 topic-filters.js（与详情页徽标同源）。
+    const TOPIC_FILTERS = window.RNTopicFilters.TOPIC_FILTERS;
     let currentTopic = 'all';
 
-    function nodeSegments(d) {
-      if (d._segs) return d._segs;
-      const base = (d.id || '').toLowerCase().replace(/\.md$/, '');
-      d._segs = new Set(base.split(/[/._-]/).filter(Boolean));
-      return d._segs;
-    }
-
     function nodeMatchesTopic(d) {
-      if (currentTopic === 'all') return true;
-      const cfg = TOPIC_FILTERS[currentTopic];
-      if (!cfg) return true;
-      const segs = nodeSegments(d);
-      if (cfg.excludeSegments) {
-        for (const ex of cfg.excludeSegments) if (segs.has(ex)) return false;
-      }
-      if (cfg.ids && cfg.ids.has(d.id)) return true;
-      if (cfg.communities && cfg.communities.has(d.community)) return true;
-      if (cfg.segments) {
-        for (const seg of cfg.segments) if (segs.has(seg)) return true;
-      }
-      return false;
+      return window.RNTopicFilters.matches(d, currentTopic);
     }
 
     /* ── 可变物理参数 ── */
@@ -3637,6 +3533,12 @@
     /* ════════════════════════════════════════════
        ?focus=<id> URL 参数：页面加载后飞行定位
     ════════════════════════════════════════════ */
+
+    /* ?topic=<key> URL 参数：从详情页"专题徽标"跳入时自动激活对应专题视图 */
+    const topicParam = new URLSearchParams(location.search).get('topic');
+    if (topicParam && TOPIC_FILTERS[topicParam]) {
+      setActiveTopic(topicParam);
+    }
 
     const focusId = new URLSearchParams(location.search).get('focus');
     if (focusId) {

--- a/docs/main.js
+++ b/docs/main.js
@@ -2570,6 +2570,31 @@
     });
   }
 
+  // 详情页"属于 X 专题"轻量徽标：复用 graph.html 的专题命中规则（topic-filters.js），
+  // 命中则给出跳转图谱专题视图的链接；无命中或无依赖时静默隐藏（空态降级）。
+  function renderDetailTopicBadges(detailPage) {
+    var wrap = document.getElementById('detailTopicBadges');
+    if (!wrap) return;
+    var TF = window.RNTopicFilters;
+    var currentPath = (detailPage && detailPage.path) || '';
+    if (!TF || !currentPath) { wrap.hidden = true; return; }
+
+    fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
+      var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
+      if (!node) { wrap.hidden = true; return; }
+      var topics = TF.topicsForNode({ id: node.id, community: node.community });
+      if (!topics.length) { wrap.hidden = true; return; }
+      var html = '<span class="detail-topic-badges-label">所属专题</span>' + topics.map(function (key) {
+        var meta = TF.TOPIC_META[key] || { emoji: '🏷️', label: key };
+        return '<a class="detail-topic-badge" href="graph.html?topic=' + encodeURIComponent(key) +
+          '" title="在知识图谱中查看「' + escapeHtml(meta.label) + '」专题视图">' +
+          '<span>' + meta.emoji + '</span><span>' + escapeHtml(meta.label) + '</span></a>';
+      }).join('');
+      wrap.innerHTML = html;
+      wrap.hidden = false;
+    }).catch(function () { wrap.hidden = true; });
+  }
+
   function renderDetailMiniMap(detailPage, detailPages) {
     var wrap = document.getElementById('detailMiniMapWrap');
     var svgEl = document.getElementById('detailMiniMapSvg');
@@ -2964,6 +2989,7 @@
     renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。');
 
     renderDetailMiniMap(detailPage, detailPages);
+    renderDetailTopicBadges(detailPage);
     renderDetailRecentIngestTimeline(detailPage);
 
     var hashForLayoutScroll = window.location.hash.replace(/^#/, '');

--- a/docs/style.css
+++ b/docs/style.css
@@ -645,6 +645,35 @@ body.sponsor-dialog-open {
   max-width: 100%;
   padding: 14px 16px;
 }
+.detail-topic-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+.detail-topic-badges-label {
+  font-size: .78rem;
+  color: var(--text-muted);
+}
+.detail-topic-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 212, 255, 0.3);
+  background: rgba(0, 212, 255, 0.06);
+  color: var(--text);
+  font-size: .8rem;
+  text-decoration: none;
+  transition: background .15s ease, border-color .15s ease;
+}
+.detail-topic-badge:hover {
+  background: rgba(0, 212, 255, 0.14);
+  border-color: rgba(0, 212, 255, 0.5);
+}
+.detail-topic-badge span:first-child { font-size: .85rem; line-height: 1; }
 .detail-mini-map {
   background: var(--bg-alt);
   border: 1px solid var(--border);

--- a/docs/topic-filters.js
+++ b/docs/topic-filters.js
@@ -1,0 +1,161 @@
+/*
+ * 专题视图（Topic Filters）单一事实源。
+ * 由 graph.html（专题筛选）与 detail.html / main.js（详情页"属于 X 专题"徽标）共享，
+ * 避免两处各写一份命中规则导致漂移。
+ *
+ * 命中优先级（与 graph.html nodeMatchesTopic 一致）：
+ *   excludeSegments 命中 → 直接排除；ids 显式纳入 → 命中；
+ *   communities 命中 → 命中；segments 命中任一 → 命中。
+ */
+(function (global) {
+  'use strict';
+
+  var TOPIC_FILTERS = {
+    'motion-retargeting': {
+      communities: new Set(['community-3']),
+      segments: new Set([
+        'retargeting', 'retarget', 'gmr', 'nmr', 'reactor', 'sonic', 'exoactor',
+        'spider', 'wilor', 'mocap', 'teleoperation', 'deepmimic', 'amp',
+        'character', 'animation', 'keyframe', 'pipeline'
+      ])
+    },
+    'grasp': {
+      segments: new Set([
+        'grasp', 'graspnet', 'anygrasp', 'dexterous', 'manipulation',
+        'pick', 'place', 'bimanual', 'curobo'
+      ])
+    },
+    'tactile': {
+      segments: new Set([
+        'tactile', 'haptic', 'impedance', 'force', 'contact', 'visuo'
+      ]),
+      excludeSegments: new Set(['reinforcement'])
+    },
+    'communication': {
+      segments: new Set([
+        'ethercat', 'can', 'uart', 'dds', 'foxglove', 'rs485', 'rs232',
+        'serial', 'communication', 'protocol', 'bus', 'protocols', 'firmware'
+      ])
+    },
+    'wbc': {
+      communities: new Set(['community-0']),
+      segments: new Set([
+        'wbc', 'tsid', 'hqp', 'cbf', 'clf', 'whole', 'body', 'balance', 'hierarchical'
+      ])
+    },
+    'locomotion': {
+      communities: new Set(['community-11', 'community-9']),
+      segments: new Set([
+        'locomotion', 'gait', 'mpc', 'zmp', 'lip', 'walking', 'swing', 'stance', 'capture'
+      ])
+    },
+    'vla': {
+      communities: new Set(['community-5']),
+      segments: new Set([
+        'vla', 'foundation', 'octo', 'openvla', 'rt', 'pi0', 'gr00t'
+      ])
+    },
+    'learning': {
+      communities: new Set(['community-4', 'community-6']),
+      segments: new Set([
+        'imitation', 'reinforcement', 'ppo', 'sac', 'behavior', 'cloning', 'dreamer'
+      ])
+    },
+    'sim2real': {
+      segments: new Set([
+        'sim2real', 'randomization', 'domain'
+      ])
+    },
+    'state-estimation': {
+      segments: new Set([
+        'estimation', 'ekf', 'ukf', 'slam', 'vio', 'odometry'
+      ])
+    },
+    'wbt': {
+      segments: new Set([
+        'wbt', 'tracking', 'beyondmimic', 'sdamp', 'heracles', 'opentrack',
+        'maskedmimic', 'sonic', 'any2any', 'twist', 'twist2'
+      ])
+    },
+    'cross-embodiment': {
+      segments: new Set([
+        'embodiment', 'any2any', 'transfer'
+      ])
+    },
+    'safe-fine-tuning': {
+      communities: new Set(['community-13']),
+      segments: new Set([
+        'safe', 'safety', 'cbf', 'clf', 'barrier', 'lyapunov', 'slowrl', 'lora', 'cmdp'
+      ])
+    },
+    'vision-backbone': {
+      segments: new Set([
+        'backbone', 'backbones', 'cnn', 'vit', 'resnet', 'yolo', 'detection'
+      ]),
+      ids: new Set([
+        'wiki/concepts/visual-representation-for-policy.md',
+        'wiki/concepts/generative-vision-pretraining.md'
+      ])
+    }
+  };
+
+  /* 专题展示元信息（emoji + 简称），与 graph.html chips 顺序一致。 */
+  var TOPIC_META = {
+    'motion-retargeting': { emoji: '🤸', label: '动作重定向' },
+    'grasp': { emoji: '🤏', label: '抓取' },
+    'tactile': { emoji: '✋', label: '触觉' },
+    'communication': { emoji: '🔌', label: '通信协议' },
+    'wbc': { emoji: '🦾', label: 'WBC' },
+    'locomotion': { emoji: '🚶', label: 'Locomotion' },
+    'vla': { emoji: '👀', label: 'VLA' },
+    'learning': { emoji: '🎓', label: 'IL/RL' },
+    'sim2real': { emoji: '🔁', label: 'Sim2Real' },
+    'state-estimation': { emoji: '📊', label: '状态估计' },
+    'wbt': { emoji: '🕺', label: 'WBT' },
+    'cross-embodiment': { emoji: '🔀', label: '跨具身' },
+    'safe-fine-tuning': { emoji: '🛡️', label: '安全微调' },
+    'vision-backbone': { emoji: '👁️', label: '视觉骨干' }
+  };
+
+  function nodeSegments(node) {
+    if (node && node._segs) return node._segs;
+    var base = ((node && node.id) || '').toLowerCase().replace(/\.md$/, '');
+    var segs = new Set(base.split(/[/._-]/).filter(Boolean));
+    if (node) node._segs = segs;
+    return segs;
+  }
+
+  /* 判定单个节点是否命中某专题（topicKey 为 'all' 时恒真）。 */
+  function matches(node, topicKey) {
+    if (topicKey === 'all') return true;
+    var cfg = TOPIC_FILTERS[topicKey];
+    if (!cfg) return true;
+    var segs = nodeSegments(node);
+    if (cfg.excludeSegments) {
+      for (var ex of cfg.excludeSegments) if (segs.has(ex)) return false;
+    }
+    if (cfg.ids && cfg.ids.has(node.id)) return true;
+    if (cfg.communities && node.community && cfg.communities.has(node.community)) return true;
+    if (cfg.segments) {
+      for (var seg of cfg.segments) if (segs.has(seg)) return true;
+    }
+    return false;
+  }
+
+  /* 返回节点命中的全部专题 key 列表（不含 'all'）。 */
+  function topicsForNode(node) {
+    var out = [];
+    for (var key in TOPIC_FILTERS) {
+      if (matches(node, key)) out.push(key);
+    }
+    return out;
+  }
+
+  global.RNTopicFilters = {
+    TOPIC_FILTERS: TOPIC_FILTERS,
+    TOPIC_META: TOPIC_META,
+    nodeSegments: nodeSegments,
+    matches: matches,
+    topicsForNode: topicsForNode
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/log.md
+++ b/log.md
@@ -1,5 +1,12 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-15] structural | docs/detail.html + docs/main.js + docs/topic-filters.js — V24 P3 详情页"所属专题"轻量徽标，专题命中规则抽共享模块并收口 V24
+
+- 新增 `docs/topic-filters.js` 作为专题命中规则单一事实源（`TOPIC_FILTERS` / `TOPIC_META` / `matches` / `topicsForNode`）；`docs/graph.html` 移除内联 `TOPIC_FILTERS` 与 `nodeMatchesTopic` 实现改为消费共享模块，并新增 `?topic=<key>` URL 参数自动激活对应专题视图
+- `docs/main.js` 新增 `renderDetailTopicBadges`：复用 `link-graph.json` 现成社区数据计算当前页命中的专题，渲染"所属专题"徽标 → `graph.html?topic=<key>`（无命中静默隐藏）；`docs/detail.html` 增 `#detailTopicBadges` 容器，`docs/style.css` 增 `.detail-topic-badge` 胶囊样式
+- `docs/checklists/tech-stack-next-phase-checklist-v24.md`：P3 可选项打勾，验收标准（make lint / 节点边数 / community 均衡 / log 记录）逐条复核打勾，V24 全部条目收口
+- 验证：`make lint` 退出码 0（「✅ 所有检查通过！」）；节点 1183 / 边 7292、`community_quality_warning=false`、最大社区占比 0.179；Puppeteer 端到端截图归档 `.cursor-artifacts/screenshots/detail-topic-badge.png`、`graph-topic-from-url.png`（详情页徽标→图谱专题视图链路打通）
+
 ## [2026-06-15] ingest | sources/repos/gen2humanoid.md — 入库 Gen2Humanoid 文本→HY-Motion→GMR 人形管线；新建 wiki/entities/gen2humanoid.md；交叉 hy-motion-1、motion-retargeting-gmr、motion-retargeting-pipeline
 
 ## [2026-06-15] ingest | MoveIt/MoveIt 2 一手资料 — sources/sites/moveit-*.md + sources/repos/moveit-*.md、ros-planning-srdfdom.md；新建 wiki/entities/moveit2.md；交叉 manipulation、curobo、ros2-official-documentation


### PR DESCRIPTION
## 摘要

- 落地 V24 P3 可选项「详情页同专题相关页提示」：详情页对命中某专题的页面给出"所属专题"轻量徽标，点击跳转图谱对应专题视图（空态降级隐藏）。
- 顺手把分散在 `graph.html` 内联的专题命中规则抽到共享模块 `docs/topic-filters.js`，作为单一事实源，避免详情页与图谱页各写一份导致漂移。
- V24 全部条目收口：P3 可选项与四条验收标准逐条复核打勾。

## 改动

- **新增** `docs/topic-filters.js`：`TOPIC_FILTERS`（命中规则）/ `TOPIC_META`（emoji+简称）/ `matches` / `topicsForNode`，graph.html 与 detail.html 同源消费。
- `docs/graph.html`：移除内联 `TOPIC_FILTERS` 与 `nodeMatchesTopic` 实现，改用共享模块；新增 `?topic=<key>` URL 参数，与 `?focus=` 同一加载时机自动激活对应专题视图。
- `docs/main.js`：`renderDetailTopicBadges` 复用 `link-graph.json` 现成社区数据计算当前页命中的专题，渲染徽标 → `graph.html?topic=<key>`。
- `docs/detail.html`：hero 区新增 `#detailTopicBadges` 容器；`docs/style.css`：新增 `.detail-topic-badge` 胶囊样式。
- `docs/checklists/tech-stack-next-phase-checklist-v24.md`、`log.md`：收口记录。

## 验证

- `make lint` 通过（退出码 0，「✅ 所有检查通过！」）。
- 图谱规模 节点 1183 / 边 7292，`community_quality_warning=false`，最大社区占比 0.179（均满足 V24 DoD）。
- Puppeteer 端到端：`vision-backbones` 详情页渲染「👁️ 视觉骨干」徽标（href=`graph.html?topic=vision-backbone`）；点击跳转后 graph 自动激活 `vision-backbone` 专题（active chip 校验通过）。

## 验证截图

``&lt;img alt="详情页所属专题徽标" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-topic-badge.png" /&gt;``
``&lt;img alt="图谱从 URL 参数激活专题视图" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/graph-topic-from-url.png" /&gt;``

https://claude.ai/code/session_01BSER96L6kx8StY6W4RqHYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSER96L6kx8StY6W4RqHYM)_