### PR TITLE
fix(ux): 修复 3D 首次切换空白卡住，并改为仅初次布局后自动适配一次

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -166,6 +166,7 @@
     var customMeshesInstalled = false;
     var meshInstallScheduled = false;
     var pendingFirstShowKick = false;
+    var initialFitDone = false;
 
     function rebuildNodeIndex() {
       nodeById = new Map(nodes3d.map(function (n) { return [n.id, n]; }));
@@ -580,9 +581,13 @@
     }
 
     function scheduleInitialFit(ms) {
+      // 只在「首次力布局结束」时自动适配一次；适配后注销 onEngineStop，
+      // 之后任何交互（hover / 点击 / 拖拽引发的 reheat）都不再自动适配屏幕。
+      if (initialFitDone) return;
       var duration = ms == null ? 450 : ms;
       function runFit() {
-        if (!graph) return;
+        if (!graph || initialFitDone) return;
+        initialFitDone = true;
         // 用基于节点数据坐标的安全 fit：库自带 zoomToFit 在场景对象尚未生成时
         // （getGraphBbox 返回 null）会静默 no-op，首次切换易停在未取景的相机上。
         zoomFitToNodes(duration);
@@ -657,19 +662,22 @@
       return graph;
     }
 
-    // 首次创建 WebGL 渲染器后，部分浏览器/GPU 需要一次额外的 resize + resume + fit
-    // 才会真正出图（否则 2D 第一次切到 3D 时画布停在空白，要拖动/缩放才出现）。幂等。
+    // Chrome 下 2D 第一次切到 3D 偶发整屏空白（新建 WebGL 渲染器后首帧渲染管线未完成），
+    // 现象上只有「切回 2D 再切 3D」能恢复——本质是在已建好的渲染器上重跑一次 graphData。
+    // 这里在首次 show 后幂等地复刻该恢复动作，避免用户手动来回切。
     function firstShowKick() {
       if (!pendingFirstShowKick) return;
       pendingFirstShowKick = false;
-      [180, 520].forEach(function (delay) {
-        window.setTimeout(function () {
-          if (!graph || container.hidden) return;
-          syncViewport();
-          resumeRenderLoop();
-          zoomFitToNodes(0);
-        }, delay);
-      });
+      window.setTimeout(function () {
+        if (!graph || container.hidden) return;
+        syncViewport();
+        pauseRenderLoop();
+        graph.graphData({ nodes: nodes3d, links: buildLinks() });
+        afterGraphDataApplied(function () {
+          if (!graph) return;
+          reheatAfterGraphData();
+        });
+      }, 250);
     }
 
     return {
@@ -686,7 +694,6 @@
           if (!graph) return;
           reheatAfterGraphData();
           syncViewport();
-          zoomFitToNodes(0);
           // 默认渲染把 nodeOpacity 当标量，传入函数会得到 NaN 不透明度（节点全透明不可见）。
           // 装上自定义 mesh 后由 createNodeMesh / updateNodeMeshes 写入逐节点数值不透明度。
           scheduleCustomMeshInstall(function () {

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -165,6 +165,7 @@
     var sharedSphereGeometry = null;
     var customMeshesInstalled = false;
     var meshInstallScheduled = false;
+    var pendingFirstShowKick = false;
 
     function rebuildNodeIndex() {
       nodeById = new Map(nodes3d.map(function (n) { return [n.id, n]; }));
@@ -582,10 +583,8 @@
       var duration = ms == null ? 450 : ms;
       function runFit() {
         if (!graph) return;
-        if (typeof graph.zoomToFit === 'function') {
-          graph.zoomToFit(duration, 100);
-          return;
-        }
+        // 用基于节点数据坐标的安全 fit：库自带 zoomToFit 在场景对象尚未生成时
+        // （getGraphBbox 返回 null）会静默 no-op，首次切换易停在未取景的相机上。
         zoomFitToNodes(duration);
       }
       if (typeof graph.onEngineStop === 'function') {
@@ -654,7 +653,23 @@
       graph = window.ForceGraph3D()(container);
       graph.pauseAnimation();
       bindGraphInstance();
+      pendingFirstShowKick = true;
       return graph;
+    }
+
+    // 首次创建 WebGL 渲染器后，部分浏览器/GPU 需要一次额外的 resize + resume + fit
+    // 才会真正出图（否则 2D 第一次切到 3D 时画布停在空白，要拖动/缩放才出现）。幂等。
+    function firstShowKick() {
+      if (!pendingFirstShowKick) return;
+      pendingFirstShowKick = false;
+      [180, 520].forEach(function (delay) {
+        window.setTimeout(function () {
+          if (!graph || container.hidden) return;
+          syncViewport();
+          resumeRenderLoop();
+          zoomFitToNodes(0);
+        }, delay);
+      });
     }
 
     return {
@@ -671,7 +686,7 @@
           if (!graph) return;
           reheatAfterGraphData();
           syncViewport();
-          if (typeof graph.zoomToFit === 'function') graph.zoomToFit(0, 90);
+          zoomFitToNodes(0);
           // 默认渲染把 nodeOpacity 当标量，传入函数会得到 NaN 不透明度（节点全透明不可见）。
           // 装上自定义 mesh 后由 createNodeMesh / updateNodeMeshes 写入逐节点数值不透明度。
           scheduleCustomMeshInstall(function () {
@@ -680,6 +695,7 @@
             scheduleInitialFit(350);
           });
           scheduleInitialFit(650);
+          firstShowKick();
         });
       },
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2232,9 +2232,8 @@
         }
         graph3dView.show();
         graph3dView.syncFilters();
-        window.setTimeout(function () {
-          if (is3DView() && graph3dView) graph3dView.fitToScreen(0);
-        }, 120);
+        // 不在切换时自动适配：仅首次力布局结束后由 graph-3d 自动适配一次，
+        // 之后只有用户点「适配屏幕」按钮才适配。
       } else {
         if (graph3dView) graph3dView.hide();
         graphCanvas3d.hidden = true;
@@ -3872,7 +3871,7 @@
       if (!updateGraphViewport()) return;
       if (graph3dView) graph3dView.resize();
       if (is3DView()) {
-        if (graph3dView) graph3dView.fitToScreen(0);
+        // 3D：仅同步视口尺寸（上面 resize() 已处理），不自动适配屏幕。
         return;
       }
       if (timelineAnimating) {


### PR DESCRIPTION
## 摘要

承接已合并的 #813（修复 3D 节点 `nodeOpacity` 传函数得 NaN 导致全不可见）。#813 合入后又暴露两个体验问题，本 PR 修复：

1. **Chrome 下 2D 第一次切到 3D 偶发整屏空白**，只有「切回 2D 再切」才能恢复。
2. **3D 视图碰一下 / 拖一下节点就自动适配屏幕**（非预期），应只在初次力布局后适配一次。

### 改动（`docs/graph-3d.js` + `docs/graph.html`）

- **空白修复**：用户确认「切回 2D 再切」可恢复 —— 其本质是在已建好的 WebGL 渲染器上重跑一次 `graphData`。`firstShowKick` 现在于首次 `show` 后（250ms）幂等地复刻该恢复动作（`syncViewport` + 重跑 `graphData` + reheat），免去手动来回切。
- **适配改为一次性**：仅在「首次力布局结束」（`onEngineStop`，2s 兜底）时 `zoomFitToNodes` 适配一次，置 `initialFitDone` 后注销自动适配；此后 hover / 点击 / 拖拽引发的 reheat 不再触发适配。
- 移除三处多余自动适配：切换时的 120ms 适配、`resize` 时的适配、`show` 内提前的 `zoomFitToNodes`。
- 「适配屏幕」按钮与「重新布局」仍走显式 `fitToScreen`，不受影响。

> 说明：整屏空白只在真实 Chrome 复现，headless（swiftshader）始终复现不出，故空白修复是基于用户确认的恢复路径做的对症修复（程序化替用户做一次「切回再切」）；适配改为一次性的行为已在本地完整验证。

## 验证

- 本地静态站 2D→3D 首次切换：1338 节点正常渲染（含 8× CPU 节流场景），无空白 / 闪烁，`material.opacity` 全为数值，无 console / page 报错。
- 初次适配后模拟拖拽 reheat → 相机坐标纹丝不动（`[-555,370,7442]` → `[-555,370,7442]`，位移 0）→ 不再自动适配。
- 点「适配屏幕」按钮 → 相机重新取景正常。
- `make ci-preflight` 12/12 通过（仅前端 JS 改动，导出/schema 未触及）。

## 验证截图

``&lt;img alt="3D 首次切换正常渲染并仅初次适配一次" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/3d-fit-once-and-blank-fix.png" /&gt;``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXJp9VxS7smDCgTZHVTBXe

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXJp9VxS7smDCgTZHVTBXe)_