### PR TITLE
feat(ux): 详情页「查看源文件」链接移至正文同步内容框右下角

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -54,7 +54,6 @@
               <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
               <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
             </div>
-            <div id="detailMetaSource" class="detail-meta-source-wrap" hidden></div>
           </aside>
         </div>
         <aside id="detailMiniMapWrap" class="detail-mini-map" aria-label="知识地图局部视图" hidden>
@@ -109,7 +108,12 @@
         <div class="detail-content-main">
           <section id="detail-content-body">
             <h2 class="section-title">正文同步内容</h2>
-            <article id="detailContent" class="detail-markdown-body data-loading">正在读取正文同步内容…</article>
+            <div class="detail-content-sync">
+              <article id="detailContent" class="detail-markdown-body data-loading">正在读取正文同步内容…</article>
+              <div class="detail-content-sync-foot">
+                <a id="detailContentSourceLink" class="detail-mini-map-all-link" href="#" target="_blank" rel="noopener noreferrer" hidden>在 GitHub 查看源文件 →</a>
+              </div>
+            </div>
           </section>
 
           <section class="section" id="detail-tags" style="padding: 40px 0;">

--- a/docs/main.js
+++ b/docs/main.js
@@ -2708,17 +2708,16 @@
   }
 
   function renderDetailMetaSource(detailPage) {
-    var wrap = document.getElementById('detailMetaSource');
-    if (!wrap) return;
+    var link = document.getElementById('detailContentSourceLink');
+    if (!link) return;
     var path = (detailPage && detailPage.path) || '';
     if (!path) {
-      wrap.innerHTML = '';
-      wrap.hidden = true;
+      link.removeAttribute('href');
+      link.hidden = true;
       return;
     }
-    wrap.innerHTML = '<a class="detail-meta-source-link" href="https://github.com/ImChong/Robotics_Notebooks/blob/main/' +
-      escapeHtml(path) + '" target="_blank" rel="noopener noreferrer">在 GitHub 查看源文件 →</a>';
-    wrap.hidden = false;
+    link.href = 'https://github.com/ImChong/Robotics_Notebooks/blob/main/' + path;
+    link.hidden = false;
   }
 
   // 详情页"属于 X 专题"轻量徽标：复用 graph.html 的专题命中规则（topic-filters.js），

--- a/docs/style.css
+++ b/docs/style.css
@@ -662,9 +662,6 @@ body.sponsor-dialog-open {
   gap: 8px;
   margin-top: 14px;
 }
-.detail-meta-source-wrap {
-  margin-top: 14px;
-}
 .detail-topic-badges-label {
   font-size: .78rem;
   color: var(--text-muted);
@@ -772,12 +769,25 @@ body.sponsor-dialog-open {
   overflow-wrap: normal;
   word-break: normal;
 }
-.detail-meta-source-link {
-  color: var(--accent);
-  text-decoration: none;
-  font-size: .88rem;
+.detail-content-sync {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  padding: 0 0 6px;
 }
-.detail-meta-source-link:hover { text-decoration: underline; }
+.detail-content-sync .detail-markdown-body {
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  padding-bottom: 0;
+}
+.detail-content-sync-foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+  padding: 0 20px 4px;
+}
 .empty-state code {
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将详情页「在 GitHub 查看源文件 →」从 hero 区「页面元信息」面板移出，放到「正文同步内容」框右下角，样式与知识地图「查看全部邻居 →」一致（复用 `.detail-mini-map-all-link` 与右对齐 foot 布局）。

## 改动说明

- `docs/detail.html`：移除元信息面板内的 `#detailMetaSource`；正文区新增 `.detail-content-sync` 容器与 `#detailContentSourceLink` 底部链接。
- `docs/main.js`：`renderDetailMetaSource` 改为更新正文区链接的 `href` / `hidden`，不再向元信息面板注入 HTML。
- `docs/style.css`：新增 `.detail-content-sync` / `.detail-content-sync-foot`；移除已不再使用的 `.detail-meta-source-*` 样式。

## 验证

- `npm run lint:js` 通过
- 本地静态站预览：`detail.html?id=wiki-entities-pybullet`，链接位于正文框右下角，元信息面板不再显示源文件链接

## 验证截图

![正文同步内容框右下角查看源文件链接](https://cursor.com/artifacts/c/art-488915cf-f817-4cf0-b5d4-8145ad2a6479)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c5a13ad-707b-4f6b-9045-4b3d829e879f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c5a13ad-707b-4f6b-9045-4b3d829e879f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

