### PR TITLE
fix(ux): 图谱页适配屏幕按钮图标与筛选区分

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1449,7 +1449,7 @@
       <div class="toolbar-sep"></div>
       <button id="physics-toggle" class="chip" title="力导向参数、布局刷新与时序动画"><span>⚙</span><span> 参数</span></button>
       <div class="toolbar-sep"></div>
-      <button id="fit-to-screen" class="chip" title="适配屏幕"><span>📐</span><span> 适配屏幕</span></button>
+      <button id="fit-to-screen" class="chip" title="适配屏幕"><span>🖥️</span><span> 适配屏幕</span></button>
       <div class="toolbar-sep"></div>
       <a href="index.html" id="graph-back">← 返回首页</a>
     </div>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1449,7 +1449,7 @@
       <div class="toolbar-sep"></div>
       <button id="physics-toggle" class="chip" title="力导向参数、布局刷新与时序动画"><span>⚙</span><span> 参数</span></button>
       <div class="toolbar-sep"></div>
-      <button id="fit-to-screen" class="chip" title="适配屏幕"><span>🔍</span><span> 适配屏幕</span></button>
+      <button id="fit-to-screen" class="chip" title="适配屏幕"><span>📐</span><span> 适配屏幕</span></button>
       <div class="toolbar-sep"></div>
       <a href="index.html" id="graph-back">← 返回首页</a>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 图谱工具栏中「筛选」与「适配屏幕」原先均使用 🔍，视觉含义重复
- 将「适配屏幕」按钮图标改为 🖥️，与筛选的放大镜语义区分

## 验证
- 仅修改 `docs/graph.html` 一处 emoji，无 wiki / 派生文件变更

## 改动
| 按钮 | 改前 | 改后 |
|------|------|------|
| 筛选 | 🔍 | 🔍（不变） |
| 适配屏幕 | 🔍 | 🖥️ |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4c6712d-a641-4370-8728-7a0e516bd43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4c6712d-a641-4370-8728-7a0e516bd43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

