### PR TITLE
fix(ux): 加载页在构图渲染后即关闭，力布局不再计入进度

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -507,9 +507,72 @@
       }
     }
 
-    /* 加载状态仅由工具栏 #graph-node-count 提示，不遮挡画布 */
+    /* ── 加载页：2D / 3D 图就绪前覆盖画布，带进度条 ── */
     #graph-loading {
-      display: none !important;
+      position: absolute;
+      inset: 0;
+      z-index: 5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background:
+        radial-gradient(circle at 20% 20%, rgba(96,165,250,.06) 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, rgba(52,211,153,.06) 0%, transparent 50%),
+        #0d1117;
+      opacity: 1;
+      transition: opacity .45s ease;
+    }
+    #graph-loading[hidden] { display: none !important; }
+    #graph-loading.is-hidden { opacity: 0; pointer-events: none; }
+    .graph-loading-inner {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+      width: min(320px, 72vw);
+      text-align: center;
+    }
+    .graph-loading-spinner {
+      width: 38px;
+      height: 38px;
+      border-radius: 50%;
+      border: 3px solid rgba(255,255,255,0.12);
+      border-top-color: #00d4ff;
+      animation: graph-loading-spin .8s linear infinite;
+    }
+    @keyframes graph-loading-spin { to { transform: rotate(360deg); } }
+    .graph-loading-title {
+      font-size: .92rem;
+      font-weight: 600;
+      color: #e6edf3;
+      letter-spacing: .02em;
+    }
+    .graph-loading-bar {
+      width: 100%;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.1);
+      overflow: hidden;
+    }
+    .graph-loading-bar-fill {
+      width: 0%;
+      height: 100%;
+      border-radius: 999px;
+      background: linear-gradient(90deg, #60a5fa, #34d399);
+      transition: width .3s ease;
+    }
+    .graph-loading-pct {
+      font-size: .8rem;
+      color: rgba(255,255,255,0.55);
+      font-variant-numeric: tabular-nums;
+    }
+    #graph-loading.is-error .graph-loading-spinner {
+      animation: none;
+      border-color: rgba(248,113,113,0.3);
+      border-top-color: #f87171;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .graph-loading-spinner { animation-duration: 1.8s; }
     }
 
     /* ── 移动端优化 ── */
@@ -680,6 +743,20 @@
     [data-theme="light"] #graph-wrap::before {
       background-image: radial-gradient(circle, rgba(0,0,0,.06) 1px, transparent 1px);
     }
+    /* 加载页（浅色主题） */
+    [data-theme="light"] #graph-loading {
+      background:
+        radial-gradient(circle at 20% 20%, rgba(96,165,250,.09) 0%, transparent 50%),
+        radial-gradient(circle at 80% 80%, rgba(52,211,153,.09) 0%, transparent 50%),
+        #eef2f7;
+    }
+    [data-theme="light"] .graph-loading-title { color: #2f2d29; }
+    [data-theme="light"] .graph-loading-spinner {
+      border-color: rgba(0,0,0,0.12);
+      border-top-color: #2563eb;
+    }
+    [data-theme="light"] .graph-loading-bar { background: rgba(0,0,0,0.1); }
+    [data-theme="light"] .graph-loading-pct { color: rgba(0,0,0,0.45); }
     /* Tooltip */
     [data-theme="light"] #graph-tooltip {
       background: rgba(255,255,255,0.98);
@@ -1545,7 +1622,14 @@
 
   <!-- ── 图谱容器 ── -->
   <div id="graph-wrap">
-    <div id="graph-loading" hidden aria-hidden="true"></div>
+    <div id="graph-loading" role="status" aria-live="polite">
+      <div class="graph-loading-inner">
+        <div class="graph-loading-spinner" aria-hidden="true"></div>
+        <div class="graph-loading-title" id="graph-loading-title">知识图谱加载中…</div>
+        <div class="graph-loading-bar"><div class="graph-loading-bar-fill" id="graph-loading-fill"></div></div>
+        <div class="graph-loading-pct" id="graph-loading-pct">0%</div>
+      </div>
+    </div>
     <svg id="graph-canvas"></svg>
     <div id="graph-canvas-3d" hidden aria-label="3D 知识图谱"></div>
     <div id="graph-tooltip" class="hidden" role="tooltip"></div>
@@ -2384,21 +2468,87 @@
       }
     }
 
