### PR TITLE
feat(ux): 图谱研究机构改为按机构着色模式

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1103,17 +1103,6 @@
       scrollbar-width: thin;
       scrollbar-color: rgba(255,255,255,0.28) transparent;
     }
-    /* 研究机构筛选列表：独立于着色维度，限高滚动，避免面板过长 */
-    .filter-institution-list {
-      display: flex;
-      flex-direction: column;
-      gap: 1px;
-      max-height: 220px;
-      overflow-y: auto;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255,255,255,0.28) transparent;
-      padding: 4px 0 8px;
-    }
     .filter-body::-webkit-scrollbar {
       width: 8px;
     }
@@ -1563,16 +1552,10 @@
           <button class="filter-topic-chip" type="button" data-topic="data-pipeline" title="训练数据管线"><span>📦</span><span>训练数据</span></button>
         </div>
       </details>
-      <details class="filter-topic-section" id="filter-institution-section">
-        <summary class="filter-topic-summary">
-          <span class="filter-topic-summary-label">研究机构</span>
-          <span class="filter-topic-summary-current" id="filter-institution-current"><span>🏛️</span><span>全部</span></span>
-        </summary>
-        <div class="filter-institution-list" id="filter-institution-list"></div>
-      </details>
       <div class="filter-mode-tabs" id="filter-mode-tabs" aria-label="筛选维度">
         <button id="filter-mode-type" class="chip" type="button">按类型</button>
         <button id="filter-mode-community" class="chip active" type="button">按社区</button>
+        <button id="filter-mode-institution" class="chip" type="button">按机构</button>
         <button id="filter-mode-health" class="chip" type="button">按健康度</button>
       </div>
       <div class="filter-subtitle" id="filter-subtitle">当前按社区着色与筛选</div>
@@ -1731,6 +1714,7 @@
     const filterSubtitle = document.getElementById('filter-subtitle');
     const filterModeTypeBtn = document.getElementById('filter-mode-type');
     const filterModeCommunityBtn = document.getElementById('filter-mode-community');
+    const filterModeInstitutionBtn = document.getElementById('filter-mode-institution');
     const filterModeHealthBtn = document.getElementById('filter-mode-health');
     const filterPanelBody = document.getElementById('filter-panel-body');
     const filterPanelScrim = document.getElementById('filter-panel-scrim');
@@ -1843,62 +1827,32 @@
       });
     }
 
+    function formatInstitutionOptionLabel(institutionId) {
+      const meta = institutionMetaMap.get(institutionId);
+      const label = institutionLabelMap.get(institutionId) || institutionId;
+      if (!meta || meta.size == null) return label;
+      return label + ' (' + meta.size + ')';
+    }
+
     function nodeInstitutions(d) {
       return Array.isArray(d.institutions) ? d.institutions : [];
     }
 
-    // 研究机构筛选：独立于着色维度的过滤面（与「专题视图」同类），多选；命中任一
-    // 所选机构即保留，着色仍由 colorMode 决定（社区/类型/健康度），不改图例配色。
-    const activeInstitutions = new Set();
-
-    function nodeMatchesInstitutionFilter(d) {
-      if (!activeInstitutions.size) return true;
-      return nodeInstitutions(d).some((id) => activeInstitutions.has(id));
-    }
-
-    function updateInstitutionFilterSummary() {
-      const cur = document.getElementById('filter-institution-current');
-      if (!cur) return;
-      const n = activeInstitutions.size;
-      cur.innerHTML = '<span>🏛️</span><span>' + (n ? n + ' 个机构' : '全部') + '</span>';
-    }
-
-    function renderInstitutionFilterSection() {
-      const listEl = document.getElementById('filter-institution-list');
-      if (!listEl) return;
-      const insts = getSortedInstitutions();
-      if (!insts.length) {
-        listEl.innerHTML = '<div class="filter-empty">暂无机构数据</div>';
-        updateInstitutionFilterSummary();
-        return;
-      }
-      listEl.innerHTML = insts.map((inst) => {
-        const checked = activeInstitutions.has(inst.id) ? ' checked' : '';
-        const color = institutionColorMap.get(inst.id) || COMMUNITY_COLORS[9];
-        const countBadge = inst.size != null
-          ? '<span class="filter-count-badge">' + escapeHtml(String(inst.size)) + '</span>'
-          : '';
-        return '<label class="filter-item">'
-          + '<input type="checkbox" data-institution-filter value="' + escapeHtml(inst.id) + '"' + checked + ' /> '
-          + '<span class="filter-dot" style="background:' + escapeHtml(color) + '"></span>'
-          + '<span class="filter-item-label">' + escapeHtml(institutionLabelMap.get(inst.id) || inst.id) + '</span>'
-          + countBadge
-          + '</label>';
-      }).join('');
-      listEl.querySelectorAll('input[data-institution-filter]').forEach((cb) => {
-        cb.addEventListener('change', () => {
-          if (areFiltersLocked()) return;
-          if (cb.checked) activeInstitutions.add(cb.value);
-          else activeInstitutions.delete(cb.value);
-          applyFilters();
-          updateFilterCount();
-          updateInstitutionFilterSummary();
-        });
-      });
-      updateInstitutionFilterSummary();
+    /** 多机构节点取规模最大的机构作为主色/磁吸簇（与社区单值维度对齐） */
+    function primaryInstitution(d) {
+      const insts = nodeInstitutions(d);
+      if (!insts.length) return null;
+      return insts.slice().sort((a, b) => {
+        const sa = institutionMetaMap.get(a)?.size || 0;
+        const sb = institutionMetaMap.get(b)?.size || 0;
+        if (sb !== sa) return sb - sa;
+        return String(institutionLabelMap.get(a) || a).localeCompare(
+          String(institutionLabelMap.get(b) || b), 'zh-CN');
+      })[0];
     }
 
     let focusedCommunityId = null;
+    let focusedInstitutionId = null;
     let focusedType = null;
     let focusedHealth = null;
 
@@ -1970,6 +1924,10 @@
       if (colorMode === 'community') {
         return communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
       }
+      if (colorMode === 'institution') {
+        const instId = primaryInstitution(d);
+        return instId ? (institutionColorMap.get(instId) || COMMUNITY_COLORS[9]) : '#94a3b8';
+      }
       if (colorMode === 'health') {
         return HEALTH_COLORS[d.health_score != null ? Math.min(d.health_score, 3) : 0];
       }
@@ -2000,6 +1958,20 @@
             ? `<span class="legend-count">${escapeHtml(String(community.size))}</span>`
             : '';
           rows.push(`<div class="legend-row ${isActive ? 'active' : ''}" data-community-id="${escapeHtml(String(communityId))}">
+            <div class="legend-dot" style="background:${escapeHtml(String(color))}"></div><span class="legend-label-text">${escapeHtml(String(label))}</span>${countHtml}
+          </div>`);
+        }
+      } else if (colorMode === 'institution') {
+        rows.push('<div class="legend-title">按机构着色</div>');
+        for (const inst of getSortedInstitutions()) {
+          const instId = inst.id;
+          const label = institutionLabelMap.get(instId) || inst.label || instId;
+          const color = institutionColorMap.get(instId) || COMMUNITY_COLORS[9];
+          const isActive = (focusedInstitutionId === instId);
+          const countHtml = inst.size != null
+            ? `<span class="legend-count">${escapeHtml(String(inst.size))}</span>`
+            : '';
+          rows.push(`<div class="legend-row ${isActive ? 'active' : ''}" data-institution-id="${escapeHtml(String(instId))}">
             <div class="legend-dot" style="background:${escapeHtml(String(color))}"></div><span class="legend-label-text">${escapeHtml(String(label))}</span>${countHtml}
           </div>`);
         }
@@ -2039,6 +2011,7 @@
       if (graphLegendFab) {
         const fabLabels = {
           community: '按社区着色',
+          institution: '按机构着色',
           health: '按健康度着色',
           type: '按类型着色',
         };
@@ -2070,7 +2043,6 @@
 
     initCommunityMapsFromGraph();
     initInstitutionMapsFromGraph();
-    renderInstitutionFilterSection();
     renderLegend();
 
     /* ── 计算节点度数 ── */
@@ -2235,10 +2207,15 @@
       simulation.force('charge').strength(chargeStrength);
       
       if (isMagnetic) {
-        const categories = (colorMode === 'community') 
-          ? Array.from(communityLabelMap.keys())
-          : Array.from(new Set(nodes.map(n => n.type)));
-          
+        let categories;
+        if (colorMode === 'community') {
+          categories = Array.from(communityLabelMap.keys());
+        } else if (colorMode === 'institution') {
+          categories = Array.from(institutionLabelMap.keys());
+        } else {
+          categories = Array.from(new Set(nodes.map(n => n.type)));
+        }
+
         const angleStep = (2 * Math.PI) / (categories.length || 1);
         const radius = Math.min(W, H) * 0.25;
         const centers = {};
@@ -2249,14 +2226,13 @@
           };
         });
 
-        const getTargetX = d => {
-          const key = (colorMode === 'community') ? d.community : d.type;
-          return centers[key]?.x || W/2;
+        const getClusterKey = d => {
+          if (colorMode === 'community') return d.community;
+          if (colorMode === 'institution') return primaryInstitution(d);
+          return d.type;
         };
-        const getTargetY = d => {
-          const key = (colorMode === 'community') ? d.community : d.type;
-          return centers[key]?.y || H/2;
-        };
+        const getTargetX = d => centers[getClusterKey(d)]?.x || W/2;
+        const getTargetY = d => centers[getClusterKey(d)]?.y || H/2;
 
         simulation.force('x', d3.forceX(getTargetX).strength(0.18));
         simulation.force('y', d3.forceY(getTargetY).strength(0.18));
@@ -2328,6 +2304,13 @@
           color: communityColorMap.get(community.id) || COMMUNITY_COLORS[9]
         }));
       }
+      if (colorMode === 'institution') {
+        return getSortedInstitutions().map((inst) => ({
+          value: inst.id,
+          label: formatInstitutionOptionLabel(inst.id),
+          color: institutionColorMap.get(inst.id) || COMMUNITY_COLORS[9]
+        }));
+      }
       if (colorMode === 'health') {
         return HEALTH_FILTER_OPTIONS;
       }
@@ -2336,6 +2319,7 @@
 
     function getColorModeLabel(mode) {
       if (mode === 'community') return '按社区';
+      if (mode === 'institution') return '按机构';
       if (mode === 'health') return '按健康度';
       return '按类型';
     }
@@ -2348,6 +2332,7 @@
       if (filterSubtitle) filterSubtitle.textContent = '当前' + getColorModeLabel(colorMode) + '着色与筛选';
       if (filterModeTypeBtn) filterModeTypeBtn.classList.toggle('active', colorMode === 'type');
       if (filterModeCommunityBtn) filterModeCommunityBtn.classList.toggle('active', colorMode === 'community');
+      if (filterModeInstitutionBtn) filterModeInstitutionBtn.classList.toggle('active', colorMode === 'institution');
       if (filterModeHealthBtn) filterModeHealthBtn.classList.toggle('active', colorMode === 'health');
       if (!filterPanelBody) return;
       const options = getFilterOptions();
@@ -2358,7 +2343,8 @@
           '<div class="filter-section-title">' + escapeHtml(getColorModeLabel(colorMode)) + '筛选</div>'
           + options.map(option => {
               const checked = activeFilters.has(option.value) ? ' checked' : '';
-              const meta = colorMode === 'community' ? communityMetaMap.get(option.value) : null;
+              const meta = colorMode === 'community' ? communityMetaMap.get(option.value)
+                : colorMode === 'institution' ? institutionMetaMap.get(option.value) : null;
               const countBadge = meta && meta.size != null
                 ? '<span class="filter-count-badge">' + escapeHtml(String(meta.size)) + '</span>'
                 : '';
@@ -2400,6 +2386,7 @@
       colorMode = mode;
       activeFilters.clear();
       focusedCommunityId = null;
+      focusedInstitutionId = null;
       focusedType = null;
       focusedHealth = null;
       updateFilterCount();
@@ -2410,6 +2397,7 @@
 
     if (filterModeTypeBtn) filterModeTypeBtn.addEventListener('click', () => setColorMode('type'));
     if (filterModeCommunityBtn) filterModeCommunityBtn.addEventListener('click', () => setColorMode('community'));
+    if (filterModeInstitutionBtn) filterModeInstitutionBtn.addEventListener('click', () => setColorMode('institution'));
     if (filterModeHealthBtn) filterModeHealthBtn.addEventListener('click', () => setColorMode('health'));
 
     function syncGraphDomFromSimulation() {
@@ -2578,8 +2566,8 @@
 
     function hasActiveGraphFilter() {
       return topDegreeIds !== null || activeFilters.size > 0 || searchQuery.length > 0
-        || focusedCommunityId || focusedType || focusedHealth !== null
-        || activeInstitutions.size > 0 || currentTopic !== 'all';
+        || focusedCommunityId || focusedInstitutionId || focusedType || focusedHealth !== null
+        || currentTopic !== 'all';
     }
 
     function edgeNodeId(endpoint) {
@@ -2870,15 +2858,30 @@
       if (!row) return;
 
       const cid = row.getAttribute('data-community-id');
+      const iid = row.getAttribute('data-institution-id');
       const type = row.getAttribute('data-type');
       const health = row.getAttribute('data-health');
 
       if (cid) {
         focusedCommunityId = (focusedCommunityId === cid) ? null : cid;
+        focusedInstitutionId = null;
+        focusedType = null;
+        focusedHealth = null;
+      } else if (iid) {
+        focusedInstitutionId = (focusedInstitutionId === iid) ? null : iid;
+        focusedCommunityId = null;
+        focusedType = null;
+        focusedHealth = null;
       } else if (type) {
         focusedType = (focusedType === type) ? null : type;
+        focusedCommunityId = null;
+        focusedInstitutionId = null;
+        focusedHealth = null;
       } else if (health !== null) {
         focusedHealth = (focusedHealth === health) ? null : health;
+        focusedCommunityId = null;
+        focusedInstitutionId = null;
+        focusedType = null;
       } else {
         return;
       }
@@ -2894,19 +2897,23 @@
     document.getElementById('filter-clear').addEventListener('click', () => {
       if (areFiltersLocked()) return;
       activeFilters.clear();
-      activeInstitutions.clear();
       topDegreeLimit = totalNodeCount;
       topDegreeIds = null;
+      focusedCommunityId = null;
+      focusedInstitutionId = null;
+      focusedType = null;
+      focusedHealth = null;
       initDegreeTopSlider();
       renderFilterPanel();
-      renderInstitutionFilterSection();
       setActiveTopic('all');
     });
     renderFilterPanel();
 
     /* ── checkbox 筛选 ── */
     function updateFilterCount() {
-      const count = activeFilters.size + activeInstitutions.size + (topDegreeIds ? 1 : 0) + (currentTopic && currentTopic !== 'all' ? 1 : 0);
+      const count = activeFilters.size + (topDegreeIds ? 1 : 0) + (currentTopic && currentTopic !== 'all' ? 1 : 0)
+        + (focusedCommunityId ? 1 : 0) + (focusedInstitutionId ? 1 : 0)
+        + (focusedType ? 1 : 0) + (focusedHealth !== null ? 1 : 0);
       const countEl = document.getElementById('filter-count');
       if (count > 0) {
         countEl.textContent = count;
@@ -2957,11 +2964,15 @@
 
     function nodeMatchesCurrentFilter(d) {
       if (focusedCommunityId) return d.community === focusedCommunityId;
+      if (focusedInstitutionId) return nodeInstitutions(d).includes(focusedInstitutionId);
       if (focusedType) return d.type === focusedType;
       if (focusedHealth !== null) return String(d.health_score != null ? d.health_score : 0) === focusedHealth;
       if (!activeFilters.size) return true;
       if (colorMode === 'community') {
         return activeFilters.has(d.community);
+      }
+      if (colorMode === 'institution') {
+        return nodeInstitutions(d).some((id) => activeFilters.has(id));
       }
       if (colorMode === 'health') {
         return activeFilters.has(String(d.health_score != null ? d.health_score : 0));
@@ -2971,11 +2982,15 @@
 
     function edgeMatchesCurrentFilter(n) {
       if (focusedCommunityId) return n.community === focusedCommunityId;
+      if (focusedInstitutionId) return nodeInstitutions(n).includes(focusedInstitutionId);
       if (focusedType) return n.type === focusedType;
       if (focusedHealth !== null) return String(n.health_score != null ? n.health_score : 0) === focusedHealth;
       if (!activeFilters.size) return true;
       if (colorMode === 'community') {
         return activeFilters.has(n.community);
+      }
+      if (colorMode === 'institution') {
+        return nodeInstitutions(n).some((id) => activeFilters.has(id));
       }
       if (colorMode === 'health') {
         return activeFilters.has(String(n.health_score != null ? n.health_score : 0));
@@ -2997,7 +3012,7 @@
 
       node.each(function(d) {
         const ok = nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
-          && nodeMatchesSearch(d) && nodeMatchesTopic(d) && nodeMatchesInstitutionFilter(d);
+          && nodeMatchesSearch(d) && nodeMatchesTopic(d);
         if (ok) { visible++; visibleNodeIds.add(d.id); }
 
         // V21 修复：显式重置节点整体 opacity (移除 openSidebar 可能留下的残留)
@@ -3030,8 +3045,8 @@
           const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
           if (!s || !t) return 0.2;
           return (nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
-                  && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s) && nodeMatchesInstitutionFilter(s)
-                  && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t) && nodeMatchesInstitutionFilter(t)) ? 1 : 0.2;
+                  && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s)
+                  && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t)) ? 1 : 0.2;
         })
         .attr('stroke-width', e => {
           if (!hasFilter) return linkWidthBase;
@@ -3039,8 +3054,8 @@
           const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
           if (!s || !t) return linkWidthBase * 0.5;
           const edgeOk = nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
-            && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s) && nodeMatchesInstitutionFilter(s)
-            && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t) && nodeMatchesInstitutionFilter(t);
+            && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s)
+            && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t);
           return edgeOk ? linkWidthBase : linkWidthBase * 0.5;
         });
       updateCount(visible);
@@ -3839,6 +3854,7 @@
        与图例点击同源（focusedCommunityId），布局稳定后框定该社区可见节点 */
     const communityParam = new URLSearchParams(location.search).get('community');
     if (communityParam && communityMetaMap.has(communityParam)) {
+      setColorMode('community');
       focusedCommunityId = communityParam;
       renderLegend();
       renderFilterPanel();
@@ -3847,6 +3863,20 @@
       const fitFocusedCommunity = () => fitToVisibleNodes();
       simulation.on('end.community', () => { fitFocusedCommunity(); simulation.on('end.community', null); });
       setTimeout(fitFocusedCommunity, 1400);
+    }
+
+    /* ?institution=<id> URL 参数：从详情页"所属机构"徽标跳入时聚焦该机构 */
+    const institutionParam = new URLSearchParams(location.search).get('institution');
+    if (institutionParam && institutionMetaMap.has(institutionParam)) {
+      setColorMode('institution');
+      focusedInstitutionId = institutionParam;
+      renderLegend();
+      renderFilterPanel();
+      applyFilters();
+      updateFilterCount();
+      const fitFocusedInstitution = () => fitToVisibleNodes();
+      simulation.on('end.institution', () => { fitFocusedInstitution(); simulation.on('end.institution', null); });
+      setTimeout(fitFocusedInstitution, 1400);
     }
 
     const focusId = new URLSearchParams(location.search).get('focus');

--- a/docs/main.js
+++ b/docs/main.js
@@ -2840,8 +2840,8 @@
       (gd.institutions || []).forEach(function (it) { labelById[it.id] = it.label; });
       var html = ids.map(function (id) {
         var label = labelById[id] || id;
-        return '<a class="detail-meta-badge" href="index.html?institution=' + encodeURIComponent(id) +
-          '#wiki-search" title="在首页筛选「' + escapeHtml(label) + '」相关页面">' +
+        return '<a class="detail-meta-badge" href="graph.html?institution=' + encodeURIComponent(id) +
+          '" title="在知识图谱中查看「' + escapeHtml(label) + '」机构视图">' +
           '<span>🏛️</span><span>' + escapeHtml(label) + '</span></a>';
       }).join('');
       renderDetailMetaItemRow(instRowId, '所属机构', html);

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-23] structural | schema/institutions.json + scripts/generate_link_graph.py — 扩展机构派生（tag 连字符拆分、entity 路径/sources/URL）并为 159 个 wiki 页补全 frontmatter institutions
+
+- 派生增强：`derive_node_institutions` 支持 `unitree-go2` 等连字符 tag、entity 页路径/标题/sources/主链 URL
+- 批量写入：`scripts/bump_wiki_institutions.py` → 159 个 `wiki/...` 页新增 `institutions:`（图谱节点 80→159）
+- 相关页面：见 `python3 scripts/bump_wiki_institutions.py --dry-run` 输出列表；图谱按机构着色见 `docs/graph.html`
+
 ## [2026-06-23] ingest | sources/sites/nvidia-research-gear-lab.md — NVIDIA GEAR Lab 主页；升格 wiki/entities/nvidia-gear-lab.md 并交叉 EgoScale/ENPIRE/SONIC/GR00T-WBC
 
 ## [2026-06-23] ingest | sources/papers/vesta_arxiv_2606_20905.md — Vesta 通才具身 planner；升格 wiki/entities/paper-vesta-generalist-embodied-reasoning.md 并交叉更新 vla / VLN / SayCan

