### PR TITLE
fix(ux): 所属社区徽标颜色与图谱社区色一致

### DIFF
--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -141,6 +141,60 @@
     return String(label).replace(/\s*社区\s*$/, '').trim() || '未分类';
   }
 
+  /** 与 graph.html COMMUNITY_COLORS 一致：Tableau10 + 扩展色 */
+  var COMMUNITY_COLORS_FALLBACK = [
+    '#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f',
+    '#edc948', '#b07aa1', '#ff9da7', '#9c755f', '#bab0ac',
+    '#e377c2', '#bcbd22', '#17becf', '#aec7e8', '#ffbb78', '#98df8a', '#c5b0d5'
+  ];
+
+  function getCommunityColors() {
+    if (typeof window !== 'undefined' && window.d3 && window.d3.schemeTableau10) {
+      return window.d3.schemeTableau10.concat(COMMUNITY_COLORS_FALLBACK.slice(10));
+    }
+    return COMMUNITY_COLORS_FALLBACK.slice();
+  }
+
+  /** 与 graph.html getSortedCommunities 一致，保证徽标色与图谱社区色对齐 */
+  function getSortedCommunities(communities) {
+    var list = (communities || []).slice();
+    return list.sort(function (a, b) {
+      if (a.id === 'community-other') return 1;
+      if (b.id === 'community-other') return -1;
+      var sizeDiff = (b.size || 0) - (a.size || 0);
+      if (sizeDiff !== 0) return sizeDiff;
+      return String(a.label || a.id).localeCompare(String(b.label || b.id), 'zh-CN');
+    });
+  }
+
+  function buildCommunityColorMap(communities) {
+    var palette = getCommunityColors();
+    var map = {};
+    getSortedCommunities(communities).forEach(function (c, idx) {
+      map[c.id] = palette[idx % palette.length];
+    });
+    return map;
+  }
+
+  function hexToRgbChannels(hex) {
+    var h = String(hex || '').replace('#', '').trim();
+    if (h.length === 3) {
+      h = h.split('').map(function (ch) { return ch + ch; }).join('');
+    }
+    if (h.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(h)) return null;
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16)
+    };
+  }
+
+  function communityBadgeStyleAttr(color) {
+    var rgb = hexToRgbChannels(color);
+    if (!rgb) return '';
+    return ' style="--community-r:' + rgb.r + ';--community-g:' + rgb.g + ';--community-b:' + rgb.b + '"';
+  }
+
   /** 浮窗/侧边栏类型徽章：优先用社区色着色，不再单独展示社区色块 */
   function buildMetaBadgesHtml(opts) {
     opts = opts || {};
@@ -158,12 +212,13 @@
     return '<div class="tt-meta-badges">' + html + '</div>';
   }
 