+    /* ── 加载页进度控制 ──
+       下载数据(5→78%) → 解析(→80%) → 构图渲染/力布局展开(88→99%) → 就绪(100%)，逐段推进。 */
+    const loadingEl    = document.getElementById('graph-loading');
+    const loadingFill  = document.getElementById('graph-loading-fill');
+    const loadingPct   = document.getElementById('graph-loading-pct');
+    const loadingTitle = document.getElementById('graph-loading-title');
+    let loadingValue = 0;
+    let loadingDone  = false;
+
+    function setLoadingProgress(pct) {
+      if (loadingDone) return;
+      pct = Math.max(loadingValue, Math.min(99, pct));  // 单调递增、封顶 99，完成时才到 100
+      loadingValue = pct;
+      if (loadingFill) loadingFill.style.width = pct.toFixed(0) + '%';
+      if (loadingPct)  loadingPct.textContent = Math.round(pct) + '%';
+    }
+
+    function finishLoading() {
+      if (loadingDone) return;
+      loadingDone = true;
+      if (loadingFill) loadingFill.style.width = '100%';
+      if (loadingPct)  loadingPct.textContent = '100%';
+      if (loadingEl) {
+        loadingEl.classList.add('is-hidden');
+        setTimeout(() => { loadingEl.hidden = true; }, 500);
+      }
+    }
+
+    function failLoading(msg) {
+      if (loadingDone) return;
+      loadingDone = true;  // 停止后续进度推进
+      if (loadingEl) loadingEl.classList.add('is-error');
+      if (loadingTitle) loadingTitle.textContent = msg || '加载失败，请刷新页面重试';
+      if (loadingPct) loadingPct.textContent = '';
+    }
+
+    /* 流式读取以反映真实下载进度；无法读取流或缺少 Content-Length 时退化为一次性解析。 */
+    async function fetchJsonWithProgress(url, onProgress) {
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const total = Number(resp.headers.get('Content-Length')) || 0;
+      if (!resp.body || !resp.body.getReader || !total) return resp.json();
+      const reader = resp.body.getReader();
+      const chunks = [];
+      let received = 0;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        received += value.length;
+        if (onProgress) onProgress(Math.min(1, received / total));
+      }
+      let size = 0;
+      for (const c of chunks) size += c.length;
+      const merged = new Uint8Array(size);
+      let pos = 0;
+      for (const c of chunks) { merged.set(c, pos); pos += c.length; }
+      return JSON.parse(new TextDecoder('utf-8').decode(merged));
+    }
+
+    setLoadingProgress(5);
+
     /* ── 加载数据 ──
        仅首屏阻塞 link-graph.json（~570KB，含 summary）。
        index-v1.json（~3.4MB）懒加载，供节点侧栏的 tags / related / source_links 使用。 */
     let graphData;
     let indexItems = [];
     try {
-      graphData = await fetch('exports/link-graph.json').then(r => r.json());
+      graphData = await fetchJsonWithProgress('exports/link-graph.json', frac => {
+        setLoadingProgress(5 + frac * 73);   // 下载阶段（首屏主要耗时）：5% → 78%
+      });
     } catch (e) {
       const countEl = document.getElementById('graph-node-count');
       if (countEl) {
         countEl.textContent = '数据加载失败';
         countEl.title = e.message || '';
       }
+      failLoading('数据加载失败，请刷新页面重试');
       return;
     }
+    setLoadingProgress(80);   // 数据解析完成，进入构图渲染
     fetch('exports/index-v1.json')
       .then(r => r.json())
       .then(d => { indexItems = d.items || []; })
