### PR TITLE
fix(actions): Pages 部署前安装 pyyaml/numpy 以修复 export 失败

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,9 +25,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: requirements-ci-lite.txt
+
+      - name: Install lightweight dependencies
+        run: pip install -r requirements-ci-lite.txt
 
       # 站点大 JSON（search-index / index-v1 / site-data-v1 / link-graph）与 sitemap
-      # 不入库，部署时现场生成（等价 make export graph，纯标准库依赖，约 40s）
+      # 不入库，部署时现场生成（等价 make export graph，约 40s）
       - name: Generate site data
         run: |
           python3 scripts/export_minimal.py


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- **Deploy GitHub Pages** workflow 在 `Generate site data` 步骤失败：`search_indexing.py` 依赖 `pyyaml`，但 `pages.yml` 未安装任何 Python 依赖。
- 与 `export.yml` / `lint.yml` 等 workflow 对齐，部署前安装 `requirements-ci-lite.txt`（`pyyaml` + `numpy`），并启用 pip cache。

## 根因
```
ModuleNotFoundError: No module named 'yaml'
```
发生在 run `27667752815`（PR #685 合并后的 Pages 部署）。

## 验证
- 本地安装 `requirements-ci-lite.txt` 后，Pages 同款四条 export 命令全部成功：
  - `export_minimal.py`
  - `generate_link_graph.py`
  - `generate_home_stats.py`
  - `graph_exports_sync.py`
- 其余 CI workflow（Tests / Lint / Export）均已通过，仅 Pages 缺失依赖安装步骤。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22b37036-22a5-4481-9f26-dac0a04129ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22b37036-22a5-4481-9f26-dac0a04129ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

