### PR TITLE
fix(ux): 详情页正文去重关联页面与参考来源

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3419,9 +3419,10 @@
         sbRelSec.hidden = true;
       }
 
-      const paperLinks = (item?.source_links || []).filter(url =>
-        String(url).includes('Humanoid_Robot_Learning_Paper_Notebooks')
-      );
+      const paperLinks = (item?.source_links || []).filter(function (entry) {
+        const url = typeof entry === 'string' ? entry : (entry && entry.url) || '';
+        return String(url).includes('Humanoid_Robot_Learning_Paper_Notebooks');
+      });
       if (paperLinks.length) {
         sbPaperList.innerHTML = paperLinks.slice(0, 6).map((url, idx) => {
           if (!isSafeUrl(url)) return '';

--- a/docs/main.js
+++ b/docs/main.js
@@ -130,7 +130,7 @@
   }
 
   // 详情页正文与独立 UI 区块重复展示的 H2 导航节（与 wiki_to_marp 跳过规则对齐子集）。
-  var DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面'];
+  var DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面', '参考来源'];
 
   function stripDetailContentSections(markdown, sectionLabels) {
     var labels = Array.isArray(sectionLabels) ? sectionLabels : [];
@@ -2318,6 +2318,25 @@
     });
   }
 
+  function normalizeSourceLink(entry) {
+    if (entry == null) return { label: '', url: '', detail_id: '' };
+    if (typeof entry === 'string') {
+      return { label: entry, url: entry, detail_id: '' };
+    }
+    return {
+      label: String(entry.label || entry.url || entry.detail_id || ''),
+      url: String(entry.url || ''),
+      detail_id: String(entry.detail_id || '')
+    };
+  }
+
+  function sourceLinkHref(entry) {
+    var item = normalizeSourceLink(entry);
+    if (item.detail_id) return detailHref(item.detail_id);
+    if (item.url && isSafeUrl(item.url)) return item.url;
+    return '';
+  }
+
   function renderSourceCards(container, links, emptyText) {
     if (!container) return;
     if (!Array.isArray(links) || !links.length) {
@@ -2326,16 +2345,26 @@
       return;
     }
 
-    container.innerHTML = links.map(function (url) {
-      const safe = isSafeUrl(url);
-      const linkHtml = safe
-        ? '<a href="' + escapeHtml(url) + '" target="_blank" rel="noopener noreferrer">打开来源</a>'
-        : '<span class="data-meta">来源链接无效或不安全</span>';
+    container.innerHTML = links.map(function (entry) {
+      const item = normalizeSourceLink(entry);
+      const href = sourceLinkHref(entry);
+      const isExternal = href && /^https?:/i.test(href);
+      const linkHtml = href
+        ? (isExternal
+          ? '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">打开来源</a>'
+          : '<a href="' + escapeHtml(href) + '">打开详情</a>')
+        : '';
+      const titleHtml = linkHtml
+        ? '<h3>' + linkHtml + '</h3>'
+        : '<h3>' + escapeHtml(item.label || '参考条目') + '</h3>';
+      const metaHtml = href
+        ? '<p class="data-submeta detail-source-url" title="' + escapeHtml(href) + '"><code>' + escapeHtml(item.label || href) + '</code></p>'
+        : '<p class="data-submeta">' + escapeHtml(item.label || '') + '</p>';
       return [
         '<article class="card data-card">',
         '  <div>',
-        '    <h3>' + linkHtml + '</h3>',
-        '    <p class="data-submeta detail-source-url" title="' + escapeHtml(url) + '"><code>' + escapeHtml(url) + '</code></p>',
+        '    ' + titleHtml,
+        '    ' + metaHtml,
         '  </div>',
         '</article>'
       ].join('');
@@ -3716,9 +3745,13 @@
             '  </div>',
             '  <div>',
             '    <h4>来源链接</h4>',
-            '    <ul>' + (sources.length ? sources.map(function (url) {
-                   const safe = isSafeUrl(url);
-                   return '<li>' + (safe ? '<a href="' + escapeHtml(url) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(url) + '</a>' : '<code>' + escapeHtml(url) + '</code> (unsafe)') + '</li>';
+            '    <ul>' + (sources.length ? sources.map(function (entry) {
+                   const item = normalizeSourceLink(entry);
+                   const href = sourceLinkHref(entry);
+                   const label = item.label || href || '参考条目';
+                   if (!href) return '<li>' + escapeHtml(label) + '</li>';
+                   const external = /^https?:/i.test(href);
+                   return '<li><a href="' + escapeHtml(href) + '"' + (external ? ' target="_blank" rel="noopener noreferrer"' : '') + '>' + escapeHtml(label) + '</a></li>';
                  }).join('') : '<li>暂无来源链接</li>') + '</ul>',
             '  </div>',
             '  <div class="chip-list">',

--- a/docs/main.js
+++ b/docs/main.js
@@ -130,7 +130,64 @@
   }
 
   // 详情页正文与独立 UI 区块重复展示的 H2 导航节（与 wiki_to_marp 跳过规则对齐子集）。
-  var DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面', '参考来源'];
+  var DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面'];
+
+  function referenceSourceLineHasLink(line) {
+    var trimmed = String(line || '').trim();
+    if (!trimmed) return false;
+    if (/\[[^\]]+\]\([^)]+\)/.test(trimmed)) return true;
+    if (/https?:\/\/[^)\s>]+/.test(trimmed)) return true;
+    return false;
+  }
+
+  /** 参考来源：带链条目进「来源链接」，纯文本条目保留在正文该节。 */
+  function stripLinkedReferenceSourceLines(markdown) {
+    var lines = String(markdown || '').replace(/\r\n/g, '\n').split('\n');
+    var out = [];
+    var inReferenceSection = false;
+    var pendingReferenceHeading = null;
+    var referencePlainLines = [];
+
+    function flushReferenceSection() {
+      if (referencePlainLines.length) {
+        if (pendingReferenceHeading) out.push(pendingReferenceHeading);
+        for (var r = 0; r < referencePlainLines.length; r++) {
+          out.push(referencePlainLines[r]);
+        }
+      }
+      pendingReferenceHeading = null;
+      referencePlainLines = [];
+      inReferenceSection = false;
+    }
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var trimmed = line.trim();
+      if (/^##\s+/.test(trimmed)) {
+        flushReferenceSection();
+        var headingText = trimmed.replace(/^##\s+/, '');
+        if (headingText.indexOf('参考来源') >= 0) {
+          inReferenceSection = true;
+          pendingReferenceHeading = line;
+          continue;
+        }
+        out.push(line);
+        continue;
+      }
+      if (inReferenceSection) {
+        if (!trimmed || !referenceSourceLineHasLink(line)) {
+          referencePlainLines.push(line);
+        }
+        continue;
+      }
+      out.push(line);
+    }
+    flushReferenceSection();
+    while (out.length && !out[out.length - 1].trim()) {
+      out.pop();
+    }
+    return out.join('\n');
+  }
 
   function stripDetailContentSections(markdown, sectionLabels) {
     var labels = Array.isArray(sectionLabels) ? sectionLabels : [];
@@ -3002,7 +3059,9 @@
       removeLoadingState(breadcrumb);
     }
 
-    const contentMarkdown = stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS);
+    const contentMarkdown = stripLinkedReferenceSourceLines(
+      stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS)
+    );
     var detailMermaidPromise = Promise.resolve();
     const detailHeadings = collectMarkdownHeadings(contentMarkdown);
     if (tocSectionEl) {

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -453,7 +453,9 @@ def parse_reference_line(line: str, current_path: Path) -> List[Dict[str, str]]:
     return [{"label": clean_reference_label(stripped)}]
 
 
-def collect_reference_sources(text: str, current_path: Path, limit: int = 32) -> List[Dict[str, str]]:
+def collect_reference_sources(
+    text: str, current_path: Path, limit: int = 32
+) -> List[Dict[str, str]]:
     section = extract_section_body(text, ["参考来源"])
     if not section:
         return [{"label": url, "url": url} for url in collect_external_links(text)[:limit]]

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -368,6 +368,110 @@ def collect_external_links(text: str) -> List[str]:
     return out
 
 
+GITHUB_BLOB_BASE = "https://github.com/ImChong/Robotics_Notebooks/blob/main/"
+
+
+def clean_reference_label(text: str) -> str:
+    text = text.strip()
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = text.replace("**", "")
+    text = re.sub(r"\s+", " ", text)
+    return text.strip(" ：:，,。")
+
+
+def extract_section_body(text: str, heading_labels: List[str]) -> str:
+    lines = text.splitlines()
+    collecting = False
+    section_lines: List[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("## ") or stripped.startswith("### "):
+            heading = re.sub(r"^#+\s*", "", stripped)
+            if any(label in heading for label in heading_labels):
+                collecting = True
+                section_lines = []
+                continue
+            if collecting:
+                break
+        if collecting:
+            section_lines.append(line)
+    return "\n".join(section_lines).strip()
+
+
+def resolve_reference_target(target: str, current_path: Path) -> Dict[str, str]:
+    target = target.split("#", 1)[0].strip()
+    if target.startswith(("http://", "https://")):
+        return {"url": target.rstrip(".,")}
+    if not target.endswith(".md"):
+        return {"url": target}
+    resolved = (current_path.parent / target).resolve()
+    try:
+        rel_path = resolved.relative_to(ROOT)
+    except ValueError:
+        return {"url": target}
+    rel_posix = rel_path.as_posix()
+    if _is_indexed_link_target(resolved):
+        return {"detail_id": path_to_id(resolved, ROOT)}
+    return {"url": f"{GITHUB_BLOB_BASE}{rel_posix}"}
+
+
+def _reference_entry_key(entry: Dict[str, str]) -> str:
+    return entry.get("detail_id") or entry.get("url") or entry.get("label", "")
+
+
+def parse_reference_line(line: str, current_path: Path) -> List[Dict[str, str]]:
+    stripped = line.strip()
+    if stripped.startswith("- "):
+        stripped = stripped[2:].strip()
+    if not stripped:
+        return []
+
+    link_matches = list(re.finditer(r"\[([^\]]+)\]\(([^)]+)\)", stripped))
+    if link_matches:
+        entries: List[Dict[str, str]] = []
+        for match in link_matches:
+            label = match.group(1).strip()
+            target = match.group(2).strip()
+            tail = stripped[match.end() :].strip()
+            if tail.startswith(("—", "-")):
+                tail = tail.lstrip("—-").strip()
+                if tail:
+                    label = f"{label} — {tail}"
+            entry: Dict[str, str] = {"label": label}
+            entry.update(resolve_reference_target(target, current_path))
+            entries.append(entry)
+        return entries
+
+    urls = re.findall(r"https?://[^)\s>]+", stripped)
+    if urls:
+        url = urls[0].rstrip(".,")
+        label = clean_reference_label(re.sub(r"https?://\S+", "", stripped))
+        if not label:
+            label = url
+        return [{"label": label, "url": url}]
+
+    return [{"label": clean_reference_label(stripped)}]
+
+
+def collect_reference_sources(text: str, current_path: Path, limit: int = 32) -> List[Dict[str, str]]:
+    section = extract_section_body(text, ["参考来源"])
+    if not section:
+        return [{"label": url, "url": url} for url in collect_external_links(text)[:limit]]
+
+    results: List[Dict[str, str]] = []
+    seen: set[str] = set()
+    for line in section.splitlines():
+        for entry in parse_reference_line(line, current_path):
+            key = _reference_entry_key(entry)
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            results.append(entry)
+            if len(results) >= limit:
+                return results
+    return results
+
+
 def parse_roadmap_stages(text: str, current_path: Path) -> List[Dict[str, Any]]:
     stages: List[Dict[str, Any]] = []
     current: Dict[str, Any] | None = None
@@ -408,7 +512,7 @@ def build_item(path: Path) -> dict[str, Any]:
         "content_markdown": extract_body_markdown(text),
         "tags": infer_tags(path, title, text),
         "related": collect_markdown_links(text, path),
-        "source_links": collect_external_links(text),
+        "source_links": collect_reference_sources(body_text, path),
         "status": "active",
     }
 

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -462,6 +462,8 @@ def collect_reference_sources(text: str, current_path: Path, limit: int = 32) ->
     seen: set[str] = set()
     for line in section.splitlines():
         for entry in parse_reference_line(line, current_path):
+            if not entry.get("url") and not entry.get("detail_id"):
+                continue
             key = _reference_entry_key(entry)
             if not key or key in seen:
                 continue

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -416,7 +416,9 @@ console.log('ok');
     def test_main_js_strips_related_section_from_detail_body(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         expected_snippets = [
-            "DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面', '参考来源']",
+            "DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面']",
+            "function stripLinkedReferenceSourceLines(markdown)",
+            "stripLinkedReferenceSourceLines(",
             "function stripDetailContentSections(markdown, sectionLabels)",
             "stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS)",
         ]
@@ -468,13 +470,12 @@ console.log('ok');
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         self.assertIn("ok", result.stdout)
 
-    def test_strip_detail_content_sections_removes_reference_sources_heading_block(self):
+    def test_strip_linked_reference_source_lines_keeps_plain_text_only(self):
         node = r"""
 const fs = require('fs');
 const content = fs.readFileSync(process.argv[2], 'utf8');
-const start = content.indexOf('var DETAIL_CONTENT_SKIP_SECTIONS');
-const fnStart = content.indexOf('function stripDetailContentSections', start);
-const fnEnd = content.indexOf('function buildMarkdownRouteIndex', fnStart);
+const start = content.indexOf('function referenceSourceLineHasLink');
+const fnEnd = content.indexOf('function renderHomeStats', start);
 eval(content.slice(start, fnEnd));
 const sample = [
   '## 核心内容',
@@ -484,14 +485,16 @@ const sample = [
   '## 参考来源',
   '',
   '- [Paper](https://example.com/paper)',
+  '- Tobin et al. 2017, Domain Randomization paper',
   '',
   '## 常见误区',
   '',
   '误区说明。',
 ].join('\n');
-const stripped = stripDetailContentSections(sample, DETAIL_CONTENT_SKIP_SECTIONS);
-if (stripped.includes('## 参考来源')) throw new Error('reference heading should be removed');
-if (stripped.includes('example.com/paper')) throw new Error('reference links should be removed');
+const stripped = stripLinkedReferenceSourceLines(sample);
+if (!stripped.includes('## 参考来源')) throw new Error('reference heading should remain for plain text');
+if (stripped.includes('example.com/paper')) throw new Error('linked reference should be removed from body');
+if (!stripped.includes('Tobin et al. 2017')) throw new Error('plain text reference should remain in body');
 if (!stripped.includes('## 常见误区')) throw new Error('missing trailing heading');
 console.log('ok');
 """

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -416,7 +416,7 @@ console.log('ok');
     def test_main_js_strips_related_section_from_detail_body(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         expected_snippets = [
-            "DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面']",
+            "DETAIL_CONTENT_SKIP_SECTIONS = ['关联页面', '参考来源']",
             "function stripDetailContentSections(markdown, sectionLabels)",
             "stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS)",
         ]
@@ -468,6 +468,49 @@ console.log('ok');
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         self.assertIn("ok", result.stdout)
 
+    def test_strip_detail_content_sections_removes_reference_sources_heading_block(self):
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('var DETAIL_CONTENT_SKIP_SECTIONS');
+const fnStart = content.indexOf('function stripDetailContentSections', start);
+const fnEnd = content.indexOf('function buildMarkdownRouteIndex', fnStart);
+eval(content.slice(start, fnEnd));
+const sample = [
+  '## 核心内容',
+  '',
+  '正文段落。',
+  '',
+  '## 参考来源',
+  '',
+  '- [Paper](https://example.com/paper)',
+  '',
+  '## 常见误区',
+  '',
+  '误区说明。',
+].join('\n');
+const stripped = stripDetailContentSections(sample, DETAIL_CONTENT_SKIP_SECTIONS);
+if (stripped.includes('## 参考来源')) throw new Error('reference heading should be removed');
+if (stripped.includes('example.com/paper')) throw new Error('reference links should be removed');
+if (!stripped.includes('## 常见误区')) throw new Error('missing trailing heading');
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
+
+    def test_style_css_contains_heading_anchor_active_toc_and_hash_target_styles(self):
         style_content = (ROOT / "docs" / "style.css").read_text(encoding="utf-8")
         expected_snippets = [
             ".heading-anchor-link",

--- a/tests/test_reference_sources_export.py
+++ b/tests/test_reference_sources_export.py
@@ -1,0 +1,48 @@
+import unittest
+from pathlib import Path
+
+from export_minimal import collect_reference_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+SIM2REAL = ROOT / "wiki" / "concepts" / "sim2real.md"
+
+
+class ReferenceSourcesExportTests(unittest.TestCase):
+    def test_collect_reference_sources_from_section(self) -> None:
+        text = SIM2REAL.read_text(encoding="utf-8")
+        sources = collect_reference_sources(text, SIM2REAL)
+        self.assertGreaterEqual(len(sources), 10)
+        labels = [entry["label"] for entry in sources]
+        self.assertTrue(any("KungFuAthleteBot" in label for label in labels))
+        self.assertTrue(any("Tobin" in label for label in labels))
+        detail_ids = [entry.get("detail_id", "") for entry in sources]
+        self.assertIn("reference-papers-sim2real", detail_ids)
+        github_urls = [entry.get("url", "") for entry in sources]
+        self.assertTrue(
+            any(url.startswith("https://github.com/ImChong/Robotics_Notebooks/blob/main/sources/") for url in github_urls)
+        )
+
+    def test_collect_reference_sources_fallback_to_external_links(self) -> None:
+        sample = (
+            "# Title\n\n"
+            "## 核心内容\n\n"
+            "正文含 https://example.com/paper 链接。\n"
+        )
+        path = ROOT / "wiki" / "concepts" / "sample.md"
+        sources = collect_reference_sources(sample, path)
+        self.assertEqual(sources, [{"label": "https://example.com/paper", "url": "https://example.com/paper"}])
+
+    def test_parse_reference_line_keeps_plain_text_entry(self) -> None:
+        sample = (
+            "## 参考来源\n\n"
+            "- Tobin et al. 2017, *Domain Randomization for Transferring Deep Neural Networks from Simulation to the Real World*\n"
+        )
+        path = ROOT / "wiki" / "concepts" / "sample.md"
+        sources = collect_reference_sources(sample, path)
+        self.assertEqual(len(sources), 1)
+        self.assertIn("Tobin", sources[0]["label"])
+        self.assertNotIn("url", sources[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reference_sources_export.py
+++ b/tests/test_reference_sources_export.py
@@ -19,18 +19,19 @@ class ReferenceSourcesExportTests(unittest.TestCase):
         self.assertIn("reference-papers-sim2real", detail_ids)
         github_urls = [entry.get("url", "") for entry in sources]
         self.assertTrue(
-            any(url.startswith("https://github.com/ImChong/Robotics_Notebooks/blob/main/sources/") for url in github_urls)
+            any(
+                url.startswith("https://github.com/ImChong/Robotics_Notebooks/blob/main/sources/")
+                for url in github_urls
+            )
         )
 
     def test_collect_reference_sources_fallback_to_external_links(self) -> None:
-        sample = (
-            "# Title\n\n"
-            "## 核心内容\n\n"
-            "正文含 https://example.com/paper 链接。\n"
-        )
+        sample = "# Title\n\n## 核心内容\n\n正文含 https://example.com/paper 链接。\n"
         path = ROOT / "wiki" / "concepts" / "sample.md"
         sources = collect_reference_sources(sample, path)
-        self.assertEqual(sources, [{"label": "https://example.com/paper", "url": "https://example.com/paper"}])
+        self.assertEqual(
+            sources, [{"label": "https://example.com/paper", "url": "https://example.com/paper"}]
+        )
 
     def test_collect_reference_sources_excludes_plain_text_entry(self) -> None:
         sample = (

--- a/tests/test_reference_sources_export.py
+++ b/tests/test_reference_sources_export.py
@@ -14,7 +14,7 @@ class ReferenceSourcesExportTests(unittest.TestCase):
         self.assertGreaterEqual(len(sources), 10)
         labels = [entry["label"] for entry in sources]
         self.assertTrue(any("KungFuAthleteBot" in label for label in labels))
-        self.assertTrue(any("Tobin" in label for label in labels))
+        self.assertFalse(any(label.startswith("Tobin") for label in labels))
         detail_ids = [entry.get("detail_id", "") for entry in sources]
         self.assertIn("reference-papers-sim2real", detail_ids)
         github_urls = [entry.get("url", "") for entry in sources]
@@ -32,16 +32,18 @@ class ReferenceSourcesExportTests(unittest.TestCase):
         sources = collect_reference_sources(sample, path)
         self.assertEqual(sources, [{"label": "https://example.com/paper", "url": "https://example.com/paper"}])
 
-    def test_parse_reference_line_keeps_plain_text_entry(self) -> None:
+    def test_collect_reference_sources_excludes_plain_text_entry(self) -> None:
         sample = (
             "## 参考来源\n\n"
             "- Tobin et al. 2017, *Domain Randomization for Transferring Deep Neural Networks from Simulation to the Real World*\n"
+            "- [Paper notes](https://example.com/paper)\n"
         )
         path = ROOT / "wiki" / "concepts" / "sample.md"
         sources = collect_reference_sources(sample, path)
         self.assertEqual(len(sources), 1)
-        self.assertIn("Tobin", sources[0]["label"])
-        self.assertNotIn("url", sources[0])
+        self.assertEqual(sources[0]["url"], "https://example.com/paper")
+        labels = [entry["label"] for entry in sources]
+        self.assertFalse(any("Tobin" in label for label in labels))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页导航区块去重（关联页面 / 参考来源）+ 修复 GitHub Actions `ruff format --check` 失败。

## CI 修复

`make ci-test` 在 `ruff format --check` 阶段失败：
- `scripts/export_minimal.py`
- `tests/test_reference_sources_export.py`

已执行 `ruff format` 对齐格式，本地 `make ci-test` 与 `make ci-preflight` 均通过。

## 验证

- `make ci-test` 通过（185 tests）
- `make ci-preflight` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f5a9e13-c27b-4e8c-8437-525de232b947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f5a9e13-c27b-4e8c-8437-525de232b947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

