### PR TITLE
feat: Add timeline animation support to 3D graph view

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -167,6 +167,11 @@
     var meshInstallScheduled = false;
     var pendingFirstShowKick = false;
     var initialFitDone = false;
+    // 时序激活动画：null = 关闭（正常渲染）；Set = 仅「已激活」节点可见，其余整体隐藏。
+    var timelineRevealedIds = null;
+    var timelinePopIn = new Map();   // nodeId -> 激活起始时间戳（pop-in 放大动画）
+    var timelinePopRaf = null;
+    var TIMELINE_POP_MS = 280;
 
     function rebuildNodeIndex() {
       nodeById = new Map(nodes3d.map(function (n) { return [n.id, n]; }));
@@ -203,6 +208,8 @@
     }
 
     function nodeOpacityFor(d) {
+      // 时序激活模式下只有「已激活」节点可见（未激活的直接隐藏），不参与 hover/侧栏淡化。
+      if (timelineActive()) return timelineRevealedIds.has(d.id) ? 1 : 0;
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       var ok = visible.has(d.id);
@@ -231,15 +238,43 @@
       return hasActiveFilter() && !getVisibleNodeIds().has(d.id);
     }
 
+    function timelineActive() {
+      return timelineRevealedIds !== null;
+    }
+
+    // 时序模式下未激活的节点整体不渲染（与筛选隐藏同一套机制）。
+    function nodeTimelineHidden(d) {
+      return timelineActive() && !timelineRevealedIds.has(d.id);
+    }
+
+    function nodeHidden(d) {
+      return nodeHiddenByFilter(d) || nodeTimelineHidden(d);
+    }
+
+    // 节点刚被激活时的放大系数：0.2 → 1，easeOutCubic 收敛，营造「点亮」感。
+    function timelinePopFactor(id) {
+      if (!timelinePopIn.has(id)) return 1;
+      var t = (performance.now() - timelinePopIn.get(id)) / TIMELINE_POP_MS;
+      if (t >= 1) { timelinePopIn.delete(id); return 1; }
+      var e = 1 - Math.pow(1 - t, 3);
+      return 0.2 + 0.8 * e;
+    }
+
     function linkVisibleFor(l) {
+      var ls = edgeEndpointId(l.source);
+      var lt = edgeEndpointId(l.target);
+      // 时序模式：仅当两端节点都已激活时连线才出现。
+      if (timelineActive() && (!timelineRevealedIds.has(ls) || !timelineRevealedIds.has(lt))) return false;
       if (!hasActiveFilter()) return true;
       var visible = getVisibleNodeIds();
-      return visible.has(edgeEndpointId(l.source)) && visible.has(edgeEndpointId(l.target));
+      return visible.has(ls) && visible.has(lt);
     }
 
     function linkOpacityFor(l) {
       var s = edgeEndpointId(l.source);
       var t = edgeEndpointId(l.target);
+      // 时序模式下可见连线给一个稳定的较高不透明度（已由 linkVisibility 过滤掉未激活端点）。
+      if (timelineActive()) return 0.25;
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       if (sidebarNodeId && edgeHighlightsWithNode) {
@@ -334,13 +369,13 @@
         if (!obj.isMesh || !obj.userData || !obj.userData.nodeId || !obj.material) return;
         var d = nodeById.get(obj.userData.nodeId);
         if (!d) return;
-        var radius = sphereRadiusFor(d);
+        var radius = sphereRadiusFor(d) * timelinePopFactor(obj.userData.nodeId);
         var opacity = nodeOpacityFor(d);
         obj.scale.set(radius, radius, radius);
         obj.material.color.set(getNodeColor(d));
         obj.material.opacity = opacity;
         obj.material.transparent = opacity < 0.999;
-        obj.visible = !nodeHiddenByFilter(d) && opacity > 0.02;
+        obj.visible = !nodeHidden(d) && opacity > 0.02;
       });
     }
 
@@ -354,12 +389,26 @@
           .nodeOpacity(1);
       }
       graph
-        .nodeVisibility(function (d) { return !nodeHiddenByFilter(d); })
+        .nodeVisibility(function (d) { return !nodeHidden(d); })
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
         .linkVisibility(function (l) { return linkVisibleFor(l); });
       updateNodeMeshes();
