### PR TITLE
fix(ux): 放大 3D 图谱适配屏幕取景，对齐 2D 上下边距

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -475,6 +475,11 @@
       graph.height(next.height);
     }
 
+    function graphFitPadPx() {
+      var view = measureContainerSize(container);
+      return Math.min(view.width, view.height) < 520 ? 48 : 120;
+    }
+
     function bboxFromNodeData(nodeFilter) {
       var filterFn = nodeFilter || function () { return true; };
       var minX = Infinity;
@@ -486,7 +491,7 @@
       var count = 0;
       nodes3d.forEach(function (n) {
         if (!filterFn(n) || n.x == null || n.y == null || n.z == null) return;
-        var r = sphereRadiusFor(n) + 8;
+        var r = sphereRadiusFor(n) + 4;
         count += 1;
         minX = Math.min(minX, n.x - r);
         maxX = Math.max(maxX, n.x + r);
@@ -507,17 +512,13 @@
       return Math.sqrt(halfX * halfX + halfY * halfY + halfZ * halfZ);
     }
 
-    function inflateBbox(bbox, nodeFilter) {
-      var padR = 0;
-      nodes3d.forEach(function (n) {
-        if (nodeFilter && !nodeFilter(n)) return;
-        if (n.x == null || n.y == null || n.z == null) return;
-        padR = Math.max(padR, sphereRadiusFor(n) + 8);
-      });
+    function inflateBbox(bbox) {
+      // bbox 已含节点半径；仅留极小呼吸空间，避免与 fitCameraToBbox 的边距重复叠加。
+      var pad = 8;
       return {
-        x: [bbox.x[0] - padR, bbox.x[1] + padR],
-        y: [bbox.y[0] - padR, bbox.y[1] + padR],
-        z: [bbox.z[0] - padR, bbox.z[1] + padR],
+        x: [bbox.x[0] - pad, bbox.x[1] + pad],
+        y: [bbox.y[0] - pad, bbox.y[1] + pad],
+        z: [bbox.z[0] - pad, bbox.z[1] + pad],
       };
     }
 
@@ -528,19 +529,18 @@
       var cz = (bbox.z[0] + bbox.z[1]) / 2;
       var halfX = Math.max((bbox.x[1] - bbox.x[0]) / 2, 8);
       var halfY = Math.max((bbox.y[1] - bbox.y[0]) / 2, 8);
-      var halfZ = Math.max((bbox.z[1] - bbox.z[0]) / 2, 8);
-      var radius = Math.sqrt(halfX * halfX + halfY * halfY + halfZ * halfZ);
 
       var view = measureContainerSize(container);
       var cam3d = graph.camera();
       var fovDeg = (cam3d && cam3d.fov) || 50;
       var fov = fovDeg * Math.PI / 180;
       var aspect = view.width / Math.max(view.height, 1);
-      var distV = radius / Math.sin(fov / 2);
+      // 与 2D computeGraphFitTransform 对齐：按轴向半宽/半高分别取景，再取较远相机距离。
+      var pad = graphFitPadPx() / 2;
+      var distV = (halfY + pad) / Math.tan(fov / 2);
       var hFov = 2 * Math.atan(Math.tan(fov / 2) * aspect);
-      var distH = radius / Math.sin(hFov / 2);
-      var dist = Math.max(distV, distH, 48);
-      dist *= 0.78;
+      var distH = (halfX + pad) / Math.tan(hFov / 2);
+      var dist = Math.max(distV, distH, 32);
 
       var lookAt = { x: cx, y: cy, z: cz };
       var cur = graph.cameraPosition();
@@ -575,9 +575,9 @@
         if (sceneSpan >= dataSpan * 0.25) bbox = sceneBbox;
         else bbox = dataBbox;
       }
-      if (bbox) bbox = inflateBbox(bbox, filterFn);
+      if (bbox) bbox = inflateBbox(bbox);
       if (!fitCameraToBbox(bbox, duration)) {
-        graph.zoomToFit(duration, 80, filterFn);
+        graph.zoomToFit(duration, graphFitPadPx() / 2, filterFn);
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

3D 视图的「适配屏幕」取景偏保守，节点画面比 2D 小一圈。本次调整 `docs/graph-3d.js` 中的相机取景逻辑，使上下最外侧节点更接近窗口边缘，观感与 2D 的 `fitToScreen` 一致。

## 改动要点

- **取景算法**：由 3D 包围球半径改为与 2D 相同的轴向半宽/半高分别计算相机距离（`min(垂直, 水平)` 约束），避免深度轴把画面整体缩小。
- **边距对齐**：复用 2D 的 `graphFitPadding` 规则（桌面 120px / 移动 48px，折合每侧约一半）。
- **去除重复 padding**：`bbox` 已含节点半径后不再二次按最大球半径膨胀；`zoomToFit` 回退 padding 同步收紧。

## 验证

- 本地静态服务已启动并完成 `make export graph`
- 变更仅涉及前端取景逻辑，未改 wiki / 派生索引；无需 `make ci-preflight`

## 如何手动验证

1. `make export graph && cd docs && python3 -m http.server 8765`
2. 打开 `graph.html`，切换到 **3D 立体**
3. 等待力布局收敛后点击 **适配屏幕**，对比 2D 同按钮：上下最外侧节点应接近窗口边缘

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d90565c-cfda-408d-a4cc-2f2fd68729df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d90565c-cfda-408d-a4cc-2f2fd68729df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

