### PR TITLE
structural: 明示数据层四段衔接（来源→质量→重定向→策略）

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v25.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v25.md
@@ -34,8 +34,8 @@
 - [x] **训练数据管线知识链 (+2)**：
     - [x] `wiki/queries/humanoid-training-data-pipeline.md`（端到端 Query：原始动作捕捉 / 人体视频 → 重定向 → RL/IL 训练输入的选型决策树，覆盖参考运动来源、重定向方案、训练范式三层的取舍与典型失败模式）。（2026-06-19 完成：三层决策树（来源/重定向/范式）+ Mermaid 流程图 + 端到端 pipeline + 5 条误区 + 缩写速查；来源层接 humanoid-reference-motion-datasets 五集表，质量评估接 motion-data-quality 四轴。）
     - [x] `wiki/concepts/motion-data-quality.md`（动作数据质量维度概念页：物理可行性 / 接触一致性 / 形态差距（morphology gap）/ 规模与多样性四个评估轴，与重定向必要性的因果关系）。（2026-06-19 完成：四轴串联门模型 + 四轴↔重定向必要性因果链 + 五集数据集四轴对照表；并补 motion-retargeting.md 与五集对比页对本页/Query 的入链，无孤儿。）
-- [ ] **数据层专题交叉补强**：
-    - [ ] 在 `wiki/comparisons/humanoid-reference-motion-datasets.md` 与 `wiki/concepts/motion-retargeting.md` 中明示「数据来源 → 质量评估 → 重定向 → 策略输入」的衔接，并与 P1 新页形成双向回链，消除孤儿页。
+- [x] **数据层专题交叉补强**：
+    - [x] 在 `wiki/comparisons/humanoid-reference-motion-datasets.md` 与 `wiki/concepts/motion-retargeting.md` 中明示「数据来源 → 质量评估 → 重定向 → 策略输入」的衔接，并与 P1 新页形成双向回链，消除孤儿页。（2026-06-20 完成：对比页新增「四段衔接」表 + 因果判据段，重定向页新增「上游衔接」表把重定向定位为链路第③段、由 motion-data-quality 四轴的形态差距/接触/物理轴决定触发与补层；两页均显式回链 motion-data-quality 与 humanoid-training-data-pipeline，双向闭环；`make lint` 0 errors。）
 
 ## P2: 事实库与矛盾检测扩展 (Quantity)
 

--- a/log.md
+++ b/log.md
@@ -2132,3 +2132,9 @@
 ## [2026-05-15] structural | schema/search-regression-cases.json — WBC×QP BM25 回归 expected_top_k 3→5（语料扩张后 whole-body-control 概念页常居第 4–5 位）
 
 ## [2026-05-15] ingest | sources/repos/pytorch-official.md — 收录 pytorch.org 与 get-started/docs/tutorials；新建 wiki/entities/pytorch.md；互链深度学习基础、Isaac Lab
+
+## [2026-06-20] structural | checklist-v25 P1 数据层专题交叉补强 —— motion-retargeting 与 humanoid-reference-motion-datasets 明示「数据来源 → 质量评估 → 重定向 → 策略输入」四段衔接
+
+- `wiki/comparisons/humanoid-reference-motion-datasets.md` 新增「四段衔接」表与因果判据段，把五集数据落到①数据来源→②质量评估→③重定向→④策略输入四段，并显式回链 `motion-data-quality.md` 与 `humanoid-training-data-pipeline.md`。
+- `wiki/concepts/motion-retargeting.md` 新增「上游衔接」表，把重定向定位为链路第③段，明示其触发与补层由 motion-data-quality 四轴（形态差距/接触/物理）决定，与 P1 新页形成双向回链、消除孤儿。
+- `make lint` 0 errors（仅 3 条既有信息型预警）；勾选 v25 P1「数据层专题交叉补强」条目。

