### PR TITLE
fix(ux): 拆分 2D/3D 视图磁吸按钮状态

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2053,7 +2053,17 @@
     const nodeScale      = 1.0;    // 节点大小倍数
     const linkWidthBase  = 1.0;    // 连接线基础粗细（px）
     const fontSliderVal  = 15;     // 字体缩放（相对 nodeScale）
-    let isMagnetic     = false;
+    let isMagnetic2D = false;
+    let isMagnetic3D = false;
+    const checkMagneticEl = document.getElementById('check-magnetic');
+
+    function isMagneticForCurrentView() {
+      return is3DView() ? isMagnetic3D : isMagnetic2D;
+    }
+
+    function syncMagneticCheckbox() {
+      if (checkMagneticEl) checkMagneticEl.checked = isMagneticForCurrentView();
+    }
 
     const SPATIAL_VIEW_KEY = 'rn-graph-spatial-view';
     let spatialViewMode = (function () {
@@ -2092,7 +2102,7 @@
     }
 
     function getMagneticConfig3D() {
-      if (!isMagnetic) return null;
+      if (!isMagnetic3D) return null;
       const categories = (colorMode === 'community')
         ? Array.from(communityLabelMap.keys())
         : Array.from(new Set(nodes.map(n => n.type)));
@@ -2228,6 +2238,8 @@
       updateViewModeButtons();
       updateGraphHint();
       syncTimeline3DState();
+      syncMagneticCheckbox();
+      updateForces();
     }
 
     function syncTimeline3DState() {
@@ -2557,7 +2569,7 @@
       if (is3DView()) return;
       simulation.force('charge').strength(chargeStrength);
       
-      if (isMagnetic) {
+      if (isMagnetic2D) {
         const categories = (colorMode === 'community') 
           ? Array.from(communityLabelMap.keys())
           : Array.from(new Set(nodes.map(n => n.type)));
@@ -2744,7 +2756,7 @@
       updateFilterCount();
       refreshNodeColors();
       applyFilters();
-      if (isMagnetic) updateForces();
+      if (isMagneticForCurrentView()) updateForces();
     }
 
     if (filterModeTypeBtn) filterModeTypeBtn.addEventListener('click', () => setColorMode('type'));
@@ -3902,11 +3914,14 @@
       updateForces();
     });
 
-    /* 磁吸模式 checkbox */
-    document.getElementById('check-magnetic').addEventListener('change', ev => {
-      isMagnetic = ev.target.checked;
-      updateForces();
-    });
+    /* 磁吸模式 checkbox（2D / 3D 各自独立记忆） */
+    if (checkMagneticEl) {
+      checkMagneticEl.addEventListener('change', ev => {
+        if (is3DView()) isMagnetic3D = ev.target.checked;
+        else isMagnetic2D = ev.target.checked;
+        updateForces();
+      });
+    }
 
     if (viewMode2dBtn) {
       viewMode2dBtn.addEventListener('click', () => setSpatialViewMode('2d'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复知识图谱物理面板中「磁吸模式」在 2D/3D 视图切换时状态不同步的问题。

**原问题：** 2D 开启磁吸后切到 3D，复选框仍显示勾选，但 3D 实际未按磁吸布局（或状态与视觉不一致）。

**改动：**
- 将单一 `isMagnetic` 拆为 `isMagnetic2D` / `isMagnetic3D`，各自独立记忆
- 切换视图时调用 `syncMagneticCheckbox()` 同步复选框显示
- 切换后 `updateForces()` 按当前视图的磁吸状态应用力导向
- 勾选/取消只影响当前视图的状态

## 验证

- 2D 勾选磁吸 → 切 3D → 复选框应取消勾选
- 3D 再切回 2D → 复选框恢复勾选，2D 磁吸布局生效
- 在 3D 单独开启磁吸后切回 2D，各自状态互不影响

## 风险

- 仅改动 `docs/graph.html` 内联脚本，无 wiki / 派生文件变更
- 磁吸状态仍为会话内内存态，未做 localStorage 持久化（与改前一致）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-683e361b-3978-4afe-b066-c24f2c0ed4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-683e361b-3978-4afe-b066-c24f2c0ed4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

