### PR TITLE
fix(ux): 统一路线页元信息行格式并修复阶段徽标跳转

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1591,6 +1591,7 @@
     setRoadmapFlowChromeVisible(true);
     var treeHtml = buildRoadmapVerticalTreeHTML(stages, roadmapId, detailPages);
     flowRoot.innerHTML = treeHtml;
+    syncRoadmapStagesMetaHref(roadmapPage);
   }
 
   function renderDetailMath(container) {
@@ -2783,6 +2784,48 @@
     return renderMetaCommunityBadge((detailPage && detailPage.path) || '', 'detailMetaCommunity');
   }
 
+  function findRoadmapStageHeadingId(stage, contentEl) {
+    if (!contentEl || !stage) return '';
+    var sid = String(stage.id || '').toLowerCase();
+    if (!sid) return '';
+    var h2 = Array.from(contentEl.querySelectorAll('h2[id]')).find(function (h) {
+      return h.id === sid || h.id.indexOf(sid + '-') === 0;
+    });
+    return h2 ? h2.id : '';
+  }
+
+  /** 阶段已嵌入正文时 #roadmap-flow 会隐藏，需把元信息徽标改指向首个 L 章节。 */
+  function syncRoadmapStagesMetaHref(roadmapPage) {
+    var link = document.querySelector('#roadmapMetaStages a.detail-meta-badge');
+    if (!link || !roadmapPage) return;
+    var flowSection = document.getElementById('roadmap-flow');
+    if (flowSection && !flowSection.hidden) {
+      link.href = '#roadmap-flow';
+      link.title = '跳转到阶段速览';
+      return;
+    }
+    var stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
+    if (!stages.length) return;
+    var contentEl = document.getElementById('roadmapContent');
+    var targetId = '';
+    var targetStage = stages[0];
+    var i;
+    for (i = 0; i < stages.length; i++) {
+      targetId = findRoadmapStageHeadingId(stages[i], contentEl);
+      if (targetId) {
+        targetStage = stages[i];
+        break;
+      }
+    }
+    if (targetId) {
+      link.href = '#' + targetId;
+      link.title = '跳转到「' + (targetStage.title || targetStage.id || targetId) + '」等学习阶段';
+      return;
+    }
+    link.href = '#roadmap-content';
+    link.title = '跳转到路线正文';
+  }
+
   function renderRoadmapMetaPanel(roadmapPage, roadmapId, detailPages) {
     var metaEl = document.getElementById('roadmapMeta');
     var detail = (detailPages && detailPages[roadmapId]) || {};
@@ -3531,6 +3574,7 @@
       notifyTocSpyScrollSync();
       removeLoadingState(contentEl);
     }
+    syncRoadmapStagesMetaHref(roadmapPage);
   }
 
   function renderTechMapNodeCard(node, detailPages) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将 `roadmap.html` 英雄区「路线元信息」与详情页元信息对齐：采用 `detail-meta-item` 分行展示，去掉技术向 `id` 与冗长的「互链枢纽」说明。

- **更新时间**：有 `detail_pages` 导出字段时显示
- **学习阶段**：以徽标展示阶段数；点击后跳转阶段入口
- **所属社区 / 所属专题**：复用 `link-graph.json` 与专题过滤规则

**补充修复**：主路线 `roadmap-motion-control` 的阶段已嵌入正文，`#roadmap-flow` 会被隐藏；阶段徽标现改为跳转首个 L 章节（如 `#l0-数学与编程基础`），并自动展开对应折叠块。

## 验证

- `npx eslint docs/main.js` 通过
- 点击「8 个阶段」→ 正文 **L0 数学与编程基础** 章节

## 验证截图

![路线页元信息面板](https://cursor.com/artifacts/c/art-376b4cfb-883c-4d12-8d18-1c0c11ab459a)

![点击 8 个阶段后跳转到 L0 章节](https://cursor.com/artifacts/c/art-d360d4a5-7a35-4c74-989e-4392992ac34a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a2cb9d-f2f3-434c-a33b-6c2b0932113f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a2cb9d-f2f3-434c-a33b-6c2b0932113f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