@@ -2790,6 +2940,7 @@
     function finishSimulationLoad() {
       node.select('.node-label').transition().duration(400).style('opacity', 0.85);
       whenGraphViewportReady(() => fitToScreen());
+      finishLoading();   // 力布局收敛 → 图就绪，关闭加载页
     }
 
     function restartForceSimulation() {
@@ -2810,6 +2961,16 @@
       if (is3DView()) return;
       syncGraphDomFromSimulation();
     });
+
+    /* 构图渲染 / 力布局展开阶段推进进度条：alpha 由 1 衰减，映射到 88% → 99%（2D / 3D 通用）。 */
+    simulation.on('tick.loading', () => {
+      if (loadingDone) return;
+      setLoadingProgress(88 + (1 - simulation.alpha()) * 11);
+    });
+
+    /* 加载页揭幕（2D）：数据与首屏渲染就绪、力布局展开约 1.2s 后揭幕。
+       大图完全收敛较慢，剩余收敛实时可见，无需一直遮挡画布。3D 由 enter3dWhenReady 关闭。 */
+    if (!is3DView()) setTimeout(() => finishLoading(), 1200);
 
     /* ── 布局稳定后标签渐显 ── */
     simulation.on('end', () => {
@@ -4394,7 +4555,9 @@
       const enter3dWhenReady = () => {
         if (entered3dOnLoad) return;
         entered3dOnLoad = true;
-        setSpatialViewMode('3d', { force: true });
+        // 即便 3D 初始化抛错（如无 WebGL），也必须关闭加载页，避免画布被永久遮挡。
+        try { setSpatialViewMode('3d', { force: true }); }
+        finally { finishLoading(); }
       };
       simulation.on('end.initial3d', () => {
         simulation.on('end.initial3d', null);

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2469,7 +2469,7 @@
     }
 
     /* ── 加载页进度控制 ──
-       下载数据(5→78%) → 解析(→80%) → 构图渲染/力布局展开(88→99%) → 就绪(100%)，逐段推进。 */
+       下载数据(5→78%) → 解析(→80%) → 构图渲染(→100%)；力布局在加载页关闭后于画布上继续展开。 */
     const loadingEl    = document.getElementById('graph-loading');
     const loadingFill  = document.getElementById('graph-loading-fill');
     const loadingPct   = document.getElementById('graph-loading-pct');
@@ -2770,6 +2770,7 @@
     }
 
     /* ── 渲染边 ── */
+    setLoadingProgress(88);   // 开始挂载节点/边 DOM
     const gEdges = gRoot.append('g').attr('class', 'edges');
     const link = gEdges.selectAll('line')
       .data(edges)
@@ -2826,6 +2827,24 @@
       .attr('fill', labelFill())
       .attr('pointer-events', 'none')
       .style('opacity', 0);
+
+    let entered3dOnLoad = false;
+    function enter3dOnLoadOnce() {
+      if (entered3dOnLoad) return;
+      entered3dOnLoad = true;
+      try { setSpatialViewMode('3d', { force: true }); }
+      catch (err) { console.error('3D graph init failed on load:', err); }
+    }
+
+    function finishGraphRenderLoad() {
+      finishLoading();
+      if (spatialViewMode === '3d') {
+        requestAnimationFrame(() => whenGraphViewportReady(enter3dOnLoadOnce));
+      }
+    }
+
+    syncGraphDomFromSimulation();
+    whenGraphViewportReady(() => finishGraphRenderLoad());
 
     function getFilterOptions() {
       if (colorMode === 'community') {
@@ -2940,7 +2959,6 @@
     function finishSimulationLoad() {
       node.select('.node-label').transition().duration(400).style('opacity', 0.85);
       whenGraphViewportReady(() => fitToScreen());
-      finishLoading();   // 力布局收敛 → 图就绪，关闭加载页
     }
 
     function restartForceSimulation() {
@@ -2961,16 +2979,6 @@
       if (is3DView()) return;
       syncGraphDomFromSimulation();
     });
-
-    /* 构图渲染 / 力布局展开阶段推进进度条：alpha 由 1 衰减，映射到 88% → 99%（2D / 3D 通用）。 */
-    simulation.on('tick.loading', () => {
-      if (loadingDone) return;
-      setLoadingProgress(88 + (1 - simulation.alpha()) * 11);
-    });
-
-    /* 加载页揭幕（2D）：数据与首屏渲染就绪、力布局展开约 1.2s 后揭幕。
-       大图完全收敛较慢，剩余收敛实时可见，无需一直遮挡画布。3D 由 enter3dWhenReady 关闭。 */
-    if (!is3DView()) setTimeout(() => finishLoading(), 1200);
 
     /* ── 布局稳定后标签渐显 ── */
     simulation.on('end', () => {
@@ -4545,25 +4553,6 @@
         simulation.on('end.focus', () => { flyToFocus(); simulation.on('end.focus', null); });
         setTimeout(flyToFocus, 1400);
       }
-    }
-
-    if (spatialViewMode === '3d') {
-      // 只进入一次：simulation 收敛(end.initial3d)与 2200ms 兜底都会触发，需去重，
-      // 否则二次以 force:true 重跑 setSpatialViewMode('3d') → show() 重入，徒增 graphData
-      // 重排与渲染环 pause/resume 抢跑风险。
-      let entered3dOnLoad = false;
-      const enter3dWhenReady = () => {
-        if (entered3dOnLoad) return;
-        entered3dOnLoad = true;
-        // 即便 3D 初始化抛错（如无 WebGL），也必须关闭加载页，避免画布被永久遮挡。
-        try { setSpatialViewMode('3d', { force: true }); }
-        finally { finishLoading(); }
-      };
-      simulation.on('end.initial3d', () => {
-        simulation.on('end.initial3d', null);
-        whenGraphViewportReady(enter3dWhenReady);
-      });
-      setTimeout(() => whenGraphViewportReady(enter3dWhenReady), 2200);
     }
 
   })();

--- a/scripts/verify_graph_loading_2d3d.cjs
+++ b/scripts/verify_graph_loading_2d3d.cjs
@@ -1,0 +1,222 @@
+// Verify PR #830: loading overlay dismisses on 2D/3D ready; 2D↔3D switch works.
+// Usage: node scripts/verify_graph_loading_2d3d.cjs [baseUrl] [outDir] [--headed]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+const headed = process.argv.includes('--headed');
+const args = process.argv.filter((a) => a !== '--headed');
+const baseUrl = args[2] || 'http://127.0.0.1:8765/graph.html';
+const outDir = path.resolve(args[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots'));
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function openPhysicsPanel(page) {
+  await page.evaluate(() => {
+    const panel = document.getElementById('physics-panel');
+    if (panel && panel.hidden) {
+      document.getElementById('physics-toggle')?.click();
+    }
+  });
+  await sleep(300);
+}
+
+async function clickViewMode(page, mode) {
+  await openPhysicsPanel(page);
+  const sel = mode === '3d' ? '#view-mode-3d' : '#view-mode-2d';
+  await page.waitForSelector(sel, { visible: true, timeout: 10000 });
+  const btn = await page.$(sel);
+  if (!btn) throw new Error(`missing ${sel}`);
+  await btn.click();
+  await sleep(400);
+}
+
+function is3dViewActive(view) {
+  return view.has3dCanvas && view.svgDisplay === 'none';
+}
+
+function is2dViewActive(view) {
+  return view.c3dHidden && view.svgDisplay !== 'none';
+}
+
+function loadingState(page) {
+  return page.evaluate(() => {
+    const el = document.getElementById('graph-loading');
+    if (!el) return { exists: false };
+    const cs = window.getComputedStyle(el);
+    return {
+      exists: true,
+      hidden: el.hidden,
+      display: cs.display,
+      opacity: cs.opacity,
+      hasIsHidden: el.classList.contains('is-hidden'),
+      pct: document.getElementById('graph-loading-pct')?.textContent || '',
+      title: document.getElementById('graph-loading-title')?.textContent || '',
+      isError: el.classList.contains('is-error'),
+    };
+  });
+}
+
+function viewState(page) {
+  return page.evaluate(() => {
+    const svg = document.getElementById('graph-canvas');
+    const c3d = document.getElementById('graph-canvas-3d');
+    const btn2d = document.getElementById('view-mode-2d');
+    const btn3d = document.getElementById('view-mode-3d');
+    const svgDisplay = svg ? window.getComputedStyle(svg).display : 'none';
+    const c3dHidden = c3d ? c3d.hidden : true;
+    const nodes2d = document.querySelectorAll('#graph-canvas .node-circle').length;
+    return {
+      svgDisplay,
+      c3dHidden,
+      btn2dActive: btn2d?.classList.contains('is-active'),
+      btn3dActive: btn3d?.classList.contains('is-active'),
+      nodes2d,
+      has3dCanvas: !!c3d && !c3dHidden,
+    };
+  });
+}
+
+function isLoadingDismissed(st) {
+  return !st.exists || st.hidden || st.display === 'none' || st.hasIsHidden;
+}
+
+(async () => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const exe = process.env.PUPPETEER_EXECUTABLE_PATH
+    || (fs.existsSync('/usr/local/bin/google-chrome') ? '/usr/local/bin/google-chrome' : 'google-chrome');
+  const d3Local = path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js');
+  const d3Body = fs.existsSync(d3Local) ? fs.readFileSync(d3Local) : null;
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: headed ? false : 'new',
+    slowMo: headed ? 80 : 0,
+    args: [
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--window-size=1440,900',
+      ...(headed ? [] : []),
+    ],
+    defaultViewport: headed ? null : { width: 1440, height: 900, deviceScaleFactor: 1 },
+  });
+
+  const report = { cases: [], ok: true };
+
+  try {
+    const page = await browser.newPage();
+    if (!headed) {
+      await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+    }
+
+    if (d3Body) {
+      await page.setRequestInterception(true);
+      page.on('request', (req) => {
+        const u = req.url();
+        if (u.includes('cdn.jsdelivr.net/npm/d3')) {
+          req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+        } else {
+          req.continue();
+        }
+      });
+    }
+
+    // Case 1: 2D initial load — loading visible then dismissed
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    const earlyLoad = await loadingState(page);
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-loading');
+      if (!el) return true;
+      return el.hidden || el.classList.contains('is-hidden');
+    }, { timeout: 90000 });
+    await sleep(800);
+    const after2dLoad = await loadingState(page);
+    const view2d = await viewState(page);
+    const simStillRunning = await page.evaluate(() => {
+      const circles = document.querySelectorAll('#graph-canvas .node-circle');
+      return circles.length > 0;
+    });
+    const case1 = {
+      name: '2D initial load dismisses before force layout settles',
+      earlyVisible: earlyLoad.exists && !earlyLoad.hidden,
+      loadingDismissed: isLoadingDismissed(after2dLoad),
+      view2dActive: view2d.btn2dActive && !view2d.btn3dActive,
+      nodesRendered: view2d.nodes2d > 0,
+      graphVisibleDuringSim: simStillRunning,
+      pct: after2dLoad.pct,
+    };
+    case1.pass = case1.loadingDismissed && case1.view2dActive && case1.nodesRendered && case1.graphVisibleDuringSim;
+    report.cases.push(case1);
+    await page.screenshot({ path: path.join(outDir, 'graph-loading-2d-ready.png') });
+
+    // Case 2: switch to 3D — loading stays dismissed, 3D canvas shown
+    await clickViewMode(page, '3d');
+    await sleep(2500);
+    const after3dSwitch = await loadingState(page);
+    const view3d = await viewState(page);
+    const case2 = {
+      name: '2D → 3D switch without loading overlay blocking',
+      loadingDismissed: isLoadingDismissed(after3dSwitch),
+      view3dActive: view3d.btn3dActive && !view3d.btn2dActive,
+      has3dCanvas: view3d.has3dCanvas,
+      svgHidden: view3d.svgDisplay === 'none',
+    };
+    case2.pass = case2.loadingDismissed && is3dViewActive(view3d);
+    report.cases.push(case2);
+    await page.screenshot({ path: path.join(outDir, 'graph-loading-3d-switched.png') });
+
+    // Case 3: switch back to 2D
+    await clickViewMode(page, '2d');
+    await sleep(2000);
+    const after2dSwitch = await loadingState(page);
+    const view2dAgain = await viewState(page);
+    const case3 = {
+      name: '3D → 2D switch restores 2D graph',
+      loadingDismissed: isLoadingDismissed(after2dSwitch),
+      view2dActive: view2dAgain.btn2dActive && !view2dAgain.btn3dActive,
+      nodesRendered: view2dAgain.nodes2d > 0,
+      c3dHidden: view2dAgain.c3dHidden,
+    };
+    case3.pass = case3.loadingDismissed && is2dViewActive(view2dAgain) && case3.nodesRendered;
+    report.cases.push(case3);
+    await page.screenshot({ path: path.join(outDir, 'graph-loading-2d-switched-back.png') });
+
+    // Case 4: initial 3D load via ?view=3d
+    await page.goto(`${baseUrl}${baseUrl.includes('?') ? '&' : '?'}view=3d`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60000,
+    });
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-loading');
+      if (!el) return true;
+      return el.hidden || el.classList.contains('is-hidden');
+    }, { timeout: 90000 });
+    await sleep(2500);
+    const after3dInit = await loadingState(page);
+    const view3dInit = await viewState(page);
+    const case4 = {
+      name: 'Initial ?view=3d dismisses loading and enters 3D',
+      loadingDismissed: isLoadingDismissed(after3dInit),
+      view3dActive: view3dInit.btn3dActive,
+      has3dCanvas: view3dInit.has3dCanvas,
+    };
+    case4.pass = case4.loadingDismissed && is3dViewActive(view3dInit);
+    report.cases.push(case4);
+    await page.screenshot({ path: path.join(outDir, 'graph-loading-3d-initial.png') });
+
+    report.ok = report.cases.every((c) => c.pass);
+    const outJson = path.join(outDir, 'graph-loading-2d3d-verify.json');
+    fs.writeFileSync(outJson, JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) process.exitCode = 1;
+    if (headed) await sleep(1500);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 调整 PR #830 加载页逻辑：**进度条仅覆盖数据下载 → 解析 → 构图 DOM 挂载**，不再映射力导向 `simulation.alpha()`，也不在力布局收敛后才关闭加载页。
- 构图渲染完成（节点/边挂载 + 首帧同步）后立即 `finishLoading()`；力布局在画布上继续展开，用户可实时看到节点运动。
- 3D 首屏：`finishLoading()` 与 `setSpatialViewMode('3d')` 解耦，加载页不再等待 2.2s 兜底或力模拟结束。
- 新增 `scripts/verify_graph_loading_2d3d.cjs` 自动化验证 2D/3D 切换与加载页行为。

## 变更要点
| 之前 | 之后 |
|------|------|
| 进度 88%→99% 绑定 `simulation.alpha()` | 移除 `tick.loading` 进度映射 |
| 2D 约 1.2s 后或力模拟 `end` 才关闭加载页 | 构图 DOM 就绪即关闭 |
| 3D 首屏等 2.2s / 力模拟后再关加载页 | 构图就绪即关，3D 切换异步进行 |

## 验证
- `node scripts/verify_graph_loading_2d3d.cjs` 四项全绿（`ok: true`）
- 无需 `make ci-preflight`（仅 `docs/graph.html` + 验证脚本）

## 验证截图
[构图渲染后加载页已关闭，力布局仍在展开](https://cursor.com/agents/bc-c23a3e58-502a-4915-88c8-c8ef02959c36/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-loading-2d-ready.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c23a3e58-502a-4915-88c8-c8ef02959c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c23a3e58-502a-4915-88c8-c8ef02959c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

