### PR TITLE
perf(ux): 优化 3D 图谱加载与重置卡顿

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -134,7 +134,9 @@
     var lastPointer = { clientX: 0, clientY: 0 };
     var size = measureContainerSize(container);
     var bundledThree = null;
+    var sharedSphereGeometry = null;
     var customMeshesInstalled = false;
+    var meshInstallScheduled = false;
 
     function rebuildNodeIndex() {
       nodeById = new Map(nodes3d.map(function (n) { return [n.id, n]; }));
@@ -251,18 +253,24 @@
     }
 
     function nodeValFor(d) {
-      // 自定义 mesh 安装前（最初约 700ms）由 3d-force-graph 默认球体渲染，
-      // 其半径 = cbrt(nodeVal) × nodeRelSize。配合 nodeRelSize(1) 取 radius³，
-      // 使默认球体半径恰为 sphereRadiusFor，避免进入 3D 瞬间“大球→骤缩”的跳变。
+      // 自定义 mesh 安装前由 3d-force-graph 默认球体渲染；nodeResolution(8) 仅作短暂占位。
       var radius = sphereRadiusFor(d);
       return radius * radius * radius;
+    }
+
+    function ensureSharedSphereGeometry(T) {
+      if (!sharedSphereGeometry) {
+        // 单位球 + mesh.scale：1336 节点共享一份几何体，避免逐节点 new SphereGeometry 阻塞主线程。
+        sharedSphereGeometry = new T.SphereGeometry(1, 12, 10);
+      }
+      return sharedSphereGeometry;
     }
 
     function createNodeMesh(d) {
       if (!bundledThree) return null;
       var radius = sphereRadiusFor(d);
       var opacity = nodeOpacityFor(d);
-      var geometry = new bundledThree.SphereGeometry(radius, 18, 14);
+      var geometry = ensureSharedSphereGeometry(bundledThree);
       var MaterialCtor = bundledThree.MeshLambertMaterial;
       var material = new MaterialCtor({
         color: getNodeColor(d),
@@ -270,6 +278,7 @@
         opacity: opacity,
       });
       var mesh = new bundledThree.Mesh(geometry, material);
+      mesh.scale.set(radius, radius, radius);
       mesh.userData.nodeId = d.id;
       return mesh;
     }
@@ -282,7 +291,9 @@
         if (!obj.isMesh || !obj.userData || !obj.userData.nodeId || !obj.material) return;
         var d = nodeById.get(obj.userData.nodeId);
         if (!d) return;
+        var radius = sphereRadiusFor(d);
         var opacity = nodeOpacityFor(d);
+        obj.scale.set(radius, radius, radius);
         obj.material.color.set(getNodeColor(d));
         obj.material.opacity = opacity;
         obj.material.transparent = opacity < 0.999;
@@ -308,6 +319,7 @@
       if (customMeshesInstalled || !graph) return false;
       bundledThree = captureBundledThree(graph);
       if (!bundledThree) return false;
+      ensureSharedSphereGeometry(bundledThree);
       graph
         .nodeThreeObject(function (d) { return createNodeMesh(d); })
         .nodeThreeObjectExtend(false);
@@ -316,6 +328,46 @@
       customMeshesInstalled = true;
       refreshAppearance();
       return true;
