### PR TITLE
fix: nodeOpacity 配置改为常量 1，逐节点淡化交由自定义 mesh

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -332,10 +332,12 @@
 
     function refreshAppearance() {
       if (!customMeshesInstalled) {
+        // nodeOpacity 是标量配置：传函数会算出 NaN 不透明度让默认球体全透明。
+        // 自定义 mesh 装上前用常量 1 保底可见，逐节点淡化交给 updateNodeMeshes。
         graph
           .nodeColor(function (d) { return getNodeColor(d); })
           .nodeVal(nodeValFor)
-          .nodeOpacity(function (d) { return nodeOpacityFor(d); });
+          .nodeOpacity(1);
       }
       graph
         .linkColor(function (l) { return linkColorFor(l); })
@@ -621,7 +623,7 @@
         .nodeResolution(8)
         .nodeColor(function (d) { return getNodeColor(d); })
         .nodeVal(nodeValFor)
-        .nodeOpacity(function (d) { return nodeOpacityFor(d); })
+        .nodeOpacity(1)
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
@@ -670,6 +672,13 @@
           reheatAfterGraphData();
           syncViewport();
           if (typeof graph.zoomToFit === 'function') graph.zoomToFit(0, 90);
+          // 默认渲染把 nodeOpacity 当标量，传入函数会得到 NaN 不透明度（节点全透明不可见）。
+          // 装上自定义 mesh 后由 createNodeMesh / updateNodeMeshes 写入逐节点数值不透明度。
+          scheduleCustomMeshInstall(function () {
+            if (!graph) return;
+            reheatAfterGraphData();
+            scheduleInitialFit(350);
+          });
           scheduleInitialFit(650);
         });
       },


### PR DESCRIPTION
## 摘要

修复 3D 图表节点透明度配置问题。将 `nodeOpacity` 从函数改为常量 `1`，因为默认渲染器将函数返回值作为标量处理，导致 NaN 不透明度使节点全透明不可见。逐节点的淡化效果改由自定义 mesh 的 `createNodeMesh` / `updateNodeMeshes` 处理。同时在自定义 mesh 装载后补充重热和视口同步逻辑。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

**问题根源：**
- 默认渲染器的 `nodeOpacity` 配置期望标量值，但代码传入了函数 `nodeOpacityFor(d)`
- 函数返回值被当作标量处理，导致计算出 NaN 不透明度，节点全透明不可见

**解决方案：**
1. 在 `refreshAppearance()` 中（自定义 mesh 装载前）将 `nodeOpacity` 设为常量 `1`，保证默认球体可见
2. 在 `initGraph()` 中同样改为常量 `1`
3. 在自定义 mesh 装载完成后（`scheduleCustomMeshInstall` 回调中）执行 `reheatAfterGraphData()` 和 `scheduleInitialFit(350)`，由自定义 mesh 的逐节点处理逻辑负责淡化效果

**代码变更：**
- 第 339 行：`nodeOpacity` 从函数改为常量 `1`，并补充中文注释说明原因
- 第 626 行：同步改为常量 `1`
- 第 675-680 行：新增 `scheduleCustomMeshInstall` 回调，在自定义 mesh 装载后重新加热图表并调整视口

## 验证

- N/A（前端逻辑修复，无自动化测试）
- 本地验证：3D 图表节点在默认渲染和自定义 mesh 两个阶段均可见，淡化效果由自定义 mesh 逐节点处理

https://claude.ai/code/session_01PXJp9VxS7smDCgTZHVTBXe