### PR TITLE
fix(ux): 节点浮窗类型徽章改用类型色、社区改用社区色块

### DIFF
--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -107,10 +107,75 @@
     return s;
   }
 
+  var GRAPH_NODE_TYPE_LABEL = {
+    concept: '概念', method: '方法', task: '任务',
+    entity: '工具', comparison: '对比', query: 'Query',
+    formalization: '形式化', overview: '总览', reference: '参考',
+    '': 'Wiki'
+  };
+
+  var GRAPH_NODE_TYPE_COLOR = {
+    concept: '#60a5fa', method: '#34d399', task: '#f472b6',
+    entity: '#fbbf24', comparison: '#c084fc', query: '#94a3b8',
+    formalization: '#fb923c', overview: '#64748b', reference: '#64748b',
+    '': '#64748b'
+  };
+
+  function escapeHtml(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function colorBadgeHtml(className, label, bgColor, textColor) {
+    var fg = textColor || '#0d1117';
+    return '<span class="' + className + '" style="background:' + escapeHtml(String(bgColor)) +
+      ';color:' + escapeHtml(String(fg)) + '">' + escapeHtml(String(label)) + '</span>';
+  }
+
+  /** 类型徽章用类型色；社区徽章用社区色 */
+  function buildMetaBadgesHtml(opts) {
+    opts = opts || {};
+    var typeKey = opts.type != null ? opts.type : '';
+    var typeLabels = opts.typeLabels || GRAPH_NODE_TYPE_LABEL;
+    var typeColors = opts.typeColors || GRAPH_NODE_TYPE_COLOR;
+    var typeLabel = typeLabels[typeKey] || typeKey || 'Wiki';
+    var typeColor = typeColors[typeKey] || typeColors[''] || '#64748b';
+    var html = colorBadgeHtml('tt-type', typeLabel, typeColor);
+    if (opts.communityLabel) {
+      var communityColor = opts.communityColor || '#64748b';
+      html += colorBadgeHtml('tt-community', opts.communityLabel, communityColor);
+    }
+    return '<div class="tt-meta-badges">' + html + '</div>';
+  }
+
+  function buildNodeTooltipHtml(opts) {
+    opts = opts || {};
+    var badges = buildMetaBadgesHtml(opts);
+    var title = escapeHtml(String(opts.title || opts.id || ''));
+    var summary = opts.summary
+      ? '<div class="tt-summary">' + escapeHtml(String(opts.summary)) + '</div>'
+      : '';
+    var extra = opts.extraHtml || '';
+    var link = opts.linkHtml || '';
+    return badges +
+      '<div class="tt-title">' + title + '</div>' +
+      summary +
+      extra +
+      link;
+  }
+
   window.RNGraphTooltip = {
     bindBlankDismiss: bindGraphTooltipBlankDismiss,
     bindOutsideDismiss: bindGraphTooltipOutsideDismiss,
     isMetadataOnlySummary: isMetadataOnlySummary,
-    formatTooltipSummary: formatTooltipSummary
+    formatTooltipSummary: formatTooltipSummary,
+    GRAPH_NODE_TYPE_LABEL: GRAPH_NODE_TYPE_LABEL,
+    GRAPH_NODE_TYPE_COLOR: GRAPH_NODE_TYPE_COLOR,
+    buildMetaBadgesHtml: buildMetaBadgesHtml,
+    buildNodeTooltipHtml: buildNodeTooltipHtml
   };
 })();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1330,10 +1330,28 @@
       border-bottom: 1px solid rgba(255,255,255,0.07);
       gap: 10px;
     }