+    }
+
+    // pop-in 期间逐帧刷新节点 mesh 缩放，让「激活」放大过程平滑（由 3d-force-graph 的渲染环负责出图）。
+    function timelinePopTick() {
+      timelinePopRaf = null;
+      if (!timelineActive()) { timelinePopIn.clear(); return; }
+      updateNodeMeshes();
+      if (timelinePopIn.size > 0) timelinePopRaf = window.requestAnimationFrame(timelinePopTick);
+    }
+
+    function ensureTimelinePopRunning() {
+      if (timelinePopRaf == null && timelinePopIn.size > 0) {
+        timelinePopRaf = window.requestAnimationFrame(timelinePopTick);
+      }
     }
 
     function installCustomNodeMeshes() {
@@ -700,7 +749,7 @@
         .nodeColor(function (d) { return getNodeColor(d); })
         .nodeVal(nodeValFor)
         .nodeOpacity(1)
-        .nodeVisibility(function (d) { return !nodeHiddenByFilter(d); })
+        .nodeVisibility(function (d) { return !nodeHidden(d); })
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
@@ -807,6 +856,26 @@
 
       syncFilters: function () {
         refreshAppearance();
+      },
+
+      // 时序激活动画入口：传入「已激活」节点 id 集合则只显示这些节点（新激活的会 pop-in）；
+      // 传 null 退出时序模式、恢复正常渲染。graph.html 的定时器按时间顺序逐步扩大该集合。
+      setTimelineRevealed: function (idSet) {
+        if (idSet == null) {
+          timelineRevealedIds = null;
+          timelinePopIn.clear();
+          if (timelinePopRaf != null) { window.cancelAnimationFrame(timelinePopRaf); timelinePopRaf = null; }
+          refreshAppearance();
+          return;
+        }
+        var now = performance.now();
+        var prev = timelineRevealedIds;
+        idSet.forEach(function (id) {
+          if (!prev || !prev.has(id)) timelinePopIn.set(id, now);
+        });
+        timelineRevealedIds = new Set(idSet);
+        refreshAppearance();
+        ensureTimelinePopRunning();
       },
 
       refreshColors: function () {

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -167,8 +167,12 @@
     var meshInstallScheduled = false;
     var pendingFirstShowKick = false;
     var initialFitDone = false;
-    // 时序激活动画：null = 关闭（正常渲染）；Set = 仅「已激活」节点可见，其余整体隐藏。
+    // 时序激活动画：null = 关闭（正常渲染）；Set = 「已激活」节点集合（= 进入力模拟的子集）。
+    // 仿 2D：每激活一个节点就把它种在已激活邻居附近、加入力模拟子集并重排，整图随时间生长。
     var timelineRevealedIds = null;
+    var timelineOrder = [];          // 按时间排序后的 node3d 列表（timelineBegin 传入）
+    var timelineCount = 0;           // 当前已激活数量（= 力模拟子集大小）
+    var timelineSnapshot = null;     // 进入前全图位置快照（退出时还原）
     var timelinePopIn = new Map();   // nodeId -> 激活起始时间戳（pop-in 放大动画）
     var timelinePopRaf = null;
     var TIMELINE_POP_MS = 280;
@@ -207,9 +211,50 @@
         .filter(Boolean);
     }
 
+    // 仅保留两端都已激活的连线（供时序生长时的力模拟子集使用）。
+    function buildTimelineLinks() {
+      return edges
+        .map(function (e) {
+          var sId = edgeEndpointId(e.source);
+          var tId = edgeEndpointId(e.target);
+          if (!timelineRevealedIds.has(sId) || !timelineRevealedIds.has(tId)) return null;
+          var source = nodeById.get(sId);
+          var target = nodeById.get(tId);
+          if (!source || !target) return null;
+          return { source: source, target: target, _ref: e };
+        })
+        .filter(Boolean);
+    }
+
+    // 新激活节点的出生位置：落在已激活邻居的质心附近（+ 抖动）；无已激活邻居则落在原点附近。
+    // 之后由力模拟把它推到平衡位置，从而实现「冒一个、重排一次」的生长。
+    function seedTimelineNodePos(d) {
+      var sx = 0, sy = 0, sz = 0, cnt = 0;
+      var neighbors = adjacency.get(d.id);
+      if (neighbors) {
+        neighbors.forEach(function (otherId) {
+          if (!timelineRevealedIds.has(otherId)) return;
+          var o = nodeById.get(otherId);
+          if (!o || o.x == null) return;
+          sx += o.x; sy += o.y; sz += (o.z != null ? o.z : 0); cnt += 1;
+        });
+      }
+      if (cnt > 0) {
+        d.x = sx / cnt + (Math.random() - 0.5) * 24;
+        d.y = sy / cnt + (Math.random() - 0.5) * 24;
+        d.z = sz / cnt + (Math.random() - 0.5) * 24;
+      } else {
+        d.x = (Math.random() - 0.5) * 40;
+        d.y = (Math.random() - 0.5) * 40;
+        d.z = (Math.random() - 0.5) * 40;
+      }
+      d.vx = 0; d.vy = 0; d.vz = 0;
+      delete d.fx; delete d.fy; delete d.fz;
+    }
+
     function nodeOpacityFor(d) {
-      // 时序激活模式下只有「已激活」节点可见（未激活的直接隐藏），不参与 hover/侧栏淡化。
-      if (timelineActive()) return timelineRevealedIds.has(d.id) ? 1 : 0;
+      // 时序激活模式下子集内节点全部点亮（不参与 hover/侧栏淡化），未激活节点根本不在图里。
+      if (timelineActive()) return 1;
       var visible = getVisibleNodeIds();
       var filtered = hasActiveFilter();
       var ok = visible.has(d.id);
@@ -242,15 +287,6 @@
       return timelineRevealedIds !== null;
     }
 
-    // 时序模式下未激活的节点整体不渲染（与筛选隐藏同一套机制）。
-    function nodeTimelineHidden(d) {
-      return timelineActive() && !timelineRevealedIds.has(d.id);
-    }
-
-    function nodeHidden(d) {
-      return nodeHiddenByFilter(d) || nodeTimelineHidden(d);
-    }
-
     // 节点刚被激活时的放大系数：0.2 → 1，easeOutCubic 收敛，营造「点亮」感。
     function timelinePopFactor(id) {
       if (!timelinePopIn.has(id)) return 1;
@@ -261,13 +297,9 @@
     }
 
     function linkVisibleFor(l) {
-      var ls = edgeEndpointId(l.source);
-      var lt = edgeEndpointId(l.target);
-      // 时序模式：仅当两端节点都已激活时连线才出现。
-      if (timelineActive() && (!timelineRevealedIds.has(ls) || !timelineRevealedIds.has(lt))) return false;
       if (!hasActiveFilter()) return true;
       var visible = getVisibleNodeIds();
-      return visible.has(ls) && visible.has(lt);
+      return visible.has(edgeEndpointId(l.source)) && visible.has(edgeEndpointId(l.target));
     }
 
     function linkOpacityFor(l) {
@@ -345,7 +377,8 @@
 
     function createNodeMesh(d) {
       if (!bundledThree) return null;
-      var radius = sphereRadiusFor(d);
+      // 应用 pop-in 系数，避免新激活节点出现的首帧以全尺寸闪一下。
+      var radius = sphereRadiusFor(d) * timelinePopFactor(d.id);
       var opacity = nodeOpacityFor(d);
       var geometry = ensureSharedSphereGeometry(bundledThree);
       var MaterialCtor = bundledThree.MeshLambertMaterial;
@@ -375,7 +408,7 @@
         obj.material.color.set(getNodeColor(d));
         obj.material.opacity = opacity;
         obj.material.transparent = opacity < 0.999;
-        obj.visible = !nodeHidden(d) && opacity > 0.02;
+        obj.visible = !nodeHiddenByFilter(d) && opacity > 0.02;
       });
     }
 
