### PR TITLE
fix(ux): 修复 3D 图谱节点不可见

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -64,28 +64,56 @@
     };
   }
 
+  function isSphereGeometryType(geometry) {
+    if (!geometry || !geometry.type) return false;
+    return /^Sphere(Buffer)?Geometry$/i.test(geometry.type);
+  }
+
+  function captureBundledThreeFromMesh(obj) {
+    return {
+      SphereGeometry: obj.geometry.constructor,
+      MeshLambertMaterial: obj.material.constructor,
+      Mesh: obj.constructor,
+      AmbientLight: null,
+      DirectionalLight: null,
+    };
+  }
+
+  function validateBundledThree(T) {
+    if (!T || !T.SphereGeometry || !T.MeshLambertMaterial || !T.Mesh) return false;
+    try {
+      var probe = new T.SphereGeometry(1, 8, 6);
+      if (probe && probe.dispose) probe.dispose();
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  /**
+   * 只从 three-forcegraph 的默认节点球体抓取 THREE 构造器。
+   * 若误抓连线 TubeGeometry，后续 new SphereGeometry(...) 会失败，导致 3D 节点全空。
+   */
   function captureBundledThree(graph) {
     if (!graph || !graph.scene) return null;
     var scene = graph.scene();
     if (!scene) return null;
     var captured = null;
     scene.traverse(function (obj) {
-      if (!captured && obj.isMesh && obj.geometry && obj.material) {
-        captured = {
-          SphereGeometry: obj.geometry.constructor,
-          MeshLambertMaterial: obj.material.constructor,
-          Mesh: obj.constructor,
-          AmbientLight: null,
-          DirectionalLight: null,
-        };
-      }
-      if (captured && obj.isLight) {
-        if (obj.type === 'AmbientLight') captured.AmbientLight = obj.constructor;
-        if (obj.type === 'DirectionalLight') captured.DirectionalLight = obj.constructor;
+      if (!obj.isMesh || !obj.geometry || !obj.material) return;
+      if (obj.__graphObjType !== 'node') return;
+      if (!isSphereGeometryType(obj.geometry)) return;
+      if (!captured || obj.__graphDefaultObj) {
+        captured = captureBundledThreeFromMesh(obj);
       }
     });
-    if (!captured || !captured.SphereGeometry || !captured.Mesh) return null;
-    return captured;
+    if (!captured) return null;
+    scene.traverse(function (obj) {
+      if (!captured || !obj.isLight) return;
+      if (obj.type === 'AmbientLight') captured.AmbientLight = obj.constructor;
+      if (obj.type === 'DirectionalLight') captured.DirectionalLight = obj.constructor;
+    });
+    return validateBundledThree(captured) ? captured : null;
   }
 
   function ensureSceneLights(scene, T) {
@@ -339,20 +367,40 @@
       if (meshInstallScheduled) return;
       meshInstallScheduled = true;
       var attempts = 0;
+      var maxAttempts = 90;
+      var onReadyCalled = false;
+      function finish(onReadyFn) {
+        meshInstallScheduled = false;
+        if (onReadyFn && !onReadyCalled) {
+          onReadyCalled = true;
+          onReadyFn();
+        }
+      }
       function tryInstall() {
         attempts += 1;
         if (installCustomNodeMeshes()) {
-          meshInstallScheduled = false;
-          if (onReady) onReady();
+          finish(onReady);
           return;
         }
-        if (attempts < 12) {
+        if (attempts < maxAttempts) {
           window.requestAnimationFrame(tryInstall);
         } else {
-          meshInstallScheduled = false;
+          finish(onReady);
         }
       }
       window.requestAnimationFrame(tryInstall);
+    }
+
+    function pauseRenderLoop() {
+      if (!graph) return;
+      if (typeof graph.pauseAnimation === 'function') graph.pauseAnimation();
+      if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0);
+    }
+
+    function resumeRenderLoop() {
+      if (!graph) return;
+      if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
+      if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.25);
     }
 
     function resetNodePositionsInPlace() {
@@ -371,12 +419,16 @@
       });
     }
 
