### PR TITLE
perf: enable high-performance GPU preference in 3D graph renderer

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -814,7 +814,12 @@
       if (graph) return graph;
       size = measureContainerSize(container);
       // init 末尾会同步启动 rAF；先 pause，待 graphData onFinishUpdate 后再 resume。
-      graph = window.ForceGraph3D()(container);
+      // rendererConfig 透传给内部 three.js WebGLRenderer：powerPreference='high-performance'
+      // 提示浏览器/驱动在双显卡设备（典型为带集显+独显的笔记本）上优先选用独立 GPU。
+      // 仅为性能提示——单 GPU 设备无效果，浏览器亦可忽略，不影响渲染正确性。
+      graph = window.ForceGraph3D({
+        rendererConfig: { powerPreference: 'high-performance' },
+      })(container);
       graph.pauseAnimation();
       bindGraphInstance();
       pendingFirstShowKick = true;


### PR DESCRIPTION
## 摘要

为 ForceGraph3D 的 WebGLRenderer 配置 `powerPreference: 'high-performance'`，提示浏览器在双显卡设备（如笔记本的集显+独显）上优先使用独立 GPU，以提升 3D 图渲染性能。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] 无需测试（配置项透传，仅为性能提示，不影响渲染正确性）

## 相关 Issue

无

https://claude.ai/code/session_01PhQchk8tvyriqULx7oThjc