-    .sb-type-badge {
-      display: inline-block; font-size: .68rem; font-weight: 700;
-      padding: 2px 8px; border-radius: 4px; text-transform: uppercase;
-      letter-spacing: .04em; margin-bottom: 6px; flex-shrink: 0;
+    #graph-sidebar .tt-meta-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-bottom: 6px;
+    }
+    #graph-sidebar .tt-type {
+      display: inline-block;
+      font-size: .68rem;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 4px;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+    }
+    #graph-sidebar .tt-community {
+      display: inline-block;
+      font-size: .68rem;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 4px;
+      letter-spacing: .02em;
     }
     .sb-title { font-size: .92rem; font-weight: 700; color: #e6edf3; line-height: 1.3; }
     .sb-close {
@@ -1350,23 +1368,6 @@
       background: rgba(255,255,255,0.07); color: rgba(255,255,255,0.55);
     }
     .sb-summary { font-size: .78rem; color: rgba(255,255,255,0.45); line-height: 1.55; margin-bottom: 12px; }
-    .sb-meta-block { margin-bottom: 12px; }
-    .sb-community-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      font-size: .72rem;
-      padding: 4px 9px;
-      border-radius: 999px;
-      background: rgba(255,255,255,0.07);
-      color: rgba(255,255,255,0.72);
-    }
-    .sb-community-dot {
-      width: 9px;
-      height: 9px;
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
     .sb-section-title {
       font-size: .7rem; font-weight: 700; color: rgba(255,255,255,0.3);
       text-transform: uppercase; letter-spacing: .06em; margin-bottom: 7px;
@@ -1402,7 +1403,6 @@
     [data-theme="light"] .sb-title { color: #1a1a1a; }
     [data-theme="light"] .sb-summary { color: rgba(0,0,0,0.5); }
     [data-theme="light"] .sb-tag { background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.5); }
-    [data-theme="light"] .sb-community-badge { background: rgba(0,0,0,0.06); color: rgba(0,0,0,0.62); }
     [data-theme="light"] .sb-section-title { color: rgba(0,0,0,0.35); }
     [data-theme="light"] .sb-close { color: rgba(0,0,0,0.35); }
     [data-theme="light"] .sb-close:hover { color: rgba(0,0,0,0.8); }
@@ -1591,7 +1591,7 @@
   <aside id="graph-sidebar" aria-label="节点详情">
     <div class="sb-header">
       <div>
-        <span class="sb-type-badge" id="sb-type-badge"></span>
+        <div id="sb-meta-badges"></div>
         <div class="sb-title" id="sb-title">选择节点查看详情</div>
       </div>
       <button id="sb-close" class="sb-close" aria-label="关闭侧边栏">✕</button>
@@ -1599,13 +1599,6 @@
     <div class="sb-body">
       <div class="sb-tags" id="sb-tags"></div>
       <p class="sb-summary" id="sb-summary"></p>
-      <div class="sb-meta-block" id="sb-community-block" hidden>
-        <div class="sb-section-title">所属社区</div>
-        <div class="sb-community-badge" id="sb-community-badge">
-          <span class="sb-community-dot" id="sb-community-dot"></span>
-          <span id="sb-community-label"></span>
-        </div>
-      </div>
       <div id="sb-neighbors-section" hidden>
         <div class="sb-section-title">图邻居 <span id="sb-neighbors-count" class="sb-neighbors-count"></span></div>
         <ul class="sb-related-list sb-neighbors-list" id="sb-neighbors-list"></ul>
@@ -3451,13 +3444,10 @@
     ════════════════════════════════════════════ */
 
     const sidebar      = document.getElementById('graph-sidebar');
-    const sbTypeBadge  = document.getElementById('sb-type-badge');
+    const sbMetaBadges = document.getElementById('sb-meta-badges');
     const sbTitle      = document.getElementById('sb-title');
     const sbTags       = document.getElementById('sb-tags');
     const sbSummary    = document.getElementById('sb-summary');
-    const sbCommunityBlock = document.getElementById('sb-community-block');
-    const sbCommunityDot   = document.getElementById('sb-community-dot');
-    const sbCommunityLabel = document.getElementById('sb-community-label');
     const sbNeighborsSec  = document.getElementById('sb-neighbors-section');
     const sbNeighborsList = document.getElementById('sb-neighbors-list');
     const sbNeighborsCount = document.getElementById('sb-neighbors-count');
@@ -3517,25 +3507,25 @@
           return edgeHighlightsWithNode(e, d.id) ? linkWidthBase * 1.5 : linkWidthBase;
         });
 
-      const color = nodeColor(d);
       const info  = d._info;
-      const typeLabel = TYPE_LABEL[d.type] || d.type || 'Wiki';
       const detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
       const summary = (info.summary || '').slice(0, 150) + (info.summary?.length > 150 ? '…' : '');
 