+    }
+
+    function scheduleCustomMeshInstall(onReady) {
+      if (customMeshesInstalled) {
+        if (onReady) onReady();
+        return;
+      }
+      if (meshInstallScheduled) return;
+      meshInstallScheduled = true;
+      var attempts = 0;
+      function tryInstall() {
+        attempts += 1;
+        if (installCustomNodeMeshes()) {
+          meshInstallScheduled = false;
+          if (onReady) onReady();
+          return;
+        }
+        if (attempts < 12) {
+          window.requestAnimationFrame(tryInstall);
+        } else {
+          meshInstallScheduled = false;
+        }
+      }
+      window.requestAnimationFrame(tryInstall);
+    }
+
+    function resetNodePositionsInPlace() {
+      sourceNodes.forEach(function (src) {
+        var n3 = nodeById.get(src.id);
+        if (!n3) return;
+        n3.x = src.x != null ? src.x : (Math.random() - 0.5) * 80;
+        n3.y = src.y != null ? src.y : (Math.random() - 0.5) * 80;
+        n3.z = src.z != null ? src.z : (Math.random() - 0.5) * 80;
+        n3.vx = 0;
+        n3.vy = 0;
+        n3.vz = 0;
+        delete n3.fx;
+        delete n3.fy;
+        delete n3.fz;
+      });
     }
 
     function applyMagneticForces() {
@@ -371,10 +423,11 @@
       .graphData({ nodes: nodes3d, links: buildLinks() })
       .backgroundColor(backgroundColor())
       .showNavInfo(false)
-      .warmupTicks(40)
+      .warmupTicks(0)
+      .cooldownTicks(24)
       .nodeId('id')
       .nodeRelSize(1)
-      .nodeResolution(24)
+      .nodeResolution(8)
       .nodeColor(function (d) { return getNodeColor(d); })
       .nodeVal(nodeValFor)
       .nodeOpacity(function (d) { return nodeOpacityFor(d); })
@@ -401,6 +454,8 @@
     var chargeForce = graph.d3Force('charge');
     if (chargeForce && chargeForce.strength) chargeForce.strength(getChargeStrength());
 
+    scheduleCustomMeshInstall();
+
     return {
       show: function () {
         container.hidden = false;
@@ -411,11 +466,13 @@
         this.resumeSimulation();
         var self = this;
         window.requestAnimationFrame(function () { syncViewport(); });
-        window.setTimeout(function () {
-          if (!customMeshesInstalled) installCustomNodeMeshes();
-          self.fitToScreen(800);
-        }, 700);
-        window.setTimeout(function () { self.fitToScreen(600); }, 2600);
+        if (customMeshesInstalled) {
+          self.fitToScreen(450);
+        } else {
+          scheduleCustomMeshInstall(function () {
+            self.fitToScreen(450);
+          });
+        }
       },
 
       hide: function () {
@@ -452,10 +509,17 @@
         var charge = graph.d3Force('charge');
         if (charge && charge.strength) charge.strength(getChargeStrength());
         applyMagneticForces();
-        graph.d3ReheatSimulation();
+        if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.45);
+        if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.22);
+        else if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
       },
 
       restartSimulation: function () {
+        if (customMeshesInstalled) {
+          resetNodePositionsInPlace();
+          this.updateForces();
+          return;
+        }
         nodes3d = sourceNodes.map(cloneNodeFor3D);
         rebuildNodeIndex();
         graph.graphData({ nodes: nodes3d, links: buildLinks() });

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2760,7 +2760,7 @@
     function restartForceSimulation() {
       if (is3DView() && graph3dView) {
         graph3dView.restartSimulation();
-        graph3dView.fitToScreen();
+        graph3dView.fitToScreen(350);
         return;
       }
       node.select('.node-label').style('opacity', 0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

当前知识图谱约 **1336 节点 / 9109 边**，3D 视图在首次进入和点击「重置布局」时会出现明显主线程卡顿。本次针对 `docs/graph-3d.js` 做了几项低开销优化，减少重复 Three.js 对象创建与同步物理预热。

## 根因

1. **每节点独立 `SphereGeometry`**：安装自定义 mesh 时为每个节点 `new SphereGeometry(radius, 18, 14)`，约 1300 次几何体分配阻塞主线程。
2. **700ms 延迟 + 二次 `graphData`**：进入 3D 后先渲染高分辨率默认球，再整图重建自定义 mesh。
3. **`warmupTicks(40)`**：创建视图时在主线程同步跑 40 轮力导向，大图下耗时明显。
4. **重置走全量 `graphData`**：销毁并重建全部 Three 对象，而非仅更新坐标。

## 改动

- 节点改用 **共享单位球几何体 + `mesh.scale`**，材质仍按节点独立（便于 hover/筛选改色）。
- `warmupTicks(0)`，占位默认球 `nodeResolution` 降至 8；创建后 **首帧 rAF** 安装自定义 mesh（去掉 700ms / 2600ms 双次 `fitToScreen`）。
- **重置**：mesh 已安装时仅 `resetNodePositionsInPlace()` + 轻量 `d3Alpha(0.45)` reheat，跳过 `graphData` 全量重建。
- 重置后 `fitToScreen(350)`，动画更短。

## 验证

- `node --check docs/graph-3d.js` 通过

## 预期效果

- 首次切换 3D：减少「黑屏/假死」感，mesh 安装从 ~700ms 推迟变为下一帧尝试。
- 点击重置：避免 1300+ mesh 销毁重建，卡顿应明显缩短。

若仍觉得模拟阶段 CPU 偏高，后续可考虑：隐藏时彻底 `pauseAnimation`、按视距 LOD 降低边渲染、或对边集做抽样显示。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34848adb-4a88-42ea-9725-8ccfa9ead364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34848adb-4a88-42ea-9725-8ccfa9ead364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