-  /** 与详情页一致的社区跳转按钮 */
-  function buildCommunityBadgeHtml(communityId, communityLabel) {
+  /** 与详情页一致的社区跳转按钮；communityColor 与图谱节点社区色一致 */
+  function buildCommunityBadgeHtml(communityId, communityLabel, communityColor) {
     if (!communityId || !communityLabel) return '';
     var label = shortenCommunityLabel(communityLabel);
-    return '<a class="detail-meta-badge detail-community-badge" href="graph.html?community=' +
-      encodeURIComponent(communityId) + '" title="在知识图谱中查看「' + escapeHtml(label) + '」社区视图">' +
+    return '<a class="detail-meta-badge detail-community-badge"' + communityBadgeStyleAttr(communityColor) +
+      ' href="graph.html?community=' + encodeURIComponent(communityId) +
+      '" title="在知识图谱中查看「' + escapeHtml(label) + '」社区视图">' +
       '<span>🧭</span><span>' + escapeHtml(label) + '</span></a>';
   }
 
@@ -191,6 +246,11 @@
     GRAPH_NODE_TYPE_LABEL: GRAPH_NODE_TYPE_LABEL,
     GRAPH_NODE_TYPE_COLOR: GRAPH_NODE_TYPE_COLOR,
     shortenCommunityLabel: shortenCommunityLabel,
+    COMMUNITY_COLORS_FALLBACK: COMMUNITY_COLORS_FALLBACK,
+    getCommunityColors: getCommunityColors,
+    getSortedCommunities: getSortedCommunities,
+    buildCommunityColorMap: buildCommunityColorMap,
+    communityBadgeStyleAttr: communityBadgeStyleAttr,
     buildMetaBadgesHtml: buildMetaBadgesHtml,
     buildCommunityBadgeHtml: buildCommunityBadgeHtml,
     buildNodeTooltipHtml: buildNodeTooltipHtml

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3542,7 +3542,8 @@
       }
       if (sbCommunity) {
         if (d.community && communityLabel && window.RNGraphTooltip?.buildCommunityBadgeHtml) {
-          sbCommunity.innerHTML = window.RNGraphTooltip.buildCommunityBadgeHtml(d.community, communityLabel);
+          sbCommunity.innerHTML = window.RNGraphTooltip.buildCommunityBadgeHtml(
+            d.community, communityLabel, communityColor);
           sbCommunity.hidden = false;
         } else {
           sbCommunity.innerHTML = '';

--- a/docs/main.js
+++ b/docs/main.js
@@ -2789,10 +2789,14 @@
       if (!node || !node.community) { renderDetailMetaItemRow(communityRowId, '所属社区', ''); return; }
       var community = (gd.communities || []).find(function (c) { return c.id === node.community; });
       if (!community) { renderDetailMetaItemRow(communityRowId, '所属社区', ''); return; }
-      var label = shortenCommunityLabel(community.label);
-      var html = '<a class="detail-meta-badge detail-community-badge" href="graph.html?community=' +
-        encodeURIComponent(community.id) + '" title="在知识图谱中查看「' + escapeHtml(label) + '」社区视图">' +
-        '<span>🧭</span><span>' + escapeHtml(label) + '</span></a>';
+      var tooltipApi = window.RNGraphTooltip || {};
+      var colorMap = tooltipApi.buildCommunityColorMap
+        ? tooltipApi.buildCommunityColorMap(gd.communities || [])
+        : {};
+      var communityColor = colorMap[community.id] || '';
+      var html = tooltipApi.buildCommunityBadgeHtml
+        ? tooltipApi.buildCommunityBadgeHtml(community.id, community.label, communityColor)
+        : '';
       renderDetailMetaItemRow(communityRowId, '所属社区', html);
     }).catch(function () { renderDetailMetaItemRow(communityRowId, '所属社区', ''); });
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -698,12 +698,12 @@ body.sponsor-dialog-open {
 }
 .detail-meta-badge span:first-child { font-size: .95em; line-height: 1; }
 .detail-community-badge {
-  border-color: rgba(167, 139, 250, 0.35);
-  background: rgba(167, 139, 250, 0.08);
+  border-color: rgba(var(--community-r, 167), var(--community-g, 139), var(--community-b, 250), 0.35);
+  background: rgba(var(--community-r, 167), var(--community-g, 139), var(--community-b, 250), 0.08);
 }
 .detail-community-badge:hover {
-  border-color: rgba(167, 139, 250, 0.55);
-  background: rgba(167, 139, 250, 0.16);
+  border-color: rgba(var(--community-r, 167), var(--community-g, 139), var(--community-b, 250), 0.55);
+  background: rgba(var(--community-r, 167), var(--community-g, 139), var(--community-b, 250), 0.16);
 }
 .detail-meta-date {
   border-color: rgba(155, 155, 160, 0.38);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页、路线页与图谱侧边栏的「所属社区」徽标此前使用固定的紫色样式，与图谱「按社区着色」模式下的社区颜色不一致。本次改动让徽标边框/背景通过 CSS 变量 `--community-r/g/b` 绑定到与 `graph.html` 相同的社区色板与排序规则。

## 改动说明

- `docs/graph-tooltip.js`：新增 `buildCommunityColorMap`、`communityBadgeStyleAttr` 等共享工具；`buildCommunityBadgeHtml` 接受 `communityColor` 参数
- `docs/main.js`：详情/路线页社区徽标复用上述工具生成带社区色的 HTML
- `docs/graph.html`：侧边栏社区徽标传入 `communityColor`
- `docs/style.css`：`.detail-community-badge` 改为基于 CSS 变量的动态着色（保留紫色作为无颜色时的回退）

## 验证

- 本地 `make export graph` 后静态站详情页元信息面板渲染正常
- 社区徽标颜色与 `link-graph.json` 中对应社区在图谱中的着色一致

## 验证截图

![详情页所属社区徽标与社区色一致](https://cursor.com/artifacts/c/art-76cd4962-c325-4faa-b0ac-f7b4bdf11e7c)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d17a529-e9c1-4f4a-b25e-da0197f9edaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d17a529-e9c1-4f4a-b25e-da0197f9edaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