-      sbTypeBadge.style.background = color;
-      sbTypeBadge.style.color = '#0d1117';
-      sbTypeBadge.textContent = typeLabel;
+      const communityLabel = communityLabelMap.get(d.community);
+      const communityColor = communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
+      if (sbMetaBadges && window.RNGraphTooltip?.buildMetaBadgesHtml) {
+        sbMetaBadges.innerHTML = window.RNGraphTooltip.buildMetaBadgesHtml({
+          type: d.type || '',
+          typeLabels: TYPE_LABEL,
+          typeColors: TYPE_COLOR,
+          communityLabel: communityLabel || '',
+          communityColor: communityLabel ? communityColor : '',
+        });
+      } else if (sbMetaBadges) {
+        sbMetaBadges.innerHTML = '';
+      }
       sbTitle.textContent = info.title || d.label;
       sbSummary.textContent = summary;
-      const sbCommunityText = communityLabelMap.get(d.community);
-      if (sbCommunityText) {
-        sbCommunityBlock.hidden = false;
-        sbCommunityDot.style.background = communityColorMap.get(d.community) || color;
-        sbCommunityLabel.textContent = sbCommunityText;
-      } else {
-        sbCommunityBlock.hidden = true;
-      }
 
       // tags from index
       const item = indexItems.find(it => it.path === d.id);

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -307,9 +307,26 @@
       font-weight: 700;
       padding: 2px 7px;
       border-radius: 4px;
-      margin-bottom: 6px;
       text-transform: uppercase;
       letter-spacing: .04em;
+    }
+    .tt-community {
+      display: inline-block;
+      font-size: .7rem;
+      font-weight: 700;
+      padding: 2px 7px;
+      border-radius: 4px;
+      letter-spacing: .02em;
+    }
+    .tt-meta-badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-bottom: 6px;
+    }
+    .tt-meta-badges .tt-type,
+    .tt-meta-badges .tt-community {
+      margin-bottom: 0;
     }
     .tt-title { font-size: .92rem; font-weight: 700; color: #e6edf3; margin-bottom: 5px; line-height: 1.3; }
     .tt-summary { font-size: .78rem; color: rgba(255,255,255,0.45); line-height: 1.5; }
@@ -1624,12 +1641,15 @@
       comparison:    '#c084fc',
       query:         '#94a3b8',
       formalization: '#fb923c',
+      overview:      '#64748b',
+      reference:     '#64748b',
       '':            '#64748b',
     };
     const TYPE_LABEL = {
       concept: '概念', method: '方法', task: '任务',
       entity: '工具', comparison: '对比', query: 'Query',
-      formalization: '形式化', '': 'Wiki',
+      formalization: '形式化', overview: '总览', reference: '参考',
+      '': 'Wiki',
     };
     const TYPE_FILTER_OPTIONS = [
       { value: 'concept', label: '概念', color: '#60a5fa' },
@@ -2355,20 +2375,24 @@
     }
 
     function tooltipHtml(d) {
-      const color = nodeColor(d);
       const info = d._info;
-      const typeLabel = TYPE_LABEL[d.type] || d.type || 'Wiki';
       const summary = tooltipSummary(info.summary);
       const detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
       const communityLabel = communityLabelMap.get(d.community);
-      const community = communityLabel
-        ? `<div class="tt-summary">社区：${escapeHtml(String(communityLabel))}</div>`
-        : '';
-      return `<span class="tt-type" style="background:${escapeHtml(String(color))};color:#0d1117">${escapeHtml(String(typeLabel))}</span>` +
-             `<div class="tt-title">${escapeHtml(String(info.title || d.label))}</div>` +
-             (summary ? `<div class="tt-summary">${escapeHtml(String(summary))}</div>` : '') +
-             community +
-             `<a class="tt-link" href="${escapeHtml(detailUrl)}" target="_self">打开详情页 →</a>`;
+      const communityColor = communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
+      if (window.RNGraphTooltip?.buildNodeTooltipHtml) {
+        return window.RNGraphTooltip.buildNodeTooltipHtml({
+          type: d.type || '',
+          typeLabels: TYPE_LABEL,
+          typeColors: TYPE_COLOR,
+          title: info.title || d.label,
+          summary,
+          communityLabel: communityLabel || '',
+          communityColor: communityLabel ? communityColor : '',
+          linkHtml: `<a class="tt-link" href="${escapeHtml(detailUrl)}" target="_self">打开详情页 →</a>`
+        });
+      }
+      return '';
     }
 
     function showTooltip(ev, d) {

--- a/docs/main.js
+++ b/docs/main.js
@@ -2509,17 +2509,7 @@
     return null;
   }
 
