### PR TITLE
fix(ux): 参考来源节无纯文本时隐藏正文同步标题

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -148,8 +148,15 @@
     var pendingReferenceHeading = null;
     var referencePlainLines = [];
 
+    function referencePlainLinesHasText() {
+      for (var p = 0; p < referencePlainLines.length; p++) {
+        if (String(referencePlainLines[p] || '').trim()) return true;
+      }
+      return false;
+    }
+
     function flushReferenceSection() {
-      if (referencePlainLines.length) {
+      if (referencePlainLinesHasText()) {
         if (pendingReferenceHeading) out.push(pendingReferenceHeading);
         for (var r = 0; r < referencePlainLines.length; r++) {
           out.push(referencePlainLines[r]);
@@ -175,7 +182,7 @@
         continue;
       }
       if (inReferenceSection) {
-        if (!trimmed || !referenceSourceLineHasLink(line)) {
+        if (!referenceSourceLineHasLink(line)) {
           referencePlainLines.push(line);
         }
         continue;

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -513,6 +513,48 @@ console.log('ok');
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         self.assertIn("ok", result.stdout)
 
+    def test_strip_linked_reference_source_lines_removes_heading_when_only_links(self):
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('function referenceSourceLineHasLink');
+const fnEnd = content.indexOf('function renderHomeStats', start);
+eval(content.slice(start, fnEnd));
+const sample = [
+  '## 核心内容',
+  '',
+  '正文段落。',
+  '',
+  '## 参考来源',
+  '',
+  '- [Paper](https://example.com/paper)',
+  '- [Repo](https://github.com/example/repo)',
+  '',
+  '## 常见误区',
+  '',
+  '误区说明。',
+].join('\n');
+const stripped = stripLinkedReferenceSourceLines(sample);
+if (stripped.includes('## 参考来源')) throw new Error('reference heading should be removed when only links');
+if (stripped.includes('example.com/paper')) throw new Error('linked reference should be removed from body');
+if (!stripped.includes('## 常见误区')) throw new Error('missing trailing heading');
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
+
     def test_style_css_contains_heading_anchor_active_toc_and_hash_target_styles(self):
         style_content = (ROOT / "docs" / "style.css").read_text(encoding="utf-8")
         expected_snippets = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页「正文同步内容」在渲染 wiki 正文时，会把 `## 参考来源` 中带链接的条目剥离到下方「来源链接」卡片；仅保留纯文本条目在正文中展示。

此前若参考来源节**只有链接、没有纯文本**，空行仍会被计入「有内容」，导致正文里仍显示孤立的 `## 参考来源` 标题。本次修复：仅当节内存在非空纯文本行时才输出该标题。

## 改动

- `docs/main.js`：`stripLinkedReferenceSourceLines` 增加 `referencePlainLinesHasText()` 判断；收集参考来源行时不再把空行当作有效正文。
- `tests/test_content_sync.py`：新增「仅链接时去掉标题」用例，保留原有「有纯文本时保留标题」用例。

## 验证

- `pytest tests/test_content_sync.py::DetailContentSyncTests::test_strip_linked_reference_source_lines_keeps_plain_text_only`
- `pytest tests/test_content_sync.py::DetailContentSyncTests::test_strip_linked_reference_source_lines_removes_heading_when_only_links`

两项均通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c9ca484-a299-4b64-89bd-5ba85f17bf62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c9ca484-a299-4b64-89bd-5ba85f17bf62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

