### PR TITLE
fix(ux): 撤销 186ec7da 之后的节点筛选逻辑改动

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -176,19 +176,18 @@
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       var ok = visible.has(d.id);
-      var dimOpacity = filtered ? 0.02 : 0.15;
       if (sidebarNodeId) {
         if (d.id === sidebarNodeId || sidebarDirect.has(d.id)) return 1;
         if (sidebarSecondary.has(d.id)) return 0.4;
-        return filtered && !ok ? 0.02 : 0.05;
+        return 0.05;
       }
       if (hoverNodeId) {
         if (!filtered) return hoverNodeId === d.id || isNeighborOf(hoverNodeId, d.id) ? 1 : 0.15;
-        if (!ok) return 0.02;
-        return hoverNodeId === d.id || isNeighborOf(hoverNodeId, d.id) ? 1 : dimOpacity;
+        if (!ok) return 0.08;
+        return hoverNodeId === d.id || isNeighborOf(hoverNodeId, d.id) ? 1 : 0.15;
       }
       if (!filtered) return 1;
-      return ok ? 1 : 0.02;
+      return ok ? 1 : 0.08;
     }
 
     function isNeighborOf(nodeId, otherId) {
@@ -213,8 +212,8 @@
         if (eRef && edgeHighlightsWithNode) return edgeHighlightsWithNode(eRef, hoverNodeId) ? 0.45 : 0.1;
       }
       if (!filtered) return 0.06;
-      if (!visible.has(s) || !visible.has(t)) return 0.012;
-      return 0.08;
+      if (!visible.has(s) || !visible.has(t)) return 0.03;
+      return 0.06;
     }
 
     function linkColorFor(l) {
@@ -250,9 +249,7 @@
 
     function sphereRadiusFor(d) {
       var r = getNodeRadius(d);
-      var base = Math.max(11, r * 1.65);
-      if (hasActiveFilter() && getVisibleNodeIds().has(d.id)) return base * 1.12;
-      return base;
+      return Math.max(11, r * 1.65);
     }
 
     function nodeValFor(d) {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -182,16 +182,6 @@
       text-decoration: none;
     }
     .topic-intro-link:hover { color: #7dd3fc; text-decoration: underline; }
-    #filter-toggle.is-filter-active {
-      background: rgba(96, 165, 250, 0.18);
-      border-color: rgba(96, 165, 250, 0.62);
-      color: #e6edf3;
-      box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.18);
-    }
-    #filter-toggle.is-filter-active:hover {
-      border-color: rgba(96, 165, 250, 0.82);
-      color: #fff;
-    }
     .node-topic-hub .node-glow { fill-opacity: 0.28 !important; }
     .node-topic-hub .node-circle {
       stroke-width: 2.5px !important;
@@ -662,12 +652,6 @@
     }
     [data-theme="light"] .topic-intro-text { color: rgba(15, 23, 42, 0.68); }
     [data-theme="light"] .topic-intro-link { color: #1659b4; }
-    [data-theme="light"] #filter-toggle.is-filter-active {
-      background: #e6f7ff;
-      border-color: #1659b4;
-      color: #1659b4;
-      box-shadow: 0 0 0 1px rgba(22, 89, 180, 0.12);
-    }
     [data-theme="light"] .node-topic-hub .node-label { fill: rgba(15, 23, 42, 0.88) !important; }
     [data-theme="light"] .toolbar-sep { background: rgba(0,0,0,0.1); }
     [data-theme="light"] #graph-node-count { color: rgba(0,0,0,0.38); }
@@ -2227,8 +2211,8 @@
           window.alert('3D 视图初始化失败，请刷新页面后重试');
           return;
         }
-        applyFilters();
         graph3dView.show();
+        graph3dView.syncFilters();
       } else {
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;
@@ -2244,7 +2228,6 @@
       updateViewModeButtons();
       updateGraphHint();
       syncTimeline3DState();
-      applyFilters();
     }
 
     function syncTimeline3DState() {
@@ -2948,12 +2931,12 @@
       return typeof endpoint === 'object' ? endpoint.id : endpoint;
     }
 
-    /** 悬停/聚焦高亮：3D 筛选态下与灰色节点相连的边不参与高亮 */
+    /** 悬停/聚焦高亮：筛选态下与灰色节点相连的边不参与高亮 */
     function edgeHighlightsWithNode(e, nodeId) {
       const s = edgeNodeId(e.source);
       const t = edgeNodeId(e.target);
       if (s !== nodeId && t !== nodeId) return false;
-      if (!is3DView() || !hasActiveGraphFilter()) return true;
+      if (!hasActiveGraphFilter()) return true;
       return visibleNodeIds.has(s) && visibleNodeIds.has(t);
     }
 
@@ -2967,15 +2950,14 @@
           if (sidebarFocusIds && sidebarFocusIds.has(d.id)) showTooltip(ev, d);
           return;
         }
-        // 3D 筛选态下灰色节点不响应悬停（pointer-events 已关，此处作兜底）
-        if (is3DView() && hasActiveGraphFilter() && !visibleNodeIds.has(d.id)) return;
+        // 筛选态下灰色节点不响应悬停（pointer-events 已关，此处作兜底）
+        if (hasActiveGraphFilter() && !visibleNodeIds.has(d.id)) return;
 
         buildNeighborSet(d);
         const hasFilter = hasActiveGraphFilter();
