### PR TITLE
fix(ux): 页面元信息将所属机构移至最下方

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -50,8 +50,8 @@
             <div id="detailMeta" class="detail-meta-list data-loading">
               <p id="detailMetaUpdated" class="detail-meta-item data-meta">正在读取更新时间…</p>
               <p id="detailMetaCommunity" class="detail-meta-item" hidden></p>
-              <p id="detailMetaInstitution" class="detail-meta-item" hidden></p>
               <p id="detailMetaTopic" class="detail-meta-item" hidden></p>
+              <p id="detailMetaInstitution" class="detail-meta-item" hidden></p>
             </div>
           </aside>
         </div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -2921,15 +2921,15 @@
     }
 
     renderDetailMetaItemRow('roadmapMetaCommunity', '所属社区', '');
-    renderDetailMetaItemRow('roadmapMetaInstitution', '所属机构', '');
     renderDetailMetaItemRow('roadmapMetaTopic', '所属专题', '');
+    renderDetailMetaItemRow('roadmapMetaInstitution', '所属机构', '');
     if (metaEl) removeLoadingState(metaEl);
 
     var graphPath = detail.path || '';
     return Promise.all([
       renderMetaCommunityBadge(graphPath, 'roadmapMetaCommunity'),
-      renderMetaInstitutionBadges(graphPath, 'roadmapMetaInstitution'),
-      renderMetaTopicBadges(graphPath, 'roadmapMetaTopic')
+      renderMetaTopicBadges(graphPath, 'roadmapMetaTopic'),
+      renderMetaInstitutionBadges(graphPath, 'roadmapMetaInstitution')
     ]);
   }
 
@@ -3178,8 +3178,8 @@
       renderDetailMetaSource(null);
       setDetailMetaReadyState('true');
       renderDetailMetaItemRow('detailMetaCommunity', '所属社区', '');
-      renderDetailMetaItemRow('detailMetaInstitution', '所属机构', '');
       renderDetailMetaItemRow('detailMetaTopic', '所属专题', '');
+      renderDetailMetaItemRow('detailMetaInstitution', '所属机构', '');
       if (tocSectionEl) tocSectionEl.hidden = true;
       if (tocEl) {
         tocEl.innerHTML = '';
@@ -3249,16 +3249,16 @@
         detailPage.updated ? renderDetailMetaDateBadge(detailPage.updated) : ''
       );
       renderDetailMetaItemRow('detailMetaCommunity', '所属社区', '');
-      renderDetailMetaItemRow('detailMetaInstitution', '所属机构', '');
       renderDetailMetaItemRow('detailMetaTopic', '所属专题', '');
+      renderDetailMetaItemRow('detailMetaInstitution', '所属机构', '');
       removeLoadingState(metaEl);
     }
     renderDetailMetaSource(detailPage);
     setDetailMetaReadyState('pending');
     Promise.all([
       renderDetailCommunityBadge(detailPage),
-      renderDetailInstitutionBadges(detailPage),
-      renderDetailTopicBadges(detailPage)
+      renderDetailTopicBadges(detailPage),
+      renderDetailInstitutionBadges(detailPage)
     ]).finally(function () {
       setDetailMetaReadyState('true');
     });

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -51,8 +51,8 @@
               <p id="roadmapMetaUpdated" class="detail-meta-item data-meta">正在读取更新时间…</p>
               <p id="roadmapMetaStages" class="detail-meta-item" hidden></p>
               <p id="roadmapMetaCommunity" class="detail-meta-item" hidden></p>
-              <p id="roadmapMetaInstitution" class="detail-meta-item" hidden></p>
               <p id="roadmapMetaTopic" class="detail-meta-item" hidden></p>
+              <p id="roadmapMetaInstitution" class="detail-meta-item" hidden></p>
             </div>
           </aside>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页与路线页的「页面元信息」面板中，将「所属机构」行移至最下方（位于「所属专题」之后）。
- 同步调整 `docs/main.js` 中的初始化与异步渲染顺序，与 HTML 结构保持一致。

## 验证
- `npm run lint:js` 通过
- 本地静态站详情页 `detailMetaPanel` 截图确认顺序：更新时间 → 所属社区 → 所属专题 → 所属机构

## 验证截图
![页面元信息：所属机构位于最下方](https://cursor.com/artifacts/c/art-3be254a9-0066-4662-88b8-d79c2032ead7)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86469e2e-58ef-4cf2-ac14-086a549004dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86469e2e-58ef-4cf2-ac14-086a549004dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

