### PR TITLE
fix: 补足移动端图表工具栏 min-height 避免露出背景灰条

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -521,6 +521,10 @@
       #graph-toolbar {
         padding: 6px 12px;
         gap: 6px;
+        /* 移动端工具栏内容仅 ~43px，但 #graph-wrap 顶部按 header+46px 定位；
+           补足 min-height 让工具栏正好填满该 46px 带，避免底部露出比画布更浅的
+           页面背景(#1c1c1e)形成一条灰条。 */
+        min-height: 46px;
       }
       #graph-search {
         width: 120px;


### PR DESCRIPTION
## 摘要

补足 `#graph-toolbar` 的 `min-height: 46px`，确保移动端工具栏高度与其容器 `#graph-wrap` 顶部定位（header + 46px）对齐，避免底部露出页面背景色形成视觉缺陷。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] 无需测试（纯 CSS 样式调整，修复移动端视觉对齐问题）

## 相关 Issue

无

https://claude.ai/code/session_019FRdGUd2DeQPbgUjovQSua