### PR TITLE
feat: 数据集选型脚手架强化 — 新增 `--dataset` 旗标

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v25.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v25.md
@@ -26,8 +26,8 @@
 
 - [x] **数据集页元数据巡检 V1**：
     - [x] `scripts/lint_wiki.py` 新增 `dataset_metadata_check`：对 `tags` 含 `dataset` 的实体页，检查正文是否含规模 / 模态 / 许可证 / 重定向就绪度等标准化速查字段，缺失给出 INFO 级提示（不阻塞 CI），并写入 lint 报告基线快照；新增用例覆盖到 `tests/`。（2026-06-17 完成：新增 `_check_dataset_entity_metadata` 与 result key `dataset_missing_metadata`（INFO 级，不计失败总数）；正文按关键词命中近似四维度，全库巡检命中 17 页基线写入 `exports/lint-report.md`；新增 `tests/test_lint_wiki_dataset_metadata.py` 4 用例。）
-- [ ] **数据集选型脚手架强化**：
-    - [ ] 复用 `scripts/scaffold_wiki_page.py`，为 `entity`（数据集）类型补充含「规模 / 模态 / 许可证 / 适配形态 / 重定向就绪度」速查块的骨架模板，降低后续数据集 ingest 的手工成本；自带 `--dry-run` 与 lint 自检。
+- [x] **数据集选型脚手架强化**：
+    - [x] 复用 `scripts/scaffold_wiki_page.py`，为 `entity`（数据集）类型补充含「规模 / 模态 / 许可证 / 适配形态 / 重定向就绪度」速查块的骨架模板，降低后续数据集 ingest 的手工成本；自带 `--dry-run` 与 lint 自检。（2026-06-18 完成：新增 `--dataset` 旗标（仅 entity 类型，否则 rc=2），生成「## 数据集速查」五维度速查块并在 frontmatter 写入 `dataset` tag；速查块关键词全覆盖 lint `dataset_metadata_check` 四维度，新建数据集页 0 缺失；新增 3 条用例（速查块/tag/位置、lint 巡检 0 缺失、非 entity 拒绝）至 `tests/test_scaffold_wiki_page.py`，`ruff` 与 `lint_wiki` 通过。）
 
 ## P1: 人形训练数据管线专题 (Quality)
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-18] structural | scripts/scaffold_wiki_page.py — V25 P0「数据集选型脚手架强化」：新增 `--dataset` 旗标生成数据集实体骨架（五维度速查块 + `dataset` tag）
+
+- 改动：`scripts/scaffold_wiki_page.py` 新增 `--dataset`（仅 `entity` 类型，否则 rc=2），输出「## 数据集速查」表格覆盖「规模 / 模态 / 许可证 / 适配形态 / 重定向就绪度」并在 frontmatter 写入 `dataset` tag；速查块关键词全覆盖 `lint_wiki._check_dataset_entity_metadata` 四维度，新建数据集页元数据巡检 0 缺失。
+- 测试：[`tests/test_scaffold_wiki_page.py`](tests/test_scaffold_wiki_page.py) 新增 3 用例（速查块/tag/位置、lint 巡检 0 缺失、非 entity 拒绝）；`ruff check/format` 与 `python3 scripts/lint_wiki.py` 通过。
+- 清单：[`docs/checklists/tech-stack-next-phase-checklist-v25.md`](docs/checklists/tech-stack-next-phase-checklist-v25.md) P0「数据集选型脚手架强化」打勾。
+
 ## [2026-06-18] ingest | sources/papers/ume_exo_arxiv_2606_14218.md、sources/sites/ume-exo-project.md — UME 外骨骼力矩反馈遥操作；wiki/entities/paper-ume-exo.md；交叉 teleoperation、bimanual-manipulation、loco-manipulation、motion-retargeting、action-chunking
 
 ## [2026-06-18] ingest | sources/blogs/allenai_molmo_motion.md — MolmoMotion 语言条件 3D 点轨迹预测；wiki/entities/molmo-motion.md；交叉 generative-world-models、manipulation、video-as-simulation

--- a/scripts/scaffold_wiki_page.py
+++ b/scripts/scaffold_wiki_page.py
@@ -8,7 +8,10 @@
 用法：
     python3 scripts/scaffold_wiki_page.py concept "视觉伺服" --slug visual-servoing-intro
     python3 scripts/scaffold_wiki_page.py query "机器人感知选型" --slug perception-pick --dry-run
+    python3 scripts/scaffold_wiki_page.py entity "AMASS" --slug amass --dataset --dry-run
 
