### PR TITLE
fix(export): 修复详情页 summary 中多余反斜杠

### DIFF
--- a/scripts/search_indexing.py
+++ b/scripts/search_indexing.py
@@ -6,7 +6,9 @@ import math
 import re
 from collections import Counter
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Any, Dict, Iterable, List
+
+import yaml
 
 from utils.paths import path_to_id
 
@@ -38,26 +40,38 @@ TOKEN_SYNONYMS = {
 }
 
 
+def _normalize_frontmatter_value(value: Any) -> str | list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)
+    return str(value)
+
+
 def parse_frontmatter(content: str) -> dict[str, str | list[str]]:
-    fm: dict[str, str | list[str]] = {}
     if not content.startswith("---"):
-        return fm
+        return {}
     end = content.find("\n---", 3)
     if end == -1:
-        return fm
+        return {}
     block = content[3:end].strip()
-    for line in block.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or ":" not in line:
+    if not block:
+        return {}
+    try:
+        parsed = yaml.safe_load(block)
+    except yaml.YAMLError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    fm: dict[str, str | list[str]] = {}
+    for key, value in parsed.items():
+        if not isinstance(key, str):
             continue
-        key, _, val = line.partition(":")
-        key = key.strip()
-        val = val.strip()
-        if val.startswith("[") and val.endswith("]"):
-            items = [v.strip().strip("\"'") for v in val[1:-1].split(",") if v.strip()]
-            fm[key] = items
-        else:
-            fm[key] = val.strip("\"'")
+        normalized = _normalize_frontmatter_value(value)
+        if normalized is not None:
+            fm[key] = normalized
     return fm
 
 

--- a/scripts/search_indexing.py
+++ b/scripts/search_indexing.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
 import yaml
-
 from utils.paths import path_to_id
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_search_indexing_unit.py
+++ b/tests/test_search_indexing_unit.py
@@ -57,11 +57,7 @@ key: value
         self.assertEqual(parse_frontmatter(content), expected)
 
     def test_parse_frontmatter_unescapes_yaml_quotes(self):
-        content = (
-            '---\n'
-            'summary: "ZeroWBC 把\\"教人形机器人做事\\"的重心搬到视频"\n'
-            "---\n"
-        )
+        content = '---\nsummary: "ZeroWBC 把\\"教人形机器人做事\\"的重心搬到视频"\n---\n'
         expected = {"summary": 'ZeroWBC 把"教人形机器人做事"的重心搬到视频'}
         self.assertEqual(parse_frontmatter(content), expected)
 

--- a/tests/test_search_indexing_unit.py
+++ b/tests/test_search_indexing_unit.py
@@ -56,6 +56,15 @@ key: value
         expected = {"title": "Test", "key": "value"}
         self.assertEqual(parse_frontmatter(content), expected)
 
+    def test_parse_frontmatter_unescapes_yaml_quotes(self):
+        content = (
+            '---\n'
+            'summary: "ZeroWBC 把\\"教人形机器人做事\\"的重心搬到视频"\n'
+            "---\n"
+        )
+        expected = {"summary": 'ZeroWBC 把"教人形机器人做事"的重心搬到视频'}
+        self.assertEqual(parse_frontmatter(content), expected)
+
 
 class TestSearchIndexingText(unittest.TestCase):
     def test_strip_frontmatter_removes_block(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页 `entity-paper-notebook-zerowbc`（及大量 Paper Notebook 实体页）的摘要中出现多余反斜杠，例如 `把\"教人形机器人做事\"` 被渲染为带 `\` 的文本。

根因：`scripts/search_indexing.py` 的 `parse_frontmatter` 使用逐行手工解析，只剥掉首尾引号，未处理 YAML 双引号字符串内的 `\"` 转义。`sync_paper_notebook_summaries.py` 写入 frontmatter 时会正确转义中文引号，导出链路却未正确解码。

## 修改

- 将 `parse_frontmatter` 改为使用 `yaml.safe_load` 解析 frontmatter 块，并规范化值为 `str | list[str]`
- 新增单元测试 `test_parse_frontmatter_unescapes_yaml_quotes`

## 验证

- `make ci-preflight` 通过
- 本地导出后 `entity-paper-notebook-zerowbc` 的 `summary` 反斜杠计数为 0
- 静态站详情页渲染正常

## 验证截图

![ZeroWBC 详情页修复后截图](https://cursor.com/artifacts/c/art-06b43c22-3b30-428b-9713-8227b5a2d0dc)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aa9df2f-723a-446c-9e6c-4f95433808c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aa9df2f-723a-446c-9e6c-4f95433808c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

