### PR TITLE
feat(ux): 详情页元信息调整社区专题横排与源链接位置

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -45,7 +45,7 @@
             <h1 id="detailTitle">正在读取详情页…</h1>
             <p id="detailSummary" class="detail-summary data-loading">当前页面直接消费 <code>exports/site-data-v1.json</code>，展示 detail page 元信息、正文与站内跳转。</p>
           </div>
-          <aside class="hero-panel detail-meta-panel">
+          <aside id="detailMetaPanel" class="hero-panel detail-meta-panel">
             <h3>页面元信息</h3>
             <div id="detailMeta" class="detail-meta-list data-loading">
               <p class="data-meta">正在读取更新时间…</p>

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -48,10 +48,13 @@
           <aside class="hero-panel detail-meta-panel">
             <h3>页面元信息</h3>
             <div id="detailMeta" class="detail-meta-list data-loading">
-              <p class="data-meta">正在读取更新时间 / 源链接…</p>
+              <p class="data-meta">正在读取更新时间…</p>
             </div>
-            <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
-            <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
+            <div id="detailBadgeRow" class="detail-badge-row" hidden>
+              <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
+              <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
+            </div>
+            <div id="detailMetaSource" class="detail-meta-source-wrap" hidden></div>
           </aside>
         </div>
         <aside id="detailMiniMapWrap" class="detail-mini-map" aria-label="知识地图局部视图" hidden>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2606,6 +2606,29 @@
     });
   }
 
+  function syncDetailBadgeRowVisibility() {
+    var row = document.getElementById('detailBadgeRow');
+    var communityWrap = document.getElementById('detailCommunityBadges');
+    var topicWrap = document.getElementById('detailTopicBadges');
+    if (!row) return;
+    var hasVisible = (communityWrap && !communityWrap.hidden) || (topicWrap && !topicWrap.hidden);
+    row.hidden = !hasVisible;
+  }
+
+  function renderDetailMetaSource(detailPage) {
+    var wrap = document.getElementById('detailMetaSource');
+    if (!wrap) return;
+    var path = (detailPage && detailPage.path) || '';
+    if (!path) {
+      wrap.innerHTML = '';
+      wrap.hidden = true;
+      return;
+    }
+    wrap.innerHTML = '<a class="detail-meta-source-link" href="https://github.com/ImChong/Robotics_Notebooks/blob/main/' +
+      escapeHtml(path) + '" target="_blank" rel="noopener noreferrer">在 GitHub 查看源文件 →</a>';
+    wrap.hidden = false;
+  }
+
   // 详情页"属于 X 专题"轻量徽标：复用 graph.html 的专题命中规则（topic-filters.js），
   // 命中则给出跳转图谱专题视图的链接；无命中或无依赖时静默隐藏（空态降级）。
   function renderDetailTopicBadges(detailPage) {
@@ -2613,13 +2636,13 @@
     if (!wrap) return;
     var TF = window.RNTopicFilters;
     var currentPath = (detailPage && detailPage.path) || '';
-    if (!TF || !currentPath) { wrap.hidden = true; return; }
+    if (!TF || !currentPath) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
 
     fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
-      if (!node) { wrap.hidden = true; return; }
+      if (!node) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
       var topics = TF.topicsForNode({ id: node.id, community: node.community });
-      if (!topics.length) { wrap.hidden = true; return; }
+      if (!topics.length) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
       var html = '<span class="detail-topic-badges-label">所属专题</span>' + topics.map(function (key) {
         var meta = TF.TOPIC_META[key] || { emoji: '🏷️', label: key };
         return '<a class="detail-topic-badge" href="graph.html?topic=' + encodeURIComponent(key) +
@@ -2628,7 +2651,8 @@
       }).join('');
       wrap.innerHTML = html;
       wrap.hidden = false;
-    }).catch(function () { wrap.hidden = true; });
+      syncDetailBadgeRowVisibility();
+    }).catch(function () { wrap.hidden = true; syncDetailBadgeRowVisibility(); });
   }
 
   // 详情页"所属社区"轻量徽标：复用 link-graph.json 的社区划分定位当前页所在社区，
