### PR TITLE
fix(ux): 优化 3D 图谱适配屏幕、浮窗闪烁与筛选可见性

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -174,18 +174,19 @@
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       var ok = visible.has(d.id);
+      var dimOpacity = filtered ? 0.02 : 0.15;
       if (sidebarNodeId) {
         if (d.id === sidebarNodeId || sidebarDirect.has(d.id)) return 1;
         if (sidebarSecondary.has(d.id)) return 0.4;
-        return 0.05;
+        return filtered && !ok ? 0.02 : 0.05;
       }
       if (hoverNodeId) {
         if (!filtered) return hoverNodeId === d.id || isNeighborOf(hoverNodeId, d.id) ? 1 : 0.15;
-        if (!ok) return 0.08;
-        return hoverNodeId === d.id || isNeighborOf(hoverNodeId, d.id) ? 1 : 0.15;
+        if (!ok) return 0.02;
+        return hoverNodeId === d.id || isNeighborOf(hoverNodeId, d.id) ? 1 : dimOpacity;
       }
       if (!filtered) return 1;
-      return ok ? 1 : 0.08;
+      return ok ? 1 : 0.02;
     }
 
     function isNeighborOf(nodeId, otherId) {
@@ -210,8 +211,8 @@
         if (eRef && edgeHighlightsWithNode) return edgeHighlightsWithNode(eRef, hoverNodeId) ? 0.45 : 0.1;
       }
       if (!filtered) return 0.06;
-      if (!visible.has(s) || !visible.has(t)) return 0.03;
-      return 0.06;
+      if (!visible.has(s) || !visible.has(t)) return 0.012;
+      return 0.08;
     }
 
     function linkColorFor(l) {
@@ -247,7 +248,9 @@
 
     function sphereRadiusFor(d) {
       var r = getNodeRadius(d);
-      return Math.max(11, r * 1.65);
+      var base = Math.max(11, r * 1.65);
+      if (hasActiveFilter() && getVisibleNodeIds().has(d.id)) return base * 1.12;
+      return base;
     }
 
     function nodeValFor(d) {
@@ -271,6 +274,7 @@
       });
       var mesh = new bundledThree.Mesh(geometry, material);
       mesh.userData.nodeId = d.id;
+      mesh.userData.baseRadius = Math.max(11, getNodeRadius(d) * 1.65);
       return mesh;
     }
 
@@ -287,6 +291,10 @@
         obj.material.opacity = opacity;
         obj.material.transparent = opacity < 0.999;
         obj.visible = opacity > 0.02;
+        var targetR = sphereRadiusFor(d);
+        var baseR = obj.userData.baseRadius || targetR;
+        var scale = baseR > 0 ? targetR / baseR : 1;
+        obj.scale.set(scale, scale, scale);
       });
     }
 
@@ -355,6 +363,71 @@
       var next = measureContainerSize(container);
       graph.width(next.width);
       graph.height(next.height);