-        const dimNodes = is3DView();
         node.select('.node-circle').attr('fill-opacity', n => {
-          // 3D 筛选后被隐藏的节点保持原始低透明度，不被 hover 恢复
-          if (dimNodes && hasFilter && !visibleNodeIds.has(n.id)) return 0.06;
+          // 过滤后被隐藏的节点保持原始低透明度，不被 hover 恢复
+          if (hasFilter && !visibleNodeIds.has(n.id)) return 0.06;
           return neighborSet.has(n.id) ? 1 : 0.15;
         });
         node.select('.node-glow').attr('fill-opacity', n =>
@@ -3271,13 +3253,8 @@
     function updateFilterCount() {
       const count = activeFilters.size + activeInstitutions.size + (topDegreeIds ? 1 : 0) + (currentTopic && currentTopic !== 'all' ? 1 : 0);
       const countEl = document.getElementById('filter-count');
-      const filterActive = hasActiveGraphFilter();
-      if (filterToggle) filterToggle.classList.toggle('is-filter-active', filterActive);
       if (count > 0) {
         countEl.textContent = count;
-        countEl.style.display = 'inline-flex';
-      } else if (filterActive) {
-        countEl.textContent = '•';
         countEl.style.display = 'inline-flex';
       } else {
         countEl.style.display = 'none';
@@ -3360,7 +3337,6 @@
     function applyFilters() {
       if (timelineAnimating) return;
       const hasFilter = hasActiveGraphFilter();
-      const dimNodes = is3DView();
       visibleNodeIds.clear();
       let visible = 0;
 
@@ -3373,9 +3349,9 @@
         const g = d3.select(this);
         const hub = isCurrentTopicHub(d);
         g.classed('node-topic-hub', hub);
-        g.style('opacity', dimNodes && hasFilter ? (ok ? 1 : 0.08) : 1);
-        // 3D 筛选态下灰色节点不捕获指针；2D 保持全部节点可交互
-        g.style('pointer-events', dimNodes && hasFilter && !ok ? 'none' : null);
+        g.style('opacity', hasFilter ? (ok ? 1 : 0.08) : 1);
+        // 灰色节点不捕获指针，避免触发浮窗/点击；解除筛选后恢复
+        g.style('pointer-events', hasFilter && !ok ? 'none' : null);
 
         const hubR = hub ? scaledRadius(d) * 1.28 : scaledRadius(d);
         d3.select(this).select('.node-glow')
@@ -3383,8 +3359,8 @@
           .attr('fill-opacity', hub && ok ? 0.28 : 0);
         d3.select(this).select('.node-circle')
           .attr('r', hubR)
-          .attr('fill-opacity', dimNodes && hasFilter && !ok ? 0.06 : 1)
-          .attr('stroke-opacity', ok ? (hub ? 0.85 : 0.35) : (dimNodes && hasFilter ? 0.05 : 0.35))
+          .attr('fill-opacity', ok ? 1 : 0.06)
+          .attr('stroke-opacity', ok ? (hub ? 0.85 : 0.35) : 0.05)
           .attr('stroke-width', hub ? 2.5 : 1.5);
         d3.select(this).select('.node-label')
           .style('opacity', ok && (searchQuery || hub) ? 0.92 : null)
@@ -3413,7 +3389,6 @@
           return edgeOk ? linkWidthBase : linkWidthBase * 0.5;
         });
       updateCount(visible);
-      updateFilterCount();
       if (graph3dView && is3DView()) graph3dView.syncFilters();
       if (searchQuery) flyToVisible();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

撤销 `186ec7da` 之后引入的节点筛选行为变更，恢复 2D/3D 统一的筛选逻辑：

- **2D 图谱**：筛选时再次对不匹配节点降透明度（`opacity: 0.08`）、禁用指针事件，与 `186ec7da` 行为一致
- **3D 图谱**：恢复 `nodeOpacityFor` / `linkOpacityFor` 的原始对比度（`0.08` / `0.03`），移除筛选命中节点的放大系数
- **悬停高亮**：`edgeHighlightsWithNode` 在 2D/3D 下均按筛选态处理，不再仅限 3D
- **视图切换**：恢复 `graph3dView.syncFilters()` 调用顺序，移除多余的 `applyFilters()` 补丁
- **移除**：筛选按钮 `is-filter-active` 高亮样式与计数徽章 `•` 补丁

保留的非筛选改动（未回滚）：
- 3D 节点拖拽松手回弹（`delete fx/fy/fz`）
- 3D 加载/重置性能优化（共享几何体、rAF 安装 mesh）
- 3D 适配屏幕（`zoomFitToNodes` / bbox 相机定位）
- 浮窗 `visibility` 防闪烁修复

## 验证

- 仅改动 `docs/graph.html` 与 `docs/graph-3d.js`，不涉及 wiki 派生文件
- 逻辑已与 `186ec7da` 的筛选相关代码对齐（diff 中仅剩 fit-to-screen / tooltip 等非筛选差异）

## 风险

- 2D 筛选时灰色节点再次不可点击（与 `186ec7da` 一致）；若需 2D 全交互 + 3D 降透明度，需单独设计而非本次回滚范围
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75fcef35-8566-4307-8eac-c100d316ff91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75fcef35-8566-4307-8eac-c100d316ff91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