@@ -2637,20 +2661,21 @@
     var wrap = document.getElementById('detailCommunityBadges');
     if (!wrap) return;
     var currentPath = (detailPage && detailPage.path) || '';
-    if (!currentPath) { wrap.hidden = true; return; }
+    if (!currentPath) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
 
     fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
-      if (!node || !node.community) { wrap.hidden = true; return; }
+      if (!node || !node.community) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
       var community = (gd.communities || []).find(function (c) { return c.id === node.community; });
-      if (!community) { wrap.hidden = true; return; }
+      if (!community) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
       var label = shortenCommunityLabel(community.label);
       wrap.innerHTML = '<span class="detail-topic-badges-label">所属社区</span>' +
         '<a class="detail-topic-badge detail-community-badge" href="graph.html?community=' +
         encodeURIComponent(community.id) + '" title="在知识图谱中查看「' + escapeHtml(label) + '」社区视图">' +
         '<span>🧭</span><span>' + escapeHtml(label) + '</span></a>';
       wrap.hidden = false;
-    }).catch(function () { wrap.hidden = true; });
+      syncDetailBadgeRowVisibility();
+    }).catch(function () { wrap.hidden = true; syncDetailBadgeRowVisibility(); });
   }
 
   function renderDetailMiniMap(detailPage, detailPages) {
@@ -2893,6 +2918,13 @@
         metaEl.innerHTML = '<p class="data-meta">当前没有匹配到 detail_pages 项。</p>';
         removeLoadingState(metaEl);
       }
+      renderDetailMetaSource(null);
+      var badgeRow = document.getElementById('detailBadgeRow');
+      if (badgeRow) badgeRow.hidden = true;
+      var communityBadges = document.getElementById('detailCommunityBadges');
+      if (communityBadges) communityBadges.hidden = true;
+      var topicBadges = document.getElementById('detailTopicBadges');
+      if (topicBadges) topicBadges.hidden = true;
       if (tocSectionEl) tocSectionEl.hidden = true;
       if (tocEl) {
         tocEl.innerHTML = '';
@@ -2960,13 +2992,10 @@
       if (detailPage.updated) {
         metaRows.push('<p><strong>更新时间：</strong>' + escapeHtml(detailPage.updated) + '</p>');
       }
-      if (detailPage.path) {
-        metaRows.push('<p><a class="detail-meta-source-link" href="https://github.com/ImChong/Robotics_Notebooks/blob/main/' +
-          escapeHtml(detailPage.path) + '" target="_blank" rel="noopener noreferrer">在 GitHub 查看源文件 →</a></p>');
-      }
       metaEl.innerHTML = metaRows.join('');
       removeLoadingState(metaEl);
     }
+    renderDetailMetaSource(detailPage);
     if (breadcrumb) {
       breadcrumb.innerHTML = [
         '<a href="index.html">首页</a>',

--- a/docs/main.js
+++ b/docs/main.js
@@ -2606,6 +2606,12 @@
     });
   }
 