+    }
+
+    function inflateBbox(bbox, nodeFilter) {
+      var padR = 0;
+      nodes3d.forEach(function (n) {
+        if (nodeFilter && !nodeFilter(n)) return;
+        if (n.x == null || n.y == null || n.z == null) return;
+        padR = Math.max(padR, sphereRadiusFor(n) + 8);
+      });
+      return {
+        x: [bbox.x[0] - padR, bbox.x[1] + padR],
+        y: [bbox.y[0] - padR, bbox.y[1] + padR],
+        z: [bbox.z[0] - padR, bbox.z[1] + padR],
+      };
+    }
+
+    function fitCameraToBbox(bbox, duration) {
+      if (!graph || !bbox) return false;
+      var cx = (bbox.x[0] + bbox.x[1]) / 2;
+      var cy = (bbox.y[0] + bbox.y[1]) / 2;
+      var cz = (bbox.z[0] + bbox.z[1]) / 2;
+      var halfX = Math.max((bbox.x[1] - bbox.x[0]) / 2, 8);
+      var halfY = Math.max((bbox.y[1] - bbox.y[0]) / 2, 8);
+      var halfZ = Math.max((bbox.z[1] - bbox.z[0]) / 2, 8);
+      var radius = Math.sqrt(halfX * halfX + halfY * halfY + halfZ * halfZ);
+
+      var view = measureContainerSize(container);
+      var cam3d = graph.camera();
+      var fovDeg = (cam3d && cam3d.fov) || 50;
+      var fov = fovDeg * Math.PI / 180;
+      var aspect = view.width / Math.max(view.height, 1);
+      var distV = radius / Math.sin(fov / 2);
+      var hFov = 2 * Math.atan(Math.tan(fov / 2) * aspect);
+      var distH = radius / Math.sin(hFov / 2);
+      var dist = Math.max(distV, distH, 48);
+      dist *= 0.78;
+
+      var lookAt = { x: cx, y: cy, z: cz };
+      var cur = graph.cameraPosition();
+      var dx = cur.x - cur.lookAt.x;
+      var dy = cur.y - cur.lookAt.y;
+      var dz = cur.z - cur.lookAt.z;
+      var len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (len < 1e-3) {
+        dx = 0.35;
+        dy = 0.55;
+        dz = 1.0;
+        len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      }
+      graph.cameraPosition(
+        { x: cx + (dx / len) * dist, y: cy + (dy / len) * dist, z: cz + (dz / len) * dist },
+        lookAt,
+        duration == null ? 650 : duration
+      );
+      return true;
+    }
+
+    function zoomFitToNodes(duration, nodeFilter) {
+      if (!graph) return;
+      var filterFn = nodeFilter || function () { return true; };
+      var bbox = graph.getGraphBbox(filterFn);
+      if (bbox) bbox = inflateBbox(bbox, filterFn);
+      if (!fitCameraToBbox(bbox, duration)) {
+        graph.zoomToFit(duration, 0, filterFn);
+      }
     }
 
     function onContainerPointerMove(ev) {
@@ -463,12 +536,12 @@
       },
 
       fitToScreen: function (ms) {
-        graph.zoomToFit(ms == null ? 650 : ms, 16);
+        zoomFitToNodes(ms == null ? 650 : ms);
       },
 
       fitToVisible: function (ms) {
         var visible = getVisibleNodeIds();
-        graph.zoomToFit(ms == null ? 650 : ms, 64, function (n) { return visible.has(n.id); });
+        zoomFitToNodes(ms == null ? 650 : ms, function (n) { return visible.has(n.id); });
       },
 
       focusNode: function (node, ms) {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -182,6 +182,46 @@
       text-decoration: none;
     }
     .topic-intro-link:hover { color: #7dd3fc; text-decoration: underline; }
+    /* 3D 筛选态提示条（右上角，筛选激活时显示） */
+    .graph-3d-filter-banner {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      z-index: 12;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      max-width: min(360px, calc(100% - 24px));
+      padding: 9px 12px;
+      border-radius: 10px;
+      border: 1px solid rgba(96, 165, 250, 0.45);
+      background: rgba(13, 17, 23, 0.9);
+      backdrop-filter: blur(8px);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(96, 165, 250, 0.12);
+      pointer-events: none;
+      font-size: .78rem;
+      font-weight: 600;
+      color: #bfdbfe;
+      letter-spacing: .01em;
+    }
+    .graph-3d-filter-banner-icon {
+      font-size: .95rem;
+      line-height: 1;
+    }
+    .graph-3d-filter-banner strong {
+      color: #e0f2fe;
+      font-weight: 800;
+    }
+    #filter-toggle.is-filter-active {
+      background: rgba(96, 165, 250, 0.18);
+      border-color: rgba(96, 165, 250, 0.62);
+      color: #e6edf3;
+      box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.18);
+    }
+    #filter-toggle.is-filter-active:hover {
+      border-color: rgba(96, 165, 250, 0.82);
+      color: #fff;
+    }
     .node-topic-hub .node-glow { fill-opacity: 0.28 !important; }
     .node-topic-hub .node-circle {
       stroke-width: 2.5px !important;
@@ -307,9 +347,15 @@
       max-height: 70vh;
       overflow-y: auto;
       pointer-events: none;
+      visibility: visible;
       transition: opacity .12s;
     }
-    #graph-tooltip.hidden { opacity: 0; pointer-events: none !important; }
+    #graph-tooltip.hidden {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none !important;
+      transition: none;
+    }
     #graph-tooltip.tt-pinned {
       pointer-events: auto;
       border-color: rgba(0,212,255,0.35);
@@ -646,6 +692,19 @@
     }
     [data-theme="light"] .topic-intro-text { color: rgba(15, 23, 42, 0.68); }
     [data-theme="light"] .topic-intro-link { color: #1659b4; }
+    [data-theme="light"] .graph-3d-filter-banner {
+      background: rgba(255, 255, 255, 0.94);
+      border-color: rgba(22, 89, 180, 0.35);
+      color: #1659b4;
+      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12), 0 0 0 1px rgba(22, 89, 180, 0.1);
+    }
+    [data-theme="light"] .graph-3d-filter-banner strong { color: #0f3d7a; }
+    [data-theme="light"] #filter-toggle.is-filter-active {
+      background: #e6f7ff;
+      border-color: #1659b4;
+      color: #1659b4;
+      box-shadow: 0 0 0 1px rgba(22, 89, 180, 0.12);
+    }
     [data-theme="light"] .node-topic-hub .node-label { fill: rgba(15, 23, 42, 0.88) !important; }
     [data-theme="light"] .toolbar-sep { background: rgba(0,0,0,0.1); }
     [data-theme="light"] #graph-node-count { color: rgba(0,0,0,0.38); }
@@ -1547,6 +1606,10 @@
       <p class="topic-intro-text" id="topic-intro-text"></p>
       <a id="topic-intro-link" class="topic-intro-link" href="#">打开专题汇总页 →</a>
     </div>