--- a/schema/institutions.json
+++ b/schema/institutions.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "研究机构注册表（单一事实源）。generate_link_graph.py 据此从每个 wiki 节点的 frontmatter tags 派生「所属机构」，页面也可用 frontmatter `institutions: [..]` 显式覆盖。aliases 为精确匹配的 tag token（小写），不做子串匹配以避免误命中。新增机构在此追加即可，无需改前端。",
+  "_doc": "研究机构注册表（单一事实源）。generate_link_graph.py 据此从每个 wiki 节点的 frontmatter tags / institutions 派生「所属机构」；页面可用 frontmatter `institutions: [..]` 显式覆盖。aliases 为精确匹配的 tag token（小写），tag 连字符可拆分（如 unitree-go2→unitree）；entity 页另从路径/标题、sources 路径与主链 URL 派生。新增机构在此追加即可，无需改前端。",
   "registry": {
     "nvidia": { "label": "NVIDIA", "aliases": ["nvidia", "gear"] },
     "google-deepmind": { "label": "Google DeepMind", "aliases": ["deepmind", "google-deepmind"] },

--- a/scripts/bump_wiki_institutions.py
+++ b/scripts/bump_wiki_institutions.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""为可派生机构的 wiki 页写入 frontmatter `institutions:`。
+
+复用 generate_link_graph.derive_node_institutions 的完整派生规则；仅当派生结果
+超出当前 tags/显式 institutions 覆盖范围时才写入，且尊重非空显式 institutions 覆盖。
+
+用法：
+  python3 scripts/bump_wiki_institutions.py
+  python3 scripts/bump_wiki_institutions.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WIKI_DIR = REPO_ROOT / "wiki"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import generate_link_graph as glg  # noqa: E402
+
+
+def _format_institutions_yaml(institutions: list[str]) -> str:
+    if len(institutions) == 1:
+        return f"institutions: [{institutions[0]}]"
+    lines = ["institutions:"]
+    lines.extend(f"  - {inst_id}" for inst_id in institutions)
+    return "\n".join(lines)
+
+
+def bump_institutions(path: Path, dry_run: bool = False) -> bool:
+    content = path.read_text(encoding="utf-8")
+    page_id = str(path.relative_to(REPO_ROOT))
+    explicit = glg.parse_frontmatter_list(content, "institutions")
+    if explicit:
+        return False
+
+    derived = glg.derive_node_institutions(content, page_id=page_id)
+    if not derived:
+        return False
+
+    fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not fm_match:
+        return False
+
+    fm_block = fm_match.group(1).rstrip()
+    inst_yaml = _format_institutions_yaml(derived)
+    new_fm = fm_block + f"\n{inst_yaml}\n"
+    new_content = f"---\n{new_fm}\n---" + content[fm_match.end() :]
+    if new_content == content:
+        return False
+    if not dry_run:
+        path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="为 wiki 页补全 frontmatter institutions")
+    parser.add_argument("--dry-run", action="store_true", help="只打印将修改的页面")
+    args = parser.parse_args()
+
+    changed: list[str] = []
+    for page in sorted(WIKI_DIR.rglob("*.md")):
+        if page.name == "README.md":
+            continue
+        if bump_institutions(page, dry_run=args.dry_run):
+            changed.append(str(page.relative_to(REPO_ROOT)))
+
+    if changed:
+        action = "将写入" if args.dry_run else "已写入"
+        print(f"{action} institutions → {len(changed)} 个 wiki 页")
+        for rel in changed:
+            print(f"  - {rel}")
+    else:
+        print("无需更新（无可派生机构或已覆盖）")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -40,7 +40,7 @@ import re
 from collections import Counter, defaultdict
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from export_minimal import extract_summary
 from utils.wiki_cache import wiki_stem_to_path
@@ -85,6 +85,29 @@ INSTITUTION_REGISTRY: dict[str, dict[str, Any]] = _load_institution_registry(
     INSTITUTIONS_REGISTRY_PATH
 )
 INSTITUTION_ALIAS_MAP: dict[str, str] = _build_institution_alias_map(INSTITUTION_REGISTRY)
+
+# entity 页 URL 扫描（仅 sources + summary，避免正文外链误命中）
+INSTITUTION_URL_PATTERNS: dict[str, list[str]] = {
+    "nvidia": [
+        r"research\.nvidia\.com",
+        r"github\.com/nv-tlabs/",
+        r"github\.com/NVIDIA/",
+    ],
+    "google-deepmind": [r"deepmind\.google", r"deepmind\.com", r"github\.com/google-deepmind/"],
+    "google": [r"github\.com/google-research/", r"ai\.googleblog\.com"],
+    "meta": [r"ai\.meta\.com", r"github\.com/facebookresearch/", r"github\.com/fairinternal/"],
+    "microsoft": [r"microsoft\.com/research", r"github\.com/microsoft/"],
+    "berkeley": [r"berkeley\.edu", r"github\.com/berkeley-humanoid"],
+    "stanford": [r"stanford\.edu"],
+    "mit": [r"\.mit\.edu"],
+    "cmu": [r"\.cmu\.edu"],
+    "eth": [r"ethz\.ch", r"leggedrobotics\.com"],
+    "tsinghua": [r"tsinghua\.edu\.cn"],
+    "pku": [r"pku\.edu\.cn"],
+    "unitree": [r"unitree\.com", r"github\.com/unitreerobotics"],
+    "agibot": [r"agibot\.com", r"zhiyuan-robot\.com"],
+    "physical-intelligence": [r"physicalintelligence\.company"],
+}
 
 # 主社区检测（Louvain）合并后的目标社区数上限（与 MAX_COMMUNITIES 命名席位对齐）。
 PRIMARY_COMMUNITY_CAP = 16
@@ -482,11 +505,85 @@ def parse_frontmatter_list(content: str, key: str) -> list[str]:
     return []
 
 
-def derive_node_institutions(content: str, alias_map: dict[str, str] | None = None) -> list[str]:
+def _institution_tokens_from_pathish(text: str) -> list[str]:
+    return [token for token in re.split(r"[-_/.\s]+", text.lower()) if token]
+
+
+def _expand_frontmatter_institution_tokens(raw_tokens: list[str]) -> list[str]:
+    expanded: list[str] = []
+    for token in raw_tokens:
+        lowered = str(token).strip().lower()
+        if not lowered:
+            continue
+        expanded.append(lowered)
+        expanded.extend(_institution_tokens_from_pathish(lowered))
+    return expanded
+
+
+def _append_institution_token_matches(
+    tokens: Iterable[str],
+    alias_map: dict[str, str],
+    seen: set[str],
+    out: list[str],
+) -> None:
+    for token in tokens:
+        canonical = alias_map.get(token)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            out.append(canonical)
+
+
+def _derive_entity_institution_signals(
+    page_id: str,
+    content: str,
+    alias_map: dict[str, str],
+) -> list[str]:
+    """entity 页从路径/标题、sources 路径与主链 URL 派生机构（精确 token，避免子串误命中）。"""
+    if not page_id.startswith("wiki/entities/"):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    path = Path(page_id)
+    title = extract_title(content) or path.stem
+    for text in (path.stem, title):
+        _append_institution_token_matches(
+            _institution_tokens_from_pathish(text),
+            alias_map,
+            seen,
+            out,
+        )
+    for src in parse_frontmatter_list(content, "sources"):
+        _append_institution_token_matches(
+            _institution_tokens_from_pathish(Path(src).stem),
+            alias_map,
+            seen,
+            out,
+        )
+    scan_parts = parse_frontmatter_list(content, "sources")
+    summary = extract_summary(content)
+    if summary:
+        scan_parts.append(summary)
+    scan_text = "\n".join(scan_parts)
+    for inst_id, patterns in INSTITUTION_URL_PATTERNS.items():
+        for pattern in patterns:
+            if re.search(pattern, scan_text, re.IGNORECASE):
+                if inst_id not in seen:
+                    seen.add(inst_id)
+                    out.append(inst_id)
+                break
+    return out
+
+
+def derive_node_institutions(
+    content: str,
+    alias_map: dict[str, str] | None = None,
+    page_id: str | None = None,
+) -> list[str]:
     """节点「所属机构」（canonical id，去重保序，可多归属）。
 
-    frontmatter 显式 `institutions:` 非空时以其为准（覆盖）；否则从 `tags:` 派生。
-    两种来源都经 alias_map 归一到 canonical id，非机构 token 丢弃。
+    frontmatter 显式 `institutions:` 非空时以其为准（覆盖）；否则从 `tags:` 派生，
+    并在 entity 页叠加路径/标题、sources 路径与主链 URL 信号。
+    tag token 支持连字符拆分（如 unitree-go2 → unitree）。
     """
     if alias_map is None:
         alias_map = INSTITUTION_ALIAS_MAP
@@ -494,11 +591,19 @@ def derive_node_institutions(content: str, alias_map: dict[str, str] | None = No
     source = explicit if explicit else parse_frontmatter_list(content, "tags")
     out: list[str] = []
     seen: set[str] = set()
-    for token in source:
-        canonical = alias_map.get(str(token).strip().lower())
-        if canonical and canonical not in seen:
-            seen.add(canonical)
-            out.append(canonical)
+    _append_institution_token_matches(
+        _expand_frontmatter_institution_tokens(source),
+        alias_map,
+        seen,
+        out,
+    )
+    if explicit:
+        return out
+    if page_id:
+        for inst_id in _derive_entity_institution_signals(page_id, content, alias_map):
+            if inst_id not in seen:
+                seen.add(inst_id)
+                out.append(inst_id)
     return out
 
 
@@ -960,7 +1065,7 @@ def _build_graph_data() -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
             "summary": extract_summary(content),
             "_recency": wiki_recency_date(content, page).isoformat(),
         }
-        institutions = derive_node_institutions(content)
+        institutions = derive_node_institutions(content, page_id=page_id)
         if institutions:
             node["institutions"] = institutions
         nodes.append(node)

--- a/tests/test_link_graph_institutions.py
+++ b/tests/test_link_graph_institutions.py
@@ -8,6 +8,8 @@ REGISTRY = {
     "nvidia": {"label": "NVIDIA", "aliases": ["nvidia", "gear"]},
     "cmu": {"label": "卡内基梅隆大学（CMU）", "aliases": ["cmu"]},
     "tsinghua": {"label": "清华大学（Tsinghua）", "aliases": ["tsinghua", "thu"]},
+    "berkeley": {"label": "UC Berkeley", "aliases": ["berkeley"]},
+    "unitree": {"label": "Unitree", "aliases": ["unitree"]},
 }
 ALIASES = glg._build_institution_alias_map(REGISTRY)
 
@@ -46,6 +48,23 @@ def test_explicit_institutions_override_tags() -> None:
 def test_no_institution_tags_yields_empty() -> None:
     assert glg.derive_node_institutions(_page("tags: [paper, humanoid]"), ALIASES) == []
     assert glg.derive_node_institutions("# No frontmatter\n", ALIASES) == []
+
+
+def test_hyphenated_tag_splits_to_institution() -> None:
+    page = _page("tags: [unitree-go2, repo]")
+    assert glg.derive_node_institutions(page, ALIASES) == ["unitree"]
+
+
+def test_entity_path_derives_institution() -> None:
+    page = _page("tags: [paper]\nsources:\n  - ../../sources/papers/berkeley-humanoid.md")
+    page_id = "wiki/entities/paper-notebook-berkeley-humanoid.md"
+    assert glg.derive_node_institutions(page, ALIASES, page_id=page_id) == ["berkeley"]
+
+
+def test_explicit_institutions_skip_entity_signals() -> None:
+    page = _page("institutions: [cmu]\nsources:\n  - ../../sources/sites/nvidia-lab.md")
+    page_id = "wiki/entities/demo-tool.md"
+    assert glg.derive_node_institutions(page, ALIASES, page_id=page_id) == ["cmu"]
 
 
 def test_build_summary_sorts_by_size_then_label() -> None:

--- a/wiki/comparisons/hil-vs-mtrg-vs-zest-parkour-imitation.md
+++ b/wiki/comparisons/hil-vs-mtrg-vs-zest-parkour-imitation.md
@@ -17,6 +17,8 @@ sources:
   - ../../sources/sites/gfr-project.md
   - ../../sources/papers/zest.md
 summary: "跑酷/障碍穿越场景下 HIL（仿真角色 tracking+AMP）、GfR/MTRG（G1 参考塑形+goal 部署）与 ZEST（跨形态 tracking 真机）三条路线的对比与选型。"
+institutions: [unitree]
+
 ---
 
 # HIL vs MTRG vs ZEST：跑酷模仿学习路线对比

--- a/wiki/comparisons/humanoid-reference-motion-datasets.md
+++ b/wiki/comparisons/humanoid-reference-motion-datasets.md
@@ -18,6 +18,8 @@ sources:
   - ../../sources/repos/omomo_release.md
   - ../../sources/repos/phuma.md
   - ../../sources/sites/humanoideveryday.md
+institutions: [unitree]
+
 ---
 
 # 人形参考运动与操作数据集选型

--- a/wiki/comparisons/mujoco-vs-isaac-sim.md
+++ b/wiki/comparisons/mujoco-vs-isaac-sim.md
@@ -9,6 +9,10 @@ related:
   - ../methods/reinforcement-learning.md
   - ../concepts/sim2real.md
 summary: "物理引擎选型对比：MuJoCo 以极致的接触精度和控制理论背景称王；而 Isaac Sim / Gym 凭借 GPU 千万级并行霸占现代 RL 训练管线。"
+institutions:
+  - nvidia
+  - google-deepmind
+
 ---
 
 # MuJoCo vs Isaac Sim (物理引擎选型)

--- a/wiki/concepts/video-as-simulation.md
+++ b/wiki/concepts/video-as-simulation.md
@@ -22,6 +22,8 @@ sources:
   - ../../sources/papers/wem_arxiv_2605_19957.md
   - ../../sources/blogs/allenai_molmo_motion.md
 summary: "视频即仿真（Video-as-Simulation）代表了仿真技术的新范式：通过交互式视频预测器代替传统的刚体动力学引擎，实现了在像素级别进行无限逼真的反事实物理演练。"
+institutions: [google-deepmind]
+
 ---
 
 # Video-as-Simulation (视频即仿真)

--- a/wiki/concepts/wheel-legged-quadruped.md
+++ b/wiki/concepts/wheel-legged-quadruped.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/repos/robot_lab.md
 summary: "轮足四足机器人在四条腿末端集成驱动轮，平地偏滚动效率，崎岖地形仍依赖足式步态；典型如 Unitree Go2W / B2W，仿真框架 robot_lab 将其与纯四足、人形并列注册。"
+institutions: [unitree]
+
 ---
 
 # 轮足四足机器人（四轮足 / Wheel-Legged Quadruped）

--- a/wiki/entities/agibot-lingxi-x1.md
+++ b/wiki/entities/agibot-lingxi-x1.md
@@ -11,6 +11,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_jixie_robot_open_source_treasury_issue01_10_robots.md
 summary: "智元机器人（Agibot）灵犀 X1：硬件设计资料、训练/推理代码与搭建指南集中在官网文档中心；GitHub 以 AgibotTech 组织为入口。"
+institutions: [agibot]
+
 ---
 
 # 智元灵犀 X1（Agibot 开源人形）

--- a/wiki/entities/airsim.md
+++ b/wiki/entities/airsim.md
@@ -14,6 +14,8 @@ related:
 sources:
   - ../../sources/repos/airsim.md
 summary: "Microsoft AirSim：基于 Unreal/Unity 的无人机与自动驾驶视觉仿真，提供 RGB/深度/分割与 PX4 耦合，常用于 SLAM、避障与视觉 Sim2Real（项目已进入维护模式）。"
+institutions: [microsoft]
+
 ---
 
 # AirSim

--- a/wiki/entities/amp-mjlab.md
+++ b/wiki/entities/amp-mjlab.md
@@ -18,6 +18,8 @@ sources:
   - ../../sources/papers/unified_walk_run_recovery_sdamp_arxiv_2605_18611.md
   - ../../sources/personal/amp_mjlab_policy_training_essence.md
 summary: "AMP_mjlab 是基于 mjlab + rsl_rl 的 Unitree G1 统一 AMP 策略实现，用单一 actor-critic + 判别器同时覆盖 locomotion 与 fall-recovery，消除模式切换断裂。"
+institutions: [unitree]
+
 ---
 
 # AMP_mjlab (G1 统一 AMP 策略)

--- a/wiki/entities/anygrasp.md
+++ b/wiki/entities/anygrasp.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/repos/anygrasp-sdk.md
 summary: "AnyGrasp 是面向平行夹爪的稠密 7-DoF 抓取感知与跨帧跟踪管线：单前向从深度点云预测大量候选并做时空关联，官方以 SDK（预编译库 + License）形式发布。"
+institutions: [sjtu]
+
 ---
 
 # AnyGrasp（抓取感知 SDK）

--- a/wiki/entities/anymal.md
+++ b/wiki/entities/anymal.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/papers/locomotion_rl.md
 summary: "ANYmal 是由 ETH Zurich 和 ANYbotics 开发的高性能四足机器人平台。它以 SEA 力控执行器和极高的防护等级著称，是机器人强化学习与 Sim2Real 技术研究的标志性载体。"
+institutions: [eth]
+
 ---
 
 # ANYmal 四足机器人

--- a/wiki/entities/axellwppr-motion-tracking.md
+++ b/wiki/entities/axellwppr-motion-tracking.md
@@ -12,6 +12,8 @@ sources:
   - ../../sources/repos/axellwppr_motion_tracking.md
   - ../../sources/sites/motion-tracking-axell-top.md
 summary: "Axellwppr/motion_tracking：GentleHumanoid 论文对应的 mjlab 全身跟踪训练/评估/部署仓，含 AMASS/LAFAN 数据管线、WandB 训练、ONNX sim2real 与 VR 遥操作配置。"
+institutions: [unitree]
+
 ---
 
 # Axellwppr/motion_tracking

--- a/wiki/entities/berkeley-humanoid-lite.md
+++ b/wiki/entities/berkeley-humanoid-lite.md
@@ -11,6 +11,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_jixie_robot_open_source_treasury_issue01_10_robots.md
 summary: "Berkeley Humanoid Lite（BHL）：UC Berkeley Hybrid Robotics 的低成本准直驱人形开源项目，含 MuJoCo 仿真、PPO 与遥操作等入门链路。"
+institutions: [berkeley]
+
 ---
 
 # Berkeley Humanoid Lite（BHL）

--- a/wiki/entities/booster-robocup-demo.md
+++ b/wiki/entities/booster-robocup-demo.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/repos/booster-robocup-demo.md
 summary: "Booster Robotics RoboCup Demo 是专为 Booster 系列人形机器人设计的足球比赛自主决策框架，集成了 YOLOv8 感知与基于强化学习的视觉踢球算法。"
+institutions: [booster]
+
 ---
 
 # Booster Robotics RoboCup Demo

--- a/wiki/entities/botlab-motioncanvas.md
+++ b/wiki/entities/botlab-motioncanvas.md
@@ -14,6 +14,8 @@ related:
 sources:
   - ../../sources/sites/botlab_motioncanvas.md
 summary: "BotLab（站点内产品名 MotionCanvas）是地瓜机器人提供的浏览器端节点图工具：在网页里编排观测、历史堆叠、ONNX 策略与 MuJoCo 步进，并支持 MSCP 图与 Netron 模型预览，面向 Unitree G1 / Go2 等策略的快速试验与教学演示。"
+institutions: [unitree]
+
 ---
 
 # BotLab / MotionCanvas（浏览器内策略–仿真编排）

--- a/wiki/entities/brax.md
+++ b/wiki/entities/brax.md
@@ -15,6 +15,10 @@ sources:
   - ../../sources/repos/brax.md
   - ../../sources/papers/brax_arxiv_2106_13281.md
 summary: "Brax 是 Google 开源的 JAX 可微物理与 RL 训练库；当前 README 将维护重心收敛到 brax/training，并引导新环境使用 MuJoCo Playground、新物理后端使用 MJX / MuJoCo Warp。"
+institutions:
+  - google
+  - google-deepmind
+
 ---
 
 # Brax（JAX 可微物理与 RL 训练）

--- a/wiki/entities/cartographer.md
+++ b/wiki/entities/cartographer.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/repos/cartographer.md
 summary: "Google Cartographer 提供实时 2D/3D SLAM：子图 scan matching + 位姿图优化，cartographer_ros 广泛用于工业与科研。"
+institutions: [google]
+
 ---
 
 # Cartographer

--- a/wiki/entities/cosmos-3.md
+++ b/wiki/entities/cosmos-3.md
@@ -29,6 +29,8 @@ sources:
   - ../../sources/sites/cosmos3-project.md
   - ../../sources/repos/nvidia_cosmos.md
 summary: "Cosmos 3 是 NVIDIA 第三代全模态 Physical AI 世界模型：MoT 统一架构下联合理解/生成语言、图像、视频、音频与动作，Reasoner 与 Generator 双运行时面覆盖 VLM、视频 WM、正逆动力学与操纵策略。"
+institutions: [nvidia]
+
 ---
 
 # Cosmos 3（NVIDIA 全模态世界模型）

--- a/wiki/entities/curobo.md
+++ b/wiki/entities/curobo.md
@@ -22,6 +22,8 @@ related:
 sources:
   - ../../sources/repos/nvlabs-curobo.md
 summary: "cuRobo 是 NVIDIA 开源的 GPU 并行机器人运动生成库：在统一碰撞与运动学内核上叠加无碰撞 IK、几何规划、多样本并行轨迹优化与 MPPI；cuRoboV2 在同一代码基上引入 B 样条+力矩约束、稠密 ESDF 感知与面向高自由度整机的可扩展动力学模块，把叙事从典型操作臂扩展到双臂与人形。"
+institutions: [nvidia]
+
 ---
 
 # cuRobo

--- a/wiki/entities/dataset-bfm-phuma.md
+++ b/wiki/entities/dataset-bfm-phuma.md
@@ -17,6 +17,8 @@ sources:
   - ../../sources/papers/bfm_awesome_dataset_phuma_arxiv_2510_26236.md
   - ../../sources/papers/bfm_awesome_41_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_bfm_41_papers_survey.md
+institutions: [unitree]
+
 ---
 
 # PHUMA（Physically Reliable Humanoid Locomotion Dataset）

--- a/wiki/entities/deepinsight.md
+++ b/wiki/entities/deepinsight.md
@@ -15,6 +15,8 @@ related:
 sources:
   - ../../sources/papers/deepinsight_arxiv_2606_17574.md
 summary: "DeepInsight 是 XPENG Robotics 的 Physical AI 全栈统一评测基础设施：单一 runtime 贯通 System 2 基础模型、System 1 视运动策略与 System 0 全身控制，以 task/resource/result 三抽象与统一 trace 实现跨层回归定位。"
+institutions: [xpeng]
+
 ---
 
 # DeepInsight（XPENG Robotics 全栈评测基础设施）

--- a/wiki/entities/dm-control.md
+++ b/wiki/entities/dm-control.md
@@ -14,6 +14,8 @@ sources:
   - ../../sources/repos/dm_control.md
   - ../../sources/papers/dm_control_suite.md
 summary: "dm_control 是 Google DeepMind 开源的 MuJoCo Python 栈：以 Control Suite 连续控制基准为核心，并提供查看器、MJCF 组合与 locomotion 等扩展，是学术 RL 与仿真实验的常用入口之一。"
+institutions: [google-deepmind]
+
 ---
 
 # dm_control（DeepMind Control Suite 与 MuJoCo Python 栈）

--- a/wiki/entities/easy-quadruped.md
+++ b/wiki/entities/easy-quadruped.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/repos/easy_quadruped.md
 summary: "easy_quadruped 是 StanfordQuadruped（Pupper）控制栈的独立 fork：模型式 Trot 步态 + IK + MuJoCo 浮动机身闭环，附带任务调度与舵机标定，适合低成本四足控制入门。"
+institutions: [stanford]
+
 ---
 
 # easy_quadruped（Pupper 控制栈 + MuJoCo 闭环）

--- a/wiki/entities/ego-planner-swarm.md
+++ b/wiki/entities/ego-planner-swarm.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/repos/ego_planner_swarm.md
 summary: "EGO-Planner Swarm 是 ZJU FAST Lab 的单/多机局部轨迹规划器：ESDF 地图 + B-spline 优化，输出可对接 PX4 Offboard 的位置/速度设定点。"
+institutions: [zju]
+
 ---
 
 # EGO-Planner Swarm

--- a/wiki/entities/ewmbench.md
+++ b/wiki/entities/ewmbench.md
@@ -15,6 +15,8 @@ sources:
   - ../../sources/repos/ewmbench.md
   - ../../sources/sites/agibot-world.md
 summary: "EWMBench 是面向具身世界模型（EWM）视频生成的公开基准与工具链：在 Agibot-World 子集上统一初始化后，从场景守恒、末端轨迹与语义/逻辑对齐三轴评测候选文生视频模型，并开源数据与评测代码。"
+institutions: [agibot]
+
 ---
 
 # EWMBench（具身世界模型生成评测）

--- a/wiki/entities/fast-lio.md
+++ b/wiki/entities/fast-lio.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/repos/fast_lio.md
 summary: "FAST-LIO 是高效鲁棒的 LiDAR-惯性里程计：ikd-Tree + 迭代 ESKF，适合 3D 旋转激光高频状态估计。"
+institutions: [hku]
+
 ---
 
 # FAST-LIO

--- a/wiki/entities/fourier-grx-n1.md
+++ b/wiki/entities/fourier-grx-n1.md
@@ -11,6 +11,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_jixie_robot_open_source_treasury_issue01_10_robots.md
 summary: "傅利叶智能开源人形线 GRX N1：以 fftai.github.io 文档站与 FFTAI 组织 GitHub 为主入口；BOM/STEP 等物料常以网盘分发，需与官方渠道交叉校验。"
+institutions: [fourier]
+
 ---
 
 # 傅利叶 GRX N1（开源人形）

--- a/wiki/entities/ge-sim-2.md
+++ b/wiki/entities/ge-sim-2.md
@@ -16,6 +16,8 @@ sources:
   - ../../sources/repos/ge_sim_v2.md
   - ../../sources/sites/ge-sim-v2-project.md
 summary: "GE-Sim 2.0（Genie Envisioner World Simulator 2.0）在 GE-Sim 动作条件多视角视频生成上，用大规模真机数据重训并叠加本体状态专家、VLM 世界裁判与蒸馏加速，形成可闭环策略交互与可扩展评测/奖励的操纵视频世界模拟器（2B，WorldArena 榜首）。"
+institutions: [agibot]
+
 ---
 
 # GE-Sim 2.0（Genie Envisioner World Simulator 2.0）

--- a/wiki/entities/gemini-robotics.md
+++ b/wiki/entities/gemini-robotics.md
@@ -9,6 +9,10 @@ related:
   - ../methods/robotics-transformer-rt-series.md
 sources:
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
+institutions:
+  - google-deepmind
+  - google
+
 ---
 
 # Gemini Robotics

--- a/wiki/entities/go2-motion-imitation.md
+++ b/wiki/entities/go2-motion-imitation.md
@@ -11,6 +11,8 @@ related:
   - ./genesis-world-10.md
 sources:
   - ../../sources/repos/go2_motion_imitation.md
+institutions: [unitree]
+
 ---
 
 # Go2 Motion Imitation

--- a/wiki/entities/gr00t-visual-sim2real.md
+++ b/wiki/entities/gr00t-visual-sim2real.md
@@ -22,6 +22,10 @@ sources:
   - ../../sources/sites/doorman-humanoid-github-io.md
   - ../../sources/papers/viral-humanoid-visual-sim2real.md
 summary: "GR00T-VisualSim2Real 是 NVIDIA NVlabs 开源的视觉 Sim2Real 框架，包含 VIRAL 和 DoorMan 两项 CVPR 2026 研究，用 PPO Teacher + DAgger Student 蒸馏范式将仅靠 RGB 的策略零样本迁移到 Unitree G1 真机。"
