### PR TITLE
docs: update X-IONet paper metadata and summary

### DIFF
--- a/wiki/entities/paper-x-ionet-cross-platform-inertial-odometry.md
+++ b/wiki/entities/paper-x-ionet-cross-platform-inertial-odometry.md
@@ -11,7 +11,7 @@ tags:
   - pedestrian
   - unitree
 status: complete
-updated: 2026-06-22
+updated: 2026-06-24
 arxiv: "2511.08277"
 venue: "IEEE RA-L 2026"
 related:
@@ -22,12 +22,12 @@ related:
   - ../tasks/locomotion.md
 sources:
   - ../../sources/papers/x_ionet_arxiv_2511_08277.md
-summary: "X-IONet：单 IMU 跨平台惯性里程计；规则专家路由 + 双阶段 attention 位移网络输出位移/不确定性，EKF 融合；RoNIN/GrandTour/Go2 SOTA。"
+summary: "X-IONet：单 IMU 跨平台惯性里程计；规则专家路由 + 双阶段 attention 位移网络输出位移/不确定性，EKF 融合；RoNIN/GrandTour/Go2 基准相对最强基线全面领先。"
 ---
 
 # X-IONet（跨平台惯性里程计网络）
 
-**X-IONet**（Cross-Platform Inertial Odometry Network）是 Shen & Chen 提出的 **仅用单 IMU** 的跨平台惯性里程计框架（IEEE RA-L Vol. 11 No. 7, July 2026；[arXiv:2511.08277](https://arxiv.org/abs/2511.08277)）。它用 **规则式专家选择** 区分行人 vs 四足运动模式，将 IMU 序列路由到 **平台专属位移网络**；网络采用 **双阶段 attention** 同时建模时间依赖与轴间相关，回归 **位移 + 协方差**，再经 **EKF** 做鲁棒状态估计。在 **RoNIN**、**GrandTour** 与自采 **Unitree Go2** 数据上达到 SOTA，尤其 Go2 上 ATE/RTE 相对最强基线降低 **52.8% / 41.3%**。
+**X-IONet**（Cross-Platform Inertial Odometry Network）是 Shen & Chen 提出的 **仅用单 IMU** 的跨平台惯性里程计框架（IEEE RA-L Vol. 11 No. 7, July 2026；[arXiv:2511.08277](https://arxiv.org/abs/2511.08277)）。它用 **规则式专家选择** 区分行人 vs 四足运动模式，将 IMU 序列路由到 **平台专属位移网络**；网络采用 **双阶段 attention** 同时建模时间依赖与轴间相关，回归 **位移 + 协方差**，再经 **EKF** 做鲁棒状态估计。在 **RoNIN**、**GrandTour** 与自采 **Unitree Go2** 数据上（截至论文发表 2026-06）相对各自最强基线全面领先，尤其 Go2 上 ATE/RTE 相对最强基线降低 **52.8% / 41.3%**。
 
 ## 一句话定义
 


### PR DESCRIPTION
## 摘要

更新 X-IONet 论文条目的发布日期和摘要描述。调整了更新时间戳，并改进了中文摘要的表述，更准确地反映论文在三个基准数据集上的性能对比结果。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 详细变更

1. **更新时间戳**：`updated: 2026-06-22` → `2026-06-24`
2. **改进摘要表述**：
   - 原文："RoNIN/GrandTour/Go2 SOTA"
   - 新文："RoNIN/GrandTour/Go2 基准相对最强基线全面领先"
3. **扩展正文描述**：在主要段落中补充了"截至论文发表 2026-06"的时间限定，并将"达到 SOTA"改为"相对各自最强基线全面领先"，使表述更严谨准确。

## 验证

- [x] `make ci-preflight`（wiki 内容改动）
- [ ] 其他：N/A

## 相关 Issue

无

https://claude.ai/code/session_01RVKEnmqPo6DpyDD1EVwv9u