### PR TITLE
fix(ux): 统一详情页元信息字体与行格式

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -48,11 +48,9 @@
           <aside id="detailMetaPanel" class="hero-panel detail-meta-panel">
             <h3>页面元信息</h3>
             <div id="detailMeta" class="detail-meta-list data-loading">
-              <p class="data-meta">正在读取更新时间…</p>
-            </div>
-            <div id="detailBadgeRow" class="detail-badge-row" hidden>
-              <div id="detailCommunityBadges" class="detail-topic-badges" aria-label="所属社区" hidden></div>
-              <div id="detailTopicBadges" class="detail-topic-badges" aria-label="所属专题" hidden></div>
+              <p id="detailMetaUpdated" class="detail-meta-item data-meta">正在读取更新时间…</p>
+              <p id="detailMetaCommunity" class="detail-meta-item" hidden></p>
+              <p id="detailMetaTopic" class="detail-meta-item" hidden></p>
             </div>
           </aside>
         </div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2705,13 +2705,16 @@
     }
   }
 
-  function syncDetailBadgeRowVisibility() {
-    var row = document.getElementById('detailBadgeRow');
-    var communityWrap = document.getElementById('detailCommunityBadges');
-    var topicWrap = document.getElementById('detailTopicBadges');
+  function renderDetailMetaItemRow(rowId, label, valueHtml) {
+    var row = document.getElementById(rowId);
     if (!row) return;
-    var hasVisible = (communityWrap && !communityWrap.hidden) || (topicWrap && !topicWrap.hidden);
-    row.hidden = !hasVisible;
+    if (!valueHtml) {
+      row.hidden = true;
+      row.innerHTML = '';
+      return;
+    }
+    row.innerHTML = '<strong>' + escapeHtml(label) + '：</strong>' + valueHtml;
+    row.hidden = false;
   }
 
   function renderDetailMetaSource(detailPage) {
@@ -2730,58 +2733,48 @@
   // 详情页"属于 X 专题"轻量徽标：复用 graph.html 的专题命中规则（topic-filters.js），
   // 命中则给出跳转图谱专题视图的链接；无命中或无依赖时静默隐藏（空态降级）。
   function renderDetailTopicBadges(detailPage) {
-    var wrap = document.getElementById('detailTopicBadges');
-    if (!wrap) return Promise.resolve();
     var TF = window.RNTopicFilters;
     var currentPath = (detailPage && detailPage.path) || '';
     if (!TF || !currentPath) {
-      wrap.hidden = true;
-      syncDetailBadgeRowVisibility();
+      renderDetailMetaItemRow('detailMetaTopic', '所属专题', '');
       return Promise.resolve();
     }
 
     return fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
-      if (!node) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
+      if (!node) { renderDetailMetaItemRow('detailMetaTopic', '所属专题', ''); return; }
       var topics = TF.topicsForNode({ id: node.id, community: node.community });
-      if (!topics.length) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
-      var html = '<span class="detail-topic-badges-label">所属专题</span>' + topics.map(function (key) {
+      if (!topics.length) { renderDetailMetaItemRow('detailMetaTopic', '所属专题', ''); return; }
+      var html = topics.map(function (key) {
         var meta = TF.TOPIC_META[key] || { emoji: '🏷️', label: key };
-        return '<a class="detail-topic-badge" href="graph.html?topic=' + encodeURIComponent(key) +
+        return '<a class="detail-meta-badge" href="graph.html?topic=' + encodeURIComponent(key) +
           '" title="在知识图谱中查看「' + escapeHtml(meta.label) + '」专题视图">' +
           '<span>' + meta.emoji + '</span><span>' + escapeHtml(meta.label) + '</span></a>';
       }).join('');
-      wrap.innerHTML = html;
-      wrap.hidden = false;
-      syncDetailBadgeRowVisibility();
-    }).catch(function () { wrap.hidden = true; syncDetailBadgeRowVisibility(); });
+      renderDetailMetaItemRow('detailMetaTopic', '所属专题', html);
+    }).catch(function () { renderDetailMetaItemRow('detailMetaTopic', '所属专题', ''); });
   }
 
   // 详情页"所属社区"轻量徽标：复用 link-graph.json 的社区划分定位当前页所在社区，
   // 给出跳转图谱对应社区聚焦视图的链接；当前页不在图谱（无节点 / 无社区）时静默隐藏。
   function renderDetailCommunityBadge(detailPage) {
-    var wrap = document.getElementById('detailCommunityBadges');
-    if (!wrap) return Promise.resolve();
     var currentPath = (detailPage && detailPage.path) || '';
     if (!currentPath) {
-      wrap.hidden = true;
-      syncDetailBadgeRowVisibility();
+      renderDetailMetaItemRow('detailMetaCommunity', '所属社区', '');
       return Promise.resolve();
     }
 
     return fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
-      if (!node || !node.community) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
+      if (!node || !node.community) { renderDetailMetaItemRow('detailMetaCommunity', '所属社区', ''); return; }
       var community = (gd.communities || []).find(function (c) { return c.id === node.community; });
-      if (!community) { wrap.hidden = true; syncDetailBadgeRowVisibility(); return; }
+      if (!community) { renderDetailMetaItemRow('detailMetaCommunity', '所属社区', ''); return; }
       var label = shortenCommunityLabel(community.label);
-      wrap.innerHTML = '<span class="detail-topic-badges-label">所属社区</span>' +
-        '<a class="detail-topic-badge detail-community-badge" href="graph.html?community=' +
+      var html = '<a class="detail-meta-badge detail-community-badge" href="graph.html?community=' +
         encodeURIComponent(community.id) + '" title="在知识图谱中查看「' + escapeHtml(label) + '」社区视图">' +
         '<span>🧭</span><span>' + escapeHtml(label) + '</span></a>';
-      wrap.hidden = false;
-      syncDetailBadgeRowVisibility();
-    }).catch(function () { wrap.hidden = true; syncDetailBadgeRowVisibility(); });
+      renderDetailMetaItemRow('detailMetaCommunity', '所属社区', html);
+    }).catch(function () { renderDetailMetaItemRow('detailMetaCommunity', '所属社区', ''); });
   }
 
   function renderDetailMiniMap(detailPage, detailPages) {
@@ -3026,12 +3019,8 @@
       }
       renderDetailMetaSource(null);
       setDetailMetaReadyState('true');
