### PR TITLE
fix(ux): 修复 3D 视图渲染环抢跑 renderer 致黑屏（筛选不可见）

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -415,11 +415,39 @@
       if (typeof graph.d3AlphaTarget === 'function') graph.d3AlphaTarget(0);
     }
 
+    var resumeDeferrals = 0;
     function resumeRenderLoop() {
       if (!graph) return;
+      // 3d-force-graph 在 kapsule 的防抖 digest 里才创建 WebGL renderer 并由 init 自启渲染环。
+      // 主线程繁忙时本函数（经 afterGraphDataApplied 的 2×rAF 调度）可能早于该 digest 跑完，
+      // 此刻 renderer 尚未就绪；若仍 resumeAnimation，会让库内部 _animationCycle 在对象未就绪时
+      // 同步抛错——且抛错发生在 requestAnimationFrame 重排之前 → 渲染环被永久中断、整屏黑屏。
+      // 故 renderer 未就绪时推迟到下一帧重试（有上限兜底）；待库 init digest 建好 renderer 并自启
+      // 渲染环后，这里再 resumeAnimation 也只是无害的 no-op。
+      if (typeof graph.renderer === 'function' && !graph.renderer()) {
+        if (resumeDeferrals++ < 120) window.requestAnimationFrame(resumeRenderLoop);
+        return;
+      }
+      resumeDeferrals = 0;
       // 只恢复渲染环，不再把 alphaTarget 钉在 0.25（那会让力模拟永不收敛、一直微抖）。
       // alphaTarget 保持 0，配合 reheat 的 alpha=1 实现「冲一下→自然衰减到静止」。
       if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
+    }
+
+    // 渲染环自愈：万一 3d-force-graph 的 _animationCycle 仍在内部对象（renderObjs / forceGraph）
+    // 未就绪时被唤醒并同步抛错，rAF 链会断开（抛错在 requestAnimationFrame 重排之前），表现为整屏
+    // 黑屏且不再自行恢复。此处监听 window error，命中库自身的该类崩溃后下一帧重新点火渲染环；
+    // 因为抛错时 animationFrameRequestId 仍为 null，resumeRenderLoop 在 renderer 就绪后即可重启。
+    var renderLoopHealAttempts = 0;
+    function reviveRenderLoopOnError(ev) {
+      if (!graph || container.hidden) return;
+      var fname = (ev && ev.filename) || '';
+      if (fname.indexOf('3d-force-graph') === -1) return;
+      var msg = (ev && ev.message) || (ev && ev.error && ev.error.message) || '';
+      if (msg.indexOf('tick') === -1 && msg.indexOf('renderObjs') === -1 && msg.indexOf('forceGraph') === -1) return;
+      if (renderLoopHealAttempts >= 60) return;
+      renderLoopHealAttempts += 1;
+      window.requestAnimationFrame(function () { resumeRenderLoop(); });
     }
 
   /** graphData 更新完成后再 reheat / resume，避免 layout 未就绪时 tick 抛错中断 rAF。 */
@@ -641,6 +669,7 @@
     }
     container.addEventListener('mousemove', onContainerPointerMove);
     container.addEventListener('pointermove', onContainerPointerMove);
+    window.addEventListener('error', reviveRenderLoopOnError);
 
     var graph = null;
 
