### PR TITLE
fix(ux): 修复 MDP 页 KaTeX 公式在 WebKit 移动端定界符错位

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -16,6 +16,8 @@
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/fonts/KaTeX_Size3-Regular.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/fonts/KaTeX_Size4-Regular.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
 </head>
 <body>
   <header class="site-header">

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -16,6 +16,8 @@
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous" />
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/fonts/KaTeX_Size3-Regular.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/fonts/KaTeX_Size4-Regular.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
 </head>
 <body>
   <header class="site-header">

--- a/docs/style.css
+++ b/docs/style.css
@@ -60,6 +60,8 @@ body {
   line-height: 1.5;
   transition: background var(--transition), color var(--transition);
   -webkit-font-smoothing: antialiased;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   /* 用 clip 而非 hidden：避免 body 成为 sticky 的滚动容器导致 .site-header 不吸顶 */
   overflow-x: clip;
 }
@@ -1393,13 +1395,15 @@ body.sponsor-dialog-open {
   color: var(--text-muted);
 }
 .detail-markdown-body .math-inline {
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
+  vertical-align: middle;
   padding: .05em .35em;
   border-radius: 6px;
   background: rgba(45,116,218,.08);
   border: 1px solid rgba(45,116,218,.18);
-  min-height: 1.7em;
+}
+.detail-markdown-body .math-inline .katex {
+  display: inline-block;
 }
 .detail-markdown-body .math-inline .katex,
 .detail-markdown-body .math-inline .katex * {
@@ -1412,11 +1416,17 @@ body.sponsor-dialog-open {
   border: 1px dashed var(--border);
   background: rgba(45,116,218,.04);
   overflow-x: auto;
+  line-height: normal;
 }
 .detail-markdown-body .math-block .katex-display {
   margin: 0;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: visible;
+  line-height: normal;
+}
+.detail-markdown-body .math-block .katex {
+  display: inline-block;
+  max-width: 100%;
 }
 .detail-markdown-body .math-block .katex,
 .detail-markdown-body .math-block .katex * {
@@ -1428,6 +1438,12 @@ body.sponsor-dialog-open {
 }
 :root:not([data-theme="light"]) .detail-markdown-body .math-block {
   background: rgba(105,163,255,.06);
+}
+/* WebKit（iOS Safari 等）：避免父级 flex/line-height 破坏 KaTeX vlist 与可拉伸定界符 */
+@supports (-webkit-touch-callout: none) {
+  .detail-markdown-body .katex .vlist-t {
+    display: inline-table;
+  }
 }
 :root:not([data-theme="light"]) .detail-toc-list a.active,
 :root:not([data-theme="light"]) .detail-toc-list .toc-entry.active,

--- a/wiki/formalizations/contact-wrench-cone.md
+++ b/wiki/formalizations/contact-wrench-cone.md
@@ -54,7 +54,7 @@ $$
 该顶点力对 $\{C\}$ 原点的贡献为 $\begin{bmatrix} \mathbf{f}_i \\ \mathbf{p}_i \times \mathbf{f}_i \end{bmatrix}$。整个接触面在 $\{C\}$ 下的可行 wrench 就是
 
 $$
-\mathcal{W} = \left\{ \sum_{i=1}^{N}\sum_{k=1}^{K} \lambda_{i,k} \begin{bmatrix} \mathbf{s}_{i,k} \\ \mathbf{p}_i \times \mathbf{s}_{i,k} \end{bmatrix} \;\Big|\; \lambda_{i,k} \geq 0 \right\}
+\mathcal{W} = \left\{ \sum_{i=1}^{N}\sum_{k=1}^{K} \lambda_{i,k} \begin{bmatrix} \mathbf{s}_{i,k} \\ \mathbf{p}_i \times \mathbf{s}_{i,k} \end{bmatrix} \mid \lambda_{i,k} \geq 0 \right\}
 $$
 
 这正是由有限个“基础 wrench”张成的**有限凸锥**。

--- a/wiki/formalizations/mdp.md
+++ b/wiki/formalizations/mdp.md
@@ -76,11 +76,11 @@ $$\pi: S \rightarrow \text{Prob}(A)$$
 
 **状态值函数** $V^\pi(s)$：从状态 $s$ 开始，按策略 $\pi$ 行事的期望累积折扣奖励
 
-$$V^\pi(s) = \mathbb{E}_\pi\Big[ \sum_{k=0}^{\infty} \gamma^k R_{t+k} \;\Big|\; s_t = s \Big]$$
+$$V^\pi(s) = \mathbb{E}_\pi\left[\sum_{k=0}^{\infty} \gamma^k R_{t+k} \mid s_t = s\right]$$
 
 **动作值函数** $Q^\pi(s,a)$：从状态 $s$ 出发，执行动作 $a$ 后按策略 $\pi$ 行事的期望累积折扣奖励
 
-$$Q^\pi(s,a) = \mathbb{E}_\pi\Big[ \sum_{k=0}^{\infty} \gamma^k R_{t+k} \;\Big|\; s_t = s, a_t = a \Big]$$
+$$Q^\pi(s,a) = \mathbb{E}_\pi\left[\sum_{k=0}^{\infty} \gamma^k R_{t+k} \mid s_t = s, a_t = a\right]$$
 
 两者关系：
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 [MDP 形式化页](https://imchong.github.io/Robotics_Notebooks/detail.html?id=wiki-formalizations-mdp) 公式括号/分隔符在桌面与移动端（WebKit）未对齐的问题。
- **根因（两层）**：
  1. **KaTeX 字体**：iOS Safari 等 WebKit 环境未及时加载 `KaTeX_Size4`，导致 `\left[`/`\right]` 无法拉伸，方括号退化为普通字符高度。
  2. **站点 CSS**：`.math-inline` 使用 `inline-flex` + `align-items: center` 干扰 KaTeX `vlist` 垂直布局；块级公式 `overflow-y: hidden` 在部分 WebKit 下也会裁切定界符。
- **修复**：
  - `detail.html` / `roadmap.html` 预加载 `KaTeX_Size3/Size4` 字体；
  - `style.css` 改为 `inline-block`、`-webkit-text-size-adjust: 100%`、`line-height: normal`、WebKit `@supports` 保护 `vlist-t`；
  - MDP 期望式使用标准 `\left[...\mid...\right]`；Bellman 内层用 `\bigl(...\bigr)`。

## 验证
- `make ci-preflight` 通过
- 移动端视口（390×844，iPhone UA）复测：`KaTeX_Size4` 已加载，`\left[` 高度 57px（修复前仅 ~21px）

## 验证截图
[MDP 值函数公式移动端修复后](https://cursor.com/agents/bc-6602405b-8607-46d6-a3ce-af69317c8363/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fmdp-mobile-fixed-anchor.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6602405b-8607-46d6-a3ce-af69317c8363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6602405b-8607-46d6-a3ce-af69317c8363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