-      var badgeRow = document.getElementById('detailBadgeRow');
-      if (badgeRow) badgeRow.hidden = true;
-      var communityBadges = document.getElementById('detailCommunityBadges');
-      if (communityBadges) communityBadges.hidden = true;
-      var topicBadges = document.getElementById('detailTopicBadges');
-      if (topicBadges) topicBadges.hidden = true;
+      renderDetailMetaItemRow('detailMetaCommunity', '所属社区', '');
+      renderDetailMetaItemRow('detailMetaTopic', '所属专题', '');
       if (tocSectionEl) tocSectionEl.hidden = true;
       if (tocEl) {
         tocEl.innerHTML = '';
@@ -3095,11 +3084,27 @@
       removeLoadingState(summaryEl);
     }
     if (metaEl) {
-      var metaRows = [];
-      if (detailPage.updated) {
-        metaRows.push('<p><strong>更新时间：</strong>' + escapeHtml(detailPage.updated) + '</p>');
+      var updatedRow = document.getElementById('detailMetaUpdated');
+      var communityRow = document.getElementById('detailMetaCommunity');
+      var topicRow = document.getElementById('detailMetaTopic');
+      if (updatedRow) {
+        if (detailPage.updated) {
+          updatedRow.innerHTML = '<strong>更新时间：</strong>' + escapeHtml(detailPage.updated);
+          updatedRow.classList.remove('data-meta');
+          updatedRow.hidden = false;
+        } else {
+          updatedRow.hidden = true;
+          updatedRow.innerHTML = '';
+        }
       }
-      metaEl.innerHTML = metaRows.join('');
+      if (communityRow) {
+        communityRow.hidden = true;
+        communityRow.innerHTML = '';
+      }
+      if (topicRow) {
+        topicRow.hidden = true;
+        topicRow.innerHTML = '';
+      }
       removeLoadingState(metaEl);
     }
     renderDetailMetaSource(detailPage);

--- a/docs/style.css
+++ b/docs/style.css
@@ -645,45 +645,58 @@ body.sponsor-dialog-open {
   max-width: 100%;
   padding: 14px 16px;
 }
-.detail-badge-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 10px 20px;
-  margin-top: 14px;
-}
-.detail-badge-row .detail-topic-badges {
-  margin-top: 0;
-}
-.detail-topic-badges {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+.detail-meta-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 8px;
-  margin-top: 14px;
+  font-size: .88rem;
 }
