### PR TITLE
Add contact dynamics aliases to search index

### DIFF
--- a/scripts/search_wiki_core.py
+++ b/scripts/search_wiki_core.py
@@ -87,6 +87,8 @@ CANONICAL_TOPIC_PAGES: dict[str, str] = {
     "vla": "wiki/methods/vla.md",
     "vision-language-action": "wiki/methods/vla.md",
     "sim2real": "wiki/concepts/sim2real.md",
+    "接触力": "wiki/concepts/contact-dynamics.md",
+    "contact dynamics": "wiki/concepts/contact-dynamics.md",
 }
 
 COMPARISON_INTENT_MARKERS = frozenset(


### PR DESCRIPTION
## 摘要

为搜索索引添加「接触力」和「contact dynamics」两个别名，指向 `wiki/concepts/contact-dynamics.md` 页面，提升中英文搜索体验。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`
- [ ] 其他：本地验证搜索别名生效

## 相关 Issue

无

https://claude.ai/code/session_013WWFv3C1BQcp9jw3WTqzP8