### PR TITLE
fix(ux): 3D 图谱筛选对齐 2D 共享判定与边对比度

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -119,6 +119,10 @@
     var getVisibleNodeIds = opts.getVisibleNodeIds || function () { return new Set(); };
     var hasActiveFilter = opts.hasActiveFilter || function () { return false; };
     var edgeHighlightsWithNode = opts.edgeHighlightsWithNode;
+    var edgePassesFilter = opts.edgePassesFilter;
+    var getNodeSphereRadius = opts.getNodeSphereRadius;
+    var getLinkFilteredOpacity = opts.getLinkFilteredOpacity;
+    var getLinkFilteredWidth = opts.getLinkFilteredWidth;
     var getChargeStrength = opts.getChargeStrength || function () { return -800; };
     var getMagneticConfig = opts.getMagneticConfig || function () { return null; };
     var resolveSourceNode = opts.resolveSourceNode || function (id) {
@@ -212,6 +216,8 @@
         if (eRef && edgeHighlightsWithNode) return edgeHighlightsWithNode(eRef, hoverNodeId) ? 0.45 : 0.1;
       }
       if (!filtered) return 0.06;
+      var ref = l._ref;
+      if (getLinkFilteredOpacity && ref) return getLinkFilteredOpacity(ref);
       if (!visible.has(s) || !visible.has(t)) return 0.03;
       return 0.06;
     }
@@ -244,10 +250,15 @@
         var eRef = l._ref;
         if (eRef && edgeHighlightsWithNode && edgeHighlightsWithNode(eRef, hoverNodeId)) return base * 1.8;
       }
+      if (hasActiveFilter()) {
+        var fRef = l._ref;
+        if (getLinkFilteredWidth && fRef) return getLinkFilteredWidth(fRef);
+      }
       return base;
     }
 
     function sphereRadiusFor(d) {
+      if (getNodeSphereRadius) return getNodeSphereRadius(d);
       var r = getNodeRadius(d);
       return Math.max(11, r * 1.65);
     }

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2132,10 +2132,15 @@
         getVisibleNodeIds: () => visibleNodeIds,
         hasActiveFilter: hasActiveGraphFilter,
         edgeHighlightsWithNode,
