### PR TITLE
fix(ux): 3D 视图节点拖拽松手后回弹（与 2D 行为一致）

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -39,9 +39,13 @@
     copy.vx = 0;
     copy.vy = 0;
     copy.vz = 0;
-    copy.fx = null;
-    copy.fy = null;
-    copy.fz = null;
+    // 不要把 fx/fy/fz 设为 null：3d-force-graph 在拖拽结束时只有当「拖拽前该轴为
+    // undefined」才解除钉固（源码判断 void 0 === 轴值）。设成 null 会被判定为
+    // 「拖拽前已钉固」，从而保留落点、不回弹。删除属性（保持 undefined），
+    // 自由节点松手后即可回弹到力学平衡位置（与 2D drag end 清空 fx/fy 行为一致）。
+    delete copy.fx;
+    delete copy.fy;
+    delete copy.fz;
     return copy;
   }
 


### PR DESCRIPTION
## 摘要

- 修复 3D 视图中节点被拖动后固定在落点、不回弹的问题，使其与 2D 行为一致：松手后回弹到力学平衡位置。

## 根因

`cloneNodeFor3D` 把节点 `fx/fy/fz` 初始化为 `null`。而 3d-force-graph 在拖拽结束时**仅当「拖拽前该轴为 `undefined`」才解除钉固**（源码判断 `void 0 === 轴值`）；`null` 会被判定为「拖拽前已钉固」，于是松手后保留落点、不回弹。2D 不受影响是因为它在 drag end 里用 d3 自家逻辑显式清空 `fx/fy`。

改为**删除 `fx/fy/fz` 属性（保持 `undefined`）**，库的原生回弹逻辑即可生效——自由节点松手后回弹到力学平衡位置。

## 验证

此为交互行为（节点回弹运动），非静态渲染，故以无头 Chromium + WebGL 真实拖拽的行为数据为证据，不附截图：

- 初始 **1329/1329** 节点 `fx === undefined`（修复前全为 `null`）
- 真实拖拽（degree=429 的索引枢纽节点）：拖拽中 `fx = 1445`（已抓住）→ 松手后 `fx = undefined`（释放）→ 松手后位移约 **500** 世界单位（回弹）
- **0** 控制台错误
- `node -c docs/graph-3d.js` 语法通过

## 改动

- `docs/graph-3d.js`：`cloneNodeFor3D` 改为删除 `fx/fy/fz`（+7/−3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEJTgdSV3X4bfRNbiQnms5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEJTgdSV3X4bfRNbiQnms5)_