### PR TITLE
fix(ux): 补全按类型图例并同步浮窗/侧栏徽章着色模式

### DIFF
--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -111,6 +111,7 @@
     concept: '概念', method: '方法', task: '任务',
     entity: '工具', comparison: '对比', query: 'Query',
     formalization: '形式化', overview: '总览', reference: '参考',
+    roadmap: '路线', roadmap_page: '路线',
     '': 'Wiki'
   };
 
@@ -118,6 +119,7 @@
     concept: '#60a5fa', method: '#34d399', task: '#f472b6',
     entity: '#fbbf24', comparison: '#c084fc', query: '#94a3b8',
     formalization: '#fb923c', overview: '#64748b', reference: '#64748b',
+    roadmap: '#22d3ee', roadmap_page: '#22d3ee',
     '': '#64748b'
   };
 
@@ -198,7 +200,7 @@
     return ' style="--community-r:' + rgb.r + ';--community-g:' + rgb.g + ';--community-b:' + rgb.b + '"';
   }
 
-  /** 浮窗/侧边栏类型徽章：优先用社区色着色，不再单独展示社区色块 */
+  /** 浮窗/侧边栏类型徽章：badgeColor 由图谱 colorMode 决定（社区/类型/健康度） */
   function buildMetaBadgesHtml(opts) {
     opts = opts || {};
     var html = '';
@@ -207,8 +209,9 @@
       var typeLabels = opts.typeLabels || GRAPH_NODE_TYPE_LABEL;
       var typeColors = opts.typeColors || GRAPH_NODE_TYPE_COLOR;
       var typeLabel = typeLabels[typeKey] || typeKey || 'Wiki';
-      var badgeColor = opts.badgeColor || opts.communityColor
-        || typeColors[typeKey] || typeColors[''] || '#64748b';
+      var badgeColor = opts.badgeColor != null ? opts.badgeColor
+        : (opts.communityColor
+          || typeColors[typeKey] || typeColors[''] || '#64748b');
       html = colorBadgeHtml('tt-type', typeLabel, badgeColor);
     }
     if (!html) return '';

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1673,9 +1673,14 @@
       entity: 'Entity', query: 'Query', overview: 'Overview',
       reference: 'Reference', roadmap_page: 'Roadmap',
     };
