### PR TITLE
fix(ux): 详情页元信息日期改为灰色胶囊展示（不可点击）

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2717,6 +2717,11 @@
     row.hidden = false;
   }
 
+  function renderDetailMetaDateBadge(dateStr) {
+    if (!dateStr) return '';
+    return '<span class="detail-meta-badge detail-meta-date">' + escapeHtml(String(dateStr)) + '</span>';
+  }
+
   function renderDetailMetaSource(detailPage) {
     var link = document.getElementById('detailContentSourceLink');
     if (!link) return;
@@ -3084,27 +3089,13 @@
       removeLoadingState(summaryEl);
     }
     if (metaEl) {
-      var updatedRow = document.getElementById('detailMetaUpdated');
-      var communityRow = document.getElementById('detailMetaCommunity');
-      var topicRow = document.getElementById('detailMetaTopic');
-      if (updatedRow) {
-        if (detailPage.updated) {
-          updatedRow.innerHTML = '<strong>更新时间：</strong>' + escapeHtml(detailPage.updated);
-          updatedRow.classList.remove('data-meta');
-          updatedRow.hidden = false;
-        } else {
-          updatedRow.hidden = true;
-          updatedRow.innerHTML = '';
-        }
-      }
-      if (communityRow) {
-        communityRow.hidden = true;
-        communityRow.innerHTML = '';
-      }
-      if (topicRow) {
-        topicRow.hidden = true;
-        topicRow.innerHTML = '';
-      }
+      renderDetailMetaItemRow(
+        'detailMetaUpdated',
+        '更新时间',
+        detailPage.updated ? renderDetailMetaDateBadge(detailPage.updated) : ''
+      );
+      renderDetailMetaItemRow('detailMetaCommunity', '所属社区', '');
+      renderDetailMetaItemRow('detailMetaTopic', '所属专题', '');
       removeLoadingState(metaEl);
     }
     renderDetailMetaSource(detailPage);

--- a/docs/style.css
+++ b/docs/style.css
@@ -705,6 +705,25 @@ body.sponsor-dialog-open {
   border-color: rgba(167, 139, 250, 0.55);
   background: rgba(167, 139, 250, 0.16);
 }
+.detail-meta-date {
+  border-color: rgba(155, 155, 160, 0.38);
+  background: rgba(155, 155, 160, 0.1);
+  color: var(--text-muted);
+  cursor: default;
+  pointer-events: none;
+}
+.detail-meta-date:hover {
+  background: rgba(155, 155, 160, 0.1);
+  border-color: rgba(155, 155, 160, 0.38);
+}
+[data-theme="light"] .detail-meta-date {
+  border-color: rgba(134, 134, 139, 0.35);
+  background: rgba(134, 134, 139, 0.08);
+}
+[data-theme="light"] .detail-meta-date:hover {
+  background: rgba(134, 134, 139, 0.08);
+  border-color: rgba(134, 134, 139, 0.35);
+}
 .detail-mini-map {
   background: var(--bg-alt);
   border: 1px solid var(--border);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「页面元信息」中的**更新时间**改为灰色胶囊体展示，视觉形态与「所属社区」「所属专题」徽标对齐。
- 日期胶囊使用 `<span>`（非链接），并禁用 hover 与指针事件，避免误点。

## 改动文件
- `docs/main.js`：新增 `renderDetailMetaDateBadge()`，更新时间行复用 `renderDetailMetaItemRow()` 统一渲染。
- `docs/style.css`：新增 `.detail-meta-date` 灰色胶囊样式（含浅色主题覆盖）。

## 验证
- `npm run lint:js` 通过
- 本地静态站 `detail.html?id=wiki-comparisons-amp-add-smp-motion-prior-variants` 元信息面板渲染正常

## 验证截图
![详情页元信息：更新时间为灰色胶囊，与社区/专题徽标同行对齐](https://cursor.com/artifacts/c/art-9eeae386-aa56-4111-b0bf-bab3ca7b1607)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99ae4b73-910e-409b-806f-0379ecbfc7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99ae4b73-910e-409b-806f-0379ecbfc7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

