### PR TITLE
Optimize 3D graph rendering and UI polish

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -13,6 +13,23 @@
     return typeof endpoint === 'object' ? endpoint.id : endpoint;
   }
 
+  /**
+   * 页面加载的是 2D 版 d3（含 forceX/forceY，但无 forceZ），3d-force-graph 内部
+   * 的 d3-force-3d 又不对外暴露。手写一个等价的 z 轴定向力供磁吸布局使用。
+   */
+  function createForceZ(getZ, strength) {
+    var nodesRef = [];
+    function force(alpha) {
+      for (var i = 0; i < nodesRef.length; i++) {
+        var n = nodesRef[i];
+        if (n.z == null) continue;
+        n.vz += (getZ(n) - n.z) * strength * alpha;
+      }
+    }
+    force.initialize = function (ns) { nodesRef = ns; };
+    return force;
+  }
+
   function cloneNodeFor3D(source) {
     var copy = Object.assign({}, source);
     if (source._info) copy._info = Object.assign({}, source._info);
@@ -120,6 +137,18 @@
     }
     rebuildNodeIndex();
 
+    // 预建邻接表：edges 在视图生命周期内不变，构建一次即可。
+    // 避免 isNeighborOf 在每次 hover 刷新时对每个节点都全量遍历边（O(N×E)）。
+    var adjacency = new Map();
+    edges.forEach(function (e) {
+      var s = edgeEndpointId(e.source);
+      var t = edgeEndpointId(e.target);
+      if (!adjacency.has(s)) adjacency.set(s, new Set());
+      if (!adjacency.has(t)) adjacency.set(t, new Set());
+      adjacency.get(s).add(t);
+      adjacency.get(t).add(s);
+    });
+
     function backgroundColor() {
       return isDark() ? '#0d1117' : '#eef2f7';
     }
@@ -156,14 +185,8 @@
     }
 
     function isNeighborOf(nodeId, otherId) {
-      for (var i = 0; i < edges.length; i++) {
-        var e = edges[i];
-        var s = edgeEndpointId(e.source);
-        var t = edgeEndpointId(e.target);
-        if (s === nodeId && t === otherId) return true;
-        if (t === nodeId && s === otherId) return true;
-      }
-      return false;
+      var set = adjacency.get(nodeId);
+      return set ? set.has(otherId) : false;
     }
 
     function linkOpacityFor(l) {
@@ -224,8 +247,11 @@
     }
 
     function nodeValFor(d) {
+      // 自定义 mesh 安装前（最初约 700ms）由 3d-force-graph 默认球体渲染，
+      // 其半径 = cbrt(nodeVal) × nodeRelSize。配合 nodeRelSize(1) 取 radius³，
+      // 使默认球体半径恰为 sphereRadiusFor，避免进入 3D 瞬间“大球→骤缩”的跳变。
       var radius = sphereRadiusFor(d);
-      return radius * radius;
+      return radius * radius * radius;
     }
 
     function createNodeMesh(d) {
@@ -298,7 +324,6 @@
       }
       var centers = magneticConfig.centers || {};
       var getKey = magneticConfig.getKey || function () { return ''; };
-      var forceZ = window.d3 && window.d3.forceZ;
       graph.d3Force('x', window.d3.forceX(function (d) {
         var key = getKey(d);
         return centers[key] ? centers[key].x : 0;
@@ -307,14 +332,10 @@
         var key = getKey(d);
         return centers[key] ? centers[key].y : 0;
       }).strength(0.18));
