### PR TITLE
fix(ux): 修复缩写速查表中 $ ... $ 内空格导致公式不渲染

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -468,10 +468,12 @@
         mathTokens.push({ token: token, html: '\\(' + expr + '\\)' });
         return token;
       })
-      .replace(/\$([^$\s](?:[^$]*[^$\s])?)\$/g, function (match, expr) {
+      .replace(/\$\s*([^$]+?)\s*\$/g, function (match, expr) {
+        const trimmed = String(expr || '').trim();
+        if (!trimmed) return match;
         const token = mathPrefix + mathTokens.length + '@@';
         // Normalize $...$ to \(...\) so downstream renderMathBlocks can catch it
-        mathTokens.push({ token: token, html: '\\(' + expr + '\\)' });
+        mathTokens.push({ token: token, html: '\\(' + trimmed + '\\)' });
         return token;
       });
 

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -389,6 +389,37 @@ console.log('ok');
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         self.assertIn("ok", result.stdout)
 
+    def test_inline_math_with_padding_spaces_in_table_cells(self):
+        """$ ... $ with spaces inside delimiters (abbrev glossary tables) should render."""
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('const matchHtmlRegExp');
+const end = content.indexOf('function normalizeMathExpr(expr)', start);
+eval(content.slice(start, end));
+const sample = '正向动力学 $ \\tau \\to \\ddot{q} $';
+const out = renderInlineMarkdown(sample, {});
+if (!out.includes('\\tau \\to \\ddot{q}')) throw new Error('math content lost: ' + out);
+if (out.includes('$')) throw new Error('raw dollar delimiters remain: ' + out);
+const tight = renderInlineMarkdown('$\\ddot{q} \\to \\tau$', {});
+if (!tight.includes('\\ddot{q} \\to \\tau')) throw new Error('tight math broken: ' + tight);
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
+
     def test_main_js_contains_toc_active_state_and_anchor_copy_hooks(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         expected_snippets = [

--- a/wiki/entities/quadruped-control-curriculum.md
+++ b/wiki/entities/quadruped-control-curriculum.md
@@ -26,8 +26,8 @@ summary: "四足控制 L0 策展：具身智能研究室《从动力学建模到
 | 缩写 | 英文全称 | 简要说明 |
 |------|----------|----------|
 | URDF | Unified Robot Description Format | 机器人连杆/关节/惯量描述格式 |
-| ABA | Articulated Body Algorithm | 正向动力学 $ \tau \to \ddot{q} $ |
-| RNEA | Recursive Newton–Euler Algorithm | 逆动力学 $ \ddot{q} \to \tau $ |
+| ABA | Articulated Body Algorithm | 正向动力学 $\tau \to \ddot{q}$ |
+| RNEA | Recursive Newton–Euler Algorithm | 逆动力学 $\ddot{q} \to \tau$ |
 | PPO | Proximal Policy Optimization | 四足 loco 主流 on-policy 算法 |
 | DR | Domain Randomization | 训练时随机化物理参数以提升迁移 |
 | RMA | Rapid Motor Adaptation | 特权教师 → 可部署学生的蒸馏范式 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

[四足控制学习策展](https://imchong.github.io/Robotics_Notebooks/detail.html?id=entity-quadruped-control-curriculum) 页「英文缩写速查」表中 ABA / RNEA 行的 `$ \tau \to \ddot{q} $` 等公式未走 KaTeX 渲染，页面上显示为原始 `$...$` 文本。

**根因：** `docs/main.js` 的 `renderInlineMarkdown` 内联公式正则要求 `$` 与内容之间不能有空格，而缩写速查表写法为 `$ \tau \to \ddot{q} $`。

**修复：**
- 放宽 `$...$` 匹配，允许分隔符内侧可选空白并 `trim` 表达式后再转 `\(...\)`
- 同步收紧 `quadruped-control-curriculum.md` 中 ABA/RNEA 两行的公式写法（去掉多余空格）
- 新增回归测试 `test_inline_math_with_padding_spaces_in_table_cells`

## 验证

- `make ci-preflight` 通过
- `pytest tests/test_content_sync.py::DetailContentSyncTests::test_inline_math_with_padding_spaces_in_table_cells` 通过
- 本地静态站 `detail.html?id=entity-quadruped-control-curriculum` 缩写速查表公式渲染正常

## 验证截图

![四足控制学习策展详情页缩写速查表公式渲染](https://cursor.com/artifacts/c/art-e190b252-6604-485e-8385-5c9ca71ca15e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7e83bbc-272f-40c6-acc1-36052b63d9f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7e83bbc-272f-40c6-acc1-36052b63d9f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

