### PR TITLE
fix(wiki): HapMorph 详情页补 SSSA 机构标签

### DIFF
--- a/schema/institutions.json
+++ b/schema/institutions.json
@@ -914,6 +914,14 @@
         "thehumanoid",
         "kinetiq"
       ]
+    },
+    "sssa": {
+      "label": "圣安娜高等研究学院（Scuola Superiore Sant'Anna）",
+      "aliases": [
+        "sssa",
+        "sant-anna",
+        "scuola-sant-anna"
+      ]
     }
   }
 }

--- a/wiki/entities/paper-hapmorph-pneumatic-haptic-render.md
+++ b/wiki/entities/paper-hapmorph-pneumatic-haptic-render.md
@@ -1,6 +1,6 @@
 ---
 type: entity
-tags: [paper, haptic, wearable, pneumatic, soft-robotics, vr, teleoperation, human-robot-interaction]
+tags: [paper, haptic, wearable, pneumatic, soft-robotics, vr, teleoperation, human-robot-interaction, sssa]
 status: complete
 updated: 2026-06-29
 arxiv: "2509.05433"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

补全 [HapMorph](https://arxiv.org/abs/2509.05433) 详情页缺失的**机构标签**（#846 合并后反馈）。

- 在 `schema/institutions.json` 注册 **SSSA**（圣安娜高等研究学院 / Scuola Superiore Sant'Anna）
- `wiki/entities/paper-hapmorph-pneumatic-haptic-render.md` 的 `tags` 补 `sssa`

## 验证

- `make ci-preflight` 通过
- `link-graph.json` 中该节点 `institutions: ["sssa"]`，详情页「所属机构」可显示徽标

## 验证截图

[HapMorph 详情页机构标签](https://cursor.com/agents/bc-07e6c2be-1d17-4748-9056-c7b5d305a7d8/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fhapmorph-detail-institution.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07e6c2be-1d17-4748-9056-c7b5d305a7d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07e6c2be-1d17-4748-9056-c7b5d305a7d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

