### PR TITLE
docs(cloud): 补充测试前需先生成站点导出的环境说明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,8 @@ This is a **pure content + tooling** repo — no backend services, databases, or
 
 ### Gotchas
 
-- `pip-audit` (used in `make ci-test`) requires `python3-venv` to be installed at the system level (`apt install python3-venv`). The update script handles `pip install` but system packages must be pre-installed.
+- `pip-audit` (used in `make ci-test`) requires `python3-venv` to be installed at the system level (`apt install python3.12-venv`). The update script handles `pip install` but system packages must be pre-installed.
+- `make test` / `make ci-test` 依赖 gitignore 的站点 JSON（`exports/site-data-v1.json` 等）。全新环境若未先生成，`test_community_naming` 与 `test_wiki_roadmaps_export` 会因 `FileNotFoundError` 失败。**跑测试前先执行一次 `make export graph`**（约 30s）生成派生数据，之后 `make test`/`make ci-test` 即可全绿。
 - Python tools (`ruff`, `mypy`, `pytest`, `pip-audit`, etc.) install to `~/.local/bin`. Ensure `PATH` includes `$HOME/.local/bin` before running Make targets.
 - `PYTHONPATH=scripts` is required for `mypy` and `pytest` (already set in the Makefile targets).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 搭建并验证了本仓库的 Cloud 开发环境（Python 3.12 + Node 22 + Make），跑通 lint / test / CI / 本地静态站点。
- 在 `AGENTS.md` 的 Cursor Cloud 说明中补充一个非显而易见的坑：`make test` / `make ci-test` 依赖 gitignore 的站点 JSON（`exports/site-data-v1.json` 等），全新环境需先 `make export graph` 再跑测试，否则 `test_community_naming`、`test_wiki_roadmaps_export` 会因 `FileNotFoundError` 失败。

## 环境与验证
- 依赖安装：`pip install --user -r requirements-dev.txt`、`npm ci`、系统包 `python3.12-venv`（`pip-audit` 需要）。
- `make lint`：✅ 全部检查通过（sources 覆盖率 1307/1336）。
- `make export graph`：✅ 生成 1380 detail pages / 图谱 1338 节点 9145 边。
- `make test`：✅ 219 passed，覆盖率 60.28%（阈值 52%）。
- `make ci-test`：✅ ruff / mypy / pip-audit / eslint / pytest 全绿。
- 本地静态站点 `cd docs && python3 -m http.server 8080`：✅ 首页 / 图谱 / 搜索 / 详情页均正常，控制台无报错。

## 验证截图与演示
[robotics_wiki_site_walkthrough.mp4](https://cursor.com/agents/bc-e8a056f0-63e3-46bd-8b26-327747f28402/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frobotics_wiki_site_walkthrough.mp4)

[D3 知识图谱渲染](https://cursor.com/agents/bc-e8a056f0-63e3-46bd-8b26-327747f28402/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgraph_rendered.webp)
[搜索强化学习结果](https://cursor.com/agents/bc-e8a056f0-63e3-46bd-8b26-327747f28402/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_results.webp)
[知识详情页](https://cursor.com/agents/bc-e8a056f0-63e3-46bd-8b26-327747f28402/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdetail_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8a056f0-63e3-46bd-8b26-327747f28402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8a056f0-63e3-46bd-8b26-327747f28402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

