### PR TITLE
fix(ux): 修复 FOC 推导页 \[...\] 块级公式未渲染

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -458,6 +458,11 @@
         mathTokens.push({ token: token, html: '$$' + expr + '$$' });
         return token;
       })
+      .replace(/\\\[([\s\S]+?)\\\]/g, function (match, expr) {
+        const token = mathPrefix + mathTokens.length + '@@';
+        mathTokens.push({ token: token, html: '\\[' + expr + '\\]' });
+        return token;
+      })
       .replace(/\\\(([\s\S]+?)\\\)/g, function (match, expr) {
         const token = mathPrefix + mathTokens.length + '@@';
         mathTokens.push({ token: token, html: '\\(' + expr + '\\)' });
@@ -555,6 +560,9 @@
     return String(text || '')
       .replace(/\\\((.+?)\\\)/g, function (_, expr) {
         return '<span class="math-inline">\\(' + expr + '\\)</span>';
+      })
+      .replace(/\\\[([\s\S]+?)\\\]/g, function (_, expr) {
+        return '<div class="math-block">\\[' + expr.trim() + '\\]</div>';
       })
       .replace(/\$\$([\s\S]+?)\$\$/g, function (_, expr) {
         return '<div class="math-block">$$' + expr.trim() + '$$</div>';
@@ -1609,6 +1617,7 @@
     window.renderMathInElement(container, {
       delimiters: [
         { left: '$$', right: '$$', display: true },
+        { left: '\\[', right: '\\]', display: true },
         { left: '\\(', right: '\\)', display: false }
       ],
       ignoredTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code', 'option'],

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -345,11 +345,44 @@ console.log('ok');
             "typeof window.renderMathInElement !== 'function'",
             "window.renderMathInElement(container, {",
             "left: '$$', right: '$$', display: true",
+            "left: '\\\\[', right: '\\\\]', display: true",
             "left: '\\\\(', right: '\\\\)', display: false",
             "renderDetailMath(contentEl);",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
+
+    def test_bracket_display_math_gets_block_wrapper(self):
+        """\\[...\\] display math (common in formalization pages) should wrap math-block for KaTeX."""
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('function renderMathBlocks(text)');
+const end = content.indexOf('function applyMathBlocksInHtmlFragment', start);
+eval(content.slice(start, end));
+const sample = '\\[ i_a + i_b + i_c = 0 \\]';
+const out = renderMathBlocks(sample);
+if (!out.includes('class="math-block"')) throw new Error('missing math-block wrapper');
+if (!out.includes('i_a + i_b + i_c = 0')) throw new Error('bracket math content lost');
+const aligned = '\\[ \\begin{aligned} i_d &= i_\\alpha \\\\ i_q &= i_\\beta \\end{aligned} \\]';
+const out2 = renderMathBlocks(aligned);
+if (!out2.includes('class="math-block"')) throw new Error('aligned block missing wrapper');
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
 
     def test_main_js_contains_toc_active_state_and_anchor_copy_hooks(self):
         content = MAIN_JS.read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

`wiki/formalizations/field-oriented-control-derivation.md` 大量使用 `\[...\]` 书写 Clarke/Park 矩阵、aligned 方程组等块级公式，但 detail 页渲染链路此前只识别 `$$...$$` 与 `\(...\)`，导致这些公式以原始 LaTeX 文本显示。

本次在 `docs/main.js` 三处补齐 `\[...\]` 支持：

- `renderInlineMarkdown`：在转义前保护 `\[...\]`（避免 `\begin{aligned}` 内 `&` 被转成 `&amp;`）
- `renderMathBlocks`：将 `\[...\]` 包裹为 `math-block` 蓝框容器
- `renderDetailMath`：为 KaTeX auto-render 增加 `\[` / `\]` 分隔符

## 验证

- `make ci-preflight` 通过
- 本地 `detail.html?id=wiki-formalizations-field-oriented-control-derivation`：KaTeX 渲染 97 个公式（81 行内 + 16 块级），`\[...\]` 矩阵与 aligned 环境正常

## 验证截图

![FOC 推导页步骤 3：Park 变换矩阵与 aligned 公式渲染正常](https://cursor.com/artifacts/c/art-1acbfdd4-2bd1-4f61-b986-fdf8812c4721)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e6560d6-2e01-4b6e-885f-3501bf23620a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e6560d6-2e01-4b6e-885f-3501bf23620a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

