### PR TITLE
chore: v26 完成，新建 v27 清单（接触力旋量闭环知识链）

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Wiki Lint](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-1513节点_10195边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
-[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-98%25-green)](docs/checklists/tech-stack-next-phase-checklist-v26.md)
+[![Sources Coverage](https://img.shields.io/badge/sources覆盖率-98%25-green)](docs/checklists/tech-stack-next-phase-checklist-v27.md)
 
 
 
@@ -66,7 +66,7 @@
 
 ## 维护看板
 
-- 当前技术栈执行清单：[V26](docs/checklists/tech-stack-next-phase-checklist-v26.md)
+- 当前技术栈执行清单：[V27](docs/checklists/tech-stack-next-phase-checklist-v27.md)
 - 前端体验优化清单：[frontend-optimization-v1](docs/checklists/frontend-optimization-v1.md)
 - 历史执行清单索引：[docs/checklists/README.md](docs/checklists/README.md)
 

--- a/docs/checklists/README.md
+++ b/docs/checklists/README.md
@@ -4,14 +4,14 @@
 
 ## 当前入口
 
-- [技术栈项目执行清单 v26](tech-stack-next-phase-checklist-v26.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
+- [技术栈项目执行清单 v27](tech-stack-next-phase-checklist-v27.md) — 当前技术栈、自动化、专题建设与 UX 推进看板。
 - [前端体验优化清单 v1](frontend-optimization-v1.md) — GitHub Pages 首页与交互体验优化计划。
 - [Cursor Cloud Agent：PR 与验证截图流程](cloud-agent-pr-workflow.md) — Cloud Agent 推送分支、开 PR、附验证截图的路径约定。
 - [GitHub Actions CI 门禁](github-actions-ci-gate.md) — 合并 `main` 前必须等全量 Actions 全绿；branch protection 建议。
 
 ## 历史执行清单
 
-这些文件记录从 v1 到 v25 的阶段性目标和已完成事项，主要用于追溯决策，不作为当前待办入口。历史版本统一存放在 [`archive/`](archive/) 子目录。
+这些文件记录从 v1 到 v26 的阶段性目标和已完成事项，主要用于追溯决策，不作为当前待办入口。历史版本统一存放在 [`archive/`](archive/) 子目录。
 
 - [v1](archive/tech-stack-next-phase-checklist-v1.md)
 - [v2](archive/tech-stack-next-phase-checklist-v2.md)
@@ -38,6 +38,7 @@
 - [v23](archive/tech-stack-next-phase-checklist-v23.md)
 - [v24](archive/tech-stack-next-phase-checklist-v24.md)
 - [v25](archive/tech-stack-next-phase-checklist-v25.md)
+- [v26](archive/tech-stack-next-phase-checklist-v26.md)
 
 ## 维护规则
 

--- a/docs/checklists/archive/tech-stack-next-phase-checklist-v26.md
+++ b/docs/checklists/archive/tech-stack-next-phase-checklist-v26.md
@@ -1,6 +1,6 @@
 # 技术栈项目执行清单 v26
 
-最后更新：2026-06-28（P3 图谱页"物理保真度"专题视图：新增 `physics-fidelity` 专题至 16 项，新建汇总枢纽页 `topic-physics-fidelity.md`，专题命中 85 节点，图谱 0 孤儿）
+最后更新：2026-06-29（P3 详情页「物理保真度」专题徽标端到端验证：复用 `topic-filters.js` 单一事实源，`contact-dynamics` 详情页实测渲染「✋ 触觉 + ⚙️ 物理保真度」双徽标，`make lint` 0 errors，**v26 清单全数完成**）
 项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
 上一版清单：[`tech-stack-next-phase-checklist-v25.md`](archive/tech-stack-next-phase-checklist-v25.md)
 方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
@@ -44,18 +44,18 @@
 
 - [x] **图谱页"物理保真度"专题视图**：
     - [x] `docs/graph.html` / `docs/topic-filters.js` 的专题命中规则在 V25 15 项基础上新增「物理保真度」专题（`physics-fidelity`），复用 path 片段并集机制（`dynamics/contact/friction/articulated-body/differentiable-simulation/urdf/floating-base/centroidal/fidelity`）并按需 `ids` 显式纳入新建 query/concept（`simulation-physics-fidelity` / `physics-fidelity-sim2real-gap` / `articulated-body-algorithms`）；同步在 `#filter-topic-chips` 增加 `data-topic="physics-fidelity"`（⚙️ 物理保真度）chip。新建专题汇总枢纽页 `wiki/overview/topic-physics-fidelity.md` 并从 query/concept 双向回链消除孤儿（`graph-stats.json` 0 orphans）；专题命中 85 节点。Puppeteer 截图归档至 `.cursor-artifacts/screenshots/graph-topic-physics-fidelity.png`（页头实测 `85 / 1512 节点`）。
-- [ ] **详情页"同专题相关页"提示**：
-    - [ ] 复用 `docs/topic-filters.js` 单一事实源，动力学 / 仿真 / 新建页命中「物理保真度」专题时渲染「⚙️ 物理保真度」轻量徽标 + 跳转 `graph.html?topic=physics-fidelity`（空态降级隐藏）。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-physics-fidelity.png`。
+- [x] **详情页"同专题相关页"提示**：
+    - [x] 复用 `docs/topic-filters.js` 单一事实源，动力学 / 仿真 / 新建页命中「物理保真度」专题时渲染「⚙️ 物理保真度」轻量徽标 + 跳转 `graph.html?topic=physics-fidelity`（空态降级隐藏）。详情页「所属专题」徽标行（`docs/main.js renderMetaTopicBadges` → `topicsForNode`）本就数据驱动，P3 把 `physics-fidelity` 写入单一事实源后自动联动，无需二次实现；node 逐页校验候选页全部稳定命中（全库 86 节点）。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-physics-fidelity.png`（`contact-dynamics` 详情页实测渲染「✋ 触觉 + ⚙️ 物理保真度」双徽标）。
 
 ---
 
 ## 验收标准 (Definition of DoD)
 
-- [ ] `make lint`: 0 errors（新引入的 `physics_concept_crosslink_check` 为 INFO 级，不阻塞 CI）。
+- [x] `make lint`: 0 errors（新引入的 `physics_concept_crosslink_check` 为 INFO 级，不阻塞 CI；现 0 页待回链，另含 2 条既有信息型预警）。
 - [x] 知识图谱节点数 **≥ 1335**，边数 **≥ 8850**（见 `exports/graph-stats.json`：现 1338 节点 / 9145 边）。
 - [x] 事实库扩展至 **210 条**（重点补 物理保真度 / 接触摩擦 / 执行器建模 矛盾检测规则）。
 - [x] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`（现 0.183；新增 `humanoid-soccer` 社区命名 override）。
-- [ ] `log.md` 记录 V26 关键改动。
+- [x] `log.md` 记录 V26 关键改动。
 
 ---
 

--- a/docs/checklists/tech-stack-next-phase-checklist-v27.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v27.md
@@ -1,0 +1,67 @@
+# 技术栈项目执行清单 v27
+
+最后更新：2026-06-29（v26 全数完成后新建：聚焦「接触力旋量闭环」知识链——把分散的接触感知/估计、力旋量表示、阻抗/混合力位控制、接触丰富操作策略沉淀为贯通 query/concept，并补矛盾检测规则与交互层专题）
+项目仓库：<https://github.com/ImChong/Robotics_Notebooks>
+上一版清单：[`tech-stack-next-phase-checklist-v26.md`](archive/tech-stack-next-phase-checklist-v26.md)
+方法论参考：[Karpathy LLM Wiki](../../wiki/references/llm-wiki-karpathy.md)
+
+---
+
+## V26 交付基线 (V27 起点)
+
+| 维度 | V26 状态 | V27 目标 |
+|------|-----------|---------|
+| 知识图谱节点 | 1513 | **≥ 1525** |
+| 知识图谱边数 | 10195 | **≥ 10260** |
+| 事实库 (CANONICAL_FACTS) | 210 条 | **≥ 220 条** |
+| 社区结构 | 15 社区，最大社区占 16.7%（`community_quality_warning: false`） | **保持 ≤ 25%，新增专题不破坏均衡** |
+| 技术专题 | 仿真物理保真度链路（V26 交付） | **建立"接触力旋量闭环"知识链** |
+| 图谱专题视图 | V26 扩至 16 项（新增「物理保真度」） | **新增「接触力控」专题至 17 项** |
+
+> 背景：V26 收尾把仿真物理底座（contact-dynamics / friction / articulated-body / floating-base）沉淀为「物理保真度」链路；与此同时近周密集 ingest 了一批**接触/操作**论文——CHORD（接触力旋量引导灵巧操作）、SceneBot（contact-prompted 全身场景交互跟踪）、HapMorph（可穿戴触觉渲染）。仓库里已各自成页的 `contact-estimation`、`force-control-basics`、`hybrid-force-position-control`、`impedance-control`、`tactile-sensing`、`visuo-tactile-fusion`、`contact-rich-manipulation` 七八页**缺一条贯通视角**——从**接触感知/估计 → 力旋量表示 → 阻抗/导纳/混合力位控制 → 接触丰富操作策略**逐层「闭环」如何分别贡献操作稳定性、各层的带宽/刚度/接触保真度取舍，尚未沉淀为独立 query / concept；事实库也缺「力控范式间矛盾」（力控 vs 位控、阻抗 vs 导纳、刚性高带宽 vs 柔顺安全、视觉 vs 触觉时延等）的矛盾检测规则。V27 优先补齐这条接触力旋量闭环知识链，并把分散的接触/力控/触觉概念页交叉链路规范化。
+
+---
+
+## P0: 自动化与工具链深度强化 (Engineering)
+
+- [ ] **接触/力控/操作概念页交叉链路巡检 V1**：
+    - [ ] `scripts/lint_wiki.py` 新增 `_check_contact_control_crosslink`：对 `tags` 含 `contact` / `force-control` / `impedance` / `manipulation` / `tactile` 的 `concepts/` 概念页，检查正文是否回链到「接触力旋量闭环」专题枢纽（`contact-wrench-closed-loop` / `topic-contact-force-control`，缺失给 INFO 级 `contact_control_crosslink` 提示，不阻塞 CI），枢纽页自身豁免；写入 lint 报告基线快照（`exports/lint-report.md`）；新增 `tests/test_lint_wiki_contact_control_crosslink.py` 用例覆盖（列表式/内联式 tag、有/无回链、枢纽豁免、INFO 不计失败）。
+
+## P1: 接触力旋量闭环知识链专题 (Quality)
+
+- [ ] **接触力旋量闭环知识链 (+2)**：
+    - [ ] `wiki/queries/contact-wrench-closed-loop.md`（端到端 Query：接触感知/估计 → 力旋量表示 → 阻抗/导纳/混合力位控制 → 接触丰富操作策略四层闭环的取舍决策树，覆盖每层对操作稳定性/安全性的贡献、带宽/刚度/时延成本与典型失败模式，配 Mermaid 流程图）。
+    - [ ] `wiki/concepts/contact-force-loop-bandwidth.md`（力控闭环带宽 ↔ 接触稳定性概念页：明示感知时延、控制刚度、接触离散化如何共同决定可达带宽与接触震荡/穿透边界，以及与阻抗/导纳选型的关系）。
+- [ ] **接触/力控层专题交叉补强**：
+    - [ ] 在 `wiki/concepts/contact-estimation.md`、`force-control-basics.md`、`hybrid-force-position-control.md`、`impedance-control.md`、`visuo-tactile-fusion.md` 五页与 P1 新页形成双向回链，明示「感知 → 力旋量 → 控制 → 操作」四层在闭环链路中的定位，消除孤儿页。
+
+## P2: 事实库与矛盾检测扩展 (Quantity)
+
+- [ ] **事实库扩展**：
+    - [ ] `schema/canonical-facts.json` 由 210 → **≥ 220 条**：新增 ≥10 条接触力控矛盾检测规则（力控带宽↑ 与控制刚度/稳定裕度冲突、阻抗 vs 导纳因果对偶在接触刚度未知时失稳、刚性高带宽与柔顺安全取舍、纯视觉时延致接触前过冲、触觉采样率不足致打滑漏检、混合力位控制方向选择错误致约束冲突、力旋量估计依赖准确惯量/雅可比、接触离散化致力旋量偏大、过度柔顺牺牲定位精度、域随机化不替代真机力标定等）；逐条经脚本校验对现存 wiki 页有 pos 命中且 0 误报（`make lint` 潜在矛盾 0 个）。
+
+## P3: 交互层"接触力控"增强 (UX/UI)
+
+- [ ] **图谱页"接触力控"专题视图**：
+    - [ ] `docs/topic-filters.js` 单一事实源新增「接触力控」专题（`contact-force-control`，⚙️/🤝 emoji 待定），复用 path 片段并集机制（`impedance` / `admittance` / `wrench` / `compliance` / `hybrid` / `forcecontrol` 等，注意与 `physics-fidelity` / `tactile` / `grasp` 既有专题的最小重叠）并按需 `ids` 显式纳入新建 query/concept；同步在 `docs/graph.html` `#filter-topic-chips` 增加对应 chip。新建专题汇总枢纽页 `wiki/overview/topic-contact-force-control.md` 并从 query/concept 双向回链消除孤儿（`graph-stats.json` 0 orphans）。Puppeteer 截图归档至 `.cursor-artifacts/screenshots/graph-topic-contact-force-control.png`。
+- [ ] **详情页"同专题相关页"提示**：
+    - [ ] 复用 `docs/topic-filters.js` 单一事实源（`renderMetaTopicBadges` → `topicsForNode` 已数据驱动），接触/力控/新建页命中「接触力控」专题时自动渲染对应轻量徽标 + 跳转 `graph.html?topic=contact-force-control`（空态降级隐藏）。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-contact-force-control.png`。
+
+---
+
+## 验收标准 (Definition of DoD)
+
+- [ ] `make lint`: 0 errors（新引入的 `contact_control_crosslink_check` 为 INFO 级，不阻塞 CI）。
+- [ ] 知识图谱节点数 **≥ 1525**，边数 **≥ 10260**（见 `exports/graph-stats.json`）。
+- [ ] 事实库扩展至 **≥ 220 条**（重点补 力控带宽 / 阻抗导纳 / 视触觉时延 矛盾检测规则）。
+- [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。
+- [ ] `log.md` 记录 V27 关键改动。
+
+---
+
+## 状态说明
+
+- `[ ]` 待执行
+- `[~]` 进行中
+- `[x]` 已完成
+- `[−]` 已评估，决定跳过（附理由）

--- a/log.md
+++ b/log.md
@@ -1,5 +1,13 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-06-29] structural | checklist-v26 P3 详情页「物理保真度」专题徽标端到端验证 —— 复用单一事实源补归档截图
+
+- 详情页「所属专题」徽标行（[`docs/main.js`](docs/main.js) `renderMetaTopicBadges`）本就以 [`docs/topic-filters.js`](docs/topic-filters.js) 为单一事实源、`topicsForNode` 数据驱动：V26 P3 把 `physics-fidelity` 写入单一事实源后，动力学/仿真/新建页命中即自动渲染「⚙️ 物理保真度」徽标并跳 `graph.html?topic=physics-fidelity`，空态降级隐藏整行，无需二次实现。
+- node 逐页校验 `contact-dynamics` / `physics-fidelity-sim2real-gap` / `simulation-physics-fidelity` / `articulated-body-algorithms` / `joint-friction-models` / `topic-physics-fidelity` 等候选页全部稳定命中 `physics-fidelity`（全库 86 节点）。
+- Puppeteer 截图归档 [`detail-topic-physics-fidelity.png`](.cursor-artifacts/screenshots/detail-topic-physics-fidelity.png)：`contact-dynamics` 详情页「所属专题」行实测渲染「✋ 触觉 + ⚙️ 物理保真度」双徽标。
+- `make lint` 0 errors（仅 2 条信息型预警，不阻塞 CI）；勾选 v26 P3「详情页『同专题相关页』提示」与 DoD「make lint 0 errors」「log.md 记录」三项，清单全数完成。
+- v26 全数完成后按维护规则新建 [`tech-stack-next-phase-checklist-v27.md`](docs/checklists/tech-stack-next-phase-checklist-v27.md)（聚焦「接触力旋量闭环」知识链：感知/估计 → 力旋量 → 阻抗/导纳/混合力位控制 → 接触丰富操作策略），把 v26 移入 `archive/` 并刷新 `docs/checklists/README.md` 当前入口/历史链接。
+
 ## [2026-06-29] ingest | sources/papers/humanoid_pnb_vmp.md — VMP β-VAE motion prior + 条件 PPO 全身跟踪；wiki/entities/paper-notebook-vmp.md；交叉 whole-body-tracking-pipeline / character-animation-vs-robotics / humanoid-motion-tracking-method-selection
 
 ## [2026-06-29] structural | wiki/entities/paper-sonic.md — 合并 Loco-Manip 161 重复 SONIC stub（#019/#103）至 canonical 实体 + 方法页


### PR DESCRIPTION
## 摘要

v26 清单全数完成（P3 详情页「物理保真度」专题徽标端到端验证）。按维护规则新建 v27 清单，聚焦「接触力旋量闭环」知识链建设——从接触感知/估计 → 力旋量表示 → 阻抗/导纳/混合力位控制 → 接触丰富操作策略的四层闭环，补齐分散概念页的贯通视角与矛盾检测规则。同步将 v26 清单移入 `archive/` 并更新当前入口。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### v26 清单完成

- **P3 详情页「物理保真度」专题徽标**：复用 `docs/topic-filters.js` 单一事实源，`renderMetaTopicBadges` 数据驱动自动渲染「⚙️ 物理保真度」徽标，无需二次实现。逐页校验 `contact-dynamics` 等 86 节点全部稳定命中，Puppeteer 截图归档。
- **DoD 全部勾选**：`make lint` 0 errors（仅 2 条信息型预警）；知识图谱 1338 节点 / 9145 边；事实库 210 条；社区质量保持 `false`；`log.md` 记录完成。

### v27 清单新建

**目标**：建立「接触力旋量闭环」知识链，补齐接触/力控/触觉分散概念页的贯通视角。

**P0 工程化**：
- 新增 `scripts/lint_wiki.py` 的 `_check_contact_control_crosslink` 检查器，对含 `contact` / `force-control` / `impedance` / `manipulation` / `tactile` 标签的概念页检查是否回链到闭环枢纽（INFO 级提示，不阻塞 CI）。

**P1 知识链**：
- 新建 `wiki/queries/contact-wrench-closed-loop.md`（端到端 Query：四层闭环取舍决策树，覆盖稳定性/安全性贡献与成本）。
- 新建 `wiki/concepts/contact-force-loop-bandwidth.md`（力控闭环带宽与接触稳定性）。
- 补强 5 页（`contact-estimation` / `force-control-basics` / `hybrid-force-position-control` / `impedance-control` / `visuo-tactile-fusion`）与新页双向回链。

**P2 事实库**：
- 扩展 ≥10 条接触力控矛盾检测规则（力控带宽 vs 刚度、阻抗 vs 导纳、刚性 vs 柔顺、视触觉时延等）。

**P3 交互**：
- 新增「接触力控」专题视图（`contact-force-control`），复用 path 片段并集机制。
- 新建汇总枢纽页 `wiki/overview/topic-contact-force-control.md`。
- 详情页自动渲染「接触力控」专题徽标。

### 文件变更

- **新增**：`docs/checklists/tech-stack-

https://claude.ai/code/session_0136vXV3dYwwarWN1a54PdEi