### PR TITLE
feat(ux): 移除首页搜索栏机构筛选下拉

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -68,9 +68,6 @@
           <select id="wikiCommunityFilter" aria-label="按社区过滤">
             <option value="">全部社区</option>
           </select>
-          <select id="wikiInstitutionFilter" aria-label="按研究机构过滤">
-            <option value="">全部机构</option>
-          </select>
         </div>
         <div id="wikiTagCloud" class="tag-cloud" aria-label="热门标签"></div>
         <div id="wikiSearchResults" class="card-grid" aria-live="polite"></div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2840,8 +2840,8 @@
       (gd.institutions || []).forEach(function (it) { labelById[it.id] = it.label; });
       var html = ids.map(function (id) {
         var label = labelById[id] || id;
-        return '<a class="detail-meta-badge" href="index.html?institution=' + encodeURIComponent(id) +
-          '#wiki-search" title="在首页筛选「' + escapeHtml(label) + '」相关页面">' +
+        return '<a class="detail-meta-badge" href="index.html?q=' + encodeURIComponent(label) +
+          '#wiki-search" title="在首页搜索「' + escapeHtml(label) + '」相关页面">' +
           '<span>🏛️</span><span>' + escapeHtml(label) + '</span></a>';
       }).join('');
       renderDetailMetaItemRow(instRowId, '所属机构', html);
@@ -4223,7 +4223,6 @@
   var searchInput = document.getElementById('wikiSearchInput');
   var searchResults = document.getElementById('wikiSearchResults');
   var communityFilter = document.getElementById('wikiCommunityFilter');
-  var institutionFilter = document.getElementById('wikiInstitutionFilter');
   var tagCloudEl = document.getElementById('wikiTagCloud');
   if (searchInput && searchResults) {
     var _indexData = null;
@@ -4236,10 +4235,6 @@
     var _communityByPath = null;
     var _communityByPathPromise = null;
     var _communitySelectPopulated = false;
-
-    // 研究机构筛选与社区筛选共用 link-graph.json：一次 fetch 同时构建两套映射。
-    var _institutionByPath = null;
-    var _institutionSelectPopulated = false;
 
     function populateCommunitySelect(communities) {
       if (!communityFilter || _communitySelectPopulated) return;
@@ -4267,30 +4262,6 @@
       }
     }
 
-    function populateInstitutionSelect(institutions) {
-      if (!institutionFilter || _institutionSelectPopulated) return;
-      _institutionSelectPopulated = true;
-      var preserved = institutionFilter.value;
-      var opts = ['<option value="">全部机构</option>'];
-      var sorted = (institutions || []).slice().sort(function (a, b) {
-        return (b.size || 0) - (a.size || 0);
-      });
-      for (var ii = 0; ii < sorted.length; ii++) {
-        var inst = sorted[ii];
-        if (!inst || !inst.id) continue;
-        var label = inst.label || inst.id;
-        if (inst.size != null) label += ' (' + inst.size + ')';
-        opts.push(
-          '<option value="' + escapeHtml(inst.id) + '">' + escapeHtml(label) + '</option>'
-        );
-      }
-      institutionFilter.innerHTML = opts.join('');
-      if (preserved) {
-        institutionFilter.value = preserved;
-        if (institutionFilter.value !== preserved) institutionFilter.value = '';
-      }
-    }
-
     function ensureCommunityByPath() {
       if (_communityByPath) return Promise.resolve(_communityByPath);
       if (_communityByPathPromise) return _communityByPathPromise;
@@ -4301,23 +4272,18 @@
         })
         .then(function(data) {
           var m = new Map();
-          var inst = new Map();
           var nodes = data.nodes || [];
           for (var ni = 0; ni < nodes.length; ni++) {
             var node = nodes[ni];
             if (!node.id) continue;
             if (node.community) m.set(node.id, node.community);
-            if (node.institutions && node.institutions.length) inst.set(node.id, node.institutions);
           }
           _communityByPath = m;
-          _institutionByPath = inst;
           populateCommunitySelect(data.communities || []);
-          populateInstitutionSelect(data.institutions || []);
           return m;
         })
         .catch(function() {
           _communityByPath = new Map();
-          _institutionByPath = new Map();
           return _communityByPath;
         });
       return _communityByPathPromise;
@@ -4606,8 +4572,7 @@
       _selectedIndex = -1;
       var q = query.trim();
       var communityVal = communityFilter ? communityFilter.value : '';
