### PR TITLE
checklist-v26: 初始化仿真物理保真度链路专题

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@
 项目执行清单与阶段性维护看板。
 
 包括：
-- 当前技术栈执行清单：[`docs/checklists/tech-stack-next-phase-checklist-v25.md`](docs/checklists/tech-stack-next-phase-checklist-v25.md)
+- 当前技术栈执行清单：[`docs/checklists/tech-stack-next-phase-checklist-v26.md`](docs/checklists/tech-stack-next-phase-checklist-v26.md)
 - 前端体验优化清单：[`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
 - 历史执行清单索引：[`docs/checklists/README.md`](docs/checklists/README.md)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Wiki Lint](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-1322节点_8809边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
-[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-98%25-green)](docs/checklists/tech-stack-next-phase-checklist-v25.md)
+[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-98%25-green)](docs/checklists/tech-stack-next-phase-checklist-v26.md)
 
 
 
@@ -66,7 +66,7 @@
 
 ## 维护看板
 
-- 当前技术栈执行清单：[V25](docs/checklists/tech-stack-next-phase-checklist-v25.md)
+- 当前技术栈执行清单：[V26](docs/checklists/tech-stack-next-phase-checklist-v26.md)
 - 前端体验优化清单：[frontend-optimization-v1](docs/checklists/frontend-optimization-v1.md)
 - 历史执行清单索引：[docs/checklists/README.md](docs/checklists/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 `docs/` 是 GitHub Pages 展示层和历史资料暂存区。当前前端页面、导出数据镜像、执行清单都在这里维护。
 
 常用入口：
-- [当前技术栈执行清单 v25](checklists/tech-stack-next-phase-checklist-v25.md)
+- [当前技术栈执行清单 v26](checklists/tech-stack-next-phase-checklist-v26.md)
 - [前端体验优化清单 v1](checklists/frontend-optimization-v1.md)
 - [历史执行清单索引](checklists/README.md)
 - [展示层变更记录](change-log.md)

--- a/docs/checklists/README.md
+++ b/docs/checklists/README.md
@@ -4,14 +4,14 @@
 
 ## 当前入口
 
-- [技术栈项目执行清单 v25](tech-stack-next-phase-checklist-v25.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
+- [技术栈项目执行清单 v26](tech-stack-next-phase-checklist-v26.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
 - [前端体验优化清单 v1](frontend-optimization-v1.md) — GitHub Pages 首页与交互体验优化计划。
 - [Cursor Cloud Agent：PR 与验证截图流程](cloud-agent-pr-workflow.md) — Cloud Agent 推送分支、开 PR、附验证截图的路径约定。
 - [GitHub Actions CI 门禁](github-actions-ci-gate.md) — 合并 `main` 前必须等全量 Actions 全绿；branch protection 建议。
 
 ## 历史执行清单
 
-这些文件记录从 v1 到 v23 的阶段性目标和已完成事项，主要用于追溯决策，不作为当前待办入口。历史版本统一存放在 [`archive/`](archive/) 子目录。
+这些文件记录从 v1 到 v25 的阶段性目标和已完成事项，主要用于追溯决策，不作为当前待办入口。历史版本统一存放在 [`archive/`](archive/) 子目录。
 
 - [v1](archive/tech-stack-next-phase-checklist-v1.md)
 - [v2](archive/tech-stack-next-phase-checklist-v2.md)
@@ -37,6 +37,7 @@
 - [v22](archive/tech-stack-next-phase-checklist-v22.md)
 - [v23](archive/tech-stack-next-phase-checklist-v23.md)
 - [v24](archive/tech-stack-next-phase-checklist-v24.md)
+- [v25](archive/tech-stack-next-phase-checklist-v25.md)
 
 ## 维护规则
 

--- a/docs/checklists/archive/tech-stack-next-phase-checklist-v25.md
+++ b/docs/checklists/archive/tech-stack-next-phase-checklist-v25.md
@@ -1,9 +1,9 @@
 # 技术栈项目执行清单 v25
 
-最后更新：2026-06-16（V24 全部条目收口，基于最新数据集 ingest 初始化 V25）
+最后更新：2026-06-24（V25 全部条目 + DoD 逐条收口，归档并初始化 V26）
 项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
-上一版清单：[`tech-stack-next-phase-checklist-v24.md`](archive/tech-stack-next-phase-checklist-v24.md)
-方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
+上一版清单：[`tech-stack-next-phase-checklist-v24.md`](tech-stack-next-phase-checklist-v24.md)
+方法论参考：[Karpathy LLM Wiki](../../../wiki/references/llm-wiki-karpathy.md)
 
 ---
 
@@ -57,7 +57,7 @@
 - [x] 知识图谱节点数 **≥ 1205**，边数 **≥ 7460**（见 `exports/graph-stats.json`）。（2026-06-22 达成：1288 节点 / 8450 边。）
 - [x] 事实库扩展至 **196 条** 以上（重点补 数据质量 / 物理可行性 / 重定向必要性 矛盾检测规则）。（2026-06-21 达成：198 条。）
 - [x] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。（2026-06-22 达成：`false`，最大社区占比 0.162。）
-- [ ] `log.md` 记录 V25 关键改动。
+- [x] `log.md` 记录 V25 关键改动。（2026-06-24 达成：P0/P1/P2/P3 各条目此前已逐条追加 log 条目；本次补「checklist-v25 \| DoD 收口 & 初始化 V26」总结条目，回填全版交付基线（图谱 1322 节点 / 8809 边、事实库 198 条、`community_quality_warning=false`、最大社区占比 0.165、15 项专题视图）。）
 
 ---
 

--- a/docs/checklists/tech-stack-next-phase-checklist-v26.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v26.md
@@ -1,0 +1,67 @@
+# 技术栈项目执行清单 v26
+
+最后更新：2026-06-24（V25 全部条目收口，基于最新仿真物理保真度 ingest 初始化 V26）
+项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
+上一版清单：[`tech-stack-next-phase-checklist-v25.md`](archive/tech-stack-next-phase-checklist-v25.md)
+方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
+
+---
+
+## V25 交付基线 (V26 起点)
+
+| 维度 | V25 状态 | V26 目标 |
+|------|-----------|---------|
+| 知识图谱节点 | 1322 | **≥ 1335** |
+| 知识图谱边数 | 8809 | **≥ 8850** |
+| 事实库 (CANONICAL_FACTS) | 198 条 | **≥ 208 条** |
+| 社区结构 | 16 社区，最大社区占 16.5%（`community_quality_warning: false`） | **保持 ≤ 25%，新增专题不破坏均衡** |
+| 技术专题 | 训练数据管线（V25 P1 交付） | **建立"仿真物理保真度链路"专题** |
+| 图谱专题视图 | V25 扩至 15 项（新增「训练数据管线」） | **新增「物理保真度」专题至 16 项** |
+
+> 背景：V25 收尾阶段（2026-06-23 前后）密集 ingest 了一批仿真物理底座概念页——`differentiable-simulation`（可微仿真）、`articulated-body-algorithms`（ABA/RNEA 刚体动力学）、`contact-dynamics` / `floating-base-dynamics` / `centroidal-dynamics`（接触与浮动基动力学）、`joint-friction-models` / `friction-compensation`（关节摩擦建模与补偿）、`urdf-robot-description`（机器人描述格式）、`procedural-terrain-generation`（程序化地形）。这些页各自成立，但仍缺一条贯通视角——从**几何/URDF 精度 → 刚体动力学算法 → 接触/摩擦模型 → 执行器模型**逐层「物理保真度」如何分别贡献 sim2real gap、以及各层建模成本与收益的取舍，尚未沉淀为独立 query / concept；事实库也缺「保真度维度间矛盾」（接触保真度 vs 可微性/吞吐、几何精度 vs 仿真速度、刚体假设 vs 软接触等）的矛盾检测规则。V26 优先补齐这条仿真物理保真度知识链，并把分散的动力学/仿真概念页交叉链路规范化。
+
+---
+
+## P0: 自动化与工具链深度强化 (Engineering)
+
+- [ ] **动力学/仿真概念页交叉链路巡检 V1**：
+    - [ ] `scripts/lint_wiki.py` 新增 `physics_concept_crosslink_check`：对 `tags` 含 `dynamics` / `simulation` / `physics` 的概念页，检查正文是否回链到 sim2real / 物理保真度专题枢纽（缺失给 INFO 级提示，不阻塞 CI），并写入 lint 报告基线快照；新增用例覆盖到 `tests/`。
+
+## P1: 仿真物理保真度链路专题 (Quality)
+
+- [ ] **物理保真度知识链 (+2)**：
+    - [ ] `wiki/queries/simulation-physics-fidelity.md`（端到端 Query：几何/URDF 精度 → 刚体动力学算法（ABA/RNEA）→ 接触/摩擦模型 → 执行器模型四层保真度的取舍决策树，覆盖每层对 sim2real gap 的贡献、建模成本与典型失败模式，配 Mermaid 流程图）。
+    - [ ] `wiki/concepts/physics-fidelity-sim2real-gap.md`（物理保真度 ↔ sim2real gap 因果概念页：四层保真度维度分层，明示每一维度的简化如何转化为可观测的 sim2real gap，以及与域随机化/系统辨识的互补关系）。
+- [ ] **仿真物理层专题交叉补强**：
+    - [ ] 在 `wiki/concepts/contact-dynamics.md`、`joint-friction-models.md`、`articulated-body-algorithms.md`、`differentiable-simulation.md`、`urdf-robot-description.md` 等页与 P1 新页形成双向回链，明示「几何 → 动力学 → 接触/摩擦 → 执行器」四层在保真度链路中的定位，消除孤儿页。
+
+## P2: 事实库与矛盾检测扩展 (Quantity)
+
+- [ ] **事实库扩展**：
+    - [ ] `schema/canonical-facts.json` 由 198 → **≥ 208 条**：新增物理保真度矛盾检测规则（接触保真度↑ 与可微性/仿真吞吐冲突、几何/URDF 精度 vs 仿真速度、刚体假设无法刻画软接触、摩擦模型简化导致打滑/接触误差、理想化执行器导致力矩 gap、可微仿真梯度质量受接触不连续制约等）；逐条经脚本校验对现存 wiki 页有 pos 命中且 0 误报。
+
+## P3: 交互层"物理保真度"增强 (UX/UI)
+
+- [ ] **图谱页"物理保真度"专题视图**：
+    - [ ] `docs/graph.html` / `docs/topic-filters.js` 的专题命中规则在 V25 15 项基础上新增「物理保真度」专题（`physics-fidelity`），复用 path 片段并集机制（`dynamics/contact/friction/articulated-body/differentiable-simulation/urdf/floating-base/centroidal`）并按需 `ids` 显式纳入新建 query/concept；同步在 `#filter-topic-chips` 增加 `data-topic="physics-fidelity"`（⚙️ 物理保真度）chip。Puppeteer 截图归档至 `.cursor-artifacts/screenshots/graph-topic-physics-fidelity.png`。
+- [ ] **详情页"同专题相关页"提示**：
+    - [ ] 复用 `docs/topic-filters.js` 单一事实源，动力学 / 仿真 / 新建页命中「物理保真度」专题时渲染「⚙️ 物理保真度」轻量徽标 + 跳转 `graph.html?topic=physics-fidelity`（空态降级隐藏）。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-physics-fidelity.png`。
+
+---
+
+## 验收标准 (Definition of DoD)
+
+- [ ] `make lint`: 0 errors（新引入的 `physics_concept_crosslink_check` 为 INFO 级，不阻塞 CI）。
+- [ ] 知识图谱节点数 **≥ 1335**，边数 **≥ 8850**（见 `exports/graph-stats.json`）。
+- [ ] 事实库扩展至 **208 条** 以上（重点补 物理保真度 / 接触摩擦 / 执行器建模 矛盾检测规则）。
+- [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。
+- [ ] `log.md` 记录 V26 关键改动。
+
+---
+
+## 状态说明
+
+- `[ ]` 待执行
+- `[~]` 进行中
+- `[x]` 已完成
+- `[−]` 已评估，决定跳过（附理由）

--- a/log.md
+++ b/log.md
@@ -1,5 +1,12 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-24] checklist-v25 | DoD 收口 & 初始化 V26
+
+- V25 全部条目收口：P0（数据集页元数据巡检 `dataset_metadata_check` + scaffold `--dataset` 旗标）、P1（`humanoid-training-data-pipeline` query + `motion-data-quality` concept + 数据层四段衔接交叉补强）、P2（事实库 186 → 198 条，新增 12 条数据层矛盾检测规则）、P3（图谱第 15 项「训练数据管线」专题视图 `data-pipeline` + 详情页徽标联动）逐条 `[x]`；DoD 末项「`log.md` 记录 V25 关键改动」由本条目收口。
+- V25 交付基线：`make lint` 0 errors（仅 1 条信息型预警），图谱 **1322 节点 / 8809 边**，事实库 **198 条**，`community_quality_warning=false`、最大社区占比 **0.165**，图谱专题视图 15 项。
+- 新建 [`docs/checklists/tech-stack-next-phase-checklist-v26.md`](docs/checklists/tech-stack-next-phase-checklist-v26.md)：专题选定为「仿真物理保真度链路」，承接 V25 收尾密集 ingest 的 `differentiable-simulation` / `articulated-body-algorithms` / `contact-dynamics` / `joint-friction-models` / `friction-compensation` / `urdf-robot-description` / `procedural-terrain-generation` 等仿真物理底座概念页，规划「几何/URDF → 刚体动力学算法 → 接触/摩擦模型 → 执行器模型」端到端保真度知识链（P1 query+concept）、物理保真度矛盾检测规则扩展（P2 事实库 198→≥208）、动力学/仿真概念页交叉链路巡检（P0）与图谱第 16 项「物理保真度」专题视图（P3）。
+- 同步将 README badge / 维护看板、`AGENTS.md`、`docs/README.md`、`docs/checklists/README.md` 的「当前清单」指针从 V25 切到 V26；V25 移入 `archive/` 并修正其内部相对链接（上一版清单同级、方法论参考 `../../../wiki/...`），进入历史归档区。
+
 ## [2026-06-24] structural | scripts/generate_link_graph.py — 兜底社区标签改为「其他（Other） 社区」
 
 ## [2026-06-24] structural | docs/topic-filters.js、docs/graph.html、wiki/overview/topic-*.md — 专题标签统一为「中文 (English)」格式（与类型图例一致）


### PR DESCRIPTION
## 摘要

完成 V25 全部条目收口，新建 V26 执行清单专注「仿真物理保真度链路」专题建设。将 V25 清单归档至 `archive/`，同步更新 README、AGENTS.md、docs/README.md 等维护看板指针。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）

## 详细说明

### V25 收口

- V25 全部 P0/P1/P2/P3 条目逐条 `[x]` 完成，DoD 末项「`log.md` 记录 V25 关键改动」由本次 log 条目收口
- V25 交付基线：
  - 图谱：**1322 节点 / 8809 边**
  - 事实库：**198 条**
  - 社区质量：`community_quality_warning=false`，最大社区占比 **0.165**
  - 图谱专题视图：15 项（新增「训练数据管线」）

### V26 初始化

新建 `docs/checklists/tech-stack-next-phase-checklist-v26.md`，规划「仿真物理保真度链路」专题：

- **P0**：动力学/仿真概念页交叉链路巡检（`physics_concept_crosslink_check` lint 规则）
- **P1**：物理保真度知识链（新增 query + concept，补强现存 5 个仿真物理底座页的双向回链）
- **P2**：事实库扩展 198 → ≥208 条（新增物理保真度矛盾检测规则）
- **P3**：图谱第 16 项「物理保真度」专题视图 + 详情页徽标联动

### 文档同步

- V25 清单移入 `docs/checklists/archive/`，修正内部相对链接
- 更新 README.md、AGENTS.md、docs/README.md、docs/checklists/README.md 的「当前清单」指针：V25 → V26
- log.md 新增 V26 初始化条目，记录 V25 交付基线与 V26 专题选定理由

## 验证

- [x] `make lint`：0 errors（新增 INFO 级预警不阻塞 CI）
- [x] 相对链接检查：V25 归档后内部链接正确（上一版清单同级、方法论参考 `../../../wiki/...`）
- [x] 维护看板指针一致性：README / AGENTS.md / docs/README.md / checklists/README.md 均指向 V26

## 相关 Issue

无

https://claude.ai/code/session_012ihzJDjGCDoKJCxtRBCLNg