+  function setDetailMetaReadyState(state) {
+    if (document.documentElement) {
+      document.documentElement.dataset.detailMetaReady = state;
+    }
+  }
+
   function syncDetailBadgeRowVisibility() {
     var row = document.getElementById('detailBadgeRow');
     var communityWrap = document.getElementById('detailCommunityBadges');
@@ -2633,12 +2639,16 @@
   // 命中则给出跳转图谱专题视图的链接；无命中或无依赖时静默隐藏（空态降级）。
   function renderDetailTopicBadges(detailPage) {
     var wrap = document.getElementById('detailTopicBadges');
-    if (!wrap) return;
+    if (!wrap) return Promise.resolve();
     var TF = window.RNTopicFilters;
     var currentPath = (detailPage && detailPage.path) || '';
-    if (!TF || !currentPath) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
+    if (!TF || !currentPath) {
+      wrap.hidden = true;
+      syncDetailBadgeRowVisibility();
+      return Promise.resolve();
+    }
 
-    fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
+    return fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
       if (!node) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
       var topics = TF.topicsForNode({ id: node.id, community: node.community });
@@ -2659,11 +2669,15 @@
   // 给出跳转图谱对应社区聚焦视图的链接；当前页不在图谱（无节点 / 无社区）时静默隐藏。
   function renderDetailCommunityBadge(detailPage) {
     var wrap = document.getElementById('detailCommunityBadges');
-    if (!wrap) return;
+    if (!wrap) return Promise.resolve();
     var currentPath = (detailPage && detailPage.path) || '';
-    if (!currentPath) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
+    if (!currentPath) {
+      wrap.hidden = true;
+      syncDetailBadgeRowVisibility();
+      return Promise.resolve();
+    }
 
-    fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
+    return fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
       if (!node || !node.community) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
       var community = (gd.communities || []).find(function (c) { return c.id === node.community; });
@@ -2919,6 +2933,7 @@
         removeLoadingState(metaEl);
       }
       renderDetailMetaSource(null);
+      setDetailMetaReadyState('true');
       var badgeRow = document.getElementById('detailBadgeRow');
       if (badgeRow) badgeRow.hidden = true;
       var communityBadges = document.getElementById('detailCommunityBadges');
@@ -2996,6 +3011,13 @@
       removeLoadingState(metaEl);
     }
     renderDetailMetaSource(detailPage);
+    setDetailMetaReadyState('pending');
+    Promise.all([
+      renderDetailCommunityBadge(detailPage),
+      renderDetailTopicBadges(detailPage)
+    ]).finally(function () {
+      setDetailMetaReadyState('true');
+    });
     if (breadcrumb) {
       breadcrumb.innerHTML = [
         '<a href="index.html">首页</a>',
@@ -3079,8 +3101,6 @@
     renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。');
 
     renderDetailMiniMap(detailPage, detailPages);
-    renderDetailTopicBadges(detailPage);
-    renderDetailCommunityBadge(detailPage);
     renderDetailRecentIngestTimeline(detailPage);
 
     var hashForLayoutScroll = window.location.hash.replace(/^#/, '');

--- a/docs/style.css
+++ b/docs/style.css
@@ -645,11 +645,24 @@ body.sponsor-dialog-open {
   max-width: 100%;
   padding: 14px 16px;
 }
+.detail-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 20px;
+  margin-top: 14px;
+}
+.detail-badge-row .detail-topic-badges {
+  margin-top: 0;
+}
 .detail-topic-badges {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+  margin-top: 14px;
+}
+.detail-meta-source-wrap {
   margin-top: 14px;
 }
 .detail-topic-badges-label {

--- a/scripts/screenshot_detail_anchor_viewport.cjs
+++ b/scripts/screenshot_detail_anchor_viewport.cjs
@@ -1,11 +1,11 @@
 'use strict';
 /**
- * 对本地 detail.html 做视口截图：等待正文与来源区渲染后，将指定 id 滚入视口再截图。
- * 供 screenshot_site_detail.sh 在传入锚点时使用（headless Chrome 的 --virtual-time-budget
- * 无法可靠等待 Mermaid / fetch 完成后再滚动）。
+ * 对本地 detail.html 做视口截图：等待正文与元信息异步渲染后，可选将指定 id 滚入视口再截图。
+ * 供 screenshot_site_detail.sh 使用（headless Chrome 的 --virtual-time-budget
+ * 无法可靠等待 fetch / Mermaid 完成）。
  *
  * 用法:
- *   node scripts/screenshot_detail_anchor_viewport.cjs <pageUrl> <outPng> <viewportHeight> <elementId>
+ *   node scripts/screenshot_detail_anchor_viewport.cjs <pageUrl> <outPng> <viewportHeight> [elementId]
  *
  * 环境变量:
  *   PUPPETEER_EXECUTABLE_PATH — Chromium/Chrome 可执行文件路径（默认 google-chrome）
@@ -15,15 +15,34 @@ const puppeteer = require('puppeteer-core');
 
 const pageUrl = process.argv[2];
 const outPath = process.argv[3];
-const viewportHeight = parseInt(process.argv[4] || '1000', 10);
-const anchorId = process.argv[5] || 'detail-sources';
+const viewportHeight = parseInt(process.argv[4] || '2400', 10);
+const anchorId = process.argv[5] || '';
 
 const executablePath =
   process.env.PUPPETEER_EXECUTABLE_PATH || process.env.CHROME || 'google-chrome';
 
+async function waitForDetailPageReady(page) {
+  await page.waitForSelector('#detailMeta:not(.data-loading)', { timeout: 90000 });
+  await page.waitForFunction(
+    function () {
+      return document.documentElement.dataset.detailMetaReady === 'true';
+    },
+    { timeout: 90000 }
+  );
+  await page.waitForFunction(
+    function () {
+      const title = document.getElementById('detailTitle');
+      if (!title) return false;
+      const text = (title.textContent || '').trim();
+      return text && !/正在读取/.test(text) && text !== '未找到对应 detail page';
+    },
+    { timeout: 90000 }
+  );
+}
+
 (async function main() {
   if (!pageUrl || !outPath) {
-    console.error('用法: node screenshot_detail_anchor_viewport.cjs <url> <out.png> <height> <elementId>');
+    console.error('用法: node screenshot_detail_anchor_viewport.cjs <url> <out.png> <height> [elementId]');
     process.exit(2);
   }
   const browser = await puppeteer.launch({
@@ -39,47 +58,56 @@ const executablePath =
       deviceScaleFactor: 1
     });
     await page.goto(pageUrl, { waitUntil: 'networkidle2', timeout: 120000 });
-    // 骨架屏同样是 article.card，不能用来判断「已写入真实来源」；以去掉 data-loading 为准。
-    await page.waitForSelector('#detailSourceList:not(.data-loading)', { timeout: 90000 });
-    await page.waitForFunction(
-      function () {
-        const root = document.getElementById('detailSourceList');
-        if (!root) return false;
-        return (
-          root.querySelector('.detail-source-url') !== null ||
-          /暂无来源|无可展示/.test(root.textContent || '')
-        );
-      },
-      { timeout: 90000 }
-    );
-    await page.waitForSelector('#' + anchorId, { timeout: 10000 });
+    await waitForDetailPageReady(page);
 
-    async function scrollAnchorIntoView() {
-      await page.evaluate(function (id) {
-        const el = document.getElementById(id);
-        if (el) el.scrollIntoView({ block: 'start', behavior: 'instant' });
-      }, anchorId);
+    if (anchorId === 'detail-sources') {
+      await page.waitForSelector('#detailSourceList:not(.data-loading)', { timeout: 90000 });
+      await page.waitForFunction(
+        function () {
+          const root = document.getElementById('detailSourceList');
+          if (!root) return false;
+          return (
+            root.querySelector('.detail-source-url') !== null ||
+            /暂无来源|无可展示/.test(root.textContent || '')
+          );
+        },
+        { timeout: 90000 }
+      );
     }
 
-    await scrollAnchorIntoView();
-    await new Promise(function (resolve) {
-      setTimeout(resolve, 600);
-    });
-    await scrollAnchorIntoView();
+    if (anchorId) {
+      await page.waitForSelector('#' + anchorId, { timeout: 10000 });
 
-    const anchorOk = await page.evaluate(function (id) {
-      const el = document.getElementById(id);
-      if (!el) return false;
-      const r = el.getBoundingClientRect();
-      // scrollIntoView(block:start) 在吸顶 header 下常见 top≈200~320，仍算「来源区已进入视口」
-      return r.top >= -80 && r.top < 520 && r.bottom > 120;
-    }, anchorId);
-    if (!anchorOk) {
-      throw new Error(
-        'screenshot_detail_anchor_viewport: 锚点 #' +
-          anchorId +
-          ' 未滚入视口上部，请检查页面 id 或等待条件。'
-      );
+      async function scrollAnchorIntoView() {
+        await page.evaluate(function (id) {
+          const el = document.getElementById(id);
+          if (el) el.scrollIntoView({ block: 'start', behavior: 'instant' });
+        }, anchorId);
+      }
+
+      await scrollAnchorIntoView();
+      await new Promise(function (resolve) {
+        setTimeout(resolve, 600);
+      });
+      await scrollAnchorIntoView();
+
+      const anchorOk = await page.evaluate(function (id) {
+        const el = document.getElementById(id);
+        if (!el) return false;
+        const r = el.getBoundingClientRect();
+        return r.top >= -80 && r.top < 520 && r.bottom > 120;
+      }, anchorId);
+      if (!anchorOk) {
+        throw new Error(
+          'screenshot_detail_anchor_viewport: 锚点 #' +
+            anchorId +
+            ' 未滚入视口上部，请检查页面 id 或等待条件。'
+        );
+      }
+    } else {
+      await new Promise(function (resolve) {
+        setTimeout(resolve, 400);
+      });
     }
 
     await page.screenshot({ path: outPath, type: 'png' });

--- a/scripts/screenshot_site_detail.sh
+++ b/scripts/screenshot_site_detail.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 # 对 docs/detail.html 做 headless 截图（供 Cloud Agent PR 验证）。
-# Chrome 在部分环境下会在「bytes written」之后仍不退出，故必须外层 timeout + 以 PNG 是否落盘为成功判据。
+# 统一使用 Node + puppeteer-core 等待元信息异步渲染完成后再截图。
 #
 # 用法（在仓库根目录）:
 #   ./scripts/screenshot_site_detail.sh wiki-methods-sonic-motion-tracking
 #   ./scripts/screenshot_site_detail.sh wiki-methods-sonic-motion-tracking /path/out.png
-#   ./scripts/screenshot_site_detail.sh wiki-concepts-sim2real /path/out.png detail-sources
-#     第三个参数为页面锚点（不带 #），例如 detail-sources 可定位到「来源链接」区块再截图视口。
+#   ./scripts/screenshot_site_detail.sh wiki-concepts-sim2real /path/to/out.png detail-sources
+#   ./scripts/screenshot_site_detail.sh wiki-concepts-vision-backbones /path/to/out.png detailMetaPanel
+#     第三个参数为页面锚点（不带 #），例如 detail-sources / detailMetaPanel。
 #
 # 环境变量:
 #   PORT   默认 8765
 #   CHROME 默认 google-chrome
-#   SCREENSHOT_HEIGHT  当提供锚点时视口高度，默认 1000（宽度固定 1280）
-#   带锚点时改用 Node + puppeteer-core 控制已安装的 Chrome（见 screenshot_detail_anchor_viewport.cjs），
-#   不再使用 headless --virtual-time-budget，以便在 Mermaid / fetch 完成后再滚动到目标区块。
+#   SCREENSHOT_HEIGHT  视口高度，默认无锚点 2400、有锚点 1000
 
 set -u
 
@@ -48,49 +47,22 @@ sleep 2
 
 URL="http://127.0.0.1:${PORT}/detail.html?id=${PAGE_ID}"
 ANCHOR="${ANCHOR_RAW#\#}"
-WIN_H=2400
-
 if [[ -n "$ANCHOR" ]]; then
   WIN_H="${SCREENSHOT_HEIGHT:-1000}"
+else
+  WIN_H="${SCREENSHOT_HEIGHT:-2400}"
 fi
 
-if [[ -n "$ANCHOR" ]]; then
-  set +e
-  timeout 120 env PUPPETEER_EXECUTABLE_PATH="$(command -v "$CHROME" 2>/dev/null || echo "$CHROME")" \
-    node "$ROOT/scripts/screenshot_detail_anchor_viewport.cjs" "$URL" "$OUT_PATH" "$WIN_H" "$ANCHOR"
-  NODE_RC=$?
-  set -e
-  if [[ "$NODE_RC" -eq 124 ]]; then
-    echo "screenshot_site_detail: 警告 Node/Puppeteer 由 timeout 结束，退出码 124" >&2
-  elif [[ "$NODE_RC" -ne 0 ]]; then
-    echo "screenshot_site_detail: Node/Puppeteer 退出码=$NODE_RC" >&2
-    exit "$NODE_RC"
-  fi
-else
-  # 75s：覆盖 virtual-time-budget + 慢磁盘；Chrome 不退出时由 timeout 强杀
-  DEBUG_PORT=$((20000 + RANDOM % 10000))
-  # 避免与残留 headless 实例争用默认调试端口（常见 9222）
-  set +e
-  timeout 75 "$CHROME" \
-    --headless=new \
-    --disable-gpu \
-    --no-sandbox \
-    --disable-dev-shm-usage \
-    --remote-debugging-port="$DEBUG_PORT" \
-    --user-data-dir="/tmp/chrome-headless-screenshot-$$" \
-    --window-size=1280,"$WIN_H" \
-    --virtual-time-budget=20000 \
-    --disable-remote-fonts \
-    --screenshot="$OUT_PATH" \
-    "$URL"
-  CHROME_RC=$?
-  set -e
-
-  if [[ "$CHROME_RC" -eq 124 ]]; then
-    echo "screenshot_site_detail: 已生成 $OUT_PATH（Chrome 由 timeout 结束，退出码 124 为预期内）"
-  elif [[ "$CHROME_RC" -ne 0 ]]; then
-    echo "screenshot_site_detail: 警告 Chrome 退出码=$CHROME_RC，但 PNG 已生成: $OUT_PATH" >&2
-  fi
+set +e
+timeout 120 env PUPPETEER_EXECUTABLE_PATH="$(command -v "$CHROME" 2>/dev/null || echo "$CHROME")" \
+  node "$ROOT/scripts/screenshot_detail_anchor_viewport.cjs" "$URL" "$OUT_PATH" "$WIN_H" "$ANCHOR"
+NODE_RC=$?
+set -e
+if [[ "$NODE_RC" -eq 124 ]]; then
+  echo "screenshot_site_detail: 警告 Node/Puppeteer 由 timeout 结束，退出码 124" >&2
+elif [[ "$NODE_RC" -ne 0 ]]; then
+  echo "screenshot_site_detail: Node/Puppeteer 退出码=$NODE_RC" >&2
+  exit "$NODE_RC"
 fi
 
 BYTES=0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「页面元信息」卡片内，将「所属社区」与「所属专题」徽标放入同一横排容器（社区在前、专题在后，组间保留约 20px 间距）
- 「在 GitHub 查看源文件」链接从元信息列表中部移至卡片底部独立区域
- 新增 `data-detail-meta-ready` 就绪信号；截图脚本改为 Puppeteer 等待元信息异步加载完成后再截图

## 验证
- `npx eslint docs/main.js` 通过
- `SCREENSHOT_HEIGHT=720 ./scripts/screenshot_site_detail.sh wiki-concepts-vision-backbones ... detailMetaPanel` 等待徽标渲染后截图

## 验证截图
![详情页元信息横排与源链接位置（加载完成后）](https://cursor.com/artifacts/c/art-8a67e845-aeab-45ed-aada-778b3e7a1dd2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6ebd5b9-cfe4-4611-8353-697051960327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6ebd5b9-cfe4-4611-8353-697051960327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

