### PR TITLE
feat(ux): 详情页元信息面板改为读者向（更新时间 + GitHub 源链接，合并专题/社区徽标）

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -44,14 +44,14 @@
           <div>
             <h1 id="detailTitle">正在读取详情页…</h1>
             <p id="detailSummary" class="detail-summary data-loading">当前页面直接消费 <code>exports/site-data-v1.json</code>，展示 detail page 元信息、正文与站内跳转。</p>
-            <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
-            <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
           </div>
           <aside class="hero-panel detail-meta-panel">
             <h3>页面元信息</h3>
             <div id="detailMeta" class="detail-meta-list data-loading">
-              <p class="data-meta">正在读取 type / status / path…</p>
+              <p class="data-meta">正在读取更新时间 / 源链接…</p>
             </div>
+            <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
+            <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
           </aside>
         </div>
         <aside id="detailMiniMapWrap" class="detail-mini-map" aria-label="知识地图局部视图" hidden>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2920,12 +2920,15 @@
       removeLoadingState(summaryEl);
     }
     if (metaEl) {
-      metaEl.innerHTML = [
-        '<p><strong>id：</strong><code>' + escapeHtml(detailPage.id || detailId) + '</code></p>',
-        '<p><strong>type：</strong>' + escapeHtml(detailPage.type || '-') + '</p>',
-        '<p><strong>status：</strong>' + escapeHtml(detailPage.status || 'active') + '</p>',
-        '<p><strong>path：</strong><code>' + escapeHtml(detailPage.path || '-') + '</code></p>'
-      ].join('');
+      var metaRows = [];
+      if (detailPage.updated) {
+        metaRows.push('<p><strong>更新时间：</strong>' + escapeHtml(detailPage.updated) + '</p>');
+      }
+      if (detailPage.path) {
+        metaRows.push('<p><a class="detail-meta-source-link" href="https://github.com/ImChong/Robotics_Notebooks/blob/main/' +
+          escapeHtml(detailPage.path) + '" target="_blank" rel="noopener noreferrer">在 GitHub 查看源文件 →</a></p>');
+      }
+      metaEl.innerHTML = metaRows.join('');
       removeLoadingState(metaEl);
     }
     if (breadcrumb) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -759,6 +759,12 @@ body.sponsor-dialog-open {
   overflow-wrap: normal;
   word-break: normal;
 }
+.detail-meta-source-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: .88rem;
+}
+.detail-meta-source-link:hover { text-decoration: underline; }
 .empty-state code {
   overflow-wrap: anywhere;
 }

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -410,6 +410,7 @@ def build_item(path: Path) -> dict[str, Any]:
         "related": collect_markdown_links(text, path),
         "source_links": collect_external_links(text),
         "status": "active",
+        "updated": fm.get("updated"),
     }
 
     parts = path.relative_to(ROOT).parts
@@ -670,6 +671,7 @@ def build_site_data(items: List[Dict]) -> Dict:
             "related": item.get("related", []),
             "source_links": item.get("source_links", []),
             "status": item.get("status", "active"),
+            "updated": item.get("updated"),
         }
         for item in items
     }


### PR DESCRIPTION
## 摘要

- 详情页「页面元信息」面板原本对**外部读者**多为噪声：`status` 恒为 `active`、`id` 与 `path` 重复、`type` 是内部枚举黑话。
- 改为只呈现读者真正需要的信息：**更新时间** + **GitHub 源链接**，并把「**所属专题 / 所属社区**」徽标合并进同一面板。

## 改动

- `scripts/export_minimal.py`：`detail_pages` 透出 frontmatter `updated`（1164/1228 页有）。
- `docs/main.js`：`#detailMeta` 渲染「更新时间」（有则显示）+「在 GitHub 查看源文件」深链；移除 id / type / status。
- `docs/detail.html`：「所属专题 / 所属社区」徽标容器重定位进元信息面板（徽标渲染 JS 按 id 取元素，无需改动）。
- `docs/style.css`：新增 `.detail-meta-source-link` 样式。

## 验证

- `make export graph` 通过：`site-data-v1.json` 共 1228 detail pages，其中 1164 带 `updated`。
- 静态站详情页渲染正常：
  - **BFM wiki 页**：面板 = 更新时间 + 源深链（href 正确）+ 所属专题（VLA / IL/RL）+ 所属社区（BFM），**无 id/type/status**。
  - **roadmap 页**：无 `updated` 优雅降级，仅保留源链接，无空值无坏链。

## 验证截图

**BFM wiki 详情页元信息面板**（更新时间 + GitHub 源链接 + 所属专题 + 所属社区）

![BFM 详情页元信息面板](https://raw.githubusercontent.com/ImChong/Robotics_Notebooks/pr-assets-screenshots/.cursor-artifacts/screenshots/bfm-meta-panel.png)

**roadmap 详情页元信息面板**（无 `updated` 优雅降级，仅保留源链接）

![roadmap 详情页元信息面板](https://raw.githubusercontent.com/ImChong/Robotics_Notebooks/pr-assets-screenshots/.cursor-artifacts/screenshots/roadmap-meta-panel.png)

注：本描述中的截图托管于分支 `pr-assets-screenshots`，需保留该分支截图才能持续显示（删除分支后 raw URL 会 404）。

https://claude.ai/code/session_016jueMbA6zS2WVwLnZof8N5