-      if (forceZ) {
-        graph.d3Force('z', forceZ(function (d) {
-          var key = getKey(d);
-          return centers[key] ? centers[key].z : 0;
-        }).strength(0.18));
-      } else {
-        graph.d3Force('z', null);
-      }
+      graph.d3Force('z', createForceZ(function (d) {
+        var key = getKey(d);
+        return centers[key] ? centers[key].z : 0;
+      }, 0.18));
     }
 
     function syncPositionsFromSource() {
@@ -348,7 +369,7 @@
       .showNavInfo(false)
       .warmupTicks(40)
       .nodeId('id')
-      .nodeRelSize(14)
+      .nodeRelSize(1)
       .nodeResolution(24)
       .nodeColor(function (d) { return getNodeColor(d); })
       .nodeVal(nodeValFor)

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2284,8 +2284,9 @@
     let graphMaxDegree = 1;
     function baseRadius(d) { return window.RNGraphNodeSize.radiusForDegree(d._degree || 0, graphMaxDegree); }
     function scaledRadius(d) { return baseRadius(d) * nodeScale; }
-    // 最终字号 = baseRadius × nodeScale × 0.4 × (fontSliderVal/10)
-    // 0.4 让 baseRadius=10 的节点在 nodeScale=1, fontSliderVal=10 时字体≈10px
+    // 最终字号 = max(6, baseRadius × nodeScale × 0.4 × (fontSliderVal/10))
+    // 当前常量 nodeScale=1、fontSliderVal=15 ⇒ 字号 = max(6, baseRadius×0.6)；
+    // baseRadius∈[4,30] 对应约 [6,18]px（6px 为下限，防止低度数节点标签过小）
     function scaledFontSize(d) { return Math.max(6, baseRadius(d) * nodeScale * 0.4 * (fontSliderVal / 10)); }
     function toDetailId(path) {
       const item = indexItems && indexItems.find(it => it.path === path || it.id === path);

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -738,10 +738,14 @@
       background: rgba(22,89,180,0.08);
       color: #1659b4;
     }
-    [data-theme="light"] .physics-action-btn.is-running,
-    [data-theme="light"] .physics-action-btn:disabled {
+    [data-theme="light"] .physics-action-btn.is-running {
       border-color: rgba(22,89,180,0.4);
       background: rgba(22,89,180,0.1);
+    }
+    [data-theme="light"] .physics-action-btn:disabled {
+      color: rgba(0,0,0,0.32);
+      border-color: rgba(0,0,0,0.1);
+      background: rgba(0,0,0,0.04);
     }
     [data-theme="light"] .slider-divider { background: rgba(0,0,0,0.06); }
     [data-theme="light"] input[type=range] { background: rgba(0,0,0,0.1); }
@@ -978,12 +982,18 @@
       color: #e6edf3;
       background: rgba(0,212,255,0.08);
     }
-    .physics-action-btn.is-running,
-    .physics-action-btn:disabled {
+    .physics-action-btn.is-running {
       opacity: 0.72;
       cursor: wait;
       border-color: rgba(0,212,255,0.55);
       background: rgba(0,212,255,0.16);
+    }
+    .physics-action-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+      color: rgba(255,255,255,0.35);
+      border-color: rgba(255,255,255,0.08);
+      background: rgba(255,255,255,0.03);
     }
     .physics-action-btn.is-timeline-active {
       border-color: rgba(0,212,255,0.55);
@@ -2169,9 +2179,14 @@
       if (mode !== '2d' && mode !== '3d') return;
       if (!opts.force && mode === spatialViewMode) return;
 
+      // 先切换状态：resumeSimulation2D / 力模拟 tick / fitToScreen 都依赖 is3DView()，
+      // 必须在调用它们之前就反映目标视图，否则回到 2D 时力模拟会被旧状态挡住、无法重启。
+      spatialViewMode = mode;
+
       if (mode === '3d') {
         if (timelineAnimating) teardownTimelineMode();
         if (!window.RNGraph3D?.isAvailable?.()) {
+          spatialViewMode = '2d';
           window.alert('3D 视图库加载失败，请刷新页面后重试');
           return;
         }
@@ -2180,6 +2195,7 @@
         graphCanvas3d.hidden = false;
         ensureGraph3DView();
         if (!graph3dView) {
+          spatialViewMode = '2d';
           graphCanvas3d.hidden = true;
           graph3dHoverNode = null;
           hideTooltip();
@@ -2202,7 +2218,6 @@
         fitToScreen();
       }
 
-      spatialViewMode = mode;
       try { localStorage.setItem(SPATIAL_VIEW_KEY, mode); } catch (_e) { /* ignore */ }
       updateViewModeButtons();
       updateGraphHint();


### PR DESCRIPTION
## 摘要

优化 3D 图谱渲染性能和交互体验：
1. 实现自定义 Z 轴定向力，支持磁吸布局的 Z 轴定位
2. 预建邻接表加速邻接关系查询（从 O(N×E) 降至 O(1)）
3. 修正节点体积计算，消除 3D 视图初始化时的视觉跳变
4. 调整禁用按钮样式，区分运行中和禁用状态
5. 修复 2D/3D 视图切换的状态管理顺序

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 核心优化

**1. 自定义 Z 轴力（`createForceZ`）**
- 页面加载的 d3 不包含 `forceZ`，3d-force-graph 内部的 d3-force-3d 也不暴露
- 手写等价实现，支持磁吸布局在 Z 轴上定位节点

**2. 邻接表预构建**
- 原 `isNeighborOf` 每次 hover 刷新时对每个节点全量遍历所有边（O(N×E)）
- 改为预建 `Map<nodeId, Set<neighborId>>`，查询降至 O(1)
- edges 在视图生命周期内不变，构建一次即可

**3. 节点体积修正**
- 3d-force-graph 默认球体半径 = `cbrt(nodeVal) × nodeRelSize`
- 原代码 `nodeVal = radius²`，导致默认球体半径 = `cbrt(r²) × 14 ≠ r`
- 改为 `nodeVal = radius³`，同时 `nodeRelSize` 从 14 改为 1
- 消除进入 3D 视图时"大球→骤缩"的跳变

### UI 改进

**4. 禁用按钮样式分离**
- 原样式将 `.is-running` 和 `:disabled` 混在一起
- 分离为两个独立规则，禁用状态显示为灰色（不可交互感更强）
- 浅色主题：禁用为 `rgba(0,0,0,0.32)` 文字 + `rgba(0,0,0,0.04)` 背景
- 深色主题：禁用为 `rgba(255,255,255,0.35)` 文字 + `rgba(255,255,255,0.03)` 背景

**5. 视图切换状态管理**
- 原逻辑先调用 `resumeSimulation2D` / 力模拟 / `fitToScreen`，再更新 `spatialViewMode`
- 这些函数依赖 `is3DView()` 判断，导致回到 2D 时力模拟被旧状态挡住
- 改为先更新 `spatialViewMode`，再执行依赖它的操作
- 异常路径（库加载失败、3D 初始化失败）也及时回滚状态

### 代码注释补充

- 添加中文注释说明 Z 轴力的必要性
- 补充 `nodeValFor` 的计算逻辑说明
- 补充字号计算的常量含义

## 验证

- 无自动化测试（前端交

https://claude.ai/code/session_01LEJTgdSV3X4bfRNbiQnms5