### PR TITLE
fix(ux): 移除图谱筛选提示条并恢复 2D 筛选时节点全可见

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -302,10 +302,6 @@
         obj.material.opacity = opacity;
         obj.material.transparent = opacity < 0.999;
         obj.visible = opacity > 0.02;
-        var targetR = sphereRadiusFor(d);
-        var baseR = obj.userData.baseRadius || targetR;
-        var scale = baseR > 0 ? targetR / baseR : 1;
-        obj.scale.set(scale, scale, scale);
       });
     }
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -182,36 +182,6 @@
       text-decoration: none;
     }
     .topic-intro-link:hover { color: #7dd3fc; text-decoration: underline; }
-    /* 3D 筛选态提示条（右上角，筛选激活时显示） */
-    .graph-3d-filter-banner {
-      position: absolute;
-      top: 12px;
-      right: 12px;
-      z-index: 12;
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      max-width: min(360px, calc(100% - 24px));
-      padding: 9px 12px;
-      border-radius: 10px;
-      border: 1px solid rgba(96, 165, 250, 0.45);
-      background: rgba(13, 17, 23, 0.9);
-      backdrop-filter: blur(8px);
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(96, 165, 250, 0.12);
-      pointer-events: none;
-      font-size: .78rem;
-      font-weight: 600;
-      color: #bfdbfe;
-      letter-spacing: .01em;
-    }
-    .graph-3d-filter-banner-icon {
-      font-size: .95rem;
-      line-height: 1;
-    }
-    .graph-3d-filter-banner strong {
-      color: #e0f2fe;
-      font-weight: 800;
-    }
     #filter-toggle.is-filter-active {
       background: rgba(96, 165, 250, 0.18);
       border-color: rgba(96, 165, 250, 0.62);
@@ -692,13 +662,6 @@
     }
     [data-theme="light"] .topic-intro-text { color: rgba(15, 23, 42, 0.68); }
     [data-theme="light"] .topic-intro-link { color: #1659b4; }
-    [data-theme="light"] .graph-3d-filter-banner {
-      background: rgba(255, 255, 255, 0.94);
-      border-color: rgba(22, 89, 180, 0.35);
-      color: #1659b4;
-      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12), 0 0 0 1px rgba(22, 89, 180, 0.1);
-    }
-    [data-theme="light"] .graph-3d-filter-banner strong { color: #0f3d7a; }
     [data-theme="light"] #filter-toggle.is-filter-active {
       background: #e6f7ff;
       border-color: #1659b4;
@@ -1606,10 +1569,6 @@
       <p class="topic-intro-text" id="topic-intro-text"></p>
       <a id="topic-intro-link" class="topic-intro-link" href="#">打开专题汇总页 →</a>
     </div>
-    <div id="graph-3d-filter-banner" class="graph-3d-filter-banner" hidden aria-live="polite">
-      <span class="graph-3d-filter-banner-icon" aria-hidden="true">🔍</span>
-      <span id="graph-3d-filter-banner-text">筛选中</span>
-    </div>
     <button id="graph-legend-fab" type="button" aria-label="打开图例" aria-expanded="false" aria-controls="graph-legend" title="图例">🎨</button>
     <div id="graph-legend-scrim" hidden aria-hidden="true"></div>
     <div id="graph-legend" role="region" aria-label="图谱图例"></div>
@@ -2130,22 +2089,6 @@
     const graphHint3dEl = document.getElementById('graph-hint-3d');
 
     function is3DView() { return spatialViewMode === '3d'; }
-
-    const graph3dFilterBanner = document.getElementById('graph-3d-filter-banner');
-    const graph3dFilterBannerText = document.getElementById('graph-3d-filter-banner-text');
-
-    function updateGraph3DFilterBanner(visibleCount) {
-      if (!graph3dFilterBanner) return;
-      const active = is3DView() && hasActiveGraphFilter();
-      if (!active) {
-        graph3dFilterBanner.hidden = true;
-        return;
-      }
-      graph3dFilterBanner.hidden = false;
-      if (graph3dFilterBannerText) {
-        graph3dFilterBannerText.innerHTML = '筛选中 · <strong>' + visibleCount + '</strong> / ' + nodes.length + ' 节点可见';
-      }
-    }
 
     function updateGraphHint() {
       const in3d = is3DView();
@@ -3005,12 +2948,12 @@
       return typeof endpoint === 'object' ? endpoint.id : endpoint;
     }
 
-    /** 悬停/聚焦高亮：筛选态下与灰色节点相连的边不参与高亮 */
+    /** 悬停/聚焦高亮：3D 筛选态下与灰色节点相连的边不参与高亮 */
     function edgeHighlightsWithNode(e, nodeId) {
       const s = edgeNodeId(e.source);
       const t = edgeNodeId(e.target);
       if (s !== nodeId && t !== nodeId) return false;
-      if (!hasActiveGraphFilter()) return true;
+      if (!is3DView() || !hasActiveGraphFilter()) return true;
       return visibleNodeIds.has(s) && visibleNodeIds.has(t);
     }
 
@@ -3024,14 +2967,15 @@
           if (sidebarFocusIds && sidebarFocusIds.has(d.id)) showTooltip(ev, d);
           return;
         }