+    function clearMagneticForces() {
+      ['x', 'y', 'z'].forEach(function (name) {
+        if (graph.d3Force(name)) graph.d3Force(name, null);
+      });
+    }
+
     function applyMagneticForces() {
       var magneticConfig = getMagneticConfig();
       if (!magneticConfig || !magneticConfig.enabled) {
-        graph.d3Force('x', null);
-        graph.d3Force('y', null);
-        graph.d3Force('z', null);
+        clearMagneticForces();
         return;
       }
       var centers = magneticConfig.centers || {};
@@ -408,6 +460,38 @@
       var next = measureContainerSize(container);
       graph.width(next.width);
       graph.height(next.height);
+    }
+
+    function bboxFromNodeData(nodeFilter) {
+      var filterFn = nodeFilter || function () { return true; };
+      var minX = Infinity;
+      var maxX = -Infinity;
+      var minY = Infinity;
+      var maxY = -Infinity;
+      var minZ = Infinity;
+      var maxZ = -Infinity;
+      var count = 0;
+      nodes3d.forEach(function (n) {
+        if (!filterFn(n) || n.x == null || n.y == null || n.z == null) return;
+        var r = sphereRadiusFor(n) + 8;
+        count += 1;
+        minX = Math.min(minX, n.x - r);
+        maxX = Math.max(maxX, n.x + r);
+        minY = Math.min(minY, n.y - r);
+        maxY = Math.max(maxY, n.y + r);
+        minZ = Math.min(minZ, n.z - r);
+        maxZ = Math.max(maxZ, n.z + r);
+      });
+      if (!count || !isFinite(minX)) return null;
+      return { x: [minX, maxX], y: [minY, maxY], z: [minZ, maxZ] };
+    }
+
+    function bboxSpan(bbox) {
+      if (!bbox) return 0;
+      var halfX = (bbox.x[1] - bbox.x[0]) / 2;
+      var halfY = (bbox.y[1] - bbox.y[0]) / 2;
+      var halfZ = (bbox.z[1] - bbox.z[0]) / 2;
+      return Math.sqrt(halfX * halfX + halfY * halfY + halfZ * halfZ);
     }
 
     function inflateBbox(bbox, nodeFilter) {
@@ -468,11 +552,34 @@
     function zoomFitToNodes(duration, nodeFilter) {
       if (!graph) return;
       var filterFn = nodeFilter || function () { return true; };
-      var bbox = graph.getGraphBbox(filterFn);
+      var sceneBbox = graph.getGraphBbox(filterFn);
+      var dataBbox = bboxFromNodeData(filterFn);
+      var bbox = dataBbox || sceneBbox;
+      if (sceneBbox && dataBbox) {
+        var sceneSpan = bboxSpan(sceneBbox);
+        var dataSpan = bboxSpan(dataBbox);
+        // 力模拟首帧前三维对象常堆在原点；数据坐标已展开时优先信 scene bbox。
+        if (sceneSpan >= dataSpan * 0.25) bbox = sceneBbox;
+        else bbox = dataBbox;
+      }
       if (bbox) bbox = inflateBbox(bbox, filterFn);
       if (!fitCameraToBbox(bbox, duration)) {
-        graph.zoomToFit(duration, 0, filterFn);
+        graph.zoomToFit(duration, 80, filterFn);
       }
+    }
+
+    function scheduleInitialFit(ms) {
+      var duration = ms == null ? 450 : ms;
+      var done = false;
+      function runFit() {
+        if (done) return;
+        done = true;
+        zoomFitToNodes(duration);
+      }
+      if (typeof graph.onEngineStop === 'function') {
+        graph.onEngineStop(function () { runFit(); });
+      }
+      window.setTimeout(runFit, 1800);
     }
 
     function onContainerPointerMove(ev) {
@@ -489,7 +596,7 @@
       .graphData({ nodes: nodes3d, links: buildLinks() })
       .backgroundColor(backgroundColor())
       .showNavInfo(false)
-      .warmupTicks(0)
+      .warmupTicks(8)
       .cooldownTicks(24)
       .nodeId('id')
       .nodeRelSize(1)
@@ -520,7 +627,8 @@
     var chargeForce = graph.d3Force('charge');
     if (chargeForce && chargeForce.strength) chargeForce.strength(getChargeStrength());
 
-    scheduleCustomMeshInstall();
+    // 构造器 init 会在 graphData 生效前同步跑一帧并抛 layout.tick 异常，需在此重启渲染环。
+    resumeRenderLoop();
 
     return {
       show: function () {
@@ -529,32 +637,26 @@
         syncViewport();
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
-        this.resumeSimulation();
-        var self = this;
+        resumeRenderLoop();
+        if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
         window.requestAnimationFrame(function () { syncViewport(); });
-        if (customMeshesInstalled) {
-          self.fitToScreen(450);
-        } else {
-          scheduleCustomMeshInstall(function () {
-            self.fitToScreen(450);
-          });
-        }
+        scheduleInitialFit(450);
+        scheduleCustomMeshInstall(function () {
+          scheduleInitialFit(350);
+        });
       },
 
       hide: function () {
-        this.pauseSimulation();
+        pauseRenderLoop();
         container.hidden = true;
       },
 
       pauseSimulation: function () {
-        if (!graph) return;
-        if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0);
+        pauseRenderLoop();
       },
 
       resumeSimulation: function () {
-        if (!graph) return;
-        if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
-        if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.25);
+        resumeRenderLoop();
       },
 
       resize: function () {

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -403,6 +403,14 @@
       if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.25);
     }
 
