### PR TITLE
feat: Add community badge to detail pages with graph navigation

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -45,6 +45,7 @@
             <h1 id="detailTitle">正在读取详情页…</h1>
             <p id="detailSummary" class="detail-summary data-loading">当前页面直接消费 <code>exports/site-data-v1.json</code>，展示 detail page 元信息、正文与站内跳转。</p>
             <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
+            <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
           </div>
           <aside class="hero-panel detail-meta-panel">
             <h3>页面元信息</h3>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3540,6 +3540,20 @@
       setActiveTopic(topicParam);
     }
 
+    /* ?community=<id> URL 参数：从详情页"所属社区"徽标跳入时聚焦该社区，
+       与图例点击同源（focusedCommunityId），布局稳定后框定该社区可见节点 */
+    const communityParam = new URLSearchParams(location.search).get('community');
+    if (communityParam && communityMetaMap.has(communityParam)) {
+      focusedCommunityId = communityParam;
+      renderLegend();
+      renderFilterPanel();
+      applyFilters();
+      updateFilterCount();
+      const fitFocusedCommunity = () => fitToVisibleNodes();
+      simulation.on('end.community', () => { fitFocusedCommunity(); simulation.on('end.community', null); });
+      setTimeout(fitFocusedCommunity, 1400);
+    }
+
     const focusId = new URLSearchParams(location.search).get('focus');
     if (focusId) {
       const focusNode = nodes.find(n => n.id === focusId ||

--- a/docs/main.js
+++ b/docs/main.js
@@ -2595,6 +2595,28 @@
     }).catch(function () { wrap.hidden = true; });
   }
 
+  // 详情页"所属社区"轻量徽标：复用 link-graph.json 的社区划分定位当前页所在社区，
+  // 给出跳转图谱对应社区聚焦视图的链接；当前页不在图谱（无节点 / 无社区）时静默隐藏。
+  function renderDetailCommunityBadge(detailPage) {
+    var wrap = document.getElementById('detailCommunityBadges');
+    if (!wrap) return;
+    var currentPath = (detailPage && detailPage.path) || '';
+    if (!currentPath) { wrap.hidden = true; return; }
+
+    fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
+      var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
+      if (!node || !node.community) { wrap.hidden = true; return; }
+      var community = (gd.communities || []).find(function (c) { return c.id === node.community; });
+      if (!community) { wrap.hidden = true; return; }
+      var label = shortenCommunityLabel(community.label);
+      wrap.innerHTML = '<span class="detail-topic-badges-label">所属社区</span>' +
+        '<a class="detail-topic-badge detail-community-badge" href="graph.html?community=' +
+        encodeURIComponent(community.id) + '" title="在知识图谱中查看「' + escapeHtml(label) + '」社区视图">' +
+        '<span>🧭</span><span>' + escapeHtml(label) + '</span></a>';
+      wrap.hidden = false;
+    }).catch(function () { wrap.hidden = true; });
+  }
+
   function renderDetailMiniMap(detailPage, detailPages) {
     var wrap = document.getElementById('detailMiniMapWrap');
     var svgEl = document.getElementById('detailMiniMapSvg');
@@ -2990,6 +3012,7 @@
 
     renderDetailMiniMap(detailPage, detailPages);
     renderDetailTopicBadges(detailPage);
+    renderDetailCommunityBadge(detailPage);
     renderDetailRecentIngestTimeline(detailPage);
 
     var hashForLayoutScroll = window.location.hash.replace(/^#/, '');

--- a/docs/style.css
+++ b/docs/style.css
@@ -674,6 +674,14 @@ body.sponsor-dialog-open {
   border-color: rgba(0, 212, 255, 0.5);
 }
 .detail-topic-badge span:first-child { font-size: .85rem; line-height: 1; }
+.detail-community-badge {
+  border-color: rgba(167, 139, 250, 0.35);
+  background: rgba(167, 139, 250, 0.08);
+}
+.detail-community-badge:hover {
+  border-color: rgba(167, 139, 250, 0.55);
+  background: rgba(167, 139, 250, 0.16);
+}
 .detail-mini-map {
   background: var(--bg-alt);
   border: 1px solid var(--border);


### PR DESCRIPTION
## 摘要

为详情页添加"所属社区"轻量徽标，复用 `link-graph.json` 的社区划分数据定位当前页所在社区，并提供跳转到知识图谱对应社区聚焦视图的链接。当前页不在图谱中时静默隐藏该徽标。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 核心功能
1. **详情页社区徽标渲染** (`main.js`)
   - 新增 `renderDetailCommunityBadge()` 函数，从 `link-graph.json` 查询当前页节点及其所属社区
   - 生成带导航链接的社区徽标，链接指向 `graph.html?community=<id>` 实现图谱聚焦
   - 页面无节点或无社区时自动隐藏徽标

2. **图谱社区聚焦** (`graph.html`)
   - 新增 `?community=<id>` URL 参数处理
   - 从详情页徽标跳入时自动聚焦指定社区，与图例点击同源
   - 布局稳定后框定该社区的可见节点

3. **样式** (`style.css`)
   - 新增 `.detail-community-badge` 样式，采用紫色配色（`rgba(167, 139, 250, ...)`）与其他徽标区分
   - 包含 hover 状态交互反馈

4. **HTML 结构** (`detail.html`)
   - 在详情页标题下方添加社区徽标容器 `detailCommunityBadges`

## 验证

- `make ci-preflight` 通过（仅前端改动，无 wiki/导出链变更）
- 详情页正常渲染社区徽标（当页面在图谱中时）
- 点击徽标成功跳转至图谱并聚焦对应社区

## 相关 Issue

无

https://claude.ai/code/session_01M8tU61jdsvaW2pkn4SuAdp