### PR TITLE
fix(wiki): 修复 MDP 页 KaTeX 公式括号与分隔符未对齐

### DIFF
--- a/wiki/formalizations/contact-wrench-cone.md
+++ b/wiki/formalizations/contact-wrench-cone.md
@@ -54,7 +54,7 @@ $$
 该顶点力对 $\{C\}$ 原点的贡献为 $\begin{bmatrix} \mathbf{f}_i \\ \mathbf{p}_i \times \mathbf{f}_i \end{bmatrix}$。整个接触面在 $\{C\}$ 下的可行 wrench 就是
 
 $$
-\mathcal{W} = \left\{ \sum_{i=1}^{N}\sum_{k=1}^{K} \lambda_{i,k} \begin{bmatrix} \mathbf{s}_{i,k} \\ \mathbf{p}_i \times \mathbf{s}_{i,k} \end{bmatrix} \;\middle|\; \lambda_{i,k} \geq 0 \right\}
+\mathcal{W} = \left\{ \sum_{i=1}^{N}\sum_{k=1}^{K} \lambda_{i,k} \begin{bmatrix} \mathbf{s}_{i,k} \\ \mathbf{p}_i \times \mathbf{s}_{i,k} \end{bmatrix} \;\Big|\; \lambda_{i,k} \geq 0 \right\}
 $$
 
 这正是由有限个“基础 wrench”张成的**有限凸锥**。

--- a/wiki/formalizations/mdp.md
+++ b/wiki/formalizations/mdp.md
@@ -76,11 +76,11 @@ $$\pi: S \rightarrow \text{Prob}(A)$$
 
 **状态值函数** $V^\pi(s)$：从状态 $s$ 开始，按策略 $\pi$ 行事的期望累积折扣奖励
 
-$$V^\pi(s) = \mathbb{E}_\pi\left[ \sum_{k=0}^{\infty} \gamma^k R_{t+k} \middle| s_t = s \right]$$
+$$V^\pi(s) = \mathbb{E}_\pi\Big[ \sum_{k=0}^{\infty} \gamma^k R_{t+k} \;\Big|\; s_t = s \Big]$$
 
 **动作值函数** $Q^\pi(s,a)$：从状态 $s$ 出发，执行动作 $a$ 后按策略 $\pi$ 行事的期望累积折扣奖励
 
-$$Q^\pi(s,a) = \mathbb{E}_\pi\left[ \sum_{k=0}^{\infty} \gamma^k R_{t+k} \middle| s_t = s, a_t = a \right]$$
+$$Q^\pi(s,a) = \mathbb{E}_\pi\Big[ \sum_{k=0}^{\infty} \gamma^k R_{t+k} \;\Big|\; s_t = s, a_t = a \Big]$$
 
 两者关系：
 
@@ -102,11 +102,11 @@ $$Q^{\pi^*}(s,a) \geq Q^\pi(s,a), \quad \forall s,a$$
 
 值函数满足递归关系（Bellman 方程）：
 
-$$V^\pi(s) = \sum_a \pi(a|s) \sum_{s'} P(s'|s,a) \left[ R(s,a,s') + \gamma V^\pi(s') \right]$$
+$$V^\pi(s) = \sum_a \pi(a|s) \sum_{s'} P(s'|s,a) \bigl( R(s,a,s') + \gamma V^\pi(s') \bigr)$$
 
 最优值函数（Bellman 最优方程）：
 
-$$V^*(s) = \max_a \sum_{s'} P(s'|s,a) \left[ R(s,a,s') + \gamma V^*(s') \right]$$
+$$V^*(s) = \max_a \sum_{s'} P(s'|s,a) \bigl( R(s,a,s') + \gamma V^*(s') \bigr)$$
 
 这是所有 RL 算法的起点——解这个方程，就得到了最优策略。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 [MDP 形式化页](https://imchong.github.io/Robotics_Notebooks/detail.html?id=wiki-formalizations-mdp) 中值函数与 Bellman 方程公式的括号/分隔符垂直未对齐问题。
- 根因：KaTeX 对 `\middle|` 与嵌套 `\left[...\right]` 的自动拉伸行为不一致，导致 `|` 明显短于 `[` `]`，或内层方括号相对外层 `\sum` 显得过小。
- 值函数期望式改用 `\Big[ ... \;\Big|\; ... \Big]`；Bellman 方程内层奖励项改用 `\bigl( ... \bigr)`；顺带修正 `contact-wrench-cone` 中同类 `\middle|` 写法。

## 验证
- `make ci-preflight` 通过
- 本地静态站 `docs/detail.html?id=wiki-formalizations-mdp` 渲染正常

## 验证截图
[MDP 值函数公式修复后](https://cursor.com/agents/bc-6602405b-8607-46d6-a3ce-af69317c8363/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmdp-after-value.png)
[MDP Bellman 方程公式修复后](https://cursor.com/agents/bc-6602405b-8607-46d6-a3ce-af69317c8363/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmdp-after-bellman.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6602405b-8607-46d6-a3ce-af69317c8363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6602405b-8607-46d6-a3ce-af69317c8363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