+institutions:
+  - unitree
+  - nvidia
+
 ---
 
 # GR00T-VisualSim2Real (NVIDIA 视觉 Sim2Real 框架)

--- a/wiki/entities/gr00t-wholebodycontrol.md
+++ b/wiki/entities/gr00t-wholebodycontrol.md
@@ -15,6 +15,8 @@ related:
 sources:
   - ../../sources/repos/gr00t_wholebodycontrol.md
 summary: "GR00T-WholeBodyControl 是 NVlabs 的人形全身控制单仓：托管解耦 WBC（GR00T N1.5/N1.6）、GEAR-SONIC（SONIC 训练/部署/C++ 推理/VR 采集）与 MotionBricks 预览子项目，并提供 Isaac Lab 对齐文档与 VLA 数据链教程。"
+institutions: [nvidia]
+
 ---
 
 # GR00T-WholeBodyControl（人形全身控制统一平台）

--- a/wiki/entities/habitat-sim.md
+++ b/wiki/entities/habitat-sim.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_shenlan_sim_platforms_top8_decade.md
 summary: "Meta AI 2019 年推出的高速具身 AI 仿真平台：单 GPU 数千至上万 FPS 渲染，使大规模真实扫描场景上的端到端 RL 训练可行；Habitat 2.0/3.0 扩展可交互物体与人类化身。"
+institutions: [meta]
+
 ---
 
 # Habitat-Sim

--- a/wiki/entities/holosoma.md
+++ b/wiki/entities/holosoma.md
@@ -16,6 +16,10 @@ related:
 sources:
   - ../../sources/repos/holosoma.md
   - ../../sources/papers/omniretarget_arxiv_2509_26633.md
+institutions:
+  - unitree
+  - booster
+
 ---
 
 # holosoma（Amazon FAR 人形 RL + 重定向框架）

--- a/wiki/entities/humannet.md
+++ b/wiki/entities/humannet.md
@@ -19,6 +19,8 @@ sources:
   - ../../sources/papers/humannet.md
   - ../../sources/papers/humannet_table1_benchmark_corpora.md
   - ../../sources/repos/humannet.md
+institutions: [pku]
+
 ---
 
 # HumanNet

--- a/wiki/entities/igibson.md
+++ b/wiki/entities/igibson.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_shenlan_sim_platforms_top8_decade.md
 summary: "斯坦福等 2020 年推出的 iGibson：在 PyBullet 上融合大规模真实感室内场景与可交互日常物体，支持长视距操作任务，为 VLA 提供更贴近现实的测试环境。"
+institutions: [stanford]
+
 ---
 
 # iGibson

--- a/wiki/entities/isaac-gym-isaac-lab.md
+++ b/wiki/entities/isaac-gym-isaac-lab.md
@@ -5,6 +5,8 @@ sources:
   - ../../sources/papers/simulation_tools.md
 summary: "Isaac Gym / Isaac Lab"
 updated: 2026-06-21
+institutions: [nvidia]
+
 ---
 
 # Isaac Gym / Isaac Lab

--- a/wiki/entities/isaac-lab.md
+++ b/wiki/entities/isaac-lab.md
@@ -21,6 +21,8 @@ sources:
   - ../../sources/papers/policy_optimization.md
   - ../../sources/blogs/wechat_embodied_ai_lab_robot_training_stack_layers_2026.md
 summary: "NVIDIA 当前官方主推的 robot learning 框架，建立在 Isaac Sim 之上，承接 IsaacGymEnvs/Orbit 用户；locomotion、manipulation 与 sim2real 新实验的首选仿真栈。"
+institutions: [nvidia]
+
 ---
 
 # Isaac Lab

--- a/wiki/entities/isaac-ros-nvblox.md
+++ b/wiki/entities/isaac-ros-nvblox.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/repos/isaac_ros_nvblox.md
 summary: "Isaac ROS Nvblox 用 GPU 维护 TSDF/ESDF 体素地图，为 Nav2 提供 3D 障碍与局部代价，支持动态场景重建。"
+institutions: [nvidia]
+
 ---
 
 # Isaac ROS Nvblox

--- a/wiki/entities/isaac-ros-visual-slam.md
+++ b/wiki/entities/isaac-ros-visual-slam.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/repos/isaac_ros_visual_slam.md
 summary: "Isaac ROS Visual SLAM 基于 NVIDIA cuVSLAM，在 Jetson/x86+GPU 上提供加速视觉里程计/SLAM，作为 ROS 2 组件接入 Nav2 感知链。"
+institutions: [nvidia]
+
 ---
 
 # Isaac ROS Visual SLAM

--- a/wiki/entities/isaac-teleop.md
+++ b/wiki/entities/isaac-teleop.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/repos/nvidia_isaac_teleop.md
 summary: "Isaac Teleop 是 NVIDIA 统一的仿真与真机遥操作框架：标准化 XR/外设接口、图式 retargeting 与 MCAP/示范录制，并作为 Isaac Lab 3.x 的 XR 遥操作主线替代 openxr 设备栈。"
+institutions: [nvidia]
+
 ---
 
 # Isaac Teleop

--- a/wiki/entities/kimera.md
+++ b/wiki/entities/kimera.md
@@ -9,6 +9,8 @@ related:
 sources:
   - ../../sources/repos/kimera.md
 summary: "Kimera 是 MIT SPARK 语义 SLAM 套件：Kimera-VIO、Kimera-RPGO、Kimera-Semantics 模块化组合。"
+institutions: [mit]
+
 ---
 
 # Kimera

--- a/wiki/entities/kimodo.md
+++ b/wiki/entities/kimodo.md
@@ -18,6 +18,10 @@ sources:
   - ../../sources/sites/kimodo-project.md
   - ../../sources/papers/kimodo_arxiv_2603_15546.md
 summary: "Kimodo 是 NVIDIA 开源的运动学扩散模型：在约 700 小时 Rigplay 动捕上训练，两阶段 root/body 去噪器支持文本与全身/末端/2D 路径约束，覆盖 SOMA / G1 / SMPL-X，并提供 Benchmark、时间线 Demo 与 ProtoMotions / GEAR-SONIC 下游衔接。"
+institutions:
+  - nvidia
+  - unitree
+
 ---
 
 # Kimodo（可控人体与人形运动扩散）

--- a/wiki/entities/lift-humanoid.md
+++ b/wiki/entities/lift-humanoid.md
@@ -27,6 +27,10 @@ sources:
   - ../../sources/sites/lift-humanoid-github-io.md
   - ../../sources/repos/bigai-lift-humanoid.md
 summary: "LIFT（BIGAI）把人形控制的「墙钟大规模仿真预训练」与「样本高效、较安全的适应微调」串成三阶段：JAX 大规模并行 SAC → 离线训练物理知情（拉格朗日 + 残差）世界模型 → 真机/目标环境确定性采集 + 仅在模型 rollout 中保留随机探索；配套开源与项目页给出 MuJoCo Playground / Brax / Booster T1 等实证叙事。"
+institutions:
+  - booster
+  - unitree
+
 ---
 
 # LIFT（人形大规模预训练 + 高效微调）

--- a/wiki/entities/metalhead.md
+++ b/wiki/entities/metalhead.md
@@ -11,6 +11,8 @@ related:
   - ../tasks/locomotion.md
 sources:
   - ../../sources/repos/metalhead.md
+institutions: [unitree]
+
 ---
 
 # MetalHead

--- a/wiki/entities/mjlab-playground.md
+++ b/wiki/entities/mjlab-playground.md
@@ -14,6 +14,10 @@ related:
 sources:
   - ../../sources/repos/mjlab_playground.md
 summary: "mujocolab 维护的 mjlab 任务集合仓库：从 MuJoCo Playground 起步移植任务，提供 uv 驱动的并行训练与策略回放入口，首批覆盖 Go1 / Booster T1 等平地摔倒恢复（getup）示例。"
+institutions:
+  - unitree
+  - booster
+
 ---
 
 # mjlab_playground（mjlab 任务集合）

--- a/wiki/entities/mujoco-mjx.md
+++ b/wiki/entities/mujoco-mjx.md
@@ -14,6 +14,8 @@ sources:
   - ../../sources/repos/mujoco-mjx.md
   - ../../sources/sites/mujoco-mjx-readthedocs.md
 summary: "MuJoCo MJX 是 MuJoCo 的 JAX/XLA 重实现：以 `mujoco-mjx` 分发、与主版本号对齐，便于在同一 MJCF 资产上做 GPU 批量与可微 rollout，功能完备度需对照官方 feature parity 文档。"
+institutions: [google-deepmind]
+
 ---
 
 # MuJoCo MJX（MuJoCo XLA）

--- a/wiki/entities/mujoco-playground.md
+++ b/wiki/entities/mujoco-playground.md
@@ -19,6 +19,8 @@ sources:
   - ../../sources/repos/mujoco_playground.md
   - ../../sources/blogs/wechat_embodied_ai_lab_robot_training_stack_layers_2026.md
 summary: "MuJoCo Playground 是 DeepMind 基于 MJX 的开源机器人 RL 环境集合，定位在「任务与训练入口层」：用四足/人形/灵巧手/机械臂等可复现环境与较短链路，把研究者从行为目标尽快带到真机策略验证（time-to-robot）。"
+institutions: [google-deepmind]
+
 ---
 
 # MuJoCo Playground

--- a/wiki/entities/mujoco.md
+++ b/wiki/entities/mujoco.md
@@ -23,6 +23,8 @@ sources:
   - ../../sources/blogs/wechat_embodied_ai_lab_robot_training_stack_layers_2026.md
   - ../../sources/blogs/wechat_shenlan_sim_platforms_top8_decade.md
 summary: "MuJoCo 是专为生物力学、机器人学开发的高精度物理引擎。开源后成为机器人强化学习的基石，以极佳的接触稳定性和解析优化支持著称。"
+institutions: [google-deepmind]
+
 ---
 
 # MuJoCo (物理引擎)

--- a/wiki/entities/newton-physics.md
+++ b/wiki/entities/newton-physics.md
@@ -21,6 +21,8 @@ sources:
   - ../../sources/sites/newton-physics-docs-overview.md
   - ../../sources/blogs/wechat_embodied_ai_lab_robot_training_stack_layers_2026.md
 summary: "Newton 是 Linux Foundation 托管的 GPU 加速、可扩展、可微物理引擎：基于 NVIDIA Warp，以 MuJoCo Warp 为主要后端，支持 URDF/MJCF/USD 与多求解器，并与 Isaac Lab、MuJoCo Playground 等机器人学习栈对接。"
+institutions: [nvidia]
+
 ---
 
 # Newton Physics（物理引擎）

--- a/wiki/entities/nvidia-gear-lab.md
+++ b/wiki/entities/nvidia-gear-lab.md
@@ -19,6 +19,8 @@ related:
 sources:
   - ../../sources/sites/nvidia-research-gear-lab.md
 summary: "NVIDIA GEAR（Generalist Embodied Agent Research）由 Jim Fan 与 Yuke Zhu 领导，公开使命是构建虚拟与物理世界的具身智能体基础模型；研究议程覆盖多模态基础模型、通用人形机器人、Foundation Agents 与仿真合成数据，并发布 GR00T、SONIC、EgoScale、ENPIRE 等代表性工作。"
+institutions: [nvidia]
+
 ---
 
 # NVIDIA GEAR Lab（Generalist Embodied Agent Research）

--- a/wiki/entities/nvidia-omniverse.md
+++ b/wiki/entities/nvidia-omniverse.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/papers/simulation.md
 summary: "NVIDIA Omniverse 是 Isaac Sim 的底层支撑平台，是一个基于 USD 格式、工业级的实时三维协作与仿真引擎，旨在为具身智能提供高保真的数字化孪生环境。"
+institutions: [nvidia]
+
 ---
 
 # NVIDIA Omniverse (具身仿真底座)

--- a/wiki/entities/nvidia-physical-ai-learning.md
+++ b/wiki/entities/nvidia-physical-ai-learning.md
@@ -13,6 +13,8 @@ sources:
   - ../../sources/sites/nvidia-physical-ai-learning.md
   - ../../sources/courses/nvidia_sim_to_real_so101_isaac.md
 summary: "NVIDIA Physical AI Learning 是官方免费自学门户，索引 Isaac、OpenUSD、医疗机器人与 SO-101 操作臂 Sim2Real 等多条动手路径，并对接 Brev 云 GPU 环境。"
+institutions: [nvidia]
+
 ---
 
 # NVIDIA Physical AI Learning

--- a/wiki/entities/nvidia-so101-sim2real-lab-workflow.md
+++ b/wiki/entities/nvidia-so101-sim2real-lab-workflow.md
@@ -19,6 +19,8 @@ sources:
   - ../../sources/courses/nvidia_sim_to_real_so101_isaac.md
   - ../../sources/sites/nvidia-physical-ai-learning.md
 summary: "NVIDIA 官方 SO-101 操作臂动手课：离心管瓶 pick-place 任务上，用 LeRobot 采集、GR00T N1.6 训练 VLA，并在 Isaac Lab 与真机上对比 DR、Co-training、Cosmos 与 SAGE+GapONet 四类 sim2real 策略。"
+institutions: [nvidia]
+
 ---
 
 # NVIDIA SO-101 Sim2Real 实验 workflow

--- a/wiki/entities/oculust-quest-teleop.md
+++ b/wiki/entities/oculust-quest-teleop.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/imitation_learning.md
 summary: "Meta Quest (Oculus) 遥操作方案是目前具身智能研究中成本最低、效率最高的数据采集手段之一，通过 VR 头显的手部追踪技术直接映射人类动作到机器人。"
+institutions: [meta]
+
 ---
 
 # Meta Quest (Oculus) 遥操作

--- a/wiki/entities/omniretarget-dataset.md
+++ b/wiki/entities/omniretarget-dataset.md
@@ -16,6 +16,8 @@ related:
 sources:
   - ../../sources/sites/omniretarget-dataset-huggingface.md
   - ../../sources/papers/omniretarget_arxiv_2509_26633.md
+institutions: [unitree]
+
 ---
 
 # OmniRetarget Dataset（G1 交互重定向轨迹）

--- a/wiki/entities/omomo-dataset.md
+++ b/wiki/entities/omomo-dataset.md
@@ -16,6 +16,8 @@ related:
 sources:
   - ../../sources/repos/omomo_release.md
   - ../../sources/papers/omniretarget_arxiv_2509_26633.md
+institutions: [stanford]
+
 ---
 
 # OMOMO（Object Motion Guided Human Motion Synthesis）

--- a/wiki/entities/open-source-humanoid-brains.md
+++ b/wiki/entities/open-source-humanoid-brains.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_hardware.md
 summary: "主流开源人形机器人“大脑”（主控电脑）选型：对比了 NVIDIA Jetson Orin、高性能 X86 工控机及国产边缘算力平台的性能边界与适用场景。"
+institutions: [nvidia]
+
 ---
 
 # 开源人形机器人“大脑” (主控电脑) 选型

--- a/wiki/entities/paper-any2any-cross-embodiment-wbt.md
+++ b/wiki/entities/paper-any2any-cross-embodiment-wbt.md
@@ -19,6 +19,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "Any2Any（arXiv:2605.23733）把单源人形 WBT 专家经运动学对齐与动力学敏感模块上的 LoRA 后训练迁到新机体，约 1% 全量训练成本将 Gear-SONIC 等骨干迁到 LimX Oli/Luna 等平台并真机验证。"
+institutions: [unitree]
+
 ---
 
 # Any2Any：跨具身高效全身跟踪迁移

--- a/wiki/entities/paper-assistmimic.md
+++ b/wiki/entities/paper-assistmimic.md
@@ -20,6 +20,8 @@ sources:
   - ../../sources/papers/assistmimic_arxiv_2603_11346.md
   - ../../sources/sites/yutoshibata07-assistmimic-github-io.md
 summary: "AssistMimic（arXiv:2603.11346，CVPR 2026）将紧密接触的双人 assistive 动作模仿表述为 MARL：联合训练 supporter/recipient 的 PHC 式 tracking 策略，以单人 prior 零填充初始化、recipient-adaptive 动态参考重定向与接触促进奖励解决高接触探索，在 Inter-X / HHI-Assist 上首次稳定跟踪力交换参考并泛化至未见动力学与扩散生成交互。"
+institutions: [cmu]
+
 ---
 
 # AssistMimic（Learning to Assist: Physics-Grounded Human-Human Control）

