### PR TITLE
fix(ux): 详情页元信息面板横向流式布局

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -3265,7 +3265,7 @@
       metaEl.innerHTML = [
         '<p><strong>id：</strong><code>' + escapeHtml(roadmapPage.id || roadmapId) + '</code></p>',
         '<p><strong>阶段数：</strong>' + escapeHtml((roadmapPage.stages || []).length) + '</p>',
-        '<p><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面（数据来自 <code>graph-stats.json</code>）。</p>'
+        '<p class="detail-meta-note"><strong>互链枢纽：</strong>下方模块展示全站 wiki 链接图中总度数最高的 10 个页面（数据来自 <code>graph-stats.json</code>）。</p>'
       ].join('');
       removeLoadingState(metaEl);
     }
@@ -3483,7 +3483,7 @@
       graphMeta.innerHTML = [
         '<p><strong>overview：</strong><a href="' + escapeHtml(detailHref((techMapPage.graph_meta || {}).overview_id || '')) + '"><code>' + escapeHtml((techMapPage.graph_meta || {}).overview_id || '-') + '</code></a></p>',
         '<p><strong>dependency_graph：</strong><a href="' + escapeHtml(detailHref((techMapPage.graph_meta || {}).dependency_graph_id || '')) + '"><code>' + escapeHtml((techMapPage.graph_meta || {}).dependency_graph_id || '-') + '</code></a></p>',
-        '<p class="data-meta">当前页面直接消费 <code>tech_map_page</code>，节点统一回流到 detail page。</p>'
+        '<p class="detail-meta-note data-meta">当前页面直接消费 <code>tech_map_page</code>，节点统一回流到 detail page。</p>'
       ].join('');
       removeLoadingState(graphMeta);
     }

--- a/docs/style.css
+++ b/docs/style.css
@@ -643,14 +643,28 @@ body.sponsor-dialog-open {
 .detail-meta-panel {
   min-height: 0;
   max-width: 100%;
-  padding: 14px 16px;
+  padding: 12px 16px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 16px;
+}
+.detail-meta-panel h3 {
+  flex: 0 0 auto;
+  margin-bottom: 0;
+  font-size: .82rem;
+  font-weight: 650;
+  color: var(--text-muted);
+  letter-spacing: .02em;
 }
 .detail-topic-badges {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
-  margin-top: 14px;
+  margin-top: 0;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 .detail-topic-badges-label {
   font-size: .78rem;
@@ -736,14 +750,47 @@ body.sponsor-dialog-open {
   stroke-width: 2.4px;
 }
 .detail-meta-list {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
   font-size: .88rem;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .detail-meta-list p {
   min-width: 0;
   margin: 0;
+  flex: 0 1 auto;
+}
+.detail-meta-list p.detail-meta-note {
+  flex: 1 1 100%;
+  line-height: 1.55;
+  color: var(--text-muted);
+  font-size: .86rem;
+}
+@media (min-width: 720px) {
+  .detail-meta-panel h3 {
+    padding-right: 14px;
+    border-right: 1px solid var(--border);
+  }
+}
+@media (max-width: 719px) {
+  .detail-meta-panel {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+  .detail-meta-panel h3 {
+    width: 100%;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  .detail-meta-list {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
 }
 .detail-meta-list code,
 .empty-state code {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将详情页「页面元信息」面板从单列左对齐改为 **横向 flex 流式布局**：标题、更新时间、GitHub 源链接、专题/社区徽标在同一行内排列，自动换行
- 桌面端（≥720px）标题右侧加分隔线，与内容区视觉分组
- 窄屏（<720px）保持纵向堆叠，标题下方加底部分隔线
- 路线页/tech-map 的长说明段落加 `.detail-meta-note`，换行时独占整行

## 验证
- `make lint-js` 通过
- 静态站详情页渲染正常（`wiki-methods-gentlehumanoid-motion-tracking`）

## 验证截图
![详情页元信息横向布局](https://cursor.com/artifacts/c/art-4a7fea1b-9c7b-4a9c-a09f-7d5718ac0c70)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08ed76e6-a20a-4f6c-a48c-e3201987f2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08ed76e6-a20a-4f6c-a48c-e3201987f2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