+  /** graphData 更新完成后再 reheat / resume，避免 layout 未就绪时 tick 抛错中断 rAF。 */
+    function reheatAfterGraphData() {
+      if (!graph) return;
+      if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.25);
+      if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
+      resumeRenderLoop();
+    }
+
     function resetNodePositionsInPlace() {
       sourceNodes.forEach(function (src) {
         var n3 = nodeById.get(src.id);
@@ -594,13 +602,16 @@
 
     var graph = null;
 
-    function ensureGraph() {
-      if (graph) return graph;
-      size = measureContainerSize(container);
-      graph = window.ForceGraph3D()(container)
+    function afterGraphDataApplied(fn) {
+      window.requestAnimationFrame(function () {
+        window.requestAnimationFrame(fn);
+      });
+    }
+
+    function bindGraphInstance() {
+      graph
         .width(size.width)
         .height(size.height)
-        .graphData({ nodes: nodes3d, links: buildLinks() })
         .backgroundColor(backgroundColor())
         .showNavInfo(false)
         .warmupTicks(8)
@@ -632,8 +643,15 @@
         });
       var chargeForce = graph.d3Force('charge');
       if (chargeForce && chargeForce.strength) chargeForce.strength(getChargeStrength());
-      // 构造器 init 首帧 layout 未就绪会抛 tick 异常并中断 rAF，此处立即重启渲染环。
-      resumeRenderLoop();
+    }
+
+    function ensureGraph() {
+      if (graph) return graph;
+      size = measureContainerSize(container);
+      // init 末尾会同步启动 rAF；先 pause，待 graphData onFinishUpdate 后再 resume。
+      graph = window.ForceGraph3D()(container);
+      graph.pauseAnimation();
+      bindGraphInstance();
       return graph;
     }
 
@@ -645,16 +663,15 @@
         syncViewport();
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
+        pauseRenderLoop();
         graph.graphData({ nodes: nodes3d, links: buildLinks() });
-        resumeRenderLoop();
-        if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
-        if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.9);
-        if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.25);
-        window.requestAnimationFrame(function () {
+        afterGraphDataApplied(function () {
+          if (!graph) return;
+          reheatAfterGraphData();
           syncViewport();
           if (typeof graph.zoomToFit === 'function') graph.zoomToFit(0, 90);
+          scheduleInitialFit(650);
         });
-        scheduleInitialFit(650);
       },
 
       hide: function () {
@@ -685,12 +702,15 @@
       },
 
       updateForces: function () {
+        if (!graph) return;
         var charge = graph.d3Force('charge');
         if (charge && charge.strength) charge.strength(getChargeStrength());
         applyMagneticForces();
-        if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.45);
-        if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.22);
-        else if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
+        afterGraphDataApplied(function () {
+          if (!graph) return;
+          if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.22);
+          else if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
+        });
       },
 
       restartSimulation: function () {

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -570,16 +570,18 @@
 
     function scheduleInitialFit(ms) {
       var duration = ms == null ? 450 : ms;
-      var done = false;
       function runFit() {
-        if (done) return;
-        done = true;
+        if (!graph) return;
+        if (typeof graph.zoomToFit === 'function') {
+          graph.zoomToFit(duration, 100);
+          return;
+        }
         zoomFitToNodes(duration);
       }
       if (typeof graph.onEngineStop === 'function') {
         graph.onEngineStop(function () { runFit(); });
       }
-      window.setTimeout(runFit, 1800);
+      window.setTimeout(runFit, 2000);
     }
 
     function onContainerPointerMove(ev) {
@@ -590,60 +592,69 @@
     container.addEventListener('mousemove', onContainerPointerMove);
     container.addEventListener('pointermove', onContainerPointerMove);
 
-    var graph = window.ForceGraph3D()(container)
-      .width(size.width)
-      .height(size.height)
-      .graphData({ nodes: nodes3d, links: buildLinks() })
-      .backgroundColor(backgroundColor())
-      .showNavInfo(false)
-      .warmupTicks(8)
-      .cooldownTicks(24)
-      .nodeId('id')
-      .nodeRelSize(1)
-      .nodeResolution(8)
-      .nodeColor(function (d) { return getNodeColor(d); })
-      .nodeVal(nodeValFor)
-      .nodeOpacity(function (d) { return nodeOpacityFor(d); })
-      .linkColor(function (l) { return linkColorFor(l); })
-      .linkWidth(function (l) { return linkWidthFor(l); })
-      .linkOpacity(function (l) { return linkOpacityFor(l); })
-      .enableNodeDrag(true)
-      .onNodeClick(function (node, ev) {
-        var src = resolveSourceNode(node.id) || node;
-        if (onNodeClick) onNodeClick(src, ev || lastPointer);
-      })
-      .onNodeHover(function (node) {
-        hoverNodeId = node ? node.id : null;
-        refreshAppearance();
-        var src = node ? (resolveSourceNode(node.id) || node) : null;
-        if (onNodeHover) onNodeHover(src, lastPointer);
-      })
-      .onBackgroundClick(function () {
-        hoverNodeId = null;
-        refreshAppearance();
-        if (opts.onBackgroundClick) opts.onBackgroundClick();
-      });
+    var graph = null;
 
-    var chargeForce = graph.d3Force('charge');
-    if (chargeForce && chargeForce.strength) chargeForce.strength(getChargeStrength());
-
-    // 构造器 init 会在 graphData 生效前同步跑一帧并抛 layout.tick 异常，需在此重启渲染环。
-    resumeRenderLoop();
+    function ensureGraph() {
+      if (graph) return graph;
+      size = measureContainerSize(container);
+      graph = window.ForceGraph3D()(container)
+        .width(size.width)
+        .height(size.height)
+        .graphData({ nodes: nodes3d, links: buildLinks() })
+        .backgroundColor(backgroundColor())
+        .showNavInfo(false)
+        .warmupTicks(8)
+        .cooldownTicks(24)
+        .nodeId('id')
+        .nodeRelSize(1)
+        .nodeResolution(8)
+        .nodeColor(function (d) { return getNodeColor(d); })
+        .nodeVal(nodeValFor)
+        .nodeOpacity(function (d) { return nodeOpacityFor(d); })
+        .linkColor(function (l) { return linkColorFor(l); })
+        .linkWidth(function (l) { return linkWidthFor(l); })
+        .linkOpacity(function (l) { return linkOpacityFor(l); })
+        .enableNodeDrag(true)
+        .onNodeClick(function (node, ev) {
+          var src = resolveSourceNode(node.id) || node;
+          if (onNodeClick) onNodeClick(src, ev || lastPointer);
+        })
+        .onNodeHover(function (node) {
+          hoverNodeId = node ? node.id : null;
+          refreshAppearance();
+          var src = node ? (resolveSourceNode(node.id) || node) : null;
+          if (onNodeHover) onNodeHover(src, lastPointer);
+        })
+        .onBackgroundClick(function () {
+          hoverNodeId = null;
+          refreshAppearance();
+          if (opts.onBackgroundClick) opts.onBackgroundClick();
+        });
+      var chargeForce = graph.d3Force('charge');
+      if (chargeForce && chargeForce.strength) chargeForce.strength(getChargeStrength());
+      // 构造器 init 首帧 layout 未就绪会抛 tick 异常并中断 rAF，此处立即重启渲染环。
+      resumeRenderLoop();
+      return graph;
+    }
 
     return {
       show: function () {
         container.hidden = false;
         syncPositionsFromSource();
+        ensureGraph();
         syncViewport();
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
+        graph.graphData({ nodes: nodes3d, links: buildLinks() });
         resumeRenderLoop();
         if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
-        window.requestAnimationFrame(function () { syncViewport(); });
-        scheduleInitialFit(450);
-        scheduleCustomMeshInstall(function () {
-          scheduleInitialFit(350);
+        if (typeof graph.d3Alpha === 'function') graph.d3Alpha(0.9);
+        if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0.25);
+        window.requestAnimationFrame(function () {
+          syncViewport();
+          if (typeof graph.zoomToFit === 'function') graph.zoomToFit(0, 90);
         });
+        scheduleInitialFit(650);
       },
 
       hide: function () {
@@ -733,7 +744,8 @@
       destroy: function () {
         container.removeEventListener('mousemove', onContainerPointerMove);
         container.removeEventListener('pointermove', onContainerPointerMove);
-        if (graph._destructor) graph._destructor();
+        if (graph && graph._destructor) graph._destructor();
+        graph = null;
         container.replaceChildren();
       },
     };

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2072,6 +2072,10 @@
         try { localStorage.setItem(SPATIAL_VIEW_KEY, '2d'); } catch (_e) { /* ignore */ }
         return '2d';
       }
+      if (spatialViewParam === '3d') {
+        try { localStorage.setItem(SPATIAL_VIEW_KEY, '3d'); } catch (_e) { /* ignore */ }
+        return '3d';
+      }
       try {
         const saved = localStorage.getItem(SPATIAL_VIEW_KEY);
         return saved === '3d' ? '3d' : '2d';
@@ -2228,7 +2232,9 @@
         }
         graph3dView.show();
         graph3dView.syncFilters();
-        graph3dView.fitToScreen(0);
+        window.setTimeout(function () {
+          if (is3DView() && graph3dView) graph3dView.fitToScreen(0);
+        }, 120);
       } else {
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2066,7 +2066,12 @@
     }
 
     const SPATIAL_VIEW_KEY = 'rn-graph-spatial-view';
+    const spatialViewParam = new URLSearchParams(location.search).get('view');
     let spatialViewMode = (function () {
+      if (spatialViewParam === '2d') {
+        try { localStorage.setItem(SPATIAL_VIEW_KEY, '2d'); } catch (_e) { /* ignore */ }
+        return '2d';
+      }
       try {
         const saved = localStorage.getItem(SPATIAL_VIEW_KEY);
         return saved === '3d' ? '3d' : '2d';
@@ -2223,6 +2228,7 @@
         }
         graph3dView.show();
         graph3dView.syncFilters();
+        graph3dView.fitToScreen(0);
       } else {
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;
@@ -4276,7 +4282,12 @@
     }
 
     if (spatialViewMode === '3d') {
-      whenGraphViewportReady(() => setSpatialViewMode('3d', { force: true }));
+      const enter3dWhenReady = () => setSpatialViewMode('3d', { force: true });
+      simulation.on('end.initial3d', () => {
+        simulation.on('end.initial3d', null);
+        whenGraphViewportReady(enter3dWhenReady);
+      });
+      setTimeout(() => whenGraphViewportReady(enter3dWhenReady), 2200);
     }
 
   })();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复知识图谱页切换到 **3D 立体** 后画布空白、看不到节点的问题。

### 根因

1. `ForceGraph3D` 构造时同步启动 rAF，首帧可能在 `layout` 未就绪时调用 `layout.tick()` 抛错并中断渲染环
2. `show()` 内在 `graphData` 完成前调用 `d3ReheatSimulation()`，会把 `engineRunning` 置 true 但 `layout` 仍为 undefined
3. 过早 `fitToScreen` 与 localStorage 直进 3D 的体验问题（前序 commit 已处理）

### 修复

- 构造后立即 `pauseAnimation()`，等 `graphData` 应用后再 `reheat` / `resume`
- 用双 `requestAnimationFrame` 延迟 reheat，避免与 graphData 更新竞态
- 支持 `?view=3d` URL 参数
- 切换 3D 后延迟 120ms 再 `fitToScreen`

## 验证

- 本地 `graph.html?view=2d` → 点击「3D 立体」→ 1336 节点可见，可拖拽旋转
- 控制台无 `layout.tick` TypeError

## 验证录像（2D → 点击 3D 立体 → 旋转）

<a href="https://cursor.com/agents/bc-26607fdb-303c-45bb-9a30-64b633309616/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph-3d-button-demo.mp4"><img src="https://cursor.com/artifacts/c/art-7466800a-2b3e-4fce-9128-399e6fc19122" alt="graph-3d-button-demo.mp4" /></a>

备用（直接 `?view=3d`）：

<a href="https://cursor.com/agents/bc-26607fdb-303c-45bb-9a30-64b633309616/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph-3d-fix-verification-v3.mp4"><img src="https://cursor.com/artifacts/c/art-52b1ff88-03c7-49fe-98c7-03673a8d7ec6" alt="graph-3d-fix-verification-v3.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26607fdb-303c-45bb-9a30-64b633309616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26607fdb-303c-45bb-9a30-64b633309616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

