### PR TITLE
fix: Randomize all axes in 3D node layout refresh

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -541,12 +541,15 @@
     }
 
     function resetNodePositionsInPlace() {
+      // 「刷新布局」时每个节点都重新随机散布在中心附近（与 2D randomizeNodePositions 对齐）。
+      // sourceNodes 与 2D 力模拟共用同一批对象，src.x/src.y 早被 2D 布局写满；若沿用 src 坐标，
+      // 刷新只会重随机 z，x/y 仍钉在上次布局——观感上几乎不变。这里三轴一律重随机，得到全新布局。
       sourceNodes.forEach(function (src) {
         var n3 = nodeById.get(src.id);
         if (!n3) return;
-        n3.x = src.x != null ? src.x : (Math.random() - 0.5) * 80;
-        n3.y = src.y != null ? src.y : (Math.random() - 0.5) * 80;
-        n3.z = src.z != null ? src.z : (Math.random() - 0.5) * 80;
+        n3.x = (Math.random() - 0.5) * 80;
+        n3.y = (Math.random() - 0.5) * 80;
+        n3.z = (Math.random() - 0.5) * 80;
         n3.vx = 0;
         n3.vy = 0;
         n3.vz = 0;


### PR DESCRIPTION
## 摘要

修复 3D 图布局刷新时节点位置的初始化逻辑。原代码在刷新时复用 2D 布局的 x/y 坐标，导致 z 轴随机但 x/y 固定，观感上布局几乎不变。现改为三轴一律重随机，与 2D 的 `randomizeNodePositions` 行为对齐。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] 代码逻辑检查：移除了条件判断 `src.x != null ? src.x : ...`，改为直接随机三轴坐标，与注释说明一致
- [ ] `make ci-preflight`（N/A，仅改 JavaScript 逻辑）

## 相关 Issue

无

https://claude.ai/code/session_01JwAwsG68zKgS9MK4zBzoqk