### PR TITLE
style(ux): 图谱「适配屏幕」按钮 emoji 改为四角边框 ⛶

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1449,7 +1449,7 @@
       <div class="toolbar-sep"></div>
       <button id="physics-toggle" class="chip" title="力导向参数、布局刷新与时序动画"><span>⚙</span><span> 参数</span></button>
       <div class="toolbar-sep"></div>
-      <button id="fit-to-screen" class="chip" title="适配屏幕"><span>🖥️</span><span> 适配屏幕</span></button>
+      <button id="fit-to-screen" class="chip" title="适配屏幕"><span>⛶</span><span> 适配屏幕</span></button>
       <div class="toolbar-sep"></div>
       <a href="index.html" id="graph-back">← 返回首页</a>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将 `docs/graph.html` 工具栏「适配屏幕」按钮图标由 🖥️ 改为 ⛶（四角边框 / fit-to-screen 常用符号），语义更贴近「缩放至视口内」而非「桌面显示器」。

## 验证
- 本地 `make export graph` 后 `http://127.0.0.1:8765/graph.html` 渲染正常。
- 桌面视口截图可见工具栏按钮已显示 ⛶ +「适配屏幕」文案。
- 移动端 `scripts/screenshot_graph_mobile_fit_verify.cjs`：点击后 `afterFit.ok=true`，1270 节点均在视口内。

## 验证截图

**桌面工具栏（⛶ 适配屏幕）**

![图谱页桌面视口：适配屏幕按钮显示四角边框 emoji](https://cursor.com/artifacts/c/art-1adfeebd-0efc-4f21-806d-f21ca1385387)

**移动端点击适配屏幕后**

![图谱页移动端：点击适配屏幕后节点缩放进视口](https://cursor.com/artifacts/c/art-d5c050ea-695d-4876-ae48-8b1c46fdf946)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d8e3eeb-6ea1-4e32-8742-546627c20650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8e3eeb-6ea1-4e32-8742-546627c20650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

