### PR TITLE
fix(ux): 修复图谱侧栏滑入空白闪动并隐藏 type 元数据

### DIFF
--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -139,16 +139,20 @@
   /** 类型徽章用类型色；社区徽章用社区色 */
   function buildMetaBadgesHtml(opts) {
     opts = opts || {};
-    var typeKey = opts.type != null ? opts.type : '';
-    var typeLabels = opts.typeLabels || GRAPH_NODE_TYPE_LABEL;
-    var typeColors = opts.typeColors || GRAPH_NODE_TYPE_COLOR;
-    var typeLabel = typeLabels[typeKey] || typeKey || 'Wiki';
-    var typeColor = typeColors[typeKey] || typeColors[''] || '#64748b';
-    var html = colorBadgeHtml('tt-type', typeLabel, typeColor);
+    var html = '';
+    if (opts.showType !== false) {
+      var typeKey = opts.type != null ? opts.type : '';
+      var typeLabels = opts.typeLabels || GRAPH_NODE_TYPE_LABEL;
+      var typeColors = opts.typeColors || GRAPH_NODE_TYPE_COLOR;
+      var typeLabel = typeLabels[typeKey] || typeKey || 'Wiki';
+      var typeColor = typeColors[typeKey] || typeColors[''] || '#64748b';
+      html = colorBadgeHtml('tt-type', typeLabel, typeColor);
+    }
     if (opts.communityLabel) {
       var communityColor = opts.communityColor || '#64748b';
       html += colorBadgeHtml('tt-community', opts.communityLabel, communityColor);
     }
+    if (!html) return '';
     return '<div class="tt-meta-badges">' + html + '</div>';
   }
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3542,7 +3542,6 @@
           typeColors: TYPE_COLOR,
           communityLabel: communityLabel || '',
           communityColor: communityLabel ? communityColor : '',
-          showType: false,
         });
       } else if (sbMetaBadges) {
         sbMetaBadges.innerHTML = '';

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -257,6 +257,7 @@
       position: fixed;
       top: calc(var(--header-h) + 46px);
       left: 0; right: 0; bottom: 0;
+      transition: right .22s cubic-bezier(.4,0,.2,1);
     }
     #graph-canvas {
       width: 100%; height: 100%;
@@ -3457,6 +3458,25 @@
     const sbPaperList  = document.getElementById('sb-paper-list');
     const sbOpenLink   = document.getElementById('sb-open-link');
     const sbClose      = document.getElementById('sb-close');
+    const SIDEBAR_TRANSITION_MS = 220;
+
+    function scheduleSidebarViewportSync() {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        wrap.removeEventListener('transitionend', onEnd);
+        clearTimeout(fallbackTimer);
+        updateGraphViewport();
+        if (!timelineAnimating) simulation.alpha(0.1).restart();
+      };
+      const onEnd = (ev) => {
+        if (ev.target !== wrap || ev.propertyName !== 'right') return;
+        finish();
+      };
+      wrap.addEventListener('transitionend', onEnd);
+      const fallbackTimer = setTimeout(finish, SIDEBAR_TRANSITION_MS + 40);
+    }
 
     function edgeNodeIds(e) {
       return {
@@ -3509,7 +3529,9 @@
 
       const info  = d._info;
       const detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
-      const summary = (info.summary || '').slice(0, 150) + (info.summary?.length > 150 ? '…' : '');
+      const summary = window.RNGraphTooltip?.formatTooltipSummary
+        ? window.RNGraphTooltip.formatTooltipSummary(info.summary || '', 150)
+        : (info.summary || '').slice(0, 150) + (info.summary?.length > 150 ? '…' : '');
 
       const communityLabel = communityLabelMap.get(d.community);
       const communityColor = communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
@@ -3520,12 +3542,19 @@
           typeColors: TYPE_COLOR,
           communityLabel: communityLabel || '',
           communityColor: communityLabel ? communityColor : '',
+          showType: false,
         });
       } else if (sbMetaBadges) {
         sbMetaBadges.innerHTML = '';
       }
       sbTitle.textContent = info.title || d.label;
-      sbSummary.textContent = summary;
+      if (summary) {
+        sbSummary.hidden = false;
+        sbSummary.textContent = summary;
+      } else {
+        sbSummary.hidden = true;
+        sbSummary.textContent = '';
+      }
 
       // tags from index
       const item = indexItems.find(it => it.path === d.id);
@@ -3586,9 +3615,11 @@
 
       sidebar.classList.add('open');
       wrap.classList.add('sidebar-open');
+      scheduleSidebarViewportSync();
     }
     function closeSidebar() {
       sidebar.classList.remove('open');
+      scheduleSidebarViewportSync();
       sidebarFocusIds = null;
       pinnedNode = null;
       if (isMobile) hideTooltip();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 graph view 节点侧栏体验：

1. **空白侧栏闪动**：`#graph-wrap` 与 `#graph-sidebar` 同步 `right` 过渡，避免画布先收缩、侧栏后滑入露出底色空白条。
2. **过滤 `type: overview.` 占位摘要**：侧栏摘要复用 `formatTooltipSummary`，不再展示仅占位元数据的 `type: xxx` 行。
3. **保留类型着色徽章**：类型徽章（如「总览」「概念」等带背景色的标签）继续显示；上一版误用 `showType: false` 整块隐藏，已恢复。

## 验证

- 点击节点：侧栏与画布同步滑入
- overview 节点：有类型着色徽章，摘要区不显示 `type: overview.`
- 普通节点：类型徽章 + 正常摘要均保留
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ca420e9-39bc-4c9c-a8b5-70777ef0e686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ca420e9-39bc-4c9c-a8b5-70777ef0e686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