@@ -849,6 +878,7 @@
       destroy: function () {
         container.removeEventListener('mousemove', onContainerPointerMove);
         container.removeEventListener('pointermove', onContainerPointerMove);
+        window.removeEventListener('error', reviveRenderLoopOnError);
         if (graph && graph._destructor) graph._destructor();
         graph = null;
         container.replaceChildren();

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -4291,7 +4291,15 @@
     }
 
     if (spatialViewMode === '3d') {
-      const enter3dWhenReady = () => setSpatialViewMode('3d', { force: true });
+      // 只进入一次：simulation 收敛(end.initial3d)与 2200ms 兜底都会触发，需去重，
+      // 否则二次以 force:true 重跑 setSpatialViewMode('3d') → show() 重入，徒增 graphData
+      // 重排与渲染环 pause/resume 抢跑风险。
+      let entered3dOnLoad = false;
+      const enter3dWhenReady = () => {
+        if (entered3dOnLoad) return;
+        entered3dOnLoad = true;
+        setSpatialViewMode('3d', { force: true });
+      };
       simulation.on('end.initial3d', () => {
         simulation.on('end.initial3d', null);
         whenGraphViewportReady(enter3dWhenReady);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

3D 视图筛选「看起来不生效」的根因是 **3D 视图在部分环境下整屏黑屏**——筛选逻辑其实正确，但 3D 根本没渲染出画面，于是用户看不到筛选效果。本 PR 修复黑屏竞态，使 3D 稳定渲染、筛选直接隐藏未命中节点。

### 根因

`3d-force-graph` 在 kapsule 的防抖（~1ms）digest 里才创建 WebGL renderer 并由 init 自启渲染环。主线程繁忙时（如加载即进入 3D + 1490 节点 2D 力模拟并发），`reheatAfterGraphData` 经 `2×rAF` 调度的 `resumeRenderLoop` 可能**早于**该 digest 跑完就调用 `resumeAnimation()`；此时内部对象未就绪，库的 `_animationCycle` 会**同步抛错**，且抛错发生在 `requestAnimationFrame` 重排之前 → 渲染环被永久中断、整屏黑屏（控制台报 `Cannot read properties of undefined (reading 'tick')`），且不会自行恢复。

### 修复（`docs/graph-3d.js`）

- `resumeRenderLoop`：renderer 未就绪（`graph.renderer()` 为空）时推迟到下一帧重试（带上限兜底），就绪后再 `resumeAnimation`，确定性消除抢跑。
- 新增 `window` error 渲染环自愈：命中库自身渲染环崩溃后下一帧重新点火，避免任何残留竞态导致永久黑屏。

### 附带修复（`docs/graph.html`）

- 「加载即进入 3D」的双触发（`simulation end` 与 2200ms 兜底）去重，避免二次以 `force:true` 重入 `show()`、徒增 `graphData` 重排与 pause/resume 抢跑风险。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] headful（DISPLAY:1 / Mesa GL）+ headless（swiftshader）puppeteer 复现并确认筛选逻辑正确：聚焦社区后 `1490 → 72 → 223 → 1490`，未命中节点直接隐藏。
- [x] GUI（computerUse）回归：硬刷新后 3D 不再黑屏、无 `tick` 报错。
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_detail_page.py`（通过；整库覆盖率门禁因单文件运行不计）。
- [x] ESLint `docs/graph-3d.js` 无错误；`node --check` 通过。
- [x] 未改动 wiki/导出链，无需 `make ci-preflight`。

## 验证截图与录屏

3D 视图下社区筛选演示（全量 1490 → 仅 72 → 仅 223 → 恢复全量，未命中节点被直接隐藏）：

[3d_view_filter_demo.mp4](https://cursor.com/agents/bc-de506db7-a6b7-4837-a8f7-85717730a1c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F3d_view_filter_demo.mp4)

[3D 全量 1490 节点](https://cursor.com/agents/bc-de506db7-a6b7-4837-a8f7-85717730a1c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F3d_filter_full_1490.png)
[筛选到人形 RL 运动控制 72 节点](https://cursor.com/agents/bc-de506db7-a6b7-4837-a8f7-85717730a1c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F3d_filter_72_nodes.png)
[筛选到 VLA 223 节点](https://cursor.com/agents/bc-de506db7-a6b7-4837-a8f7-85717730a1c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F3d_filter_223_nodes.png)

## 相关 Issue

无

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de506db7-a6b7-4837-a8f7-85717730a1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de506db7-a6b7-4837-a8f7-85717730a1c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