--- a/wiki/entities/paper-barkour-quadruped-agility-benchmark.md
+++ b/wiki/entities/paper-barkour-quadruped-agility-benchmark.md
@@ -30,6 +30,10 @@ sources:
   - ../../sources/repos/google_deepmind_barkour_robot.md
   - ../../sources/repos/mujoco_menagerie_google_barkour_models.md
 summary: "Barkour：受犬敏捷赛启发的四足障碍课与 0–1 敏捷分；专长 PPO + 导航状态机与 Locomotion-Transformer 蒸馏两基线；配套开源机体/固件与 MuJoCo Menagerie（v0/vB）。"
+institutions:
+  - google-deepmind
+  - google
+
 ---
 
 # Barkour（四足敏捷评测基准与开源生态）

--- a/wiki/entities/paper-behavior-foundation-model-humanoid.md
+++ b/wiki/entities/paper-behavior-foundation-model-humanoid.md
@@ -32,6 +32,11 @@ sources:
   - ../../sources/blogs/wechat_embodied_ai_lab_bfm_41_papers_survey.md
   - ../../sources/sites/bfm4humanoid-github-io.md
 summary: "BFM（arXiv:2509.13780）把人形全身控制重新表述为「掩码条件下的行为生成」：CVAE 生成器 + 位级二值掩码统一根/关节/关键点等控制接口，掩码在线蒸馏从特权 proxy agent 学习，潜空间插值与 classifier-free 调制支持行为组合，残差解码器实现少样本新技能（Side Salto）。Unitree G1 上 motion tracking / VR 遥操作 / locomotion 单策略多接口表现与专家持平或更好。"
+institutions:
+  - unitree
+  - shanghai-ai-lab
+  - pku
+
 ---
 
 # BFM（Behavior Foundation Model for Humanoid Robots）

--- a/wiki/entities/paper-bifrost-umi.md
+++ b/wiki/entities/paper-bifrost-umi.md
@@ -21,6 +21,8 @@ sources:
   - ../../sources/papers/bifrost_umi_arxiv_2605_03452.md
   - ../../sources/sites/bifrost-umi-project.md
 summary: "BifrostUMI（arXiv:2605.03452，BAAI Aether）将 UMI 式无机器人示范扩展到人形全身操作：Pico 追踪 + 双腕鱼眼夹爪采集关键点与视觉，扩散高层策略预测 47-D 稀疏关键点动作块，经 SKR 保留度量空间结构并重定向到 G1，再由 mink IK 与全身控制器闭环执行。"
+institutions: [unitree]
+
 ---
 
 # BifrostUMI（Bridging Robot-Free Demonstrations and Humanoid Whole-Body Manipulation）

--- a/wiki/entities/paper-dit4dit-video-action-model.md
+++ b/wiki/entities/paper-dit4dit-video-action-model.md
@@ -31,6 +31,8 @@ sources:
   - ../../sources/repos/mondo_robotics_dit4dit.md
   - ../../sources/sites/dit4dit-project.md
 summary: "DiT4DiT（arXiv:2603.10448）：端到端双 DiT Video-Action Model——Cosmos-Predict2.5 Video DiT 与 Action DiT 联合 flow matching，用固定 flow 步视频隐状态条件动作；LIBERO 98.6%、RoboCasa-GR1 50.8%，G1 真机桌面与全身 loco-manip 超 GR00T-N1.5；开源代码；同团队后续演进为 MotionWAM 实时人形 WAM。"
+institutions: [unitree]
+
 ---
 
 # DiT4DiT（双 DiT 联合视频–动作建模）

--- a/wiki/entities/paper-doorman-opening-sim2real-door.md
+++ b/wiki/entities/paper-doorman-opening-sim2real-door.md
@@ -27,6 +27,10 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "DoorMan（arXiv:2512.01061，CVPR 2026）以人形纯 RGB 开门为 loco-manipulation 基准：Isaac Lab 中特权教师 PPO 配合分阶段重置探索，经 DAgger 蒸馏到视觉学生，再用 GRPO 微调缓解部分可观测性；大规模物理与 PBR/光照随机化支撑真机零样本泛化，并在同 WBC 栈上报告相对人类遥操作的成功率与耗时优势。"
+institutions:
+  - unitree
+  - nvidia
+
 ---
 
 # DoorMan（Opening the Sim-to-Real Door for Humanoid Pixel-to-Action Policy Transfer）

--- a/wiki/entities/paper-e-sds-environment-aware-humanoid-locomotion-rl.md
+++ b/wiki/entities/paper-e-sds-environment-aware-humanoid-locomotion-rl.md
@@ -26,6 +26,8 @@ sources:
   - ../../sources/papers/sds_quadruped_arxiv_2410_11571.md
   - ../../sources/repos/rpl_cs_ucl_sds.md
 summary: "E-SDS（arXiv:2512.16446，UCL）在 SDS 式 VLM 视频分析之上，把仿真采样的地形统计并入奖励生成，使 PPO 策略显式使用高度图与 LiDAR；Isaac Lab 中 Unitree G1 四类地形实验显示相对手工感知基线显著降速跟误差，且论文称仅该方法完成楼梯下降。"
+institutions: [unitree]
+
 ---
 
 # E-SDS（Environment-aware See it, Do it, Sorted）

--- a/wiki/entities/paper-explicit-stair-geometry-humanoid-locomotion.md
+++ b/wiki/entities/paper-explicit-stair-geometry-humanoid-locomotion.md
@@ -29,6 +29,8 @@ related:
 sources:
   - ../../sources/papers/explicit_stair_geometry_arxiv_2605_09944.md
 summary: "显式楼梯几何条件化（arXiv:2605.09944）：BEV 点云预测踢面高度/踏面深度/航向与楼梯状态，直接条件化 PPO 人形策略；Isaac Lab 训练、G1 零样本实机，户外连续 33 级上楼，OOD 踢面高度泛化优于视觉 MoRE。"
+institutions: [unitree]
+
 ---
 
 # 显式楼梯几何条件化人形运动（Explicit Stair Geometry Conditioning）

--- a/wiki/entities/paper-from-agi-to-asi.md
+++ b/wiki/entities/paper-from-agi-to-asi.md
@@ -18,6 +18,10 @@ related:
 sources:
   - ../../sources/papers/agi_to_asi_arxiv_2606_12683.md
 summary: "DeepMind 技术报告 From AGI to ASI（arXiv:2606.12683）：刻画后 AGI 时代四条并行能力路径（scaling、范式演进、递归自改进、多智能体集体）与六类瓶颈；对机器人读者，价值在于把 VLA/世界模型/仿真数据飞轮与宏观算力、数据墙、抽象壁垒和具身概念发现放进同一预测框架。"
+institutions:
+  - google-deepmind
+  - google
+
 ---
 
 # From AGI to ASI（DeepMind 技术报告）

--- a/wiki/entities/paper-gamma-world-multi-agent.md
+++ b/wiki/entities/paper-gamma-world-multi-agent.md
@@ -24,6 +24,8 @@ sources:
   - ../../sources/sites/nvidia-gamma-world-project.md
   - ../../sources/repos/gamma_world.md
 summary: "Gamma-World（arXiv:2605.28816）：多智能体生成式交互世界模型，SRAE 置换对称身份 + Sparse Hub 线性跨体注意力 + 块因果学生 24 FPS；2 人训练零样本泛化 4 人，并展示真实多机协调。"
+institutions: [nvidia]
+
 ---
 
 # Gamma-World（γ-World / Generative Multi-Agent World Model）

--- a/wiki/entities/paper-halomi-humanoid-loco-manipulation.md
+++ b/wiki/entities/paper-halomi-humanoid-loco-manipulation.md
@@ -24,6 +24,8 @@ sources:
   - ../../sources/papers/halomi_arxiv_2606_18772.md
   - ../../sources/sites/halomi-humanoid-project.md
 summary: "HALOMI（arXiv:2606.18772，上交/萨塞克斯/华理）从 UMI 式无机器人 egocentric 示范学习人形 loco-manipulation：Pika 双夹爪+头盔追踪头手轨迹，BFM-Zero 潜空间流形约束全身控制器跟踪稀疏世界系目标，ego-view 对齐与控制器感知参考适配缩小人–机鸿沟，π₀.₅ VLA 在 G1 主动颈平台上五项真机任务约 85% 成功率。"
+institutions: [unitree]
+
 ---
 
 # HALOMI（Learning Humanoid Loco-Manipulation with Active Perception from Human Demonstrations）

--- a/wiki/entities/paper-host-humanoid-standingup.md
+++ b/wiki/entities/paper-host-humanoid-standingup.md
@@ -16,6 +16,8 @@ sources:
   - ../../sources/sites/host-humanoid-standingup-project.md
   - ../../sources/repos/host_internrobotics.md
 summary: "HoST（arXiv:2502.08378，RSS 2025 系统论文 finalist）用多 critic PPO、四地形课程与竖直拉力探索，从零学习 Unitree G1 跨地面/平台/墙/坡等多姿态起身，并以 L2C2 与动作 rescaler 约束实现真机直接部署。"
+institutions: [unitree]
+
 ---
 
 # HoST：跨多样姿态的人形起身控制

--- a/wiki/entities/paper-hrl-stack-22-perceptive_humanoid_parkour.md
+++ b/wiki/entities/paper-hrl-stack-22-perceptive_humanoid_parkour.md
@@ -30,6 +30,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "PHP（arXiv:2602.15827）用 motion matching 将 OmniRetarget 原子跑酷技能与 locomotion 合成为长程参考，再以 DAgger+PPO 蒸馏为单一深度学生策略，使 Unitree G1 仅凭机载深度与 2D 速度指令完成 1.25 m 攀墙与多障碍长程跑酷。"
+institutions: [unitree]
+
 ---
 
 # Perceptive Humanoid Parkour（PHP）

--- a/wiki/entities/paper-hrl-stack-27-learning_whole_body_humanoid_locomot.md
+++ b/wiki/entities/paper-hrl-stack-27-learning_whole_body_humanoid_locomot.md
@@ -23,6 +23,10 @@ sources:
   - ../../sources/papers/humanoid_rl_stack_42_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_rl_motion_survey.md
 summary: "ETH RSL 等工作（arXiv:2604.17335）将地形条件扩散运动生成器与 DeepMimic 式 RL 全身跟踪器分层耦合，经冻结生成器的闭环微调实现 onboard 感知下的全身箱攀、跨栏、楼梯与混合地形穿越，Unitree G1 真机验证。"
+institutions:
+  - unitree
+  - eth
+
 ---
 
 # Learning Whole-Body Humanoid Locomotion via Motion Generation and Motion Tracking

--- a/wiki/entities/paper-humanoid-gpt.md
+++ b/wiki/entities/paper-humanoid-gpt.md
@@ -24,6 +24,11 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "Humanoid-GPT（arXiv:2606.03985，CVPR 2026）在 2B 帧 G1 重定向语料上，以 HME 聚类训练数百 PPO motion expert，再经并行 DAgger 蒸馏为 GPT 式因果 Transformer 通用人形 tracker，同时实现高动态跟踪与未见动作零样本泛化，并给出数据/模型 scaling law；真机 G1 相对 SONIC 四类对比与 TensorRT <1.5ms 部署。"
+institutions:
+  - unitree
+  - galbot
+  - tsinghua
+
 ---
 
 # Humanoid-GPT（Scaling Data and Structure for Zero-Shot Motion Tracking）

--- a/wiki/entities/paper-interprior.md
+++ b/wiki/entities/paper-interprior.md
@@ -19,6 +19,8 @@ sources:
   - ../../sources/papers/interprior_arxiv_2602_06035.md
   - ../../sources/sites/sirui-xu-interprior-github-io.md
 summary: "InterPrior（arXiv:2602.06035，CVPR 2026 Highlight）提出物理 HOI 的规模化生成式控制：InterMimic+ 全参考 PPO 专家 → 掩码多模态目标条件变分蒸馏 → 带正则与失败态重置的 RL 微调，将模仿覆盖与 RL 鲁棒性结合，报告未见物体/目标下的全身 loco-manipulation 与用户交互控制，并展示 G1 sim-to-sim。"
+institutions: [unitree]
+
 ---
 
 # InterPrior（Scaling Generative Control for Physics-Based Human-Object Interactions）

--- a/wiki/entities/paper-ladderman-humanoid-perceptive-ladder-climbing.md
+++ b/wiki/entities/paper-ladderman-humanoid-perceptive-ladder-climbing.md
@@ -39,6 +39,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "LadderMan（arXiv:2606.05873，Amazon FAR）两阶段：hybrid motion tracking 从单参考学多几何攀爬专家，hybrid DAgger+RL 蒸馏为深度统一策略；VFM+RFM 零样本 sim-to-real；梯上双智能体遥操作相对 TWIST2 更稳；G1 真机多样梯子双向攀爬约 3.4 s/踏棍。"
+institutions: [unitree]
+
 ---
 
 # LadderMan：人形感知梯子攀爬与梯上操作

--- a/wiki/entities/paper-legs-embodied-gaussian-splatting-vla.md
+++ b/wiki/entities/paper-legs-embodied-gaussian-splatting-vla.md
@@ -22,6 +22,10 @@ sources:
   - ../../sources/blogs/wechat_embodied_ai_lab_legs_vla_3dgs_loco_manip.md
   - ../../sources/sites/legsvla-github-io.md
 summary: "LEGS（arXiv:2606.01458）用 3DGS 背景 + SAM3D mesh 前景 + MuJoCo/Sonic 合成无遥操作人形 loco-manip 演示，motion 与外观解耦可 GPU 重渲染；在 G1 上微调 ψ0/π0.5/GR00T N1.6 匹配或超过 50-demo teleop，并优于 mesh-only 合成基线。"
+institutions:
+  - unitree
+  - stanford
+
 ---
 
 # LEGS（Loco-manipulation via Embodied Gaussian Splatting）

--- a/wiki/entities/paper-loco-manip-04-oasis.md
+++ b/wiki/entities/paper-loco-manip-04-oasis.md
@@ -30,6 +30,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "OASIS（arXiv:2606.08548）用 Hunyuan3D+Qwen3-VL 从真实图建仿真场景，VR 仿真 teleop 录状态后离线 Path-Tracing 域随机化扩增，训练 Flow Matching 高层+Teleopit 低层层级策略；G1 零样本部署，纯仿真数据在多数任务匹配或超过等量真机 teleop。"
+institutions: [unitree]
+
 ---
 
 # OASIS（From Simulation Data Collection to Real-World Humanoid Loco-Manipulation）

--- a/wiki/entities/paper-mighty-hermite-spline-trajectory-planning.md
+++ b/wiki/entities/paper-mighty-hermite-spline-trajectory-planning.md
@@ -24,6 +24,8 @@ sources:
   - ../../sources/papers/mighty_arxiv_2511_10822.md
   - ../../sources/repos/mighty.md
 summary: "MIGHTY（arXiv:2511.10822 · RA-L 2026）：MIT ACL 的五次 Hermite 样条软约束 UAV 规划器——单次 NLP 联合优化 knot 位姿/速度/加速度与段时长；相对 EGO-Planner/MINCO 仿真计算 −9.3%、飞行 −13.1%；真机 clutter 最高 6.7 m/s；ROS 2 Humble 开源。"
+institutions: [mit]
+
 ---
 
 # MIGHTY（Hermite 样条高效 UAV 轨迹规划）

--- a/wiki/entities/paper-motiondisco-extreme-humanoid-loco-manipulation.md
+++ b/wiki/entities/paper-motiondisco-extreme-humanoid-loco-manipulation.md
@@ -28,6 +28,8 @@ related:
 sources:
   - ../../sources/papers/motiondisco_arxiv_2606_06139.md
 summary: "MotionDisco（arXiv:2606.06139）：LLM 引导进化式程序搜索 + 接触显式 kinodynamic TO，从零发现长时程人形 loco-manipulation 接触计划；DeepMimic 式 RL 跟踪在 G1 真机零样本部署，无需遥操作或人体重定向。"
+institutions: [unitree]
+
 ---
 
 # MotionDisco（极端人形 Loco-Manipulation 运动发现）

--- a/wiki/entities/paper-motionwam-humanoid-loco-manipulation-wam.md
+++ b/wiki/entities/paper-motionwam-humanoid-loco-manipulation-wam.md
@@ -35,6 +35,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "MotionWAM（arXiv:2606.09215）：实时人形 loco-manipulation 的 World Action Model——Video DiT 单次前向隐状态条件 Motion DiT，在统一 SONIC motion token 空间联合预测行走、躯干、身高、足端交互与双手操作；三阶段 egocentric 视频→跨具身动作→全身遥操作微调；G1 九项真机任务平均成功率 76.1%，较同演示微调 GR00T-N1.7 高约 32 个百分点。"
+institutions: [unitree]
+
 ---
 
 # MotionWAM（实时人形 Loco-Manipulation · World Action Model）

