### PR TITLE
fix(ux): 详情页正文不再重复展示关联页面

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -129,6 +129,42 @@
     return source.slice(endMatch.index + endMatch[0].length).trim();
   }
 
+  // 详情页正文与独立 UI 区块重复展示的 H2 导航节（与 wiki_to_marp 跳过规则对齐子集）。
+  var DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面'];
+
+  function stripDetailContentSections(markdown, sectionLabels) {
+    var labels = Array.isArray(sectionLabels) ? sectionLabels : [];
+    if (!labels.length) return String(markdown || '');
+    var lines = String(markdown || '').replace(/\r\n/g, '\n').split('\n');
+    var out = [];
+    var skipping = false;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var trimmed = line.trim();
+      if (/^##\s+/.test(trimmed)) {
+        var headingText = trimmed.replace(/^##\s+/, '');
+        var shouldSkip = false;
+        for (var j = 0; j < labels.length; j++) {
+          if (headingText.indexOf(labels[j]) >= 0) {
+            shouldSkip = true;
+            break;
+          }
+        }
+        if (shouldSkip) {
+          skipping = true;
+          continue;
+        }
+        skipping = false;
+      }
+      if (skipping) continue;
+      out.push(line);
+    }
+    while (out.length && !out[out.length - 1].trim()) {
+      out.pop();
+    }
+    return out.join('\n');
+  }
+
   function renderHomeStats(graphStats, coverageText) {
     var heroNodeCount = document.getElementById('heroNodeCount');
     var heroEdgeCount = document.getElementById('heroEdgeCount');
@@ -2937,7 +2973,7 @@
       removeLoadingState(breadcrumb);
     }
 
-    const contentMarkdown = detailPage.content_markdown || '';
+    const contentMarkdown = stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS);
     var detailMermaidPromise = Promise.resolve();
     const detailHeadings = collectMarkdownHeadings(contentMarkdown);
     if (tocSectionEl) {

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -413,7 +413,61 @@ console.log('ok');
         content = MAIN_JS.read_text(encoding="utf-8")
         self.assertEqual(content.count("function escapeHtml"), 1)
 
-    def test_style_css_contains_heading_anchor_active_toc_and_hash_target_styles(self):
+    def test_main_js_strips_related_section_from_detail_body(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        expected_snippets = [
+            "DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面']",
+            "function stripDetailContentSections(markdown, sectionLabels)",
+            "stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS)",
+        ]
+        for snippet in expected_snippets:
+            self.assertIn(snippet, content)
+
+    def test_strip_detail_content_sections_removes_related_heading_block(self):
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('var DETAIL_CONTENT_SKIP_SECTIONS');
+const end = content.indexOf('function stripDetailContentSections', start);
+const fnStart = content.indexOf('function stripDetailContentSections', start);
+const fnEnd = content.indexOf('function buildMarkdownRouteIndex', fnStart);
+eval(content.slice(start, fnEnd));
+const sample = [
+  '## 核心内容',
+  '',
+  '正文段落。',
+  '',
+  '## 关联页面',
+  '',
+  '- [Sim2Real](sim2real.md)',
+  '- [Locomotion](locomotion.md)',
+  '',
+  '## 常见误区',
+  '',
+  '误区说明。',
+].join('\n');
+const stripped = stripDetailContentSections(sample, DETAIL_CONTENT_SKIP_SECTIONS);
+if (stripped.includes('## 关联页面')) throw new Error('related heading should be removed');
+if (stripped.includes('sim2real.md')) throw new Error('related links should be removed');
+if (!stripped.includes('## 核心内容')) throw new Error('missing core heading');
+if (!stripped.includes('## 常见误区')) throw new Error('missing trailing heading');
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
+
         style_content = (ROOT / "docs" / "style.css").read_text(encoding="utf-8")
         expected_snippets = [
             ".heading-anchor-link",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页「正文同步内容」会完整渲染 wiki 的 `## 关联页面` 列表，而页面下方「关联项」区块又以卡片形式展示同一批 `detailPage.related` 链接，造成重复。

本次在 `renderDetailPage` 渲染正文前剥离 `## 关联页面` H2 导航节，关联链接仅保留在「关联项」区块展示。

## 验证

- `python3 -m pytest tests/test_content_sync.py -q --no-cov` 通过（含新增剥离逻辑单测）
- `npx eslint docs/main.js` 通过
- 静态站 `wiki-concepts-sim2real` 详情页：正文末尾不再出现「关联页面」标题，「关联项」卡片仍正常

## 验证截图

![Sim2Real 详情页正文（已无关联页面区块）](https://cursor.com/artifacts/c/art-39915838-1cd7-4944-ae9e-a4d87c2922bf)

![Sim2Real 详情页关联项区块](https://cursor.com/artifacts/c/art-e2552d4a-7836-415e-87f6-de0b5d14ad2a)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f5a9e13-c27b-4e8c-8437-525de232b947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f5a9e13-c27b-4e8c-8437-525de232b947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

