### PR TITLE
chore: Initialize v25 checklist & archive v24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@
 项目执行清单与阶段性维护看板。
 
 包括：
-- 当前技术栈执行清单：[`docs/checklists/tech-stack-next-phase-checklist-v24.md`](docs/checklists/tech-stack-next-phase-checklist-v24.md)
+- 当前技术栈执行清单：[`docs/checklists/tech-stack-next-phase-checklist-v25.md`](docs/checklists/tech-stack-next-phase-checklist-v25.md)
 - 前端体验优化清单：[`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
 - 历史执行清单索引：[`docs/checklists/README.md`](docs/checklists/README.md)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Wiki Lint](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-1193节点_7421边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
-[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-99%25-green)](docs/checklists/tech-stack-next-phase-checklist-v24.md)
+[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-99%25-green)](docs/checklists/tech-stack-next-phase-checklist-v25.md)
 
 
 
@@ -66,7 +66,7 @@
 
 ## 维护看板
 
-- 当前技术栈执行清单：[V24](docs/checklists/tech-stack-next-phase-checklist-v24.md)
+- 当前技术栈执行清单：[V25](docs/checklists/tech-stack-next-phase-checklist-v25.md)
 - 前端体验优化清单：[frontend-optimization-v1](docs/checklists/frontend-optimization-v1.md)
 - 历史执行清单索引：[docs/checklists/README.md](docs/checklists/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 `docs/` 是 GitHub Pages 展示层和历史资料暂存区。当前前端页面、导出数据镜像、执行清单都在这里维护。
 
 常用入口：
-- [当前技术栈执行清单 v24](checklists/tech-stack-next-phase-checklist-v24.md)
+- [当前技术栈执行清单 v25](checklists/tech-stack-next-phase-checklist-v25.md)
 - [前端体验优化清单 v1](checklists/frontend-optimization-v1.md)
 - [历史执行清单索引](checklists/README.md)
 - [展示层变更记录](change-log.md)

--- a/docs/checklists/README.md
+++ b/docs/checklists/README.md
@@ -4,7 +4,7 @@
 
 ## 当前入口
 
-- [技术栈项目执行清单 v24](tech-stack-next-phase-checklist-v24.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
+- [技术栈项目执行清单 v25](tech-stack-next-phase-checklist-v25.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
 - [前端体验优化清单 v1](frontend-optimization-v1.md) — GitHub Pages 首页与交互体验优化计划。
 - [Cursor Cloud Agent：PR 与验证截图流程](cloud-agent-pr-workflow.md) — Cloud Agent 推送分支、开 PR、附验证截图的路径约定。
 - [GitHub Actions CI 门禁](github-actions-ci-gate.md) — 合并 `main` 前必须等全量 Actions 全绿；branch protection 建议。
@@ -36,6 +36,7 @@
 - [v21](archive/tech-stack-next-phase-checklist-v21.md)
 - [v22](archive/tech-stack-next-phase-checklist-v22.md)
 - [v23](archive/tech-stack-next-phase-checklist-v23.md)
+- [v24](archive/tech-stack-next-phase-checklist-v24.md)
 
 ## 维护规则
 

--- a/docs/checklists/archive/tech-stack-next-phase-checklist-v24.md
+++ b/docs/checklists/archive/tech-stack-next-phase-checklist-v24.md
@@ -2,8 +2,8 @@
 
 最后更新：2026-06-15（P3 详情页专题徽标交付，V24 全部条目收口）
 项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
-上一版清单：[`tech-stack-next-phase-checklist-v23.md`](archive/tech-stack-next-phase-checklist-v23.md)
-方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
+上一版清单：[`tech-stack-next-phase-checklist-v23.md`](tech-stack-next-phase-checklist-v23.md)
+方法论参考：[Karpathy LLM Wiki](../../../wiki/references/llm-wiki-karpathy.md)
 
 ---
 

--- a/docs/checklists/tech-stack-next-phase-checklist-v25.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v25.md
@@ -1,0 +1,69 @@
+# 技术栈项目执行清单 v25
+
+最后更新：2026-06-16（V24 全部条目收口，基于最新数据集 ingest 初始化 V25）
+项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
+上一版清单：[`tech-stack-next-phase-checklist-v24.md`](archive/tech-stack-next-phase-checklist-v24.md)
+方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
+
+---
+
+## V24 交付基线 (V25 起点)
+
+| 维度 | V24 状态 | V25 目标 |
+|------|-----------|---------|
+| 知识图谱节点 | 1193 | **≥ 1205** |
+| 知识图谱边数 | 7421 | **≥ 7460** |
+| 事实库 (CANONICAL_FACTS) | 186 条 | **≥ 196 条** |
+| 社区结构 | 14 社区，最大社区占 17.7%（`community_quality_warning: false`） | **保持 ≤ 25%，新增专题不破坏均衡** |
+| 技术专题 | 视觉感知骨干与机器人表征（V24 P1 交付） | **建立"人形训练数据管线"专题** |
+| 图谱专题视图 | V24 扩至 14 项（新增「视觉感知骨干」） | **新增「训练数据管线」专题至 15 项** |
+
+> 背景：V24 收尾阶段（2026-06-16）密集 ingest 了 AMASS / LaFAN1 / OMOMO / PHUMA / Humanoid Everyday 五套人形参考运动与操作数据集，并新建 `wiki/comparisons/humanoid-reference-motion-datasets.md` 选型对比页与 `wiki/concepts/motion-retargeting.md` 重定向概念页。但「数据层」仍缺一条贯通视角——从**原始动作捕捉 / 视频 → 重定向 → RL/IL 策略训练输入**的端到端选型与质量评估链路尚未沉淀为独立 query / concept，事实库也缺数据质量与物理可行性维度的矛盾检测规则。V25 优先补齐这条训练数据管线知识链，并把分散的数据集实体页元数据规范化。
+
+---
+
+## P0: 自动化与工具链深度强化 (Engineering)
+
+- [ ] **数据集页元数据巡检 V1**：
+    - [ ] `scripts/lint_wiki.py` 新增 `dataset_metadata_check`：对 `tags` 含 `dataset` 的实体页，检查正文是否含规模 / 模态 / 许可证 / 重定向就绪度等标准化速查字段，缺失给出 INFO 级提示（不阻塞 CI），并写入 lint 报告基线快照；新增用例覆盖到 `tests/`。
+- [ ] **数据集选型脚手架强化**：
+    - [ ] 复用 `scripts/scaffold_wiki_page.py`，为 `entity`（数据集）类型补充含「规模 / 模态 / 许可证 / 适配形态 / 重定向就绪度」速查块的骨架模板，降低后续数据集 ingest 的手工成本；自带 `--dry-run` 与 lint 自检。
+
+## P1: 人形训练数据管线专题 (Quality)
+
+- [ ] **训练数据管线知识链 (+2)**：
+    - [ ] `wiki/queries/humanoid-training-data-pipeline.md`（端到端 Query：原始动作捕捉 / 人体视频 → 重定向 → RL/IL 训练输入的选型决策树，覆盖参考运动来源、重定向方案、训练范式三层的取舍与典型失败模式）。
+    - [ ] `wiki/concepts/motion-data-quality.md`（动作数据质量维度概念页：物理可行性 / 接触一致性 / 形态差距（morphology gap）/ 规模与多样性四个评估轴，与重定向必要性的因果关系）。
+- [ ] **数据层专题交叉补强**：
+    - [ ] 在 `wiki/comparisons/humanoid-reference-motion-datasets.md` 与 `wiki/concepts/motion-retargeting.md` 中明示「数据来源 → 质量评估 → 重定向 → 策略输入」的衔接，并与 P1 新页形成双向回链，消除孤儿页。
+
+## P2: 事实库与矛盾检测扩展 (Quantity)
+
+- [ ] **事实库扩展**：
+    - [ ] `schema/canonical-facts.json` 由 186 → **≥ 196 条**：新增数据层矛盾检测规则（动作捕捉缺接触/力信息导致物理不可行、人体视频规模大但标注/3D 信息弱、形态差距使原始动作不可直接复用、重定向不可省略、物理过滤数据集（PHUMA 类）相对纯 mocap 的可部署性等）；逐条经脚本校验对现存 wiki 页有 pos 命中且 0 误报。
+
+## P3: 交互层"数据管线"增强 (UX/UI)
+
+- [ ] **图谱页"训练数据管线"专题视图**：
+    - [ ] `docs/graph.html` / `docs/topic-filters.js` 的专题命中规则在 V24 14 项基础上新增「训练数据管线」专题（`data-pipeline`），复用 path 片段并集机制（`dataset/datasets/amass/lafan1/omomo/phuma/humanoid-everyday/motion-retargeting/training-data`）并按需 `ids` 显式纳入新建 query/concept；同步在 `#filter-topic-chips` 增加 `data-topic="data-pipeline"`（📦 训练数据）chip。Puppeteer 截图归档至 `.cursor-artifacts/screenshots/graph-topic-data-pipeline.png`。
+- [ ] **详情页"同专题相关页"提示**：
+    - [ ] 复用 `docs/topic-filters.js` 单一事实源，数据集 / 重定向 / 新建页命中「训练数据管线」专题时渲染「📦 训练数据」轻量徽标 + 跳转 `graph.html?topic=data-pipeline`（空态降级隐藏）。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-data-pipeline.png`。
+
+---
+
+## 验收标准 (Definition of DoD)
+
+- [ ] `make lint`: 0 errors（新引入的 `dataset_metadata_check` 为 INFO 级，不阻塞 CI）。
+- [ ] 知识图谱节点数 **≥ 1205**，边数 **≥ 7460**（见 `exports/graph-stats.json`）。
+- [ ] 事实库扩展至 **196 条** 以上（重点补 数据质量 / 物理可行性 / 重定向必要性 矛盾检测规则）。
+- [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。
+- [ ] `log.md` 记录 V25 关键改动。
+
+---
+
+## 状态说明
+
+- `[ ]` 待执行
+- `[~]` 进行中
+- `[x]` 已完成
+- `[−]` 已评估，决定跳过（附理由）

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-16] checklist-v25 | V24 收口 & 初始化 V25
+
+- V24 全部条目此前已收口（P0–P3 + DoD 逐条 `[x]`，`make lint` 0 errors，图谱 1193 节点 / 7421 边、`community_quality_warning=false`、最大社区占比 0.177、事实库 186 条）。
+- 新建 [`docs/checklists/tech-stack-next-phase-checklist-v25.md`](docs/checklists/tech-stack-next-phase-checklist-v25.md)：专题选定为「人形训练数据管线」，承接 V24 收尾密集 ingest 的 AMASS/LaFAN1/OMOMO/PHUMA/Humanoid Everyday 五套数据集与 motion-retargeting 概念页，规划「原始动作捕捉/视频 → 重定向 → RL/IL 训练输入」端到端知识链（P1 query+concept）、数据层矛盾检测规则扩展（P2 事实库 186→≥196）、数据集页元数据巡检（P0）与图谱第 15 项「训练数据管线」专题视图（P3）。
+- 同步将 README badge / 维护看板、`AGENTS.md`、`docs/README.md`、`docs/checklists/README.md` 的「当前清单」指针从 V24 切到 V25；V24 移入 `archive/` 并修正其内部相对链接，进入历史归档区。
+
 ## [2026-06-16] ingest | sources/repos/omomo_release.md, sources/repos/phuma.md, sources/sites/humanoideveryday.md — AMASS/LaFAN1/OMOMO/PHUMA/Humanoid Everyday 五集入库
 
 - 原始资料：[`sources/sites/amass-dataset.md`](sources/sites/amass-dataset.md)、[`sources/repos/ubisoft-laforge-animation-dataset.md`](sources/repos/ubisoft-laforge-animation-dataset.md)、[`sources/repos/omomo_release.md`](sources/repos/omomo_release.md)、[`sources/repos/phuma.md`](sources/repos/phuma.md)、[`sources/sites/humanoideveryday.md`](sources/sites/humanoideveryday.md)


### PR DESCRIPTION
## 摘要

新建 V25 技术栈执行清单，专题聚焦「人形训练数据管线」（原始动作捕捉/视频 → 重定向 → RL/IL 训练输入）。V24 全部条目已收口，移入 `archive/` 并修正相对链接；同步更新 README、AGENTS.md、docs 等维护看板指针从 V24 → V25。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）

## 详细说明

### 新增
- **`docs/checklists/tech-stack-next-phase-checklist-v25.md`**：
  - V25 起点基线：1193 节点 / 7421 边 → ≥1205 / ≥7460
  - P0：数据集页元数据巡检脚本 + 选型脚手架强化
  - P1：「人形训练数据管线」知识链（query + concept）+ 数据层交叉补强
  - P2：事实库扩展 186 → ≥196 条（数据质量 / 物理可行性 / 重定向必要性矛盾检测）
  - P3：图谱第 15 项「训练数据管线」专题视图 + 详情页徽标

### 修改
- **`log.md`**：新增 V25 初始化记录，说明 V24 收口状态与 V25 专题选定理由
- **`README.md`**：维护看板「当前清单」指针 V24 → V25；badge 链接同步
- **`AGENTS.md`**：当前技术栈执行清单指针 V24 → V25
- **`docs/README.md`**：常用入口「当前清单」指针 V24 → V25
- **`docs/checklists/README.md`**：
  - 当前入口指针 V24 → V25
  - 历史清单索引新增 v24 条目（指向 `archive/`）

### 移动 & 链接修正
- **`docs/checklists/tech-stack-next-phase-checklist-v24.md`** → **`docs/checklists/archive/tech-stack-next-phase-checklist-v24.md`**
  - 修正内部相对链接：
    - `archive/tech-stack-next-phase-checklist-v23.md` → `tech-stack-next-phase-checklist-v23.md`（同级）
    - `../../wiki/references/llm-wiki-karpathy.md` → `../../../wiki/references/llm-wiki-karpathy.md`（上升一级）

## 验证

- [x] `make lint`：0 errors（仅文档改动，无 wiki 内容变更）
- [x] 所有维护看板指针已同步（README / AGENTS.md / docs/README.md / docs/checklists/README.md）
- [x] V24 存档链接正确（相对路径已修正）
- [x] V25 清单格式与 V24 保持一致（表格 / P0–P3 / DoD / 状态说明）

## 相关 Issue

无

https://claude.ai/code/session_01XhWDCVvbLBBGDM48iRM8jK