--- a/wiki/entities/paper-mujica-wheel-legged-multi-skill.md
+++ b/wiki/entities/paper-mujica-wheel-legged-multi-skill.md
@@ -18,6 +18,8 @@ related:
 sources:
   - ../../sources/papers/mujica_arxiv_2605_13058.md
 summary: "MUJICA（arXiv:2605.13058，ICRA 2026）在 Unitree Go2-W 上用单一本体策略联合全向移动、高台攀爬与摔倒恢复，以 DC 电机硬约束 P3O 与高层技能选择器实现安全零样本 sim2real 与自主模态切换。"
+institutions: [unitree]
+
 ---
 
 # MUJICA：轮足多技能统一本体控制架构

--- a/wiki/entities/paper-notebook-berkeley-humanoid-a-research-platform-for-learni.md
+++ b/wiki/entities/paper-notebook-berkeley-humanoid-a-research-platform-for-learni.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_berkeley-humanoid-a-research-platform-for-learni.md
 summary: "Berkeley Humanoid：列入 Paper Notebooks PROGRESS.md 待深读清单；深读笔记完成后升格为完整索引实体。"
+institutions: [berkeley]
+
 ---
 
 # Berkeley Humanoid

--- a/wiki/entities/paper-notebook-berkeley-humanoid-lite-an-open-source-accessible.md
+++ b/wiki/entities/paper-notebook-berkeley-humanoid-lite-an-open-source-accessible.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_berkeley-humanoid-lite-an-open-source-accessible.md
 summary: "Berkeley Humanoid Lite：列入 Paper Notebooks PROGRESS.md 待深读清单；深读笔记完成后升格为完整索引实体。"
+institutions: [berkeley]
+
 ---
 
 # Berkeley Humanoid Lite

--- a/wiki/entities/paper-notebook-booster-gym-an-end-to-end-rl-framework-for-human.md
+++ b/wiki/entities/paper-notebook-booster-gym-an-end-to-end-rl-framework-for-human.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_booster-gym-an-end-to-end-rl-framework-for-human.md
 summary: "Booster Gym：列入 Paper Notebooks PROGRESS.md 待深读清单；深读笔记完成后升格为完整索引实体。"
+institutions: [booster]
+
 ---
 
 # Booster Gym

--- a/wiki/entities/paper-notebook-learning-bipedal-locomotion-on-gear-driven-human.md
+++ b/wiki/entities/paper-notebook-learning-bipedal-locomotion-on-gear-driven-human.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_learning-bipedal-locomotion-on-gear-driven-human.md
 summary: "Learning Bipedal Locomotion on Gear-Driven Humanoid Robot Using Foot-Mounted IMUs：列入 Paper Notebooks PROGRESS.md 待深读清单；深读笔记完成后升格为完整索引实体。"
+institutions: [nvidia]
+
 ---
 
 # Learning Bipedal Locomotion on Gear-Driven Humanoid Robot Using Foot-Mounted IMUs

--- a/wiki/entities/paper-notebook-proprioceptive-actuator-design-in-the-mit-cheeta.md
+++ b/wiki/entities/paper-notebook-proprioceptive-actuator-design-in-the-mit-cheeta.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_proprioceptive-actuator-design-in-the-mit-cheeta.md
 summary: "Proprioceptive actuator design in the MIT Cheetah：列入 Paper Notebooks PROGRESS.md 待深读清单；深读笔记完成后升格为完整索引实体。"
+institutions: [mit]
+
 ---
 
 # Proprioceptive actuator design in the MIT Cheetah

--- a/wiki/entities/paper-notebook-the-mit-humanoid-robot-design-motion-planning-an.md
+++ b/wiki/entities/paper-notebook-the-mit-humanoid-robot-design-motion-planning-an.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_the-mit-humanoid-robot-design-motion-planning-an.md
 summary: "The MIT Humanoid Robot：列入 Paper Notebooks PROGRESS.md 待深读清单；深读笔记完成后升格为完整索引实体。"
+institutions: [mit]
+
 ---
 
 # The MIT Humanoid Robot

--- a/wiki/entities/paper-notebook-unitree-h1-whitepaper.md
+++ b/wiki/entities/paper-notebook-unitree-h1-whitepaper.md
@@ -11,6 +11,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_pnb_unitree-h1-whitepaper.md
 summary: "Unitree H1 是全球首款能够完成原地后空翻的全尺寸电驱动人形机器人，凭借自研的高扭矩密度电机和强大的计算能力，成为了具身智能科研领域的\"国民级\"硬件平台。"
+institutions: [unitree]
+
 ---
 
 # Unitree H1 Humanoid Robot Whitepaper & Specifications

--- a/wiki/entities/paper-omg-omni-modal-humanoid-control.md
+++ b/wiki/entities/paper-omg-omni-modal-humanoid-control.md
@@ -23,6 +23,10 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "OMG（清华 MARS Lab）提出 generator–tracker 分层的 omni-modal 人形运动生成：OMG-DiT 将语言/音频/人体参考/运动历史及组合实时转为 G1 可跟踪轨迹，OMG-Data 约 1174.66 h；开源训练/推理/部署代码，tracker 复用 HoloMotion。"
+institutions:
+  - unitree
+  - tsinghua
+
 ---
 
 # OMG：Omni-Modal Motion Generation for Generalist Humanoid Control

--- a/wiki/entities/paper-perceptive-bfm.md
+++ b/wiki/entities/paper-perceptive-bfm.md
@@ -28,6 +28,10 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "Perceptive BFM（妙动科技等，CoRL 2026）：保留原始人体运动参考为部署命令，用机器人中心高程感知在线补落脚/间隙/接触时序；TCRS 离线合成地形监督，PMT 四阶段（盲 teacher→视觉 student→目标帧对齐蒸馏→identity-gated 残差）在 Unitree G1 上单策略覆盖跟踪、风格动作、杂技与 mocap 遥操作。"
+institutions:
+  - unitree
+  - hkust
+
 ---
 
 # Perceptive BFM：Adapting Human Motion Priors to Robot-Centric Terrain

--- a/wiki/entities/paper-phygile.md
+++ b/wiki/entities/paper-phygile.md
@@ -21,6 +21,8 @@ sources:
   - ../../sources/papers/phygile_arxiv_2603_19305.md
   - ../../sources/sites/phygile-page.md
 summary: "PhyGile（arXiv:2603.19305）以 physics-prefix 引导的 262D 机器人原生扩散生成与课程式 MoE GMT 跟踪器闭环，从文本直接产出可执行高动态全身动作，真机验证 breakdance、侧手翻与旋跳等超越低动态行走的前沿敏捷运动。"
+institutions: [shanghai-ai-lab]
+
 ---
 
 # PhyGile（Physics-Prefix Guided Motion Generation for Agile General Humanoid Motion Tracking）

--- a/wiki/entities/paper-pilot-perceptive-loco-manipulation.md
+++ b/wiki/entities/paper-pilot-perceptive-loco-manipulation.md
@@ -29,6 +29,8 @@ related:
 sources:
   - ../../sources/papers/pilot_arxiv_2601_17440.md
 summary: "PILOT（arXiv:2601.17440，上海交大）用单阶段 PPO 统一 LiDAR 高程图感知行走与大工作空间全身操作：跨模态编码器 + 4 专家 MoE + 上肢残差；G1 真机非结构化楼梯/高台 loco-manipulation 遥操作与分层 RL。"
+institutions: [unitree]
+
 ---
 
 # PILOT：非结构化场景感知统一 loco-manipulation 低层控制器

--- a/wiki/entities/paper-resmimic.md
+++ b/wiki/entities/paper-resmimic.md
@@ -19,6 +19,8 @@ sources:
   - ../../sources/sites/resmimic-github-io.md
   - ../../sources/repos/resmimic.md
 summary: "ResMimic（arXiv:2510.05070，Amazon FAR）用两阶段残差学习把大规模 GMT 先验接到物体条件 loco-manipulation：点云物体跟踪奖励、接触奖励与虚拟力课程稳定训练，G1 真机实现 92.5% sim-to-sim 成功率与 4.5–5.5 kg 全身接触搬运。"
+institutions: [unitree]
+
 ---
 
 # ResMimic（GMT → 人形全身 Loco-Manipulation 残差学习）

--- a/wiki/entities/paper-rhythm-dual-humanoid-interaction.md
+++ b/wiki/entities/paper-rhythm-dual-humanoid-interaction.md
@@ -20,6 +20,8 @@ sources:
   - ../../sources/papers/rhythm_arxiv_2603_02856.md
   - ../../sources/sites/hoshi-no-ai-rhythm-github-io.md
 summary: "Rhythm（arXiv:2603.02856）提出双 humanoid 物理交互统一框架：IAMR 解耦自运动与交互几何生成可行双人参考并发布 MAGIC 数据集，IGRL 以 MAPPO + 图结构奖励学耦合动力学，相对定位与相位同步在 Unitree G1 真机实现拥抱、共舞等复杂交互的 sim2real 迁移。"
+institutions: [unitree]
+
 ---
 
 # Rhythm（Learning Interactive Whole-Body Control for Dual Humanoids）

--- a/wiki/entities/paper-robonaldo-humanoid-soccer-shooting.md
+++ b/wiki/entities/paper-robonaldo-humanoid-soccer-shooting.md
@@ -30,6 +30,8 @@ sources:
   - ../../sources/papers/robonaldo_arxiv_2606_11092.md
   - ../../sources/sites/opendrivelab-robonaldo.md
 summary: "RoboNaldo（arXiv:2606.11092）：以单条人类踢球参考为 scaffold 的三阶段 motion-guided curriculum RL——先学稳定全身踢球先验，再适应任意球位定点射门，最后经 locomotion 命令与 kick-trigger 泛化到来球射门；G1 机载 LiDAR/IR 感知在真草场外实现 3 m 平均误差 0.73 m/0.86 m 与最高 13.10 m/s 触球球速。"
+institutions: [unitree]
+
 ---
 
 # RoboNaldo（人形足球射门 · Motion-Guided Curriculum RL）

--- a/wiki/entities/paper-rove-humanoid-vla-intervention.md
+++ b/wiki/entities/paper-rove-humanoid-vla-intervention.md
@@ -20,6 +20,8 @@ sources:
   - ../../sources/papers/rove_arxiv_2606_17011.md
   - ../../sources/sites/xpeng-robotics-rove.md
 summary: "ROVE（arXiv:2606.17011，XPENG Robotics 等）为人形 VLA 部署后训练提出人机闭环 RL：全身 MoCap 干预采集将轨迹分为 rollout/adaptation/recovery，以 OVE 状态价值 critic 与跨 embodiment 人类视频从混合质量经验中提取 advantage-conditioned 策略，真机接触丰富与精细操作任务上优于 SFT 与 HG-DAgger/Filtered BC/RECAP，并随三轮 rollout–intervention 迭代持续提升。"
+institutions: [xpeng]
+
 ---
 
 # ROVE（Unlocking Human Interventions for Humanoid Manipulation via RL）

--- a/wiki/entities/paper-rpl-robust-humanoid-perceptive-locomotion.md
+++ b/wiki/entities/paper-rpl-robust-humanoid-perceptive-locomotion.md
@@ -34,6 +34,8 @@ sources:
   - ../../sources/papers/rpl_arxiv_2602_03002.md
   - ../../sources/sites/rpl-humanoid-github-io.md
 summary: "RPL（arXiv:2602.03002，Amazon FAR）两阶段训练：特权高程图分地形专家（FALCON 双智能体 PPO）经 DAgger 蒸馏为多视角深度 Transformer 统一策略；DFSV 与 RSM 鲁棒双向行走与未见窄地形；Warp 多深度渲染约 5× 加速；G1 真机带 2 kg 载荷穿越坡/楼梯/垫脚石。"
+institutions: [unitree]
+
 ---
 
 # RPL：复杂地形上的鲁棒人形多向感知行走

--- a/wiki/entities/paper-slowrl-safe-lora-locomotion-sim2real.md
+++ b/wiki/entities/paper-slowrl-safe-lora-locomotion-sim2real.md
@@ -18,6 +18,8 @@ related:
 sources:
   - ../../sources/papers/slowrl_arxiv_2603_17092.md
 summary: "SLowRL（arXiv:2603.17092）冻结仿真预训练腿足策略，用 rank-1 LoRA 与训练期 Recovery 安全滤波在 Unitree Go2 真机上微调 jump/trot，墙钟约快 46.5%、近零摔倒，主张 sim2real 残差为低维流形对齐。"
+institutions: [unitree]
+
 ---
 
 # SLowRL：安全低秩 RL 真机运动微调

--- a/wiki/entities/paper-splitadapter-load-aware-loco-manipulation.md
+++ b/wiki/entities/paper-splitadapter-load-aware-loco-manipulation.md
@@ -24,6 +24,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "SplitAdapter（arXiv:2606.03297）冻结 PhysHSI 类 AMP 人形搬箱策略，用物体/负载与动力学双分支历史编码、分裂世界模型、GRL 交叉对抗解耦与分层 FiLM 做负载感知在线适配；MuJoCo sim-to-sim 与 Unitree G1 零样本真机在 2–6 kg 与多搬放高度下显著提升 Full-task 成功率，6 kg 重载增益最大。"
+institutions: [unitree]
+
 ---
 
 # SplitAdapter（Load-Aware Humanoid Loco-Manipulation via Factorized Adaptation）

--- a/wiki/entities/paper-sprint-humanoid-athletic-sprints.md
+++ b/wiki/entities/paper-sprint-humanoid-athletic-sprints.md
@@ -18,6 +18,8 @@ related:
 sources:
   - ../../sources/papers/sprint_arxiv_2605_28549.md
 summary: "SPRINT（arXiv:2605.28549）用 5 条 LAFAN1 重定向步态训练频率自适应频谱先验，再以冻结先验 + PPO 残差在 Unitree G1 上实现 0–6 m/s 连续变速与零样本真机冲刺 6 m/s。"
+institutions: [unitree]
+
 ---
 
 # SPRINT：人形竞技冲刺的高效频谱先验

--- a/wiki/entities/paper-ssr-humanoid-open-world-traversal.md
+++ b/wiki/entities/paper-ssr-humanoid-open-world-traversal.md
@@ -26,6 +26,10 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "SSR（arXiv:2605.30770）用单阶段第一视角深度 PPO，以想象落脚点引导、等变潜空间对称增广与分地形多判别器 AMP 联合学习安全落脚与自然全身运动，在 AgiBot X2 上零样本穿越楼梯/沟壑/高台并完成 1.3 km 户外长程。"
+institutions:
+  - agibot
+  - zju
+
 ---
 
 # SSR：开放世界人形安全对称穿越

--- a/wiki/entities/paper-swap-parkour.md
+++ b/wiki/entities/paper-swap-parkour.md
@@ -18,6 +18,8 @@ sources:
   - ../../sources/papers/swap_parkour_arxiv_2606_19928.md
   - ../../sources/sites/swap-parkour-github-io.md
 summary: "SWAP（arXiv:2606.19928）在 RSSM 潜变量世界模型与 Actor-Critic 上硬嵌入左右镜像等变（SE-CNN/MLP/GRU），端到端训练四足极限跑酷；Apollo 实机 2.13 m 远跳 / 1.63 m 攀台，并对镜像地形与户外场景零样本泛化。"
+institutions: [zju]
+
 ---
 
 # SWAP：对称等变世界模型四足跑酷

--- a/wiki/entities/paper-twist2.md
+++ b/wiki/entities/paper-twist2.md
@@ -33,6 +33,8 @@ sources:
   - ../../sources/blogs/wechat_embodied_ai_lab_bfm_41_papers_survey.md
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
+institutions: [unitree]
+
 ---
 
 # TWIST2

--- a/wiki/entities/paper-ume-exo.md
+++ b/wiki/entities/paper-ume-exo.md
@@ -18,6 +18,8 @@ sources:
   - ../../sources/papers/ume_exo_arxiv_2606_14218.md
   - ../../sources/sites/ume-exo-project.md
 summary: "UME（Universal Manipulation Exoskeleton，arXiv:2606.14218）是 Ant Group / Stanford 提出的低成本上肢外骨骼遥操作平台：实时透明触觉力矩反馈、全身臂形与关节力矩同步记录、IMU 驱动移动底座与通用 3-1-3 子链重定向；ACT 融合力矩模态学习主动柔顺双臂全身策略，在力主导与极窄空间任务上显著优于无力矩与 UMI 式末端示教。"