+        edgePassesFilter: edgePassesGraphFilter,
+        getNodeSphereRadius: sphereRadiusFor3D,
+        getLinkFilteredOpacity: linkFilterOpacity3D,
+        getLinkFilteredWidth: linkFilterWidth3D,
         getChargeStrength: () => chargeStrength,
         getMagneticConfig: getMagneticConfig3D,
         onNodeClick: (d, ev) => {
           if (timelinePlaying) return;
+          if (hasActiveGraphFilter() && !visibleNodeIds.has(d.id)) return;
           if (isMobile) {
             if (pinnedNode === d) {
               pinnedNode = null;
@@ -2221,8 +2226,13 @@
           window.alert('3D 视图初始化失败，请刷新页面后重试');
           return;
         }
+        applyFilters();
         graph3dView.show();
-        graph3dView.syncFilters();
+        if (hasActiveGraphFilter()) {
+          window.requestAnimationFrame(function () {
+            if (graph3dView) graph3dView.fitToVisible(450);
+          });
+        }
       } else {
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;
@@ -2969,8 +2979,8 @@
         const hasFilter = hasActiveGraphFilter();
         node.select('.node-circle').attr('fill-opacity', n => {
           // 过滤后被隐藏的节点保持原始低透明度，不被 hover 恢复
-          if (hasFilter && !visibleNodeIds.has(n.id)) return 0.06;
-          return neighborSet.has(n.id) ? 1 : 0.15;
+          if (hasFilter && !visibleNodeIds.has(n.id)) return GRAPH_FILTER_NODE_DIM_FILL;
+          return neighborSet.has(n.id) ? 1 : GRAPH_FILTER_NODE_HOVER_DIM;
         });
         node.select('.node-glow').attr('fill-opacity', n =>
           n.id === d.id ? 0.18 : 0);
@@ -3346,6 +3356,49 @@
           || d.id.toLowerCase().includes(searchQuery);
     }
 
+    /** 2D/3D 共享筛选外观（3D 直接复用 2D applyFilters 同款数值与判定） */
+    const GRAPH_FILTER_NODE_DIM = 0.08;
+    const GRAPH_FILTER_NODE_DIM_FILL = 0.06;
+    const GRAPH_FILTER_NODE_HOVER_DIM = 0.15;
+    const GRAPH_FILTER_LINK_DIM = 0.2;
+    const GRAPH_FILTER_LINK_3D_BASE = 0.06;
+    const GRAPH_FILTER_LINK_3D_VISIBLE = 0.3; // 对比度与 2D 的 1:0.2 同比例（×5）
+    const GRAPH_FILTER_LINK_WIDTH_DIM = 0.5;
+
+    function nodePassesGraphFilter(d) {
+      return nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
+        && nodeMatchesSearch(d) && nodeMatchesTopic(d) && nodeMatchesInstitutionFilter(d);
+    }
+
+    function edgeEndpoints(e) {
+      const s = typeof e.source === 'object' ? e.source : nodes.find(n => n.id === e.source);
+      const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
+      return { s, t };
+    }
+
+    function edgePassesGraphFilter(e) {
+      const { s, t } = edgeEndpoints(e);
+      if (!s || !t) return false;
+      return nodePassesGraphFilter(s) && nodePassesGraphFilter(t);
+    }
+
+    function sphereRadiusFor3D(d) {
+      const hub = isCurrentTopicHub(d);
+      const r = scaledRadius(d) * (hub ? 1.28 : 1);
+      return Math.max(11, r * 1.65);
+    }
+
+    function linkFilterOpacity3D(e) {
+      if (!hasActiveGraphFilter()) return GRAPH_FILTER_LINK_3D_BASE;
+      return edgePassesGraphFilter(e) ? GRAPH_FILTER_LINK_3D_VISIBLE : GRAPH_FILTER_LINK_3D_BASE;
+    }
+
+    function linkFilterWidth3D(e) {
+      const base = linkWidthBase * 0.3;
+      if (!hasActiveGraphFilter()) return base;
+      return edgePassesGraphFilter(e) ? base : base * GRAPH_FILTER_LINK_WIDTH_DIM;
+    }
+
     function applyFilters() {
       if (timelineAnimating) return;
       const hasFilter = hasActiveGraphFilter();
@@ -3353,15 +3406,14 @@
       let visible = 0;
 
       node.each(function(d) {
-        const ok = nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
-          && nodeMatchesSearch(d) && nodeMatchesTopic(d) && nodeMatchesInstitutionFilter(d);
+        const ok = nodePassesGraphFilter(d);
         if (ok) { visible++; visibleNodeIds.add(d.id); }
 
         // V21 修复：显式重置节点整体 opacity (移除 openSidebar 可能留下的残留)
         const g = d3.select(this);
         const hub = isCurrentTopicHub(d);
         g.classed('node-topic-hub', hub);
-        g.style('opacity', hasFilter ? (ok ? 1 : 0.08) : 1);
+        g.style('opacity', hasFilter ? (ok ? 1 : GRAPH_FILTER_NODE_DIM) : 1);
         // 灰色节点不捕获指针，避免触发浮窗/点击；解除筛选后恢复
         g.style('pointer-events', hasFilter && !ok ? 'none' : null);
 
@@ -3371,7 +3423,7 @@
           .attr('fill-opacity', hub && ok ? 0.28 : 0);
         d3.select(this).select('.node-circle')
           .attr('r', hubR)
-          .attr('fill-opacity', ok ? 1 : 0.06)
+          .attr('fill-opacity', ok ? 1 : GRAPH_FILTER_NODE_DIM_FILL)
           .attr('stroke-opacity', ok ? (hub ? 0.85 : 0.35) : 0.05)
           .attr('stroke-width', hub ? 2.5 : 1.5);
         d3.select(this).select('.node-label')
@@ -3383,22 +3435,15 @@
         .style('opacity', null) // V21 修复：清除 openSidebar 的内联 style 干扰
         .attr('stroke-opacity', e => {
           if (!hasFilter) return 1;
-          const s = typeof e.source === 'object' ? e.source : nodes.find(n => n.id === e.source);
-          const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
-          if (!s || !t) return 0.2;
-          return (nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
-                  && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s) && nodeMatchesInstitutionFilter(s)
-                  && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t) && nodeMatchesInstitutionFilter(t)) ? 1 : 0.2;
+          const { s, t } = edgeEndpoints(e);
+          if (!s || !t) return GRAPH_FILTER_LINK_DIM;
+          return edgePassesGraphFilter(e) ? 1 : GRAPH_FILTER_LINK_DIM;
         })
         .attr('stroke-width', e => {
           if (!hasFilter) return linkWidthBase;
-          const s = typeof e.source === 'object' ? e.source : nodes.find(n => n.id === e.source);
-          const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
-          if (!s || !t) return linkWidthBase * 0.5;
-          const edgeOk = nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
-            && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesTopic(s) && nodeMatchesInstitutionFilter(s)
-            && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesTopic(t) && nodeMatchesInstitutionFilter(t);
-          return edgeOk ? linkWidthBase : linkWidthBase * 0.5;
+          const { s, t } = edgeEndpoints(e);
+          if (!s || !t) return linkWidthBase * GRAPH_FILTER_LINK_WIDTH_DIM;
+          return edgePassesGraphFilter(e) ? linkWidthBase : linkWidthBase * GRAPH_FILTER_LINK_WIDTH_DIM;
         });
       updateCount(visible);
       if (graph3dView && is3DView()) graph3dView.syncFilters();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

让 3D 图谱的筛选行为直接复用 2D 的判定与外观常量，避免两套逻辑漂移。

主要改动：
- 抽取 `nodePassesGraphFilter` / `edgePassesGraphFilter` 等共享函数，2D `applyFilters` 与 3D 回调同源
- 3D 边透明度按 2D 的 `1:0.2` 对比度映射（可见 `0.3` / 灰色 `0.06`），筛选态边宽也同步收窄
- 3D 专题 hub 节点半径与 2D 一致放大（`×1.28`）
- 筛选态灰色节点禁止 3D 点击；切换到 3D 时重跑 `applyFilters`，有筛选时自动 `fitToVisible`

## 验证

- 本地 `make export graph` + `http.server 8765`
- Headed Chrome（`--enable-webgl --use-angle=gl`）自动化演示通过

| 步骤 | 结果 |
|------|------|
| `?topic=locomotion` 2D 加载 | **148 / 1336** 节点 |
| 切换 3D 立体 | **148 / 1336**（与 2D 一致），canvas 正常渲染 |
| 切回 2D 平面 | 计数保持 **148 / 1336** |
| 打开筛选面板 | 步态与移动专题 chip 已选中 |

## 验证录像

<a href="https://cursor.com/agents/bc-8c6e910c-ed43-408e-8122-97a4200a4377/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph-3d-filter-align-2d-verify.mp4"><img src="https://cursor.com/artifacts/c/art-c326fa68-4c07-4cdf-be46-be2dae0e56a0" alt="graph-3d-filter-align-2d-verify.mp4" /></a>

演示流程：2D 筛选计数 → 3D 立体（同色球体、同计数）→ 2D 还原 → 筛选面板确认专题激活。

## 涉及文件

- `docs/graph.html` — 共享筛选辅助函数、3D 初始化回调、切 3D 时 applyFilters
- `docs/graph-3d.js` — 消费回调，对齐边透明度/线宽与 hub 半径
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c6e910c-ed43-408e-8122-97a4200a4377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c6e910c-ed43-408e-8122-97a4200a4377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