--- a/wiki/comparisons/humanoid-reference-motion-datasets.md
+++ b/wiki/comparisons/humanoid-reference-motion-datasets.md
@@ -3,7 +3,7 @@ type: comparison
 title: 人形参考运动与操作数据集选型（AMASS / LAFAN1 / OMOMO / PHUMA / Humanoid Everyday）
 tags: [dataset, comparison, motion-retargeting, humanoid, mocap, unitree-g1]
 summary: "五类常用人形数据源的表示、任务域、是否预重定向与典型下游对照，帮助在 tracking、HOI 与真机操作之间选型。"
-updated: 2026-06-16
+updated: 2026-06-20
 status: complete
 related:
   - ../concepts/motion-retargeting.md
@@ -80,6 +80,19 @@ flowchart TD
 2. **交互 loco-manipulation**：OMOMO（+ 自采 MoCap）→ [OmniRetarget](../entities/paper-hrl-stack-03-omniretarget.md) → G1 `qpos` → RL。
 3. **轻量 recovery 原型**：LaFAN1 子集 → 重定向 → 单策略走/跑/起身（见 [SD-AMP](../entities/paper-unified-walk-run-recovery-sdamp.md)）。
 4. **操作策略（非参考轨迹）**：Humanoid Everyday 真机轨迹 → 模仿 / VLA；与 MoCap 库 **互补而非替代**。
+
+## 四段衔接：数据来源 → 质量评估 → 重定向 → 策略输入
+
+本表只解决端到端链路的**第一段（数据来源）**。把视角拉远，一份参考运动要变成 RL/IL 能消费的训练输入，需要顺次过四道关：
+
+| 段 | 视角 | 本表五集如何落位 | 主页面 |
+|----|------|----------------|--------|
+| ① 数据来源 | 选 MoCap / 视频 / 真机执行数据 | 上方对照表与决策树 | 本页 |
+| ② 质量评估 | 物理可行性 / 接触一致性 / 形态差距 / 规模多样性 四轴体检 | AMASS 弱物理、PHUMA 已过滤、Humanoid Everyday 已消除形态差距 | [Motion Data Quality](../concepts/motion-data-quality.md) |
+| ③ 重定向 | 形态差距大则几何映射 + 动力学一致化，差距可忽略则跳过 | AMASS/LaFAN1/OMOMO 必重定向；PHUMA 预重定向；Humanoid Everyday 免重定向 | [Motion Retargeting](../concepts/motion-retargeting.md) |
+| ④ 策略输入 | 喂给 WBT / AMP / IL / VLA 的最终训练数据 | 见对照表「典型下游」行 | [人形训练数据管线选型指南](../queries/humanoid-training-data-pipeline.md) |
+
+> 衔接判据由**第②段**给出：[四质量轴](../concepts/motion-data-quality.md) 按 **形态差距 → 接触 → 物理 → 规模** 顺序体检，决定第③段重定向**要不要做、要补几层**——这也是为什么 PHUMA / Humanoid Everyday 能跳过或简化重定向，而纯光学 MoCap 必须先过物理一致化层。整条链的端到端决策树见 [人形训练数据管线选型指南](../queries/humanoid-training-data-pipeline.md)。
 
 ## 常见误区
 

--- a/wiki/concepts/motion-retargeting.md
+++ b/wiki/concepts/motion-retargeting.md
@@ -3,7 +3,7 @@ title: Motion Retargeting（动作重定向）
 type: concept
 status: complete
 created: 2026-04-14
-updated: 2026-06-19
+updated: 2026-06-20
 summary: 将人类或动物参考动作映射到异构机器人骨架上，在保留运动风格和语义的同时满足机器人的关节限制和动力学约束。
 ---
 
@@ -100,6 +100,21 @@ subject to: FK(θ) = p_target (末端位置约束)
     - **QP 优化 (如 HALO)**：通过约束二次规划，强制满足固定脚位置和地表接触约束，修正 Base 位姿漂移。
     - **RL Fine-tuning**：以重定向轨迹作为参考，通过 RL 在仿真中进行鲁棒性训练。
     - **WBC 跟踪**：将重定向轨迹作为 WBC 的任务目标，由底层控制器实时处理平衡与力矩限制。