+institutions: [stanford]
+
 ---
 
 # UME-EXO（Universal Manipulation Exoskeleton）

--- a/wiki/entities/paper-unified-walk-run-recovery-sdamp.md
+++ b/wiki/entities/paper-unified-walk-run-recovery-sdamp.md
@@ -17,6 +17,8 @@ related:
 sources:
   - ../../sources/papers/unified_walk_run_recovery_sdamp_arxiv_2605_18611.md
 summary: "SD-AMP（arXiv:2605.18611）用投影重力门控在训练期切换 recovery 与速度条件 locomotion 两个 AMP 判别器，三条 LAFAN1 参考即让 Unitree G1 单策略统一走、跑与俯卧/仰卧起身，真机 50 Hz ONNX 无运行时模式切换。"
+institutions: [unitree]
+
 ---
 
 # SD-AMP：统一走、跑与起身的对抗运动先验

--- a/wiki/entities/paper-vesta-generalist-embodied-reasoning.md
+++ b/wiki/entities/paper-vesta-generalist-embodied-reasoning.md
@@ -18,6 +18,8 @@ related:
 sources:
   - ../../sources/papers/vesta_arxiv_2606_20905.md
 summary: "Vesta（arXiv:2606.20905）在 Qwen3-VL-8B 上以空间导向 SFT 混合语料与极简 image+text memory harness，统一定位、VLN、具身推理与长时程子任务规划；四轴 benchmark 平均超最强单基线 >20 pt，真机 Gr00t-N1.6+YAM 记忆任务 +38.3% 成功率。"
+institutions: [nvidia]
+
 ---
 
 # Vesta（A Generalist Embodied Reasoning Model）

--- a/wiki/entities/paper-viral-humanoid-visual-sim2real.md
+++ b/wiki/entities/paper-viral-humanoid-visual-sim2real.md
@@ -22,6 +22,11 @@ related:
 sources:
   - ../../sources/papers/viral-humanoid-visual-sim2real.md
 summary: "VIRAL（arXiv:2511.15200，CVPR 2026）给出人形 loco-manipulation 的视觉 Sim2Real 全栈配方：PPO 特权教师以 delta 命令驱动预训练 WBC，大规模分块渲染仿真中用 DAgger+BC 蒸馏 RGB 学生，并结合 SysID、相机对齐与强视觉域随机化在 Unitree G1 上零样本部署。"
+institutions:
+  - unitree
+  - nvidia
+  - cmu
+
 ---
 
 # VIRAL（Visual Sim-to-Real at Scale for Humanoid Loco-Manipulation）

--- a/wiki/entities/paper-x-ionet-cross-platform-inertial-odometry.md
+++ b/wiki/entities/paper-x-ionet-cross-platform-inertial-odometry.md
@@ -23,6 +23,8 @@ related:
 sources:
   - ../../sources/papers/x_ionet_arxiv_2511_08277.md
 summary: "X-IONet：单 IMU 跨平台惯性里程计；规则专家路由 + 双阶段 attention 位移网络输出位移/不确定性，EKF 融合；RoNIN/GrandTour/Go2 SOTA。"
+institutions: [unitree]
+
 ---
 
 # X-IONet（跨平台惯性里程计网络）

--- a/wiki/entities/protomotions.md
+++ b/wiki/entities/protomotions.md
@@ -16,6 +16,8 @@ related:
 sources:
   - ../../sources/repos/protomotions.md
 summary: "ProtoMotions3 是 NVIDIA 开源的 GPU 加速人形仿真与学习框架，强调多后端、大规模动捕数据管线、模块化任务拼装与 ONNX 化 Sim2Real 部署。"
+institutions: [nvidia]
+
 ---
 
 # ProtoMotions: 大规模人形机器人仿真框架

--- a/wiki/entities/robot-lab.md
+++ b/wiki/entities/robot-lab.md
@@ -14,6 +14,8 @@ related:
 sources:
   - ../../sources/repos/robot_lab.md
 summary: "robot_lab 是基于 NVIDIA IsaacLab 的机器人 RL 扩展库，在独立仓库中注册 24+ 速度跟踪环境与 BeyondMimic/AMP 等任务，覆盖四足、轮足与人形多厂商机型，训练后可通过 rl_sar 衔接 Gazebo/真机部署。"
+institutions: [unitree]
+
 ---
 
 # robot_lab (IsaacLab 扩展框架)

--- a/wiki/entities/robot-motion-keyframe-editors.md
+++ b/wiki/entities/robot-motion-keyframe-editors.md
@@ -15,6 +15,8 @@ sources:
   - ../../sources/repos/stanford-tml-robot-keyframe-kit.md
   - ../../sources/repos/project-instinct-robot-motion-editor.md
 summary: "三条互补的「机器人参考运动 / 关键帧」编辑链路：浏览器内 URDF+CSV（cyoahs）、MuJoCo MJCF+物理+Viser（Stanford robot_keyframe_kit）、Flask+URDF+NPZ（Project Instinct），分别服务日志后处理、仿真内关键帧编排与学习数据曲线修整。"
+institutions: [stanford]
+
 ---
 
 # 机器人关键帧与运动编辑工具（选型入口）

--- a/wiki/entities/robotic-world-model-eth-rsl.md
+++ b/wiki/entities/robotic-world-model-eth-rsl.md
@@ -13,6 +13,8 @@ sources:
   - ../../sources/repos/leggedrobotics_robotic_world_model.md
   - ../../sources/repos/leggedrobotics_robotic_world_model_lite.md
 summary: "ETH RSL 的 Robotic World Model（RWM）与 Uncertainty-Aware RWM（RWM-U）：在 Isaac Lab 中联训神经动力学与 PPO，并支持在线或纯离线想象 rollout 训练模型基策略；Lite 仓剥离仿真仅保留离线管线与 Colab 入口。"
+institutions: [eth]
+
 ---
 
 # Robotic World Model（ETH RSL：RWM / RWM-U）

--- a/wiki/entities/sage-sim2real-actuator-gap-estimator.md
+++ b/wiki/entities/sage-sim2real-actuator-gap-estimator.md
@@ -16,6 +16,10 @@ sources:
   - ../../sources/repos/sage-sim2real-actuator-gap.md
   - ../../sources/courses/nvidia_sim_to_real_so101_isaac.md
 summary: "SAGE 在 Isaac Sim 中重放关节轨迹并与真机日志对齐，用 RMSE/相关/余弦相似度等指标量化执行器层 sim2real gap，并支持导出成对数据用于 gap 补偿建模。"
+institutions:
+  - unitree
+  - nvidia
+
 ---
 
 # SAGE（Sim2Real Actuator Gap Estimator）

--- a/wiki/entities/sam-3d-body.md
+++ b/wiki/entities/sam-3d-body.md
@@ -14,6 +14,8 @@ sources:
   - ../../sources/papers/sam_3d_body_arxiv_2602_15989.md
   - ../../sources/repos/sam-3d-body.md
 summary: "SAM 3D Body（3DB）是 Meta 发布的可提示单图全身人体网格恢复基础模型：基于 MHR 参数化解耦骨架与表面，encoder–decoder 架构支持 2D 关键点/mask 引导，在 3DPW/EMDB 等基准报告 SOTA 级误差，并开放 checkpoint、数据集与 Hugging Face 推理接口。"
+institutions: [meta]
+
 ---
 
 # SAM 3D Body（3DB）

--- a/wiki/entities/sbto.md
+++ b/wiki/entities/sbto.md
@@ -16,6 +16,8 @@ related:
 sources:
   - ../../sources/repos/sbto.md
   - ../../sources/papers/dynaretarget_arxiv_2602_06827.md
+institutions: [unitree]
+
 ---
 
 # sbto（DynaRetarget SBTO 官方实现）

--- a/wiki/entities/schedulestream.md
+++ b/wiki/entities/schedulestream.md
@@ -24,6 +24,8 @@ sources:
   - ../../sources/papers/schedulestream_arxiv_2511_04758.md
   - ../../sources/repos/nvlabs-schedulestream.md
 summary: "ScheduleStream 是 NVIDIA 提出的领域无关「规划+调度+连续采样」框架：用 durative action 表达可并行多臂动作，在 TAMPAS 应用里把 PDDLStream 式 stream 批量化到 GPU，输出碰撞自由时间表而非单臂串行 TAMP 计划。"
+institutions: [nvidia]
+
 ---
 
 # ScheduleStream

--- a/wiki/entities/smp-g1-mjlab.md
+++ b/wiki/entities/smp-g1-mjlab.md
@@ -16,6 +16,10 @@ sources:
   - ../../sources/repos/smp_suz_tsinghua.md
   - ../../sources/papers/smp.md
 summary: "SUZ-tsinghua/smp 在 mjlab 上为 Unitree G1 端到端复现 SMP：DDPM 运动先验预训练、冻结 SDS 引导奖励、GSI 初始化与四类下游任务，并预置三套 prior 以跳过预训练。"
+institutions:
+  - unitree
+  - tsinghua
+
 ---
 
 # SMP on G1（mjlab 复现）

--- a/wiki/entities/soma-retargeter.md
+++ b/wiki/entities/soma-retargeter.md
@@ -15,6 +15,10 @@ sources:
   - ../../sources/repos/soma_retargeter.md
   - ../../sources/repos/nvlabs-soma-x.md
   - ../../sources/papers/genmo.md
+institutions:
+  - nvidia
+  - unitree
+
 ---
 
 # SOMA Retargeter

--- a/wiki/entities/soma-x.md
+++ b/wiki/entities/soma-x.md
@@ -15,6 +15,8 @@ sources:
   - ../../sources/repos/nvlabs-soma-x.md
   - ../../sources/sites/soma-x-docs.md
   - ../../sources/papers/soma_arxiv_2603_16858.md
+institutions: [nvidia]
+
 ---
 
 # SOMA-X（统一参数化人体模型）

--- a/wiki/entities/stanford-doggo-and-pupper.md
+++ b/wiki/entities/stanford-doggo-and-pupper.md
@@ -16,6 +16,8 @@ sources:
   - ../../sources/courses/stanford_cs123_robotics_ai.md
   - ../../sources/blogs/wechat_jixie_robot_open_source_treasury_issue02_10_robots.md
 summary: "Stanford Doggo 与 Pupper 开源四足生态：Doggo 偏高动态跳跃；Pupper 从教学版演进至 v3 伴侣平台（~$2000 自组、Pi 5 + GIM4305、仿真 RL、VLM/语音、ROS 2 monorepo 与 CS 123 课程）。"
+institutions: [stanford]
+
 ---
 
 # Stanford Doggo / Pupper（开源四足）

--- a/wiki/entities/tairan-he.md
+++ b/wiki/entities/tairan-he.md
@@ -17,6 +17,10 @@ related:
 sources:
   - ../../sources/sites/tairan-he.md
 summary: "何泰然（Tairan He）为 CMU RI 博士、NVIDIA GEAR 实习背景，研究聚焦人形规模化学习与视觉 Sim2Real；代表作含 OmniH2O、HOVER、ASAP、VIRAL / DoorMan 等，主页为论文与项目总索引。"
+institutions:
+  - cmu
+  - nvidia
+
 ---
 
 # Tairan He（何泰然）

--- a/wiki/entities/tau0-world-model.md
+++ b/wiki/entities/tau0-world-model.md
@@ -28,6 +28,8 @@ sources:
   - ../../sources/sites/tau0-wm-agibot-finch.md
   - ../../sources/repos/sii_research_tau_0_wm.md
 summary: "τ₀-WM（5B）：在 Wan-2.2 级视频扩散骨干上联合训练多视角未来 latent 与连续 action chunk，用异构约 2.73 万小时数据与模态掩码分监督；推理时策略采样 + 动作条件仿真评估 + Re-denoising Consistency，形成 propose–evaluate–revise 测试时闭环。"
+institutions: [agibot]
+
 ---
 
 # τ₀-World Model（τ0-WM）

--- a/wiki/entities/tidybot2.md
+++ b/wiki/entities/tidybot2.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_jixie_robot_open_source_treasury_issue02_10_robots.md
 summary: "TidyBot2：面向家庭物品整理的移动操作研究平台；项目站、硬件文档与论文 PDF 同源发布，代码通常挂靠在主导研究者 GitHub。"
+institutions: [princeton]
+
 ---
 
 # TidyBot2

--- a/wiki/entities/unitree-g1.md
+++ b/wiki/entities/unitree-g1.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/papers/humanoid_hardware.md
 summary: "Unitree G1 是一款由宇树科技推出的入门级教育科研用人形机器人，以其极高的性价比、高集成度以及对仿真学习框架的良好支持而备受关注。"
+institutions: [unitree]
+
 ---
 
 # Unitree G1 (人形机器人)

--- a/wiki/entities/unitree-rl-mjlab.md
+++ b/wiki/entities/unitree-rl-mjlab.md
@@ -15,6 +15,8 @@ related:
 sources:
   - ../../sources/repos/unitree_rl_mjlab.md
 summary: "unitree_rl_mjlab 是 Unitree 官方基于 mjlab 的 RL 训练框架，支持 Go2/G1/H1_2 等 7 款机型，覆盖速度跟踪与动作模仿，内建 ONNX 导出到 C++ 真机部署的完整链路。"
+institutions: [unitree]
+
 ---
 
 # unitree_rl_mjlab (Unitree 官方 RL 框架)

--- a/wiki/entities/unitree-ros.md
+++ b/wiki/entities/unitree-ros.md
@@ -15,6 +15,8 @@ sources:
   - ../../sources/repos/unitree_ros.md
   - ../../sources/repos/unitree_ros_to_real.md
 summary: "unitree_ros 是 Unitree 官方 ROS1（Melodic/Kinetic）+ Gazebo8 的机器人描述与关节级仿真栈；真机 ROS 控制依赖 unitree_ros_to_real 与 unitree_legged_msgs。README 明确 Gazebo 侧不做高层行走，与 MuJoCo 上的 unitree_rl_mjlab 形成并行官方路线。"
+institutions: [unitree]
+
 ---
 
 # unitree_ros（Unitree 官方 ROS1 / Gazebo 栈）

--- a/wiki/entities/unitree.md
+++ b/wiki/entities/unitree.md
@@ -10,6 +10,8 @@ related:
   - ./unitree-ros.md
   - ../concepts/wheel-legged-quadruped.md
   - ./dreamwaq-plus.md
+institutions: [unitree]
+
 ---
 
 # Unitree

--- a/wiki/entities/vision-banana.md
+++ b/wiki/entities/vision-banana.md
@@ -13,6 +13,8 @@ sources:
   - ../../sources/papers/vision_banana_arxiv_2604_20329.md
   - ../../sources/sites/vision-banana-project.md
 summary: "Vision Banana（arXiv:2604.20329，DeepMind）在 Nano Banana Pro 上以极低比例混入视觉任务数据做 instruction-tuning，把分割/深度/法线输出参数化为可解码 RGB 图，在 zero-shot transfer 下多项 2D/3D 基准达或超 SAM 3、Depth Anything 3 等专家，且保留图像生成能力。"
+institutions: [google-deepmind]
+
 ---
 
 # Vision Banana

--- a/wiki/entities/voxgraph.md
+++ b/wiki/entities/voxgraph.md
@@ -9,6 +9,8 @@ related:
 sources:
   - ../../sources/repos/voxgraph.md
 summary: "Voxgraph 基于 Voxblox TSDF 子图做位姿图优化，支持多会话建图与度量地图对齐。"
+institutions: [eth]
+
 ---
 
 # Voxgraph

--- a/wiki/entities/wbc-fsm.md
+++ b/wiki/entities/wbc-fsm.md
@@ -15,6 +15,8 @@ related:
 sources:
   - ../../sources/repos/wbc_fsm.md
 summary: "wbc_fsm 是针对 Unitree G1 的 C++ 全身控制部署框架，用有限状态机管理 Passive/Loco/WBC 三种模式，内嵌 LAFAN1 动捕训练的 ONNX 策略，无 ROS 依赖，支持仿真与真机双端部署。"
+institutions: [unitree]
+
 ---
 
 # wbc_fsm (G1 全身控制 FSM 部署框架)

--- a/wiki/entities/xue-bin-peng.md
+++ b/wiki/entities/xue-bin-peng.md
@@ -17,6 +17,10 @@ sources:
   - ../../sources/sites/xue-bin-peng.md
   - ../../sources/papers/deeprl_locomotion_action_space_sca2017.md
 summary: "彭学斌（Xue Bin Peng）为 SFU 助理教授兼 NVIDIA 研究科学家，博士师从 Levine / Abbeel；以 DeepMimic、AMP、ASE、动力学随机化 Sim2Real 等工作定义了物理角色与腿式机器人 RL 运动控制的一条主干研究线，并通过 MimicKit 统一开源实现。"
