### PR TITLE
3D graph: Hide filtered nodes/links instead of fading

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -354,6 +354,7 @@
           .nodeOpacity(1);
       }
       graph
+        .nodeVisibility(function (d) { return !nodeHiddenByFilter(d); })
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
@@ -670,6 +671,7 @@
         .nodeColor(function (d) { return getNodeColor(d); })
         .nodeVal(nodeValFor)
         .nodeOpacity(1)
+        .nodeVisibility(function (d) { return !nodeHiddenByFilter(d); })
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -225,6 +225,18 @@
       return set ? set.has(otherId) : false;
     }
 
+    // 3D 下「筛选 = 直接隐藏」：命中筛选集合之外的节点/连线整体不渲染，而非淡化。
+    // 2D 视图仍沿用淡化逻辑（见 graph.html applyFilters），这两个判定只作用于 3D。
+    function nodeHiddenByFilter(d) {
+      return hasActiveFilter() && !getVisibleNodeIds().has(d.id);
+    }
+
+    function linkVisibleFor(l) {
+      if (!hasActiveFilter()) return true;
+      var visible = getVisibleNodeIds();
+      return visible.has(edgeEndpointId(l.source)) && visible.has(edgeEndpointId(l.target));
+    }
+
     function linkOpacityFor(l) {
       var s = edgeEndpointId(l.source);
       var t = edgeEndpointId(l.target);
@@ -328,7 +340,7 @@
         obj.material.color.set(getNodeColor(d));
         obj.material.opacity = opacity;
         obj.material.transparent = opacity < 0.999;
-        obj.visible = opacity > 0.02;
+        obj.visible = !nodeHiddenByFilter(d) && opacity > 0.02;
       });
     }
 
@@ -344,7 +356,8 @@
       graph
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
-        .linkOpacity(function (l) { return linkOpacityFor(l); });
+        .linkOpacity(function (l) { return linkOpacityFor(l); })
+        .linkVisibility(function (l) { return linkVisibleFor(l); });
       updateNodeMeshes();
     }
 
@@ -660,6 +673,7 @@
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
+        .linkVisibility(function (l) { return linkVisibleFor(l); })
         .enableNodeDrag(true)
         .onNodeClick(function (node, ev) {
           var src = resolveSourceNode(node.id) || node;


### PR DESCRIPTION
## 摘要

在 3D 图表中，改变筛选逻辑：命中筛选集合之外的节点和连线现在直接隐藏（不渲染），而非淡化显示。2D 视图保持原有淡化逻辑不变。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 变更内容

1. **新增两个筛选判定函数**：
   - `nodeHiddenByFilter(d)`：判断节点是否应被筛选隐藏
   - `linkVisibleFor(l)`：判断连线是否应被筛选显示（两端点都在可见集合中）

2. **更新节点可见性逻辑**：
   - 修改 `updateNodeMeshes()` 中节点的 `visible` 属性，同时检查 `nodeHiddenByFilter()` 和不透明度阈值

3. **更新连线可见性逻辑**：
   - 在 `applyFilters()` 和初始化时，为 graph 对象添加 `.linkVisibility()` 回调，使用 `linkVisibleFor()` 判定

### 设计说明

- 3D 视图采用"直接隐藏"策略：筛选外的节点/连线完全不渲染，提高性能和视觉清晰度
- 2D 视图（`graph.html`）保持现有淡化逻辑，两个视图的筛选表现独立
- 筛选判定仅在有活跃筛选时生效（`hasActiveFilter()` 检查）

## 验证

- 无自动化测试（前端交互改动）
- 改动为纯逻辑层面，不涉及 wiki 内容或构建脚本

## 相关 Issue

无

https://claude.ai/code/session_012D16o57dqpDAjxpbPpAyK6