+`--dataset`（仅 entity 类型）额外附「规模 / 模态 / 许可证 / 适配形态 / 重定向就绪度」
+速查块并写入 `dataset` tag，使新建数据集页直接通过 lint 的数据集元数据巡检。
 自带 `--dry-run`（只打印不落盘）与生成后结构自检（复用 lint_wiki 判据）。
 """
 
@@ -46,13 +49,14 @@ def slugify(title: str, override: str | None) -> str:
     return ascii_only
 
 
-def _frontmatter(page_type: str, title: str) -> str:
+def _frontmatter(page_type: str, title: str, dataset: bool = False) -> str:
     today = date.today().isoformat()
+    tags = "  - dataset\n  - TODO\n" if dataset else "  - TODO\n"
     return (
         "---\n"
         f"type: {page_type}\n"
         "tags:\n"
-        "  - TODO\n"
+        f"{tags}"
         "status: draft\n"
         f"updated: {today}\n"
         f'summary: "TODO：一句话概括「{title}」是什么、为什么重要。"\n'
@@ -79,6 +83,39 @@ _TAIL_BLOCK = (
     "## 推荐继续阅读\n\n"
     "- [TODO 外部资料标题](https://example.com)\n"
 )
+
+
+# 数据集实体速查块：五维度覆盖 lint `dataset_metadata_check` 全部关键词命中，
+# 新建数据集页即满足元数据巡检（0 缺失），降低后续 ingest 手工拼写成本。
+_DATASET_QUICK_BLOCK = (
+    "## 数据集速查\n\n"
+    "| 维度 | 速查 |\n"
+    "|------|------|\n"
+    "| 规模 | TODO：序列 / 帧 / 小时 / 被试 / 轨迹等量级（如 X 小时、Y 条序列、Z 名被试）。 |\n"
+    "| 模态 | TODO：动捕 / 视频 / 深度 / 点云 / SMPL / IMU 等数据模态。 |\n"
+    "| 许可证 | TODO：开源协议 / 注册要求 / 商用约束（如 CC-BY / MIT / non-commercial）。 |\n"
+    "| 适配形态 | TODO：面向的机器人形态与骨架（人形 / 机械臂 / 通用），与本体的形态差距。 |\n"
+    "| 重定向就绪度 | TODO：能否直接作训练输入，还是需重定向；是否物理可行 / 可部署。 |\n"
+)
+
+
+def _body_dataset(title: str) -> str:
+    return (
+        f"# {title}\n\n"
+        "## 一句话定义\n\n"
+        f"**{title}**：TODO 一句话核心定义（这是什么数据集、为机器人学习提供什么）。\n\n"
+        f"{_ABBREV_BLOCK}\n"
+        f"{_DATASET_QUICK_BLOCK}\n"
+        "## 为什么重要\n\n"
+        "- **TODO 要点一：** 待补全。\n"
+        "- **TODO 要点二：** 待补全。\n\n"
+        "## 核心内容\n\n"
+        "TODO 三段式骨架：**采集与构成 → 处理与标注 → 适用范式与边界**，逐段补全。\n\n"
+        "## 常见误区或局限\n\n"
+        "- **误区：「TODO」** TODO 纠正。\n"
+        "- **局限：** TODO 待补全。\n\n"
+        f"{_TAIL_BLOCK}"
+    )
 
 
 def _body_standard(title: str) -> str:
@@ -117,7 +154,9 @@ def _body_query(title: str) -> str:
     )
 
 
-def build_skeleton(page_type: str, title: str) -> str:
+def build_skeleton(page_type: str, title: str, dataset: bool = False) -> str:
+    if dataset:
+        return _frontmatter(page_type, title, dataset=True) + "\n" + _body_dataset(title)
     body = _body_query(title) if page_type == "query" else _body_standard(title)
     return _frontmatter(page_type, title) + "\n" + body
 
@@ -158,16 +197,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("type", choices=sorted(TYPE_DIRS), help="页面类型")
     parser.add_argument("title", help="页面标题（h1 与 summary 中使用）")
     parser.add_argument("--slug", help="文件名 slug（纯中文标题必填）")
+    parser.add_argument(
+        "--dataset",
+        action="store_true",
+        help="数据集实体骨架：附「规模/模态/许可证/适配形态/重定向就绪度」速查块（仅 entity 类型）",
+    )
     parser.add_argument("--dry-run", action="store_true", help="只打印骨架，不落盘")
     parser.add_argument("--force", action="store_true", help="允许覆盖已存在文件")
     args = parser.parse_args(argv)
+
+    if args.dataset and args.type != "entity":
+        print("✗ --dataset 仅适用于 entity 类型", file=sys.stderr)
+        return 2
 
     slug = slugify(args.title, args.slug)
     if not slug:
         print("✗ 无法从标题推断 slug（纯中文？请用 --slug 指定）", file=sys.stderr)
         return 2
 
-    content = build_skeleton(args.type, args.title)
+    content = build_skeleton(args.type, args.title, dataset=args.dataset)
 
     problems = self_check(content, args.type)
     wc = word_count(content)

--- a/tests/test_scaffold_wiki_page.py
+++ b/tests/test_scaffold_wiki_page.py
@@ -46,6 +46,41 @@ def test_slugify_derives_from_ascii_title() -> None:
     assert scaf.slugify("视觉伺服", None) == ""
 
 
+def test_dataset_skeleton_has_quick_block_and_tag() -> None:
+    content = scaf.build_skeleton("entity", "AMASS", dataset=True)
+    assert scaf.self_check(content, "entity") == []
+    assert "## 数据集速查" in content
+    # frontmatter 含 dataset tag，使 lint 数据集巡检生效
+    assert "  - dataset\n" in content
+    # 五维度速查行齐全
+    for dim in ("规模", "模态", "许可证", "适配形态", "重定向就绪度"):
+        assert dim in content
+    # 速查块在「英文缩写速查」之后、「为什么重要」之前
+    assert (
+        content.find("## 英文缩写速查")
+        < content.find("## 数据集速查")
+        < content.find("## 为什么重要")
+    )
+
+
+def test_dataset_skeleton_passes_lint_metadata_check(tmp_path: Path, monkeypatch) -> None:
+    """生成的数据集页应直接通过 lint 的数据集元数据巡检（0 缺失维度）。"""
+    import lint_wiki
+
+    monkeypatch.setattr(lint_wiki, "REPO_ROOT", tmp_path)
+    page = tmp_path / "wiki" / "entities" / "demo-dataset.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(scaf.build_skeleton("entity", "Demo Dataset", dataset=True), encoding="utf-8")
+    results: dict = {"dataset_missing_metadata": []}
+    lint_wiki._check_dataset_entity_metadata([page], results)
+    assert results["dataset_missing_metadata"] == []
+
+
+def test_dataset_flag_rejected_for_non_entity(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(scaf, "REPO_ROOT", tmp_path)
+    assert scaf.main(["concept", "X", "--slug", "x", "--dataset"]) == 2
+
+
 def test_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(scaf, "REPO_ROOT", tmp_path)
     rc = scaf.main(["concept", "Demo Page", "--dry-run"])


### PR DESCRIPTION
## 摘要

为 `scripts/scaffold_wiki_page.py` 新增 `--dataset` 旗标（仅 `entity` 类型），生成包含「规模 / 模态 / 许可证 / 适配形态 / 重定向就绪度」五维度速查块的数据集实体骨架，并在 frontmatter 写入 `dataset` tag，使新建数据集页直接通过 lint 的数据集元数据巡检（0 缺失维度）。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### 核心改动

1. **`scripts/scaffold_wiki_page.py`**
   - 新增 `--dataset` 命令行旗标（仅 `entity` 类型，否则返回 rc=2）
   - 新增 `_DATASET_QUICK_BLOCK` 常量：五维度速查表格，覆盖 lint `dataset_metadata_check` 的全部关键词
   - 新增 `_body_dataset()` 函数：生成数据集实体骨架（含「一句话定义」→「英文缩写速查」→「数据集速查」→「为什么重要」→「核心内容」→「常见误区」）
   - 修改 `_frontmatter()` 和 `build_skeleton()`：支持 `dataset=True` 时在 tags 中写入 `dataset` tag

2. **`tests/test_scaffold_wiki_page.py`**
   - 新增 `test_dataset_skeleton_has_quick_block_and_tag()`：验证速查块结构、tag 存在、五维度完整、位置正确
   - 新增 `test_dataset_skeleton_passes_lint_metadata_check()`：验证生成的数据集页通过 lint 的 `dataset_metadata_check`（0 缺失维度）
   - 新增 `test_dataset_flag_rejected_for_non_entity()`：验证非 entity 类型拒绝 `--dataset` 旗标

3. **`docs/checklists/tech-stack-next-phase-checklist-v25.md`**
   - 标记「数据集选型脚手架强化」为完成状态，补充实现细节

4. **`log.md`**
   - 记录本次改动的日期、类型、内容与验证清单

### 使用示例

```bash
python3 scripts/scaffold_wiki_page.py entity "AMASS" --slug amass --dataset --dry-run
```

生成的骨架包含：
- frontmatter 中 `tags` 含 `dataset`（触发 lint 巡检）
- 「## 数据集速查」表格，五行分别对应规模、模态、许可证、适配形态、重定向就绪度
- 标准化的「一句话定义」→「为什么重要」→「核心内容」→「常见误区」结构

## 验证

- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_scaffold_wiki_page.py::test_dataset_skeleton_has_quick_block_and_tag -v` 通过
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_scaffold_wiki_page.py::test_dataset_skeleton_passes_lint_metadata_check -v` 通过
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_scaffold_wiki_page.py

https://claude.ai/code/session_017d1UkXEoH4i3EVAmoY8CYy