+institutions:
+  - nvidia
+  - berkeley
+
 ---
 
 # Xue Bin Peng（彭学斌）

--- a/wiki/entities/zhengyi-luo.md
+++ b/wiki/entities/zhengyi-luo.md
@@ -16,6 +16,10 @@ related:
 sources:
   - ../../sources/sites/zhengyiluo.md
 summary: "罗正宜（Zhengyi Luo）为 NVIDIA GEAR Lab 高级研究科学家、CMU RI 博士（Kris Kitani）；工作横跨人形通用低层控制、人–人形遥操作、视觉 Sim2Real 与交互感知，是 HOVER、ASAP、OmniH2O、PDC 与 SONIC 等社区关键论文的核心作者之一。"
+institutions:
+  - cmu
+  - nvidia
+
 ---
 
 # Zhengyi Luo（罗正宜）

--- a/wiki/methods/bc-z.md
+++ b/wiki/methods/bc-z.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
 summary: "BC-Z 通过大规模真实世界模仿学习与灵活任务条件（语言等），展示桌面操控策略对新任务的零样本泛化潜力。"
+institutions: [google]
+
 ---
 
 # BC-Z

--- a/wiki/methods/claw.md
+++ b/wiki/methods/claw.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/blogs/claw_unitree_g1_language_annotated_motion_data.md
 summary: "CLAW (Composable Language-Annotated Whole-Body Motion Data Generation) 是一种面向人形机器人的网页交互式数据生成流水线，利用 MuJoCo 仿真和底层规划器自动生成带语言标签且符合物理约束的全身运动数据。"
+institutions: [unitree]
+
 ---
 
 # CLAW (宇树 G1 全身动作数据生成管线)

--- a/wiki/methods/dart-control.md
+++ b/wiki/methods/dart-control.md
@@ -17,6 +17,8 @@ sources:
   - ../../sources/repos/zkf1997_dart.md
   - ../../sources/sites/dart-control-project.md
 summary: "DART（DartControl，ICLR 2025）：重叠运动原语上的潜扩散自回归模型，在在线文本流与历史条件下实时合成任意长 SMPL-X 运动，并在同一潜空间用噪声优化或 RL 实现空间/场景约束控制。"
+institutions: [eth]
+
 ---
 
 # DART（DartControl：实时文本驱动人体运动控制）

--- a/wiki/methods/dial-instruction-augmentation.md
+++ b/wiki/methods/dial-instruction-augmentation.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
 summary: "DIAL 用微调后的视觉语言模型为大规模无详细语言标注的演示轨迹自动生成多样指令，再训练语言条件 BC，扩展语义覆盖与泛化指令。"
+institutions: [google]
+
 ---
 
 # DIAL（指令增强）

--- a/wiki/methods/egm-efficient-general-mimic.md
+++ b/wiki/methods/egm-efficient-general-mimic.md
@@ -16,6 +16,8 @@ sources:
   - ../../sources/papers/egm_arxiv_2512_19043.md
   - ../../sources/blogs/egm_themoonlight_literature_review_2512_19043.md
 summary: "EGM（Efficient General Mimic）：以 Bin 级跨动作课程自适应采样、上下身分组的复合解耦 MoE（CDMoE）与三阶段教师–学生训练，在少量高质量重定向动捕上学习可泛化的人形高动态全身跟踪策略。"
+institutions: [unitree]
+
 ---
 
 # EGM（Efficient General Mimic，高效通用模仿跟踪）

--- a/wiki/methods/egoscale.md
+++ b/wiki/methods/egoscale.md
@@ -17,6 +17,8 @@ related:
 sources:
   - ../../sources/papers/egoscale_arxiv_2602_16710.md
   - ../../sources/sites/nvidia-research-egoscale.md
+institutions: [nvidia]
+
 ---
 
 # EgoScale

--- a/wiki/methods/enpire.md
+++ b/wiki/methods/enpire.md
@@ -20,6 +20,8 @@ related:
 sources:
   - ../../sources/papers/enpire_nvidia_gear_2026.md
   - ../../sources/sites/nvidia-research-enpire.md
+institutions: [nvidia]
+
 ---
 
 # ENPIRE

--- a/wiki/methods/genmo.md
+++ b/wiki/methods/genmo.md
@@ -16,6 +16,8 @@ sources:
   - ../../sources/papers/genmo.md
   - ../../sources/repos/genmo.md
 summary: "GENMO（官方代码与权重以 GEM 名义发布）把人体运动估计重新表述为带多模态条件的约束式扩散生成；通过 dual-mode 训练范式（估计模式 + 生成模式）与 multi-text 注入块，让同一权重在视频、2D 关键点、文本、音乐与 3D 关键帧条件下同时做轨迹恢复与合成。"
+institutions: [nvidia]
+
 ---
 
 # GENMO（统一人体运动估计与生成）

--- a/wiki/methods/gentlehumanoid-motion-tracking.md
+++ b/wiki/methods/gentlehumanoid-motion-tracking.md
@@ -20,6 +20,8 @@ sources:
   - ../../sources/sites/gentle-humanoid-axell-top.md
   - ../../sources/repos/axellwppr_motion_tracking.md
 summary: "GentleHumanoid（arXiv:2511.04679）把阻抗参考动力学嵌入全身 motion tracking：统一弹簧式 resistive/guiding 交互力、肩肘腕链上运动学一致采样、5–15 N 可调力阈值与 teacher–student PPO；Unitree G1 上验证拥抱/坐–站/软物体操控，开源工程栈见 Axellwppr/motion_tracking（mjlab）。"
+institutions: [unitree]
+
 ---
 
 # GentleHumanoid（上半身柔顺全身运动跟踪）

--- a/wiki/methods/htwk-gym.md
+++ b/wiki/methods/htwk-gym.md
@@ -11,6 +11,8 @@ related:
 sources:
   - ../../sources/repos/htwk_gym.md
 summary: "htwk-gym 是由 HTWK Leipzig 开发的人形机器人足球 RL 框架，专注于 Booster T1/K1 平台的参数化步行与踢球技能训练。"
+institutions: [booster]
+
 ---
 
 # htwk-gym

--- a/wiki/methods/learning-from-play-lmp.md
+++ b/wiki/methods/learning-from-play-lmp.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
 summary: "Learning from Play（Play-LMP）从非任务化的遥操作『玩耍』轨迹中学习潜在规划结构，再用目标条件策略完成指定任务。"
+institutions: [google]
+
 ---
 
 # Learning from Play（Play-LMP）

--- a/wiki/methods/limmt-gqs-motion-curation.md
+++ b/wiki/methods/limmt-gqs-motion-curation.md
@@ -21,6 +21,8 @@ sources:
   - ../../sources/papers/motion_cerebellum_64_catalog.md
   - ../../sources/blogs/wechat_embodied_ai_lab_humanoid_motion_cerebellum_survey.md
 summary: "LIMMT（ICML 2026）：以 GQS 三阶段管线从大规模 MoCap 中策展物理可行、行为多样且动态丰富的子集；在 Any2Track / TWIST2 上 3% AMASS 即可优于全量训练，并 plug-and-play 迁移至 PHUMA 与 G1 真机。"
+institutions: [unitree]
+
 ---
 
 # LIMMT / GQS：人形 Motion Tracking 的数据策展

--- a/wiki/methods/lwd.md
+++ b/wiki/methods/lwd.md
@@ -14,6 +14,8 @@ related:
 sources:
   - ../../sources/papers/lwd.md
 summary: "LWD 是 AGIBOT 提出的车队级 offline-to-online RL 后训练框架，通过 DIVL + QAM 把部署中的异构经验（成功/失败/人为干预）转化为单一 VLA generalist 策略的持续改进。"
+institutions: [agibot]
+
 ---
 
 # LWD（Learning while Deploying）

--- a/wiki/methods/motionbricks.md
+++ b/wiki/methods/motionbricks.md
@@ -17,6 +17,8 @@ sources:
   - ../../sources/papers/motionbricks.md
   - ../../sources/repos/gr00t_wholebodycontrol.md
 summary: "MotionBricks 是 NVIDIA 开发的高性能运动生成框架，通过模块化潜空间底座与智能基元（Smart Primitives）实现了超大规模技能库的实时、高精度合成，是 GR00T 全身控制栈的关键层。"
+institutions: [nvidia]
+
 ---
 
 # MotionBricks: 模块化生成式运动合成框架

--- a/wiki/methods/mt-opt.md
+++ b/wiki/methods/mt-opt.md
@@ -10,6 +10,8 @@ related:
 sources:
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
 summary: "MT-Opt 把多任务机器人强化学习扩展到连续动作与共享数据采集栈，用任务判定与跨任务经验共享提升样本效率。"
+institutions: [google]
+
 ---
 
 # MT-Opt

--- a/wiki/methods/mtrg-reference-goal-driven-rl.md
+++ b/wiki/methods/mtrg-reference-goal-driven-rl.md
@@ -14,6 +14,8 @@ sources:
   - ../../sources/papers/mtrg_reference_goal_driven_rl_arxiv_2602_20375.md
   - ../../sources/sites/gfr-project.md
 summary: "GfR/MTRG 用单一 goal-conditioned 策略联合参考塑形模仿与纯目标泛化，参考仅出现在训练奖励中，在 G1 箱式跑酷上超越 ZEST tracking 与 tabula rasa 的 OOD 鲁棒性。"
+institutions: [unitree]
+
 ---
 
 # MTRG / GfR: Multi-Task Reference and Goal-Driven RL

--- a/wiki/methods/neural-motion-retargeting-nmr.md
+++ b/wiki/methods/neural-motion-retargeting-nmr.md
@@ -15,6 +15,8 @@ sources:
   - ../../sources/papers/neural_motion_retargeting_nmr.md
   - ../../sources/papers/reactor_rl_physics_aware_motion_retargeting.md
 summary: "NMR 将人形运动重定向表述为从人体运动分布到机器人可行流形的学习映射；通过 CEPR 管线（筛选→GMR→聚类 RL 专家→仿真 rollout）构造物理一致的人机配对数据，训练 CNN–Transformer 非自回归网络，缓解传统优化重定向的非凸与噪声传播问题。"
+institutions: [unitree]
+
 ---
 
 # NMR（神经运动重定向与人形全身控制）

--- a/wiki/methods/paid-framework.md
+++ b/wiki/methods/paid-framework.md
@@ -14,6 +14,8 @@ sources:
   - ../../sources/repos/humanoid_soccer.md
   - ../../sources/papers/robonaldo_arxiv_2606_11092.md
 summary: "PAiD (Perception-Action integrated Decision-making) 是一种渐进式的人形机器人技能学习框架，通过模仿学习与感知-动作融合实现鲁棒的类人化踢球。"
+institutions: [unitree]
+
 ---
 
 # PAiD Framework

--- a/wiki/methods/pi07-policy.md
+++ b/wiki/methods/pi07-policy.md
@@ -13,6 +13,8 @@ related:
 sources:
   - ../../sources/papers/pi07.md
 summary: "π₀.7 是 Physical Intelligence 的通才机器人 VLA：用多模态提示（子任务语言、片段元数据、控制模态、视觉子目标）在训练时对齐异质数据，在推理时 steer 策略，从异质数据中蒸馏出可与 RL 专精模型比肩的开箱操作性能，并报告组合任务与跨本体泛化的实证迹象。"
+institutions: [physical-intelligence]
+
 ---
 
 # π₀.7（Pi-zero 0.7）通才 VLA

--- a/wiki/methods/qt-opt.md
+++ b/wiki/methods/qt-opt.md
@@ -11,6 +11,8 @@ related:
 sources:
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
 summary: "QT-Opt 用大规模离线 + 在线真实机器人数据训练视觉条件下的连续动作 Q 学习，是早期证明「像素操控可扩展」的代表系统之一。"
+institutions: [google]
+
 ---
 
 # QT-Opt

--- a/wiki/methods/robotics-transformer-rt-series.md
+++ b/wiki/methods/robotics-transformer-rt-series.md
@@ -11,6 +11,8 @@ sources:
   - ../../sources/papers/rl_foundation_models.md
   - ../../sources/blogs/ted_xiao_embodied_three_eras_primary_refs.md
 summary: "RT-1 将语言条件图像操控建模为序列预测；RT-2 将大规模视觉语言模型接入同一接口形成 VLA，是通用操作策略的关键基线系列。"
+institutions: [google]
+
 ---
 
 # Robotics Transformer（RT-1 / RT-2）

--- a/wiki/methods/smp.md
+++ b/wiki/methods/smp.md
@@ -16,6 +16,8 @@ sources:
   - ../../sources/papers/smp.md
   - ../../sources/repos/smp_suz_tsinghua.md
 summary: "SMP (Score-Matching Motion Priors) 通过预训练扩散模型作为“冻结奖励器”，实现了高效、可组合且无需原始数据的运动模仿学习。"
+institutions: [unitree]
+
 ---
 
 # SMP: 基于得分匹配的可复用运动先验

--- a/wiki/methods/sonic-motion-tracking.md
+++ b/wiki/methods/sonic-motion-tracking.md
@@ -25,6 +25,8 @@ related:
 sources:
   - ../../sources/repos/sonic-humanoid-motion-tracking.md
 summary: "SONIC 通过规模化运动跟踪监督训练通用人形策略，把海量 MoCap 帧上的轨迹跟踪当作预训练任务；以统一 token 接口接入 VR、视频、文本、音乐与 VLA（如 GR00T N1.5 演示），并可桥接实时运动学规划器做交互式导航与风格化步态。"
+institutions: [nvidia]
+
 ---
 
 # SONIC（规模化运动跟踪人形控制）

--- a/wiki/methods/switch-framework.md
+++ b/wiki/methods/switch-framework.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/papers/switch_humanoid.md
 summary: "Switch 是一种分层人形机器人控制框架，通过「增强技能图」与「缓冲节点」设计，实现了多样化敏捷技能之间的 100% 成功切换与极强的扰动鲁棒性。"
+institutions: [unitree]
+
 ---
 
 # Switch: 敏捷技能切换框架

--- a/wiki/methods/π0-policy.md
+++ b/wiki/methods/π0-policy.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/papers/diffusion_and_gen.md
 summary: "π₀ (Pi-zero) 是由 Physical Intelligence 提出的一种通用的 Vision-Language-Action 模型，通过结合流匹配（Flow Matching）与大规模预训练，实现了对复杂机器人操作任务的高效建模。"
+institutions: [google-deepmind]
+
 ---
 
 # π₀ (Pi-zero) 策略模型

--- a/wiki/overview/humanoid-actuator-102-decision-species.md
+++ b/wiki/overview/humanoid-actuator-102-decision-species.md
@@ -12,6 +12,8 @@ related:
 sources:
   - ../../sources/blogs/wechat_human_five_humanoid_actuator_102.md
   - ../../sources/raw/wechat_humanoid_actuator_102_2026-06-02.md
+institutions: [unitree]
+
 ---
 
 # Actuator 102 · 07：决策矩阵与三大物种

--- a/wiki/queries/robot-learning-three-eras-narrative.md
+++ b/wiki/queries/robot-learning-three-eras-narrative.md
@@ -29,6 +29,10 @@ related:
   - ../methods/imitation-learning.md
   - ../methods/reinforcement-learning.md
   - ../concepts/embodied-scaling-laws.md
+institutions:
+  - google-deepmind
+  - google
+
 ---
 
 > **Query 产物**：本页由以下问题触发：「围绕 Ted Xiao 访谈编译稿中出现的机器人学习话题，能否用一手文献串联成可维护的知识索引？」  


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- **图谱交互**：移除仿专题视图的研究机构折叠区，新增「按机构」着色维度（与按社区一致：图例、筛选、磁吸、深链 `?institution=`）
- **机构覆盖**：扩展 `derive_node_institutions`（连字符 tag 拆分、entity 路径/标题/sources/主链 URL），为 **159** 个可识别 wiki 页写入 `institutions:` frontmatter（图谱节点 80→159）

## 验证
- `make ci-preflight` 通过
- `make test`：209 passed
- Puppeteer：按机构模式 active、旧研究机构折叠区已移除

## 验证截图
![图谱按机构着色模式](https://cursor.com/artifacts/c/art-8e7ca2cd-0450-45df-a510-1d90cec1c508)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbf0bf44-2e81-4ec8-8a8a-fb71e66d0698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbf0bf44-2e81-4ec8-8a8a-fb71e66d0698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

