### PR TITLE
fix(schema): 修正 BitRobot 机构标签以通过 Tests CI

### DIFF
--- a/schema/institutions.json
+++ b/schema/institutions.json
@@ -175,7 +175,7 @@
       ]
     },
     "bitrobot": {
-      "label": "BitRobot 基金会（BitRobot Foundation）",
+      "label": "比特机器人基金会（BitRobot Foundation）",
       "aliases": [
         "bitrobot",
         "bit-robot"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 PR #783 合并后 **Tests** workflow 失败：`bitrobot` 机构 `label` 以英文 `BitRobot` 开头，不符合 `INSTITUTION_LABEL_RE` 要求的 **中文（English）** 格式。

## 变更

- `schema/institutions.json`：`BitRobot 基金会（BitRobot Foundation）` → `比特机器人基金会（BitRobot Foundation）`

## 验证

- `make test` 通过（219 passed，含 `test_institution_naming`）
- `make ci-preflight` 通过

## 根因

`tests/test_institution_naming.py::test_registry_labels_conform_to_pattern` 要求所有机构 `label` 以中文字符开头；原标签 `BitRobot 基金会（…）` 以拉丁字母开头导致 pytest 失败。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d37c8bd2-d59d-44e2-bdc1-9c4a60a752a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d37c8bd2-d59d-44e2-bdc1-9c4a60a752a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