-      var institutionVal = institutionFilter ? institutionFilter.value : '';
-      if (!q && !communityVal && !institutionVal) { renderEmptyState(); return; }
+      if (!q && !communityVal) { renderEmptyState(); return; }
       searchResults.innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1">加载离线搜索索引中…</p>';
       Promise.all([ensureSearchIndex(), ensureCommunityByPath()])
         .then(function(results) {
@@ -4627,17 +4592,12 @@
 
           // ⚡ Bolt Optimization: Single-pass search filtering
           // Expected impact: Eliminates redundant `substringScore` and `.map()` iterations, reducing search CPU time by ~40% for large indexes.
-          var institutionMap = _institutionByPath || new Map();
           var matched = [];
           for (var i = 0; i < docs.length; i++) {
             var doc = docs[i];
             if (communityVal) {
               var docCommunity = communityMap.get(doc.path);
               if (docCommunity !== communityVal) continue;
-            }
-            if (institutionVal) {
-              var docInst = institutionMap.get(doc.path);
-              if (!docInst || docInst.indexOf(institutionVal) < 0) continue;
             }
 
             var partial = 0;
@@ -4673,7 +4633,7 @@
             return String(a.title || '').localeCompare(String(b.title || ''));
           }).slice(0, 10);
           if (!matched.length) {
-            if ((communityVal || institutionVal) && !q) {
+            if (communityVal && !q) {
               searchResults.innerHTML = '<div style="grid-column:1/-1;color:var(--text-muted)">'
                 + '<p>当前筛选条件下暂无索引条目，或数据仍在加载。</p></div>';
             } else {
@@ -4715,7 +4675,6 @@
         searchResults.innerHTML = '';
         _selectedIndex = -1;
         if (communityFilter) communityFilter.value = '';
-        if (institutionFilter) institutionFilter.value = '';
       }
     });
 
@@ -4742,20 +4701,13 @@
       communityFilter.addEventListener('change', triggerSearch);
       ensureCommunityByPath();
     }
-    if (institutionFilter) {
-      institutionFilter.addEventListener('change', triggerSearch);
-      // 从详情页「所属机构」徽标跳入：?institution=<id> 预选机构筛选并展示结果。
-      var _instParam = new URLSearchParams(window.location.search).get('institution');
-      if (_instParam) {
-        ensureCommunityByPath().then(function () {
-          institutionFilter.value = _instParam;
-          if (institutionFilter.value === _instParam) {
-            triggerSearch();
-            var sec = document.getElementById('wiki-search');
-            if (sec) sec.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          }
-        });
-      }
+
+    var _qParam = new URLSearchParams(window.location.search).get('q');
+    if (_qParam) {
+      searchInput.value = _qParam;
+      triggerSearch();
+      var searchSec = document.getElementById('wiki-search');
+      if (searchSec) searchSec.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
 
     searchResults.addEventListener('click', function(e) {
@@ -4786,7 +4738,6 @@
       if (term && searchInput) {
         searchInput.value = term;
         if (communityFilter) communityFilter.value = '';
-        if (institutionFilter) institutionFilter.value = '';
         triggerSearch();
         searchInput.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1680,8 +1680,7 @@ body.sponsor-dialog-open {
     padding: 12px 12px;
     font-size: 1rem;
   }
-  #wikiCommunityFilter,
-  #wikiInstitutionFilter {
+  #wikiCommunityFilter {
     padding: 10px 8px;
     font-size: 0.78rem;
     background-position: right 6px center;
@@ -1710,9 +1709,8 @@ body.sponsor-dialog-open {
   color: var(--text);
   outline: none;
 }
-/* 社区 / 研究机构筛选下拉各占搜索栏约 1/4，过长文案省略 */
-#wikiCommunityFilter,
-#wikiInstitutionFilter {
+/* 社区筛选下拉占搜索栏约 1/4，过长文案省略 */
+#wikiCommunityFilter {
   flex: 0 1 26%;
   width: 26%;
   max-width: 26%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 从首页 `docs/index.html` 搜索栏移除「全部机构」研究机构筛选下拉框，仅保留搜索输入与社区筛选。
- 清理 `docs/main.js` 中机构筛选相关逻辑（下拉填充、link-graph 机构映射、筛选条件与 `?institution=` URL 预选）。
- 更新 `docs/style.css`，社区下拉样式不再与机构下拉共用选择器。
- 详情页「所属机构」徽标改为跳转 `index.html?q=<机构名>#wiki-search`，用关键词搜索替代机构筛选。

## 验证
- `npm run lint:js` 通过
- 本地静态站首页搜索区仅显示搜索框 + 社区下拉

## 验证截图
![首页搜索栏已移除机构筛选下拉](https://cursor.com/artifacts/c/art-77c3a687-ccd4-430f-8773-32baa9753e26)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cc6a701-9856-4ee9-b48c-9cf997d255b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cc6a701-9856-4ee9-b48c-9cf997d255b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