-  var TYPE_COLOR_DETAIL_MINI = {
-    concept: '#60a5fa', method: '#34d399', task: '#f472b6',
-    entity: '#fbbf24', comparison: '#c084fc', query: '#94a3b8',
-    formalization: '#fb923c', '': '#64748b'
-  };
   var DETAIL_MINI_TABLEAU10 = ['#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f', '#edc948', '#b07aa1', '#ff9da7', '#9c755f', '#bab0ac'];
-  var GRAPH_NODE_TYPE_LABEL = {
-    concept: '概念', method: '方法', task: '任务',
-    entity: '工具', comparison: '对比', query: 'Query',
-    formalization: '形式化', '': 'Wiki'
-  };
 
   function formatGraphTooltipSummary(raw) {
     if (window.RNGraphTooltip && window.RNGraphTooltip.formatTooltipSummary) {
@@ -2529,13 +2519,9 @@
   }
 
   function buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId) {
-    var color = nodeFill(d);
-    var typeLabel = GRAPH_NODE_TYPE_LABEL[d.type] || d.type || 'Wiki';
     var summary = formatGraphTooltipSummary(d.summary);
     var communityLabel = d.community && communityLabelMap[d.community];
-    var community = communityLabel
-      ? '<div class="tt-summary">社区：' + escapeHtml(String(communityLabel)) + '</div>'
-      : '';
+    var communityColor = d.community ? nodeFill(d) : '';
     var linkHtml;
     if (d.isCurrent) {
       linkHtml = '<div class="tt-summary">当前页面</div>';
@@ -2545,12 +2531,17 @@
       var linkText = pid ? '打开详情页 →' : '在完整图谱中查看 →';
       linkHtml = '<a class="tt-link" href="' + escapeHtml(href) + '">' + escapeHtml(linkText) + '</a>';
     }
-    return '<span class="tt-type" style="background:' + escapeHtml(String(color)) + ';color:#0d1117">' +
-      escapeHtml(String(typeLabel)) + '</span>' +
-      '<div class="tt-title">' + escapeHtml(String(d.label || d.id)) + '</div>' +
-      (summary ? '<div class="tt-summary">' + escapeHtml(String(summary)) + '</div>' : '') +
-      community +
-      linkHtml;
+    if (window.RNGraphTooltip && window.RNGraphTooltip.buildNodeTooltipHtml) {
+      return window.RNGraphTooltip.buildNodeTooltipHtml({
+        type: d.type || '',
+        title: d.label || d.id,
+        summary: summary,
+        communityLabel: communityLabel || '',
+        communityColor: communityColor,
+        linkHtml: linkHtml
+      });
+    }
+    return '';
   }
 
   function setupGraphHoverTooltip(tooltipEl) {
@@ -2958,7 +2949,9 @@
       function nodeFill(d) {
         var cc = d.community && communityColor[d.community];
         if (cc) return cc;
-        return TYPE_COLOR_DETAIL_MINI[d.type] || TYPE_COLOR_DETAIL_MINI[''];
+        var typeColors = window.RNGraphTooltip && window.RNGraphTooltip.GRAPH_NODE_TYPE_COLOR;
+        if (typeColors) return typeColors[d.type] || typeColors[''];
+        return '#64748b';
       }
 
       var hoverTip = setupGraphHoverTooltip(tooltipEl);

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -6,12 +6,6 @@
   var tooltip  = document.getElementById('mini-graph-tooltip');
   if (!miniWrap || !miniSvg) return;
 
-  var TYPE_LABEL = {
-    concept: '概念', method: '方法', task: '任务',
-    entity: '工具', comparison: '对比', query: 'Query',
-    formalization: '形式化', '': 'Wiki'
-  };
-
   var PREVIEW_TOP_N = 40;
   var isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
   var pinnedNode = null;
@@ -48,20 +42,21 @@
   }
 
   function tooltipHtml(d, nodeFill, communityLabelMap) {
-    var color = nodeFill(d);
-    var typeLabel = TYPE_LABEL[d.type] || d.type || 'Wiki';
     var summary = tooltipSummary(d.summary);
     var detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
     var communityLabel = d.community && communityLabelMap[d.community];
-    var community = communityLabel
-      ? '<div class="tt-summary">社区：' + escapeHtml(String(communityLabel)) + '</div>'
-      : '';
-    return '<span class="tt-type" style="background:' + escapeHtml(String(color)) + ';color:#0d1117">' +
-      escapeHtml(String(typeLabel)) + '</span>' +
-      '<div class="tt-title">' + escapeHtml(String(d.label || d.id)) + '</div>' +
-      (summary ? '<div class="tt-summary">' + escapeHtml(String(summary)) + '</div>' : '') +
-      community +
-      '<a class="tt-link" href="' + escapeHtml(detailUrl) + '">打开详情页 →</a>';
+    var communityColor = d.community ? nodeFill(d) : '';
+    if (window.RNGraphTooltip && window.RNGraphTooltip.buildNodeTooltipHtml) {
+      return window.RNGraphTooltip.buildNodeTooltipHtml({
+        type: d.type || '',
+        title: d.label || d.id,
+        summary: summary,
+        communityLabel: communityLabel || '',
+        communityColor: communityColor,
+        linkHtml: '<a class="tt-link" href="' + escapeHtml(detailUrl) + '">打开详情页 →</a>'
+      });
+    }
+    return '';
   }
 
   function showTooltip(ev, d, nodeFill, communityLabelMap) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -2269,9 +2269,26 @@ body.sponsor-dialog-open {
   font-weight: 700;
   padding: 2px 7px;
   border-radius: 4px;
-  margin-bottom: 6px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+.graph-hover-tooltip .tt-community {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 4px;
+  letter-spacing: 0.02em;
+}
+.graph-hover-tooltip .tt-meta-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.graph-hover-tooltip .tt-meta-badges .tt-type,
+.graph-hover-tooltip .tt-meta-badges .tt-community {
+  margin-bottom: 0;
 }
 .graph-hover-tooltip .tt-title {
   font-size: 0.92rem;

--- a/scripts/screenshot_graph_tooltip_verify.cjs
+++ b/scripts/screenshot_graph_tooltip_verify.cjs
@@ -1,0 +1,166 @@
+// Capture graph hover tooltips (type badge = type color, community badge = community color).
+// Usage: node scripts/screenshot_graph_tooltip_verify.cjs [basePort] [outDir]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const port = process.argv[2] || '8765';
+  const outDir = path.resolve(process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots'));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const exe = process.env.PUPPETEER_EXECUTABLE_PATH
+    || (fs.existsSync('/usr/local/bin/google-chrome') ? '/usr/local/bin/google-chrome' : 'google-chrome');
+  const d3Local = path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js');
+  const d3Body = fs.existsSync(d3Local) ? fs.readFileSync(d3Local) : null;
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--window-size=1440,900'],
+  });
+
+  async function setupPage(page) {
+    await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+    if (d3Body) {
+      await page.setRequestInterception(true);
+      page.on('request', (req) => {
+        const u = req.url();
+        if (u.includes('cdn.jsdelivr.net/npm/d3')) {
+          req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+        } else {
+          req.continue();
+        }
+      });
+    }
+  }
+
+  async function hoverGraphNodeWithCommunity(page, rootSelector, circleSelector) {
+    const sel = circleSelector || (rootSelector + ' circle');
+    const pt = await page.evaluate((circleSel) => {
+      const circles = Array.from(document.querySelectorAll(circleSel));
+      for (let i = 0; i < circles.length; i++) {
+        const circle = circles[i];
+        const rect = circle.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) continue;
+        return {
+          x: rect.left + rect.width / 2,
+          y: rect.top + rect.height / 2,
+        };
+      }
+      return null;
+    }, sel);
+    if (!pt) throw new Error('no hover target for ' + sel);
+    await page.mouse.move(pt.x, pt.y);
+    return pt;
+  }
+
+  async function waitTooltip(page, tooltipSelector, requireCommunity) {
+    await page.waitForFunction((sel, needCommunity) => {
+      const el = document.querySelector(sel);
+      if (!el || el.classList.contains('hidden')) return false;
+      const type = el.querySelector('.tt-type');
+      if (!type) return false;
+      if (!needCommunity) return true;
+      return !!el.querySelector('.tt-community');
+    }, { timeout: 30000 }, tooltipSelector, !!requireCommunity);
+    await new Promise((r) => setTimeout(r, 400));
+  }
+
+  async function screenshotTooltip(page, tooltipSelector, outPath) {
+    const box = await page.evaluate((sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.x, y: r.y, width: r.width, height: r.height };
+    }, tooltipSelector);
+    if (!box || box.width < 10) throw new Error('tooltip box missing: ' + outPath);
+    const pad = 12;
+    await page.screenshot({
+      path: outPath,
+      clip: {
+        x: Math.max(0, box.x - pad),
+        y: Math.max(0, box.y - pad),
+        width: Math.min(1440, box.width + pad * 2),
+        height: Math.min(900, box.height + pad * 2),
+      },
+    });
+    return outPath;
+  }
+
+  const shots = [];
+
+  try {
+    // 1) Full graph page
+    {
+      const page = await browser.newPage();
+      await setupPage(page);
+      await page.goto(`http://127.0.0.1:${port}/graph.html`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+      await page.waitForFunction(() => {
+        const count = document.getElementById('graph-node-count');
+        const nodes = document.querySelectorAll('#graph-canvas .node-g');
+        return count && count.textContent && !count.textContent.includes('加载中') && nodes.length > 0;
+      }, { timeout: 90000 });
+      await new Promise((r) => setTimeout(r, 4000));
+      await hoverGraphNodeWithCommunity(page, '#graph-canvas', '#graph-canvas .node-circle');
+      await waitTooltip(page, '#graph-tooltip', true);
+      const out = path.join(outDir, 'graph-tooltip-badges.png');
+      await screenshotTooltip(page, '#graph-tooltip', out);
+      const meta = await page.evaluate(() => {
+        const tip = document.querySelector('#graph-tooltip');
+        const type = tip?.querySelector('.tt-type');
+        const community = tip?.querySelector('.tt-community');
+        return {
+          typeText: type?.textContent?.trim() || '',
+          typeBg: type ? getComputedStyle(type).backgroundColor : '',
+          communityText: community?.textContent?.trim() || '',
+          communityBg: community ? getComputedStyle(community).backgroundColor : '',
+        };
+      });
+      shots.push({ page: 'graph.html', out, meta });
+      await page.close();
+    }
+
+    // 2) Homepage mini-graph
+    {
+      const page = await browser.newPage();
+      await setupPage(page);
+      await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+      await page.waitForSelector('#mini-graph-svg .mini-graph-node circle', { timeout: 60000 });
+      await new Promise((r) => setTimeout(r, 5000));
+      await hoverGraphNodeWithCommunity(page, '#mini-graph-svg', '#mini-graph-svg .mini-graph-node circle');
+      await waitTooltip(page, '#mini-graph-tooltip', true);
+      const out = path.join(outDir, 'mini-graph-tooltip-badges.png');
+      await screenshotTooltip(page, '#mini-graph-tooltip', out);
+      shots.push({ page: 'index.html', out });
+      await page.close();
+    }
+
+    // 3) Detail page knowledge mini-map
+    {
+      const page = await browser.newPage();
+      await setupPage(page);
+      await page.goto(`http://127.0.0.1:${port}/detail.html?id=wiki-concepts-sim2real`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 45000,
+      });
+      await page.waitForSelector('#detailMiniMapSvg .mini-node circle', { timeout: 60000 });
+      await new Promise((r) => setTimeout(r, 3000));
+      await hoverGraphNodeWithCommunity(page, '#detailMiniMapSvg', '#detailMiniMapSvg .mini-node circle');
+      await waitTooltip(page, '#detail-mini-map-tooltip', true);
+      const out = path.join(outDir, 'detail-mini-map-tooltip-badges.png');
+      await screenshotTooltip(page, '#detail-mini-map-tooltip', out);
+      shots.push({ page: 'detail.html', out });
+      await page.close();
+    }
+
+    const reportPath = path.join(outDir, 'graph-tooltip-verify.json');
+    fs.writeFileSync(reportPath, JSON.stringify({ shots }, null, 2));
+    console.log(JSON.stringify({ ok: true, shots, reportPath }, null, 2));
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/screenshot_graph_tooltip_verify.cjs
+++ b/scripts/screenshot_graph_tooltip_verify.cjs
@@ -118,6 +118,53 @@ const path = require('path');
         };
       });
       shots.push({ page: 'graph.html', out, meta });