-.detail-topic-badges-label {
-  font-size: .78rem;
-  color: var(--text-muted);
+.detail-meta-list p {
+  min-width: 0;
+  margin: 0;
 }
-.detail-topic-badge {
+.detail-meta-list code,
+.empty-state code {
+  padding: 2px 6px;
+  border-radius: 8px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  font-size: .92em;
+  white-space: normal;
+}
+/* 元信息栏宽度有限：anywhere 会在 graph-stats.json 等标识符中间断行；改为 normal 优先整段 code 换行 */
+.detail-meta-list code {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+.detail-meta-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 8px;
+}
+.detail-meta-item strong {
+  font-weight: 650;
+}
+.detail-meta-badge {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 3px 10px;
+  padding: 2px 9px;
   border-radius: 999px;
   border: 1px solid rgba(0, 212, 255, 0.3);
   background: rgba(0, 212, 255, 0.06);
   color: var(--text);
-  font-size: .8rem;
+  font-size: inherit;
+  line-height: 1.35;
   text-decoration: none;
   transition: background .15s ease, border-color .15s ease;
 }
-.detail-topic-badge:hover {
+.detail-meta-badge:hover {
   background: rgba(0, 212, 255, 0.14);
   border-color: rgba(0, 212, 255, 0.5);
 }
-.detail-topic-badge span:first-child { font-size: .85rem; line-height: 1; }
+.detail-meta-badge span:first-child { font-size: .95em; line-height: 1; }
 .detail-community-badge {
   border-color: rgba(167, 139, 250, 0.35);
   background: rgba(167, 139, 250, 0.08);
@@ -744,30 +757,6 @@ body.sponsor-dialog-open {
 .detail-mini-map-svg .mini-node-current circle {
   stroke: var(--accent);
   stroke-width: 2.4px;
-}
-.detail-meta-list {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 8px;
-  font-size: .88rem;
-}
-.detail-meta-list p {
-  min-width: 0;
-  margin: 0;
-}
-.detail-meta-list code,
-.empty-state code {
-  padding: 2px 6px;
-  border-radius: 8px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  font-size: .92em;
-  white-space: normal;
-}
-/* 元信息栏宽度有限：anywhere 会在 graph-stats.json 等标识符中间断行；改为 normal 优先整段 code 换行 */
-.detail-meta-list code {
-  overflow-wrap: normal;
-  word-break: normal;
 }
 .detail-content-sync {
   border: 1px solid var(--border);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
详情页「页面元信息」中 **更新时间**、**所属社区**、**所属专题** 原先分属两套结构（`detail-meta-list` 段落 vs 独立徽标行），标签字号与排版不一致。本次将三项合并为同一 `detail-meta-list` 行格式：`<strong>标签：</strong>值`，社区/专题值仍保留可点击胶囊链接。

## 改动
- `docs/detail.html`：移除 `#detailBadgeRow`，在 `#detailMeta` 内增加 `#detailMetaUpdated` / `#detailMetaCommunity` / `#detailMetaTopic` 三行容器
- `docs/main.js`：新增 `renderDetailMetaItemRow`，社区与专题渲染与「更新时间」共用同一行模板
- `docs/style.css`：以 `.detail-meta-item` + `.detail-meta-badge` 统一字号（继承 `.88rem`）与行内 flex 布局

## 与 main 合并说明
已 rebase/merge `origin/main`（含 PR #672「所属专题换行」）。冲突仅 `docs/style.css` 一处：main 为旧 `#detailBadgeRow` 增加 `flex-direction: column`，本 PR 已改为统一列表行结构，保留本分支样式即可（社区/专题本就各占独立一行）。

## 验证
- `npx eslint docs/main.js` 通过
- 本地静态站截图（`wiki-concepts-vision-backbones` 详情页元信息面板）

## 验证截图
![详情页元信息三项格式统一](https://cursor.com/artifacts/c/art-e20a49a5-4c3a-4a66-a154-fb42c3278472)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cb12c1d-9466-4437-b323-3fdf69022c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cb12c1d-9466-4437-b323-3fdf69022c80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