+    <div id="graph-3d-filter-banner" class="graph-3d-filter-banner" hidden aria-live="polite">
+      <span class="graph-3d-filter-banner-icon" aria-hidden="true">🔍</span>
+      <span id="graph-3d-filter-banner-text">筛选中</span>
+    </div>
     <button id="graph-legend-fab" type="button" aria-label="打开图例" aria-expanded="false" aria-controls="graph-legend" title="图例">🎨</button>
     <div id="graph-legend-scrim" hidden aria-hidden="true"></div>
     <div id="graph-legend" role="region" aria-label="图谱图例"></div>
@@ -2068,6 +2131,22 @@
 
     function is3DView() { return spatialViewMode === '3d'; }
 
+    const graph3dFilterBanner = document.getElementById('graph-3d-filter-banner');
+    const graph3dFilterBannerText = document.getElementById('graph-3d-filter-banner-text');
+
+    function updateGraph3DFilterBanner(visibleCount) {
+      if (!graph3dFilterBanner) return;
+      const active = is3DView() && hasActiveGraphFilter();
+      if (!active) {
+        graph3dFilterBanner.hidden = true;
+        return;
+      }
+      graph3dFilterBanner.hidden = false;
+      if (graph3dFilterBannerText) {
+        graph3dFilterBannerText.innerHTML = '筛选中 · <strong>' + visibleCount + '</strong> / ' + nodes.length + ' 节点可见';
+      }
+    }
+
     function updateGraphHint() {
       const in3d = is3DView();
       if (graphHint2dEl) graphHint2dEl.hidden = in3d;
@@ -2222,6 +2301,7 @@
       updateViewModeButtons();
       updateGraphHint();
       syncTimeline3DState();
+      applyFilters();
     }
 
     function syncTimeline3DState() {
@@ -2860,9 +2940,7 @@
 
     function hideTooltip() {
       tooltip.classList.add('hidden');
-      tooltip.style.left = '';
-      tooltip.style.top = '';
-      tooltip.style.transform = '';
+      tooltip.classList.remove('tt-pinned');
       tooltip.style.right = '';
       tooltip.style.bottom = '';
     }
@@ -3249,8 +3327,13 @@
     function updateFilterCount() {
       const count = activeFilters.size + activeInstitutions.size + (topDegreeIds ? 1 : 0) + (currentTopic && currentTopic !== 'all' ? 1 : 0);
       const countEl = document.getElementById('filter-count');
+      const filterActive = hasActiveGraphFilter();
+      if (filterToggle) filterToggle.classList.toggle('is-filter-active', filterActive);
       if (count > 0) {
         countEl.textContent = count;
+        countEl.style.display = 'inline-flex';
+      } else if (filterActive) {
+        countEl.textContent = '•';
         countEl.style.display = 'inline-flex';
       } else {
         countEl.style.display = 'none';
@@ -3385,6 +3468,8 @@
           return edgeOk ? linkWidthBase : linkWidthBase * 0.5;
         });
       updateCount(visible);
+      updateGraph3DFilterBanner(visible);
+      updateFilterCount();
       if (graph3dView && is3DView()) graph3dView.syncFilters();
       if (searchQuery) flyToVisible();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

针对知识图谱 3D 视图的三个体验问题做了修复：

1. **适配屏幕画面过小**：不再依赖 `zoomToFit` 默认以原点为中心的包围球，改为基于 `getGraphBbox` 计算节点包围盒（含球体半径），将相机对准实际图心并拉近填充视口（约 78% 距离系数）。
2. **浮窗左上角闪烁**：隐藏浮窗时保留上次坐标，并用 `visibility: hidden` + 取消过渡即时收起，避免清空 `left/top` 后在 `(0,0)` 短暂可见。
3. **筛选不够明显**：
   - 3D 中非命中节点透明度 `0.08 → 0.02`，命中节点略放大（×1.12）
   - 工具栏「筛选」按钮在任意筛选激活时高亮（`is-filter-active`）
   - 3D 模式下右上角显示「筛选中 · X / N 节点可见」提示条

## 变更文件

- `docs/graph-3d.js` — bbox 相机适配、筛选对比度、节点缩放同步
- `docs/graph.html` — 浮窗 CSS/隐藏逻辑、3D 筛选提示条与工具栏高亮

## 验证

- `make ci-preflight` 通过
- 本地静态站 `graph.html` 可正常加载 3D 库（`RNGraph3D.isAvailable()` 为 true）

## 手动验证建议

1. 打开 `graph.html` → 切换「3D 立体」→ 点击「适配屏幕」，节点应明显更大、更贴近视口
2. 悬停节点显示浮窗后移开鼠标，不应在左上角闪一下
3. 打开筛选（如专题 Sim2Real）→ 3D 下非命中节点应几乎隐去，右上角出现筛选提示条，工具栏筛选按钮高亮
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-740f0168-d8aa-4480-a8e9-37478ae5a742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-740f0168-d8aa-4480-a8e9-37478ae5a742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

