### PR TITLE
fix(ux): 详情页元信息所属专题换行至所属社区下一行

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -647,9 +647,9 @@ body.sponsor-dialog-open {
 }
 .detail-badge-row {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 10px 20px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
   margin-top: 14px;
 }
 .detail-badge-row .detail-topic-badges {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「页面元信息」面板中，「所属专题」徽标原先与「所属社区」同一行横向排列（`flex-wrap`），宽屏下容易挤在一行。
- 将 `.detail-badge-row` 改为纵向 `flex-direction: column`，使「所属专题」固定显示在「所属社区」下一行。

## 验证
- 本地 `make export graph` 后启动静态站，对 `detail.html?id=wiki-concepts-sim2real` 的 `#detailMetaPanel` 截图，社区与专题分两行展示正常。

## 验证截图
![详情页元信息：所属社区与所属专题分两行](https://cursor.com/artifacts/c/art-69104caf-47d3-4211-aaf4-87678ec4c984)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93c7cdbc-80c2-4af6-a4d8-4ec2bac81c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93c7cdbc-80c2-4af6-a4d8-4ec2bac81c10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

