### PR TITLE
feat(ux): 3D 视图支持时序动画

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -139,6 +139,7 @@
     var sharedSphereGeometry = null;
     var customMeshesInstalled = false;
     var meshInstallScheduled = false;
+    var timelineDefaultNodes = false;
 
     function rebuildNodeIndex() {
       nodeById = new Map(nodes3d.map(function (n) { return [n.id, n]; }));
@@ -297,7 +298,7 @@
     }
 
     function updateNodeMeshes() {
-      if (!graph || !bundledThree) return;
+      if (!graph || !bundledThree || !customMeshesInstalled) return;
       var scene = graph.scene && graph.scene();
       if (!scene) return;
       scene.traverse(function (obj) {
@@ -328,6 +329,23 @@
       updateNodeMeshes();
     }
 
+    function useTimelineDefaultNodes(enabled) {
+      if (!graph || enabled === timelineDefaultNodes) return;
+      timelineDefaultNodes = enabled;
+      if (enabled) {
+        graph.nodeThreeObject(null);
+        customMeshesInstalled = false;
+      } else if (bundledThree) {
+        graph
+          .nodeThreeObject(function (d) { return createNodeMesh(d); })
+          .nodeThreeObjectExtend(false);
+        customMeshesInstalled = true;
+        ensureSceneLights(graph.scene(), bundledThree);
+      } else {
+        scheduleCustomMeshInstall();
+      }
+    }
+
     function installCustomNodeMeshes() {
       if (customMeshesInstalled || !graph) return false;
       bundledThree = captureBundledThree(graph);
@@ -339,6 +357,7 @@
       graph.graphData({ nodes: nodes3d, links: buildLinks() });
       ensureSceneLights(graph.scene(), bundledThree);
       customMeshesInstalled = true;
+      timelineDefaultNodes = false;
       refreshAppearance();
       return true;
     }
@@ -507,30 +526,25 @@
 
     function syncTimelineSimulation(revealedIds) {
       if (!graph) return;
-      syncPositionsFromSource();
-      // 保持完整 graphData（自定义 mesh 在子集替换时易丢渲染）；未显现节点钉在原点且透明
-      nodes3d.forEach(function (n3) {
-        if (revealedIds.has(n3.id)) {
-          delete n3.fx;
-          delete n3.fy;
-          delete n3.fz;
-        } else {
-          n3.x = 0;
-          n3.y = 0;
-          n3.z = 0;
-          n3.vx = 0;
-          n3.vy = 0;
-          n3.vz = 0;
-          n3.fx = 0;
-          n3.fy = 0;
-          n3.fz = 0;
-        }
+      useTimelineDefaultNodes(true);
+      var revNodes = nodes3d.filter(function (n) { return revealedIds.has(n.id); });
+      revNodes.forEach(function (n3) {
+        delete n3.fx;
+        delete n3.fy;
+        delete n3.fz;
       });
-      graph.graphData({
-        nodes: nodes3d,
-        links: buildLinks(function (n) { return revealedIds.has(n.id); }),
-      });
-      refreshAppearance();
+      graph
+        .nodeColor(function (d) { return getNodeColor(d); })
+        .nodeVal(nodeValFor)
+        .nodeOpacity(function (d) { return nodeOpacityFor(d); })
+        .linkColor(function (l) { return linkColorFor(l); })
+        .linkWidth(function (l) { return linkWidthFor(l); })
+        .linkOpacity(function (l) { return linkOpacityFor(l); })
+        .graphData({
+          nodes: revNodes,
+          links: buildLinks(function (n) { return revealedIds.has(n.id); }),
+        });
+      if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
       if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.45);
       if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.22);
       else if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
@@ -538,6 +552,7 @@
 
     function restoreFullGraphData() {
       if (!graph) return;
+      useTimelineDefaultNodes(false);
       syncPositionsFromSource();
       graph.graphData({ nodes: nodes3d, links: buildLinks() });
       refreshAppearance();
@@ -675,7 +690,7 @@
     return {
       show: function () {
         container.hidden = false;
-        syncPositionsFromSource();
+        if (!isTimelineAnimating()) syncPositionsFromSource();
         syncViewport();
         graph.backgroundColor(backgroundColor());
         refreshAppearance();

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -508,8 +508,28 @@
     function syncTimelineSimulation(revealedIds) {
       if (!graph) return;
       syncPositionsFromSource();
-      var revNodes = nodes3d.filter(function (n) { return revealedIds.has(n.id); });
-      graph.graphData({ nodes: revNodes, links: buildLinks(function (n) { return revealedIds.has(n.id); }) });
+      // 保持完整 graphData（自定义 mesh 在子集替换时易丢渲染）；未显现节点钉在原点且透明
+      nodes3d.forEach(function (n3) {
+        if (revealedIds.has(n3.id)) {
+          delete n3.fx;
+          delete n3.fy;
+          delete n3.fz;
+        } else {
+          n3.x = 0;
+          n3.y = 0;
+          n3.z = 0;
+          n3.vx = 0;
+          n3.vy = 0;
+          n3.vz = 0;
+          n3.fx = 0;
+          n3.fy = 0;
+          n3.fz = 0;
+        }
+      });
+      graph.graphData({
+        nodes: nodes3d,
+        links: buildLinks(function (n) { return revealedIds.has(n.id); }),
+      });
       refreshAppearance();
       if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.45);
       if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.22);

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -118,6 +118,8 @@
     var onPointerMove = opts.onPointerMove;
     var getVisibleNodeIds = opts.getVisibleNodeIds || function () { return new Set(); };
     var hasActiveFilter = opts.hasActiveFilter || function () { return false; };
+    var isTimelineAnimating = opts.isTimelineAnimating || function () { return false; };
+    var getTimelineRevealedIds = opts.getTimelineRevealedIds || function () { return new Set(); };
     var edgeHighlightsWithNode = opts.edgeHighlightsWithNode;
     var getChargeStrength = opts.getChargeStrength || function () { return -800; };
     var getMagneticConfig = opts.getMagneticConfig || function () { return null; };
@@ -159,7 +161,7 @@
       return isDark() ? '#0d1117' : '#eef2f7';
     }
 
-    function buildLinks() {
+    function buildLinks(nodeFilter) {
       return edges
         .map(function (e) {
           var sId = edgeEndpointId(e.source);
@@ -167,12 +169,14 @@
           var source = nodeById.get(sId);
           var target = nodeById.get(tId);
           if (!source || !target) return null;
+          if (nodeFilter && (!nodeFilter(source) || !nodeFilter(target))) return null;
           return { source: source, target: target, _ref: e };
         })
         .filter(Boolean);
     }
 
     function nodeOpacityFor(d) {
+      if (isTimelineAnimating() && !getTimelineRevealedIds().has(d.id)) return 0;
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       var ok = visible.has(d.id);
@@ -199,6 +203,11 @@
     function linkOpacityFor(l) {
       var s = edgeEndpointId(l.source);
       var t = edgeEndpointId(l.target);
+      if (isTimelineAnimating()) {
+        var revealed = getTimelineRevealedIds();
+        if (!revealed.has(s) || !revealed.has(t)) return 0;
+        if (!sidebarNodeId && !hoverNodeId) return 0.35;
+      }
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       if (sidebarNodeId && edgeHighlightsWithNode) {
@@ -404,7 +413,125 @@
         if (!n3) return;
         if (src.x != null) n3.x = src.x;
         if (src.y != null) n3.y = src.y;
+        if (src.z != null) n3.z = src.z;
       });
+    }
+
+    function syncSourceFrom3D() {
+      nodes3d.forEach(function (n3) {
+        var src = resolveSourceNode(n3.id);
+        if (!src) return;
+        if (n3.x != null) src.x = n3.x;
+        if (n3.y != null) src.y = n3.y;
+        if (n3.z != null) src.z = n3.z;
+      });
+    }
+
+    function snapshotPositions() {
+      return nodes3d.map(function (n) {
+        return { id: n.id, x: n.x, y: n.y, z: n.z };
+      });
+    }
+
+    function restorePositions(saved) {
+      if (!saved || !saved.length) return;
+      var byId = new Map(saved.map(function (p) { return [p.id, p]; }));
+      nodes3d.forEach(function (n3) {
+        var p = byId.get(n3.id);
+        if (!p) return;
+        if (p.x != null) n3.x = p.x;
+        if (p.y != null) n3.y = p.y;
+        if (p.z != null) n3.z = p.z;
+        n3.vx = 0;
+        n3.vy = 0;
+        n3.vz = 0;
+        delete n3.fx;
+        delete n3.fy;
+        delete n3.fz;
+      });
+      syncSourceFrom3D();
+      graph.graphData({ nodes: nodes3d, links: buildLinks() });
+      refreshAppearance();
+    }
+
+    function seedTimelineNodePosition(sourceNode, revealedIds, incident) {
+      var n3 = nodeById.get(sourceNode.id);
+      var sx = 0;
+      var sy = 0;
+      var sz = 0;
+      var cnt = 0;
+      var inc = incident && incident.get(sourceNode.id);
+      if (inc) {
+        for (var i = 0; i < inc.length; i++) {
+          var e = inc[i];
+          var sid = edgeEndpointId(e.source);
+          var otherId = sid === sourceNode.id ? edgeEndpointId(e.target) : sid;
+          var other = resolveSourceNode(otherId);
+          if (!other || !revealedIds.has(other.id) || other.x == null) continue;
+          var other3 = nodeById.get(other.id);
+          sx += other.x;
+          sy += other.y;
+          sz += other.z != null ? other.z : (other3 && other3.z != null ? other3.z : 0);
+          cnt++;
+        }
+      }
+      var x;
+      var y;
+      var z;
+      if (cnt > 0) {
+        x = sx / cnt + (Math.random() - 0.5) * 30;
+        y = sy / cnt + (Math.random() - 0.5) * 30;
+        z = sz / cnt + (Math.random() - 0.5) * 30;
+      } else {
+        x = (Math.random() - 0.5) * 80;
+        y = (Math.random() - 0.5) * 80;
+        z = (Math.random() - 0.5) * 80;
+      }
+      sourceNode.x = x;
+      sourceNode.y = y;
+      sourceNode.z = z;
+      sourceNode.vx = 0;
+      sourceNode.vy = 0;
+      if (n3) {
+        n3.x = x;
+        n3.y = y;
+        n3.z = z;
+        n3.vx = 0;
+        n3.vy = 0;
+        n3.vz = 0;
+        delete n3.fx;
+        delete n3.fy;
+        delete n3.fz;
+      }
+    }
+
+    function syncTimelineSimulation(revealedIds) {
+      if (!graph) return;
+      syncPositionsFromSource();
+      var revNodes = nodes3d.filter(function (n) { return revealedIds.has(n.id); });
+      graph.graphData({ nodes: revNodes, links: buildLinks(function (n) { return revealedIds.has(n.id); }) });
+      refreshAppearance();
+      if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.45);
+      if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.22);
+      else if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
+    }
+
+    function restoreFullGraphData() {
+      if (!graph) return;
+      syncPositionsFromSource();
+      graph.graphData({ nodes: nodes3d, links: buildLinks() });
+      refreshAppearance();
+    }
+
+    function resumeTimelineSimulation() {
+      if (!graph) return;
+      if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
+      if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.3);
+    }
+
+    function softenTimelineSimulation() {
+      if (!graph) return;
+      if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0);
     }
 
     function syncViewport() {
@@ -603,6 +730,19 @@
         var visible = getVisibleNodeIds();
         zoomFitToNodes(ms == null ? 650 : ms, function (n) { return visible.has(n.id); });
       },
+
+      fitToTimelineNodes: function (revealedIds, ms) {
+        zoomFitToNodes(ms == null ? 650 : ms, function (n) { return revealedIds.has(n.id); });
+      },
+
+      seedTimelineNodePosition: seedTimelineNodePosition,
+      syncTimelineSimulation: syncTimelineSimulation,
+      restoreFullGraphData: restoreFullGraphData,
+      resumeTimelineSimulation: resumeTimelineSimulation,
+      softenTimelineSimulation: softenTimelineSimulation,
+      snapshotPositions: snapshotPositions,
+      restorePositions: restorePositions,
+      syncSourceFrom3D: syncSourceFrom3D,
 
       focusNode: function (node, ms) {
         var n3 = node && nodeById.get(node.id);

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2137,6 +2137,8 @@
         isDark,
         getVisibleNodeIds: () => visibleNodeIds,
         hasActiveFilter: hasActiveGraphFilter,
+        isTimelineAnimating: () => timelineAnimating,
+        getTimelineRevealedIds: () => timelineRevealedIds,
         edgeHighlightsWithNode,
         getChargeStrength: () => chargeStrength,
         getMagneticConfig: getMagneticConfig3D,
@@ -2206,7 +2208,6 @@
       spatialViewMode = mode;
 
       if (mode === '3d') {
-        if (timelineAnimating) teardownTimelineMode();
         if (!window.RNGraph3D?.isAvailable?.()) {
           spatialViewMode = '2d';
           window.alert('3D 视图库加载失败，请刷新页面后重试');
@@ -2229,7 +2230,22 @@
         }
         applyFilters();
         graph3dView.show();
+        graph3dView.syncFilters();
+        if (timelineAnimating && graph3dView) {
+          graph3dView.syncTimelineSimulation(timelineRevealedIds);
+          if (timelinePlaying) graph3dView.resumeTimelineSimulation();
+          else graph3dView.softenTimelineSimulation();
+          fitToTimelineNodes();
+        }
       } else {
+        if (timelineAnimating) {
+          if (graph3dView?.syncSourceFrom3D) graph3dView.syncSourceFrom3D();
+          syncTimelineSimulation();
+          renderTimelineStatic();
+          updateTimelineLinks(timelineRevealedIds);
+          if (timelinePlaying) simulation.alphaTarget(0.3).restart();
+          else simulation.alphaTarget(0);
+        }
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;
         graph3dHoverNode = null;
@@ -2237,7 +2253,8 @@
         svg.style('display', 'block');
         syncGraphDomFromSimulation();
         resumeSimulation2D();
-        fitToScreen();
+        if (timelineAnimating) fitToTimelineNodes();
+        else fitToScreen();
       }
 
       try { localStorage.setItem(SPATIAL_VIEW_KEY, mode); } catch (_e) { /* ignore */ }
@@ -2248,13 +2265,11 @@
     }
 
     function syncTimeline3DState() {
-      const disabled = is3DView();
-      if (timelineAnimateBtn) {
-        timelineAnimateBtn.disabled = disabled;
-        timelineAnimateBtn.title = disabled
-          ? '时序动画仅支持 2D 视图'
-          : '按页面更新时间顺序逐帧显现节点与连线（类似 Obsidian 图谱 Animate）';
-      }
+      if (!timelineAnimateBtn) return;
+      timelineAnimateBtn.disabled = false;
+      timelineAnimateBtn.title = is3DView()
+        ? '按页面更新时间顺序在 3D 视图中逐帧显现节点与连线'
+        : '按页面更新时间顺序逐帧显现节点与连线（类似 Obsidian 图谱 Animate）';
     }
 
     updateGraphHint();
@@ -3548,6 +3563,10 @@
 
     // 新节点出生位置：落在已显现邻居的质心附近；无邻居则落在画布中心附近
     function seedTimelineNodePosition(d) {
+      if (is3DView() && graph3dView) {
+        graph3dView.seedTimelineNodePosition(d, timelineRevealedIds, timelineIncident);
+        return;
+      }
       let sx = 0, sy = 0, cnt = 0;
       const inc = timelineIncident && timelineIncident.get(d.id);
       if (inc) {
@@ -3575,6 +3594,10 @@
 
     // 把力模拟成员同步为「当前已显现」的节点与其内部边
     function syncTimelineSimulation() {
+      if (is3DView() && graph3dView) {
+        graph3dView.syncTimelineSimulation(timelineRevealedIds);
+        return;
+      }
       const revNodes = nodes.filter(n => timelineRevealedIds.has(n.id));
       const revEdges = edges.filter(e => {
         const s = typeof e.source === 'object' ? e.source.id : e.source;
@@ -3589,21 +3612,42 @@
 
     // 进入前布局快照与还原（退出时回到进入前的样子）
     function snapshotTimelinePositions() {
-      timelineSavedPositions = nodes.map(n => ({ id: n.id, x: n.x, y: n.y }));
+      var by3d = new Map();
+      if (graph3dView?.snapshotPositions) {
+        graph3dView.snapshotPositions().forEach(function (p) { by3d.set(p.id, p); });
+      }
+      timelineSavedPositions = nodes.map(function (n) {
+        var p = { id: n.id, x: n.x, y: n.y };
+        var p3 = by3d.get(n.id);
+        if (p3 && p3.z != null) p.z = p3.z;
+        return p;
+      });
     }
     function restoreTimelinePositions() {
       if (!timelineSavedPositions) return;
       const byId = new Map(nodes.map(n => [n.id, n]));
       timelineSavedPositions.forEach(p => {
         const n = byId.get(p.id);
-        if (n) { n.x = p.x; n.y = p.y; n.vx = 0; n.vy = 0; n.fx = null; n.fy = null; }
+        if (!n) return;
+        n.x = p.x;
+        n.y = p.y;
+        n.vx = 0;
+        n.vy = 0;
+        n.fx = null;
+        n.fy = null;
+        if (p.z != null) n.z = p.z;
       });
+      if (graph3dView?.restorePositions) graph3dView.restorePositions(timelineSavedPositions);
     }
 
     // 相机自适应到「已显现」节点（生长时随之缩放，类似 Obsidian）
     function fitToTimelineNodes() {
       const vis = nodes.filter(n => timelineRevealedIds.has(n.id) && n.x != null);
       if (vis.length < 2) return;
+      if (is3DView() && graph3dView) {
+        graph3dView.fitToTimelineNodes(timelineRevealedIds, 500);
+        return;
+      }
       const transform = computeGraphFitTransform(vis, {
         pad: isMobile ? 56 : 160,
         minSpan: isMobile ? 120 : 200,
@@ -3637,6 +3681,7 @@
       syncTimelineSimulation();                 // 成员 = 已显现子集；暂停时力模拟仍继续
       timelineIdx = targetIdx;
       updateTimelineLinks(timelineRevealedIds);
+      if (is3DView() && graph3dView) graph3dView.syncFilters();
       updateTimelineProgress(timelineIdx, timelineTotal);
     }
 
@@ -3645,7 +3690,8 @@
       if (timelineIdx >= timelineTotal) seekTimeline(0, false); // 已到末尾再播放则从头开始
       timelinePlaying = true;
       updateTimelineControls();
-      simulation.alphaTarget(0.3).restart();    // 力模拟持续运行，新节点逐帧被带动
+      if (is3DView() && graph3dView) graph3dView.resumeTimelineSimulation();
+      else simulation.alphaTarget(0.3).restart();    // 力模拟持续运行，新节点逐帧被带动
       timelineAnimTimer = setInterval(() => {
         if (timelineIdx >= timelineTotal) { onTimelinePlaybackComplete(); return; }
         seekTimeline(timelineIdx + timelineBatchSize, true);
@@ -3658,7 +3704,8 @@
       if (timelineAnimTimer) { clearInterval(timelineAnimTimer); timelineAnimTimer = null; }
       timelinePlaying = false;
       updateTimelineControls();
-      simulation.alphaTarget(0);     // 缓缓收敛（最后一批节点落位），不立即冻结
+      if (is3DView() && graph3dView) graph3dView.softenTimelineSimulation();
+      else simulation.alphaTarget(0);     // 缓缓收敛（最后一批节点落位），不立即冻结
       fitToTimelineNodes();
     }
 
@@ -3668,8 +3715,13 @@
         timelineAnimTimer = null;
       }
       timelinePlaying = false;
-      svg.interrupt('tlfit');
-      simulation.alphaTarget(0.3).restart();   // 仅停计时器，力导向布局继续演化
+      if (is3DView() && graph3dView) {
+        // 3D 无命名 transition，直接继续力导向演化
+      } else {
+        svg.interrupt('tlfit');
+      }
+      if (is3DView() && graph3dView) graph3dView.resumeTimelineSimulation();
+      else simulation.alphaTarget(0.3).restart();   // 仅停计时器，力导向布局继续演化
       updateTimelineControls();
     }
 
@@ -3683,6 +3735,7 @@
 
       snapshotTimelinePositions();
       buildTimelineAdjacency();
+      if (is3DView()) ensureGraph3DView();
       fitToScreen();                 // 先框定整图范围（用进入前布局），生长从中心展开
 
       timelineAnimating = true;
@@ -3704,7 +3757,12 @@
       node.select('.node-label').style('opacity', 0);
       link.interrupt().attr('stroke-opacity', 0);
       syncTimelineSimulation();
-      simulation.stop();
+      if (is3DView() && graph3dView) {
+        graph3dView.syncFilters();
+        graph3dView.softenTimelineSimulation();
+      } else {
+        simulation.stop();
+      }
 
       if (timelineProgressEl) timelineProgressEl.max = String(timelineTotal);
       updateTimelineProgress(0, timelineTotal);
@@ -3722,8 +3780,10 @@
       timelineTotal = 0;
       node.interrupt().style('pointer-events', null);  // 恢复指针事件
       link.interrupt();
-      svg.interrupt('tlfit');
+      if (!is3DView()) svg.interrupt('tlfit');
       updateTimelineControls();
+
+      if (graph3dView) graph3dView.restoreFullGraphData();
 
       const linkForce = simulation.force('link');
       linkForce.links([]);
@@ -3736,6 +3796,11 @@
       teardownTimelineMode();
       // 还原进入前布局并定格
       restoreTimelinePositions();
+      if (is3DView() && graph3dView) {
+        graph3dView.softenTimelineSimulation();
+        fitToScreen();
+        return;
+      }
       simulation.stop();
       syncGraphDomFromSimulation();
       node.select('.node-label').transition().duration(350).style('opacity', 0.85);
@@ -3873,7 +3938,10 @@
       if (!updateGraphViewport()) return;
       if (graph3dView) graph3dView.resize();
       if (is3DView()) {
-        if (graph3dView) graph3dView.fitToScreen(0);
+        if (graph3dView) {
+          if (timelineAnimating) graph3dView.fitToTimelineNodes(timelineRevealedIds, 0);
+          else graph3dView.fitToScreen(0);
+        }
         return;
       }
       if (timelineAnimating) {
@@ -4138,6 +4206,7 @@
         link.style('opacity', null).style('stroke-width', null)
             .attr('stroke', edgeBaseColor()).attr('stroke-width', linkWidthBase);
         updateTimelineLinks(timelineRevealedIds);
+        if (is3DView() && graph3dView) graph3dView.syncFilters();
         wrap.classList.remove('sidebar-open');
         return;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在 **main 最新提交**（含 #805 3D 节点 scale 修复）之上，为图谱页 3D 视图启用「时序动画」：按 `recency` 逐帧显现节点与连线，支持播放/暂停/进度条，2D↔3D 切换时保持进度。

**Rebase 基线：** `e380b26d`（main）

## 验证（基于 main + 本分支）

- `node --check docs/graph-3d.js` 通过
- `node scripts/verify_3d_timeline.cjs`：3D 画布非背景像素 21599 → 48301（时序播放中）
- `node scripts/verify_3d_canvas_only.cjs`：仅 `#graph-canvas-3d` 区域采样通过

## 验证录像

<a href="https://cursor.com/agents/bc-a2da80cf-d84f-4cc1-8bbc-20e021eefc86/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F3d-timeline-verification.mp4"><img src="https://cursor.com/artifacts/c/art-115fbeba-cb1a-48ab-be55-ba862a884bf7" alt="3d-timeline-verification.mp4" /></a>

录像流程：2D 加载 → 切 3D 立体 → 开启时序动画 → 约 18 秒逐帧显现（计数器 12 → 724+ / 1336）。

## 关键实现

- `graph-3d.js`：时序模式切换默认球体渲染（避免自定义 mesh 子集替换黑屏）；`syncTimelineSimulation` 仅对已显现节点建链
- `graph.html`：解除 3D 禁用；视图切换时同步时序子集与播放状态
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2da80cf-d84f-4cc1-8bbc-20e021eefc86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2da80cf-d84f-4cc1-8bbc-20e021eefc86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