+    function formatTypeLegendLabel(type) {
+      const zh = TYPE_LABEL[type] || type;
+      const en = TYPE_LEGEND_EN[type] || type;
+      return zh + ' (' + en + ')';
+    }
     const TYPE_FILTER_OPTIONS = TYPE_LEGEND_ORDER.map((type) => ({
       value: type,
-      label: TYPE_LABEL[type] || type,
+      label: formatTypeLegendLabel(type),
       color: TYPE_COLOR[type] || TYPE_COLOR[''],
     })).concat([
       { value: '__orphan__', label: '孤儿（度≤1）', color: '#94a3b8' },
@@ -2053,7 +2058,7 @@
         const typeRows = TYPE_LEGEND_ORDER.map((type) => ({
           type,
           color: TYPE_COLOR[type] || TYPE_COLOR[''],
-          label: (TYPE_LABEL[type] || type) + ' ' + (TYPE_LEGEND_EN[type] || type),
+          label: formatTypeLegendLabel(type),
         }));
         for (const t of typeRows) {
           const isActive = (focusedType === t.type);

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1652,24 +1652,34 @@
       formalization: '#fb923c',
       overview:      '#64748b',
       reference:     '#64748b',
+      roadmap:       '#22d3ee',
+      roadmap_page:  '#22d3ee',
       '':            '#64748b',
     };
     const TYPE_LABEL = {
       concept: '概念', method: '方法', task: '任务',
       entity: '工具', comparison: '对比', query: 'Query',
       formalization: '形式化', overview: '总览', reference: '参考',
+      roadmap: '路线', roadmap_page: '路线',
       '': 'Wiki',
     };
-    const TYPE_FILTER_OPTIONS = [
-      { value: 'concept', label: '概念', color: '#60a5fa' },
-      { value: 'method', label: '方法', color: '#34d399' },
-      { value: 'task', label: '任务', color: '#f472b6' },
-      { value: 'formalization', label: '形式化', color: '#fb923c' },
-      { value: 'comparison', label: '对比', color: '#c084fc' },
-      { value: 'entity', label: '工具', color: '#fbbf24' },
-      { value: 'query', label: 'Query', color: '#94a3b8' },
-      { value: '__orphan__', label: '孤儿（度≤1）', color: '#94a3b8' }
+    const TYPE_LEGEND_ORDER = [
+      'concept', 'method', 'task', 'formalization', 'comparison',
+      'entity', 'query', 'overview', 'reference', 'roadmap_page',
     ];
+    const TYPE_LEGEND_EN = {
+      concept: 'Concept', method: 'Method', task: 'Task',
+      formalization: 'Formalization', comparison: 'Comparison',
+      entity: 'Entity', query: 'Query', overview: 'Overview',
+      reference: 'Reference', roadmap_page: 'Roadmap',
+    };
+    const TYPE_FILTER_OPTIONS = TYPE_LEGEND_ORDER.map((type) => ({
+      value: type,
+      label: TYPE_LABEL[type] || type,
+      color: TYPE_COLOR[type] || TYPE_COLOR[''],
+    })).concat([
+      { value: '__orphan__', label: '孤儿（度≤1）', color: '#94a3b8' },
+    ]);
     const HEALTH_FILTER_OPTIONS = [
       { value: '0', label: '0 分', color: '#f87171' },
       { value: '1', label: '1 分', color: '#fb923c' },
@@ -1966,6 +1976,27 @@
     }
 
     const HEALTH_COLORS = ['#f87171', '#fb923c', '#facc15', '#4ade80'];
+    function metaBadgeColor(d) {
+      if (colorMode === 'community') {
+        return d.community
+          ? (communityColorMap.get(d.community) || COMMUNITY_COLORS[9])
+          : (TYPE_COLOR[d.type] || TYPE_COLOR['']);
+      }
+      if (colorMode === 'health') {
+        const score = d.health_score != null ? Math.min(d.health_score, 3) : 0;
+        return HEALTH_COLORS[score];
+      }
+      return TYPE_COLOR[d.type] || TYPE_COLOR[''];
+    }
+    function buildNodeMetaBadges(d) {
+      if (!window.RNGraphTooltip?.buildMetaBadgesHtml) return '';
+      return window.RNGraphTooltip.buildMetaBadgesHtml({
+        type: d.type || '',
+        typeLabels: TYPE_LABEL,
+        typeColors: TYPE_COLOR,
+        badgeColor: metaBadgeColor(d),
+      });
+    }
     function nodeColor(d)  {
       if (colorMode === 'community') {
         return communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
@@ -2019,15 +2050,11 @@
         }
       } else {
         rows.push('<div class="legend-title">按类型着色</div>');
-        const typeRows = [
-          { type: 'concept',       color: '#60a5fa', label: '概念 Concept' },
-          { type: 'method',        color: '#34d399', label: '方法 Method' },
-          { type: 'task',          color: '#f472b6', label: '任务 Task' },
-          { type: 'formalization', color: '#fb923c', label: '形式化 Formalization' },
-          { type: 'comparison',    color: '#c084fc', label: '对比 Comparison' },
-          { type: 'entity',        color: '#fbbf24', label: '工具 Entity' },
-          { type: 'query',         color: '#94a3b8', label: 'Query 产物' },
-        ];
+        const typeRows = TYPE_LEGEND_ORDER.map((type) => ({
+          type,
+          color: TYPE_COLOR[type] || TYPE_COLOR[''],
+          label: (TYPE_LABEL[type] || type) + ' ' + (TYPE_LEGEND_EN[type] || type),
+        }));
         for (const t of typeRows) {
           const isActive = (focusedType === t.type);
           rows.push(`<div class="legend-row ${isActive ? 'active' : ''}" data-type="${escapeHtml(String(t.type))}">
@@ -2392,6 +2419,16 @@
         .attr('stroke', d => nodeColor(d));
       renderLegend();
       renderFilterPanel();
+      refreshMetaBadges();
+    }
+
+    function refreshMetaBadges() {
+      if (pinnedNode && tooltip && !tooltip.classList.contains('hidden')) {
+        tooltip.innerHTML = tooltipHtml(pinnedNode);
+      }
+      if (sidebarNode && sidebar?.classList.contains('open') && sbMetaBadges) {
+        sbMetaBadges.innerHTML = buildNodeMetaBadges(sidebarNode);
+      }
     }
 
     function setColorMode(mode) {
@@ -2464,6 +2501,7 @@
 
     /* ── 固定卡片状态（仅移动端使用）── */
     let pinnedNode = null;
+    let sidebarNode = null;
 
     function tooltipSummary(raw) {
       return window.RNGraphTooltip?.formatTooltipSummary
@@ -2475,13 +2513,12 @@
       const info = d._info;
       const summary = tooltipSummary(info.summary);
       const detailUrl = 'detail.html?id=' + encodeURIComponent(toDetailId(d.id));
-      const communityColor = communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
       if (window.RNGraphTooltip?.buildNodeTooltipHtml) {
         return window.RNGraphTooltip.buildNodeTooltipHtml({
           type: d.type || '',
           typeLabels: TYPE_LABEL,
           typeColors: TYPE_COLOR,
-          communityColor: d.community ? communityColor : '',
+          badgeColor: metaBadgeColor(d),
           title: info.title || d.label,
           summary,
           linkHtml: `<a class="tt-link" href="${escapeHtml(detailUrl)}" target="_self">打开详情页 →</a>`
@@ -3643,15 +3680,9 @@
 
       const communityLabel = communityLabelMap.get(d.community);
       const communityColor = communityColorMap.get(d.community) || COMMUNITY_COLORS[9];
-      if (sbMetaBadges && window.RNGraphTooltip?.buildMetaBadgesHtml) {
-        sbMetaBadges.innerHTML = window.RNGraphTooltip.buildMetaBadgesHtml({
-          type: d.type || '',
-          typeLabels: TYPE_LABEL,
-          typeColors: TYPE_COLOR,
-          communityColor: d.community ? communityColor : '',
-        });
-      } else if (sbMetaBadges) {
-        sbMetaBadges.innerHTML = '';
+      sidebarNode = d;
+      if (sbMetaBadges) {
+        sbMetaBadges.innerHTML = buildNodeMetaBadges(d);
       }
       if (sbCommunity) {
         if (d.community && communityLabel && window.RNGraphTooltip?.buildCommunityBadgeHtml) {
@@ -3737,6 +3768,7 @@
       sidebar.classList.remove('open');
       scheduleSidebarViewportSync();
       sidebarFocusIds = null;
+      sidebarNode = null;
       pinnedNode = null;
       if (isMobile) hideTooltip();
       if (timelineAnimating) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- **按类型图例缺项**：图例与筛选面板原先只有 7 种类型，缺少库内实际存在的 `overview`（97 节点）、`reference`、`roadmap_page`；现已与 `TYPE_COLOR` / `TYPE_LABEL` 对齐，共 10 项。
- **类型名称格式**：按类型图例与筛选复选框统一为「中文 (English)」形式，例如 `总览 (Overview)`、`概念 (Concept)`。
- **浮窗/侧栏徽章着色**：类型徽章随「按类型 / 按社区 / 按健康度」按钮切换，与节点着色模式一致。

## 验证

- 本地 `graph.html`：切换「按类型」后图例含「总览 (Overview)」等 10 项；筛选面板同名；侧栏徽章随着色模式变化。

## 验证截图

![图谱按类型图例与侧栏徽章着色同步](https://cursor.com/artifacts/c/art-350b1f64-0ceb-4121-9d99-e28c51586354)

## 风险

- 仅改 `docs/graph.html` 与 `docs/graph-tooltip.js`，无 wiki / CI 派生文件影响。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6736642-7c69-4f85-b530-e3a4ca84ab42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6736642-7c69-4f85-b530-e3a4ca84ab42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

