### PR TITLE
fix(ux): 恢复首页社区筛选下拉为搜索栏 1/3 宽度

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1709,11 +1709,11 @@ body.sponsor-dialog-open {
   color: var(--text);
   outline: none;
 }
-/* 社区筛选下拉占搜索栏约 1/4，过长文案省略 */
+/* 社区筛选下拉约占整条搜索栏宽度的 1/3，过长文案省略 */
 #wikiCommunityFilter {
-  flex: 0 1 26%;
-  width: 26%;
-  max-width: 26%;
+  flex: 0 0 33.333%;
+  width: 33.333%;
+  max-width: 33.333%;
   min-width: 0;
   box-sizing: border-box;
   border: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 移除「按研究机构筛选」下拉后，「全部社区」下拉仍沿用双下拉时期的 26%（约 1/4）宽度
- 将其恢复为原先单下拉布局下的 **33.333%（1/3）**，与搜索输入框比例一致

## 改动
- `docs/style.css`：`#wikiCommunityFilter` 的 `flex` / `width` / `max-width` 从 `26%` 改回 `33.333%`

## 验证
- 纯 CSS 调整，不涉及 wiki 内容与派生文件
- 首页搜索栏在桌面端应显示：输入框约 2/3，社区下拉约 1/3
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b627a3a4-20ff-4d40-a0ea-f7e8bdb932d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b627a3a4-20ff-4d40-a0ea-f7e8bdb932d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

