### PR TITLE
fix(ux): 路线页正文区右下角添加 GitHub 源文件链接

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2722,8 +2722,8 @@
     return '<span class="detail-meta-badge detail-meta-date">' + escapeHtml(String(dateStr)) + '</span>';
   }
 
-  function renderDetailMetaSource(detailPage) {
-    var link = document.getElementById('detailContentSourceLink');
+  function renderDetailMetaSource(detailPage, linkId) {
+    var link = document.getElementById(linkId || 'detailContentSourceLink');
     if (!link) return;
     var path = (detailPage && detailPage.path) || '';
     if (!path) {
@@ -3404,6 +3404,7 @@
         contentRootEmpty.innerHTML = '';
         removeLoadingState(contentRootEmpty);
       }
+      renderDetailMetaSource(null, 'roadmapContentSourceLink');
       var tocRootEmpty = document.getElementById('roadmapTocList');
       if (tocRootEmpty) removeLoadingState(tocRootEmpty);
       return;
@@ -3484,6 +3485,7 @@
 
     if (!contentMarkdown) {
       setRoadmapContentChromeVisible(false);
+      renderDetailMetaSource(null, 'roadmapContentSourceLink');
       if (contentEl) {
         contentEl.innerHTML = '';
         removeLoadingState(contentEl);
@@ -3505,6 +3507,7 @@
     if (tocEl) {
       renderDetailToc(tocEl, headings, roadmapMarkdownContext);
     }
+    renderDetailMetaSource(detail, 'roadmapContentSourceLink');
     if (contentEl) {
       contentEl.innerHTML = renderMarkdownContent(contentMarkdown, headings, roadmapMarkdownContext);
       renderDetailMath(contentEl);

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -105,7 +105,12 @@
               <p class="section-subtitle">展开任一阶段，可直接跳转到下方正文对应章节，或者点开站内相关链接。</p>
               <div id="roadmapFlowMermaidRoot" class="roadmap-flow-mermaid-host" aria-live="polite"></div>
             </section>
-            <article id="roadmapContent" class="detail-markdown-body data-loading">正在读取路线正文…</article>
+            <div class="detail-content-sync">
+              <article id="roadmapContent" class="detail-markdown-body data-loading">正在读取路线正文…</article>
+              <div class="detail-content-sync-foot">
+                <a id="roadmapContentSourceLink" class="detail-mini-map-all-link" href="#" target="_blank" rel="noopener noreferrer" hidden>在 GitHub 查看源文件 →</a>
+              </div>
+            </div>
           </section>
 
           <section class="section section-alt" id="roadmap-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -18,6 +18,7 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapFlowMermaidRoot"',
             'id="roadmapRelatedList"',
             'id="roadmapContent"',
+            'id="roadmapContentSourceLink"',
             'id="roadmapTocList"',
         ]
         for marker in required_ids:
@@ -33,6 +34,7 @@ class RoadmapPageTests(unittest.TestCase):
             "roadmap_pages",
             "graph-stats.json",
             "renderRoadmapMarkdownBody",
+            "roadmapContentSourceLink",
             "findRoadmapStageEntryAnchor",
             "bindSelftestMermaidRerender",
             "roadmap-stage-entry-embed",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 在路线图页「完整学习路线（正文）」区域，复用详情页 `detail-content-sync` 布局，于右下角添加「在 GitHub 查看源文件 →」超链接。
- 将 `renderDetailMetaSource` 泛化为可指定链接元素 id，路线页渲染正文时写入对应 wiki 源文件路径。
- 无正文或路线不存在时隐藏该链接。

## 验证

- `pytest tests/test_roadmap_page.py` 通过（2 passed）
- 本地 `make export graph` 后访问 `roadmap.html?id=roadmap-motion-control`，链接指向 `roadmap/motion-control.md` 且可见

## 验证截图

![路线页正文区右下角 GitHub 源文件链接](https://cursor.com/artifacts/c/art-b7ba853e-faaf-47b0-965d-12a6da3d9450)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d5a5ea5-819a-4eee-8a0d-02d3c49c97e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d5a5ea5-819a-4eee-8a0d-02d3c49c97e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