-        // 筛选态下灰色节点不响应悬停（pointer-events 已关，此处作兜底）
-        if (hasActiveGraphFilter() && !visibleNodeIds.has(d.id)) return;
+        // 3D 筛选态下灰色节点不响应悬停（pointer-events 已关，此处作兜底）
+        if (is3DView() && hasActiveGraphFilter() && !visibleNodeIds.has(d.id)) return;
 
         buildNeighborSet(d);
         const hasFilter = hasActiveGraphFilter();
+        const dimNodes = is3DView();
         node.select('.node-circle').attr('fill-opacity', n => {
-          // 过滤后被隐藏的节点保持原始低透明度，不被 hover 恢复
-          if (hasFilter && !visibleNodeIds.has(n.id)) return 0.06;
+          // 3D 筛选后被隐藏的节点保持原始低透明度，不被 hover 恢复
+          if (dimNodes && hasFilter && !visibleNodeIds.has(n.id)) return 0.06;
           return neighborSet.has(n.id) ? 1 : 0.15;
         });
         node.select('.node-glow').attr('fill-opacity', n =>
@@ -3416,6 +3360,7 @@
     function applyFilters() {
       if (timelineAnimating) return;
       const hasFilter = hasActiveGraphFilter();
+      const dimNodes = is3DView();
       visibleNodeIds.clear();
       let visible = 0;
 
@@ -3428,9 +3373,9 @@
         const g = d3.select(this);
         const hub = isCurrentTopicHub(d);
         g.classed('node-topic-hub', hub);
-        g.style('opacity', hasFilter ? (ok ? 1 : 0.08) : 1);
-        // 灰色节点不捕获指针，避免触发浮窗/点击；解除筛选后恢复
-        g.style('pointer-events', hasFilter && !ok ? 'none' : null);
+        g.style('opacity', dimNodes && hasFilter ? (ok ? 1 : 0.08) : 1);
+        // 3D 筛选态下灰色节点不捕获指针；2D 保持全部节点可交互
+        g.style('pointer-events', dimNodes && hasFilter && !ok ? 'none' : null);
 
         const hubR = hub ? scaledRadius(d) * 1.28 : scaledRadius(d);
         d3.select(this).select('.node-glow')
@@ -3438,8 +3383,8 @@
           .attr('fill-opacity', hub && ok ? 0.28 : 0);
         d3.select(this).select('.node-circle')
           .attr('r', hubR)
-          .attr('fill-opacity', ok ? 1 : 0.06)
-          .attr('stroke-opacity', ok ? (hub ? 0.85 : 0.35) : 0.05)
+          .attr('fill-opacity', dimNodes && hasFilter && !ok ? 0.06 : 1)
+          .attr('stroke-opacity', ok ? (hub ? 0.85 : 0.35) : (dimNodes && hasFilter ? 0.05 : 0.35))
           .attr('stroke-width', hub ? 2.5 : 1.5);
         d3.select(this).select('.node-label')
           .style('opacity', ok && (searchQuery || hub) ? 0.92 : null)
@@ -3468,7 +3413,6 @@
           return edgeOk ? linkWidthBase : linkWidthBase * 0.5;
         });
       updateCount(visible);
-      updateGraph3DFilterBanner(visible);
       updateFilterCount();
       if (graph3dView && is3DView()) graph3dView.syncFilters();
       if (searchQuery) flyToVisible();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2227,8 +2227,8 @@
           window.alert('3D 视图初始化失败，请刷新页面后重试');
           return;
         }
+        applyFilters();
         graph3dView.show();
-        graph3dView.syncFilters();
       } else {
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 回退 graph view 右上角「筛选中 · N / M 节点可见」提示条
- 2D 平面视图在筛选激活时不再淡化/禁用非命中节点，保持全图节点可见可交互
- **修复 3D 节点消失**：`updateNodeMeshes` 中 `scale` 被错误覆盖为 ~1（性能优化引入的回归），导致球体半径趋近于 0

## 验证
- `make lint` 通过

## 变更说明
| 视图 | 筛选行为 |
|------|----------|
| 2D | 全部节点保持 `opacity: 1`，可悬停/点击；连线仍按筛选淡化 |
| 3D | 维持筛选对比度；节点 scale 正确使用 `sphereRadiusFor(d)` |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-795622ec-b4e2-41f1-9687-0470d7cbc082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-795622ec-b4e2-41f1-9687-0470d7cbc082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