+
+---
+
+## 上游衔接：数据来源 → 质量评估 → 重定向 → 策略输入
+
+重定向不是链路的起点。它的**输入由前两段决定，输出喂给第四段**——是否需要重定向、需要补几层，并非由重定向本身决定，而是由**第②段的数据质量体检**给出判据：
+
+| 段 | 视角 | 关键判据 | 主页面 |
+|----|------|---------|--------|
+| ① 数据来源 | 选 MoCap / 视频 / 真机执行数据 | 表示、规模、许可证、是否预重定向 | [人形数据五集选型](../comparisons/humanoid-reference-motion-datasets.md) |
+| ② 质量评估 | 物理可行性 / 接触一致性 / 形态差距 / 规模多样性 四轴 | **形态差距大 → 本页重定向不可省略** | [Motion Data Quality](./motion-data-quality.md) |
+| ③ **重定向（本页）** | 几何映射 + 动力学一致化，把人体参考变成机器人可执行参考 | 接触保真、限位满足、物理可行 | 本页 §「两层架构模式」 |
+| ④ 策略输入 | 物理可行参考 → WBT / AMP / IL 训练数据 | 真机可执行的策略 | [人形训练数据管线选型指南](../queries/humanoid-training-data-pipeline.md) |
+
+> 因果方向：[第②段四质量轴](./motion-data-quality.md) 中的**形态差距**轴直接决定本页是否被触发（差距可忽略时如真机执行数据 [Humanoid Everyday](../entities/humanoid-everyday-dataset.md) 可跳过重定向直接 IL）；**接触一致性 / 物理可行性**两轴则决定本页 §「动力学一致化层」要补 QP / RL 几层。整条链的端到端决策树见 [人形训练数据管线选型指南](../queries/humanoid-training-data-pipeline.md)。
 
 ---
 


### PR DESCRIPTION
## 摘要

在 `motion-retargeting.md` 与 `humanoid-reference-motion-datasets.md` 中新增「衔接」章节，明示参考运动从数据来源到策略训练输入的四段流程，并与 P1 新页（`motion-data-quality.md`、`humanoid-training-data-pipeline.md`）形成双向回链，消除孤儿页。

## 变更类型

- [x] 知识入库（wiki 内容）

## 具体改动

### `wiki/concepts/motion-retargeting.md`
- 新增「上游衔接：数据来源 → 质量评估 → 重定向 → 策略输入」章节
- 用表格明示重定向在链路中的位置（第③段）
- 显式说明触发条件与补层决策由 `motion-data-quality.md` 四轴（形态差距/接触/物理）给出
- 回链 `motion-data-quality.md` 与 `humanoid-training-data-pipeline.md`

### `wiki/comparisons/humanoid-reference-motion-datasets.md`
- 新增「四段衔接」章节，把五集数据集落位到四段流程
- 用表格展示各数据源在四段中的角色（AMASS/LaFAN1/OMOMO 必重定向；PHUMA 预重定向；Humanoid Everyday 免重定向）
- 补充因果判据段，说明第②段质量评估如何决定第③段重定向的必要性与补层深度
- 回链 `motion-data-quality.md` 与 `humanoid-training-data-pipeline.md`

### `log.md`
- 记录本次改动的完成情况

### `docs/checklists/tech-stack-next-phase-checklist-v25.md`
- 勾选「数据层专题交叉补强」条目为完成状态

## 验证

- [x] `make lint` 通过（0 errors，仅 3 条既有信息型预警）
- [x] 所有新增链接指向已存在的页面（`motion-data-quality.md`、`humanoid-training-data-pipeline.md`）
- [x] 表格格式与现有 wiki 风格一致
- [x] 因果关系描述与 P1 新页内容对齐

## 相关 Issue

无

https://claude.ai/code/session_016AiCkg7mxCVjuVExQMs8a1