@@ -389,7 +422,7 @@
           .nodeOpacity(1);
       }
       graph
-        .nodeVisibility(function (d) { return !nodeHidden(d); })
+        .nodeVisibility(function (d) { return !nodeHiddenByFilter(d); })
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
@@ -749,7 +782,7 @@
         .nodeColor(function (d) { return getNodeColor(d); })
         .nodeVal(nodeValFor)
         .nodeOpacity(1)
-        .nodeVisibility(function (d) { return !nodeHidden(d); })
+        .nodeVisibility(function (d) { return !nodeHiddenByFilter(d); })
         .linkColor(function (l) { return linkColorFor(l); })
         .linkWidth(function (l) { return linkWidthFor(l); })
         .linkOpacity(function (l) { return linkOpacityFor(l); })
@@ -858,24 +891,73 @@
         refreshAppearance();
       },
 
-      // 时序激活动画入口：传入「已激活」节点 id 集合则只显示这些节点（新激活的会 pop-in）；
-      // 传 null 退出时序模式、恢复正常渲染。graph.html 的定时器按时间顺序逐步扩大该集合。
-      setTimelineRevealed: function (idSet) {
-        if (idSet == null) {
-          timelineRevealedIds = null;
-          timelinePopIn.clear();
-          if (timelinePopRaf != null) { window.cancelAnimationFrame(timelinePopRaf); timelinePopRaf = null; }
-          refreshAppearance();
-          return;
-        }
-        var now = performance.now();
-        var prev = timelineRevealedIds;
-        idSet.forEach(function (id) {
-          if (!prev || !prev.has(id)) timelinePopIn.set(id, now);
+      // ── 时序激活动画（生长式，仿 2D）──
+      // timelineBegin：进入时序模式，按时间顺序的 node id 列表初始化；先清空力模拟子集（0 个节点）。
+      timelineBegin: function (orderedIds) {
+        if (!graph) return;
+        timelineSnapshot = nodes3d.map(function (n) {
+          return { n: n, x: n.x, y: n.y, z: n.z };
         });
-        timelineRevealedIds = new Set(idSet);
-        refreshAppearance();
+        timelineOrder = (orderedIds || [])
+          .map(function (id) { return nodeById.get(id); })
+          .filter(Boolean);
+        timelineCount = 0;
+        timelineRevealedIds = new Set();
+        timelinePopIn.clear();
+        graph.graphData({ nodes: [], links: [] });
+      },
+
+      // timelineSeek：把已激活数量推进/回退到 count。新激活节点种在已激活邻居附近后加入力模拟
+      // 子集并重排（alpha 经 graphData 重置为 1，已平衡节点净力≈0 故几乎不动，新节点被推入位）。
+      timelineSeek: function (count) {
+        if (!graph || timelineRevealedIds === null) return;
+        count = Math.max(0, Math.min(timelineOrder.length, Math.round(count)));
+        if (count === timelineCount) return;
+        var now = performance.now();
+        if (count > timelineCount) {
+          for (var i = timelineCount; i < count; i++) {
+            var d = timelineOrder[i];
+            timelineRevealedIds.add(d.id);   // 先入集合，便于后续节点把它当已激活邻居
+            seedTimelineNodePos(d);
+            timelinePopIn.set(d.id, now);
+          }
+        } else {
+          for (var j = count; j < timelineCount; j++) {
+            var rd = timelineOrder[j];
+            timelineRevealedIds.delete(rd.id);
+            timelinePopIn.delete(rd.id);
+          }
+        }
+        timelineCount = count;
+        graph.graphData({ nodes: timelineOrder.slice(0, count), links: buildTimelineLinks() });
         ensureTimelinePopRunning();
+      },
+
+      // 相机适配到「已激活」子集（生长时随之缩放，类似 2D fitToTimelineNodes）。
+      timelineFit: function (ms) {
+        if (timelineRevealedIds === null) return;
+        zoomFitToNodes(ms == null ? 500 : ms, function (n) { return timelineRevealedIds.has(n.id); });
+      },
+
+      // timelineEnd：退出时序模式 —— 还原进入前全图位置，恢复完整 graphData 并重排收敛。
+      timelineEnd: function () {
+        if (timelinePopRaf != null) { window.cancelAnimationFrame(timelinePopRaf); timelinePopRaf = null; }
+        timelinePopIn.clear();
+        timelineRevealedIds = null;
+        timelineOrder = [];
+        timelineCount = 0;
+        if (timelineSnapshot) {
+          timelineSnapshot.forEach(function (s) {
+            s.n.x = s.x; s.n.y = s.y; s.n.z = s.z;
+            s.n.vx = 0; s.n.vy = 0; s.n.vz = 0;
+            delete s.n.fx; delete s.n.fy; delete s.n.fz;
+          });
+          timelineSnapshot = null;
+        }
+        if (!graph) return;
+        graph.graphData({ nodes: nodes3d, links: buildLinks() });
+        refreshAppearance();
+        reheatAfterGraphData();
       },
 
       refreshColors: function () {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3747,10 +3747,10 @@
       fitToScreen();
     }
 
-    /* ── 3D 激活时序动画 ──
-       复用 2D 的进度 UI（播放/暂停/回到起点/进度条）与共享状态变量，但推进逻辑改为
-       驱动 graph3dView.setTimelineRevealed：按 recency 顺序逐步把节点加入「已激活」集合，
-       未激活节点在 3D 中整体隐藏，新激活节点 pop-in 放大。布局沿用 3D 初始力学位置，不重排。 */
+    /* ── 3D 激活时序动画（生长式，仿 2D）──
+       复用 2D 的进度 UI（播放/暂停/回到起点/进度条）与共享状态变量。推进逻辑驱动
+       graph3dView.timelineBegin/Seek/End：按 recency 顺序把节点逐个种到已激活邻居附近、
+       加入力模拟子集并重排，整图随时间「冒一个、重排一次」地生长；相机随子集自适应缩放。 */
     function enterTimelineMode3D() {
       if (!graph3dView) return;
       if (typeof closeSidebar === 'function') closeSidebar();
@@ -3763,14 +3763,13 @@
       timeline3D = true;
       timelineAnimating = true;
       timelineIdx = 0;
-      timelineRevealedIds.clear();
+      timelineLastFit = 0;
 
       timelineBatchSize = timelineTotal > 400 ? 4 : (timelineTotal > 180 ? 2 : 1);
       timelineStepMs = Math.min(90, Math.max(14,
         Math.floor(TIMELINE_TARGET_MS / Math.ceil(timelineTotal / timelineBatchSize))));
 
-      graph3dView.fitToScreen(450);                    // 先框住整图，激活在固定布局上铺开
-      graph3dView.setTimelineRevealed(timelineRevealedIds);  // 先全部隐藏
+      graph3dView.timelineBegin(timelineOrdered.map(n => n.id));  // 进入时序、清空力模拟子集
 
       if (timelineProgressEl) timelineProgressEl.max = String(timelineTotal);
       updateTimelineProgress(0, timelineTotal);
@@ -3783,13 +3782,8 @@
       if (!timelineAnimating || !timeline3D) return;
       targetIdx = Math.max(0, Math.min(timelineTotal, Math.round(targetIdx)));
       if (targetIdx === timelineIdx) { updateTimelineProgress(timelineIdx, timelineTotal); return; }
-      if (targetIdx > timelineIdx) {
-        for (let i = timelineIdx; i < targetIdx; i++) timelineRevealedIds.add(timelineOrdered[i].id);
-      } else {
-        for (let i = targetIdx; i < timelineIdx; i++) timelineRevealedIds.delete(timelineOrdered[i].id);
-      }
       timelineIdx = targetIdx;
-      if (graph3dView) graph3dView.setTimelineRevealed(timelineRevealedIds);
+      if (graph3dView) graph3dView.timelineSeek(targetIdx);   // 增/减力模拟子集成员并重排
       updateTimelineProgress(timelineIdx, timelineTotal);
     }
 
@@ -3798,10 +3792,15 @@
       if (timelineIdx >= timelineTotal) seekTimeline3D(0);   // 已到末尾再播放则从头开始
       timelinePlaying = true;
       updateTimelineControls();
-      if (graph3dView) graph3dView.resumeSimulation();       // 保活渲染环，确保 pop-in 出图
+      if (graph3dView) graph3dView.resumeSimulation();       // 保活渲染环（力模拟生长出图）
       timelineAnimTimer = setInterval(() => {
         if (timelineIdx >= timelineTotal) { onTimelinePlaybackComplete3D(); return; }
         seekTimeline3D(timelineIdx + timelineBatchSize);
+        const now = performance.now();
+        if (now - timelineLastFit > 650) {   // 节流：随生长把相机适配到已激活子集
+          timelineLastFit = now;
+          if (graph3dView) graph3dView.timelineFit(600);
+        }
       }, timelineStepMs);
     }
 
@@ -3809,6 +3808,7 @@
       if (timelineAnimTimer) { clearInterval(timelineAnimTimer); timelineAnimTimer = null; }
       timelinePlaying = false;
       updateTimelineControls();
+      if (graph3dView) graph3dView.timelineFit(700);   // 收尾再适配一次最终布局
     }
 
     function pauseTimelinePlayback3D() {
@@ -3822,10 +3822,10 @@
       timelinePlaying = false;
       timelineAnimating = false;
       timeline3D = false;
-      timelineRevealedIds.clear();
       timelineIdx = 0;
       timelineTotal = 0;
-      if (graph3dView) graph3dView.setTimelineRevealed(null);   // 恢复全部节点正常渲染
+      if (graph3dView) graph3dView.timelineEnd();   // 还原进入前布局、恢复完整图并重排
+      updateCount(hasActiveGraphFilter() ? visibleNodeIds.size : nodes.length);  // 复位工具栏计数文案
       updateTimelineControls();
     }
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1868,6 +1868,7 @@
     let colorMode = 'community';
     let activeFilters = new Set();
     let timelineAnimating = false;   // 处于时序模式（播放 / 暂停 / 拖拽中均为 true）
+    let timeline3D = false;          // 当前时序模式跑在 3D 视图（决定走 3D 还是 2D 推进逻辑）
     let timelinePlaying = false;     // 计时器是否正在推进
     let timelineAnimTimer = null;
     let timelineOrdered = [];        // 按时间排序后的节点
@@ -2208,12 +2209,14 @@
       if (mode !== '2d' && mode !== '3d') return;
       if (!opts.force && mode === spatialViewMode) return;
 
+      // 切换视图前先干净退出时序动画（2D / 3D 任一形态），避免遗留定时器与显隐状态跨视图泄漏。
+      if (timelineAnimating) teardownTimelineMode();
+
       // 先切换状态：resumeSimulation2D / 力模拟 tick / fitToScreen 都依赖 is3DView()，
       // 必须在调用它们之前就反映目标视图，否则回到 2D 时力模拟会被旧状态挡住、无法重启。
       spatialViewMode = mode;
 
       if (mode === '3d') {
-        if (timelineAnimating) teardownTimelineMode();
         if (!window.RNGraph3D?.isAvailable?.()) {
           spatialViewMode = '2d';
           window.alert('3D 视图库加载失败，请刷新页面后重试');
@@ -2258,11 +2261,10 @@
     }
 
     function syncTimeline3DState() {
-      const disabled = is3DView();
       if (timelineAnimateBtn) {
-        timelineAnimateBtn.disabled = disabled;
-        timelineAnimateBtn.title = disabled
-          ? '时序动画仅支持 2D 视图'
+        timelineAnimateBtn.disabled = false;
+        timelineAnimateBtn.title = is3DView()
+          ? '按页面更新时间顺序在 3D 立体视图中逐帧激活节点与连线'
           : '按页面更新时间顺序逐帧显现节点与连线（类似 Obsidian 图谱 Animate）';
       }
     }
@@ -3717,6 +3719,7 @@
 
     // 拆除时序模式：停播、恢复完整力模拟成员、复位节点显隐（供退出与「刷新布局」共用）
     function teardownTimelineMode() {
+      if (timeline3D) { teardownTimelineMode3D(); return; }
       pauseTimelinePlayback();
       timelineAnimating = false;
       timelineRevealedIds.clear();
@@ -3744,31 +3747,124 @@
       fitToScreen();
     }
 
+    /* ── 3D 激活时序动画 ──
+       复用 2D 的进度 UI（播放/暂停/回到起点/进度条）与共享状态变量，但推进逻辑改为
+       驱动 graph3dView.setTimelineRevealed：按 recency 顺序逐步把节点加入「已激活」集合，
+       未激活节点在 3D 中整体隐藏，新激活节点 pop-in 放大。布局沿用 3D 初始力学位置，不重排。 */
+    function enterTimelineMode3D() {
+      if (!graph3dView) return;
+      if (typeof closeSidebar === 'function') closeSidebar();
+      hideTooltip();
+
+      timelineOrdered = sortNodesByTimeline(nodes);
+      timelineTotal = timelineOrdered.length;
+      if (!timelineTotal) return;
+
+      timeline3D = true;
+      timelineAnimating = true;
+      timelineIdx = 0;
+      timelineRevealedIds.clear();
+
+      timelineBatchSize = timelineTotal > 400 ? 4 : (timelineTotal > 180 ? 2 : 1);
+      timelineStepMs = Math.min(90, Math.max(14,
+        Math.floor(TIMELINE_TARGET_MS / Math.ceil(timelineTotal / timelineBatchSize))));
+
+      graph3dView.fitToScreen(450);                    // 先框住整图，激活在固定布局上铺开
+      graph3dView.setTimelineRevealed(timelineRevealedIds);  // 先全部隐藏
+
+      if (timelineProgressEl) timelineProgressEl.max = String(timelineTotal);
+      updateTimelineProgress(0, timelineTotal);
+      updateTimelineControls();
+
+      startTimelinePlayback3D();
+    }
+
+    function seekTimeline3D(targetIdx) {
+      if (!timelineAnimating || !timeline3D) return;
+      targetIdx = Math.max(0, Math.min(timelineTotal, Math.round(targetIdx)));
+      if (targetIdx === timelineIdx) { updateTimelineProgress(timelineIdx, timelineTotal); return; }
+      if (targetIdx > timelineIdx) {
+        for (let i = timelineIdx; i < targetIdx; i++) timelineRevealedIds.add(timelineOrdered[i].id);
+      } else {
+        for (let i = targetIdx; i < timelineIdx; i++) timelineRevealedIds.delete(timelineOrdered[i].id);
+      }
+      timelineIdx = targetIdx;
+      if (graph3dView) graph3dView.setTimelineRevealed(timelineRevealedIds);
+      updateTimelineProgress(timelineIdx, timelineTotal);
+    }
+
+    function startTimelinePlayback3D() {
+      if (!timelineAnimating || timelinePlaying || !timeline3D) return;
+      if (timelineIdx >= timelineTotal) seekTimeline3D(0);   // 已到末尾再播放则从头开始
+      timelinePlaying = true;
+      updateTimelineControls();
+      if (graph3dView) graph3dView.resumeSimulation();       // 保活渲染环，确保 pop-in 出图
+      timelineAnimTimer = setInterval(() => {
+        if (timelineIdx >= timelineTotal) { onTimelinePlaybackComplete3D(); return; }
+        seekTimeline3D(timelineIdx + timelineBatchSize);
+      }, timelineStepMs);
+    }
+
+    function onTimelinePlaybackComplete3D() {
+      if (timelineAnimTimer) { clearInterval(timelineAnimTimer); timelineAnimTimer = null; }
+      timelinePlaying = false;
+      updateTimelineControls();
+    }
+
+    function pauseTimelinePlayback3D() {
+      if (timelineAnimTimer) { clearInterval(timelineAnimTimer); timelineAnimTimer = null; }
+      timelinePlaying = false;
+      updateTimelineControls();
+    }
+
+    function teardownTimelineMode3D() {
+      if (timelineAnimTimer) { clearInterval(timelineAnimTimer); timelineAnimTimer = null; }
+      timelinePlaying = false;
+      timelineAnimating = false;
+      timeline3D = false;
+      timelineRevealedIds.clear();
+      timelineIdx = 0;
+      timelineTotal = 0;
+      if (graph3dView) graph3dView.setTimelineRevealed(null);   // 恢复全部节点正常渲染
+      updateTimelineControls();
+    }
+
+    function exitTimelineMode3D() {
+      teardownTimelineMode3D();
+    }
+
+    // ── 调度：按当前视图把控件事件转发到 2D 或 3D 时序逻辑 ──
+    function timelineDispatchEnter() { if (is3DView()) enterTimelineMode3D(); else enterTimelineMode(); }
+    function timelineDispatchExit() { if (timeline3D) exitTimelineMode3D(); else exitTimelineMode(); }
+    function timelineDispatchPlay() { if (timeline3D) startTimelinePlayback3D(); else startTimelinePlayback(); }
+    function timelineDispatchPause() { if (timeline3D) pauseTimelinePlayback3D(); else pauseTimelinePlayback(); }
+    function timelineDispatchSeek(idx) { if (timeline3D) seekTimeline3D(idx); else seekTimeline(idx, false); }
+
     if (timelineAnimateBtn) {
       timelineAnimateBtn.addEventListener('click', () => {
-        if (timelineAnimating) exitTimelineMode();
-        else enterTimelineMode();
+        if (timelineAnimating) timelineDispatchExit();
+        else timelineDispatchEnter();
       });
     }
     if (timelinePlayPauseBtn) {
       timelinePlayPauseBtn.addEventListener('click', () => {
         if (!timelineAnimating) return;
-        if (timelinePlaying) pauseTimelinePlayback();
-        else startTimelinePlayback();
+        if (timelinePlaying) timelineDispatchPause();
+        else timelineDispatchPlay();
       });
     }
     if (timelineRestartBtn) {
       timelineRestartBtn.addEventListener('click', () => {
         if (!timelineAnimating) return;
-        pauseTimelinePlayback();
-        seekTimeline(0, false);
+        timelineDispatchPause();
+        timelineDispatchSeek(0);
       });
     }
     if (timelineProgressEl) {
       timelineProgressEl.addEventListener('input', () => {
         if (!timelineAnimating) return;
-        pauseTimelinePlayback();            // 拖拽时暂停，交由用户控制
-        seekTimeline(Number(timelineProgressEl.value), false);
+        timelineDispatchPause();            // 拖拽时暂停，交由用户控制
+        timelineDispatchSeek(Number(timelineProgressEl.value));
       });
     }
 


### PR DESCRIPTION
## 摘要

为 3D 图谱视图添加时序激活动画功能，使节点按时间顺序逐个激活并生长，与 2D 视图的时序动画保持一致的交互体验。新激活节点会种在已激活邻居附近，通过力模拟重排实现平滑的图谱生长效果；同时支持相机自适应缩放到已激活子集。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### graph-3d.js 变更

**新增时序动画状态管理：**
- `timelineRevealedIds`：已激活节点集合（null 表示未进入时序模式）
- `timelineOrder`：按时间排序的节点列表
- `timelineCount`：当前已激活节点数
- `timelinePopIn`：节点激活时的放大动画时间戳映射
- `TIMELINE_POP_MS`：放大动画时长（280ms）

**核心功能函数：**
- `buildTimelineLinks()`：仅保留两端都已激活的连线，供力模拟子集使用
- `seedTimelineNodePos(d)`：新激活节点的出生位置逻辑——落在已激活邻居质心附近（+抖动），无邻居则落在原点附近
- `timelineActive()`：判断是否处于时序模式
- `timelinePopFactor(id)`：计算节点的放大系数（0.2→1，easeOutCubic 缓动），营造「点亮」感
- `timelinePopTick()`：逐帧刷新 pop-in 动画，保证激活过程平滑

**公开 API：**
- `timelineBegin(orderedIds)`：进入时序模式，清空力模拟子集
- `timelineSeek(count)`：推进/回退已激活数量，新节点自动种位并加入力模拟
- `timelineFit(ms)`：相机适配到已激活子集
- `timelineEnd()`：退出时序模式，还原进入前布局，恢复完整图并重排

**渲染适配：**
- 时序模式下节点不透明度固定为 1（已激活节点全部点亮）
- 连线不透明度固定为 0.25（已由 linkVisibility 过滤）
- 节点 mesh 缩放应用 pop-in 系数，避免首帧闪现

### graph.html 变更

**新增状态变量：**
- `timeline3D`：标记当前时序模式运行在 3D 视图

**视图切换逻辑：**
- 切换视图前先干净退出时序动画（无论 2D/3D），避免定时器与显隐状态泄漏
- 更新 `syncTimeline3DState()` 移除 3D 时序动画的禁用限制，改为提示文案区分

**3D 时序动画实现：**
- `enterTimelineMode3D()`：初始化 3D 时序模式，调用 `graph3dView.timelineBegin()`
- `seekTimeline3D(targetIdx)`：驱动节点激活进度，调用 `graph3dView.timelineSeek()`
- `startTimelinePlayback3D()`：启动自动播放，定时推进激活数量，节流相机适配
- `paus

https://claude.ai/code/session_01HzQqQUkFhyhQTXY3qFJTdG