+
+      // 1b) graph sidebar badges (PC click opens sidebar)
+      const clickPt = await page.evaluate(() => {
+        const circle = document.querySelector('#graph-canvas .node-circle');
+        if (!circle) return null;
+        const rect = circle.getBoundingClientRect();
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+      });
+      if (!clickPt) throw new Error('graph.html: no node to click for sidebar');
+      await page.mouse.click(clickPt.x, clickPt.y);
+      await page.waitForFunction(() => {
+        const sidebar = document.getElementById('graph-sidebar');
+        if (!sidebar || !sidebar.classList.contains('open')) return false;
+        const type = sidebar.querySelector('#sb-meta-badges .tt-type');
+        const community = sidebar.querySelector('#sb-meta-badges .tt-community');
+        return !!(type && community);
+      }, { timeout: 15000 });
+      await new Promise((r) => setTimeout(r, 400));
+      const sidebarOut = path.join(outDir, 'graph-sidebar-badges.png');
+      const sidebarBox = await page.evaluate(() => {
+        const el = document.getElementById('graph-sidebar');
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return { x: r.x, y: r.y, width: r.width, height: Math.min(r.height, 320) };
+      });
+      if (!sidebarBox) throw new Error('sidebar box missing');
+      await page.screenshot({
+        path: sidebarOut,
+        clip: {
+          x: Math.max(0, sidebarBox.x),
+          y: Math.max(0, sidebarBox.y),
+          width: Math.min(1440, sidebarBox.width),
+          height: Math.min(900, sidebarBox.height),
+        },
+      });
+      const sidebarMeta = await page.evaluate(() => {
+        const sidebar = document.getElementById('graph-sidebar');
+        const type = sidebar?.querySelector('#sb-meta-badges .tt-type');
+        const community = sidebar?.querySelector('#sb-meta-badges .tt-community');
+        return {
+          typeText: type?.textContent?.trim() || '',
+          typeBg: type ? getComputedStyle(type).backgroundColor : '',
+          communityText: community?.textContent?.trim() || '',
+          communityBg: community ? getComputedStyle(community).backgroundColor : '',
+        };
+      });
+      shots.push({ page: 'graph.html sidebar', out: sidebarOut, meta: sidebarMeta });
       await page.close();
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 统一 `graph-tooltip.js` 中的浮窗徽章构建逻辑：类型徽章始终使用 `TYPE_COLOR` 类型色，不再误用社区/节点填充色。
- 社区信息改为与类型并列的 `tt-community` 有色块徽章，背景使用对应社区色。
- **graph 右侧栏**复用同一套 `RNGraphTooltip.buildMetaBadgesHtml`：移除「所属社区」小圆点样式，改为与浮窗一致的类型 + 社区色块并排。
- 同步更新 `graph.html`、首页 `mini-graph.js`、详情页知识地图 `main.js` 三处浮窗，以及 `style.css` / `graph.html` 样式。

## 验证
- `make lint-js` 通过
- `scripts/screenshot_graph_tooltip_verify.cjs`：浮窗三页 + graph 侧栏截图通过

## 验证截图

### graph.html 侧栏（与浮窗同色）
- 类型「对比」= 紫色 `rgb(192, 132, 252)`；社区 = 粉色 `rgb(227, 119, 194)`

![graph 侧栏徽章与浮窗一致](https://cursor.com/artifacts/c/art-7e39d559-859a-4c30-92fe-1622fb5af844)

### graph.html 浮窗
![graph.html 节点浮窗](https://cursor.com/artifacts/c/art-6f1bc9e1-d511-4ac0-b07a-5df8cfcda76c)

### index.html mini-graph
![首页 mini-graph 浮窗](https://cursor.com/artifacts/c/art-66186bb0-705d-4643-8578-2e4c34f3beb6)

### detail.html 知识地图
![详情页知识地图浮窗](https://cursor.com/artifacts/c/art-1113def9-a670-441c-8907-4d2316dc6069)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a376a6-52ab-4dda-9169-c3bfb5ccfd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a376a6-52ab-4dda-9169-c3bfb5ccfd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

