### PR TITLE
fix(roadmap): 修复「论文互链枢纽」副标题桌面端提前换行

### DIFF
--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -126,7 +126,7 @@
 
           <section class="section section-alt" id="roadmap-paper-related" style="margin: 20px 0; padding: 20px; border-radius: 12px;">
             <h2 class="section-title">论文互链枢纽 · Top 10</h2>
-            <p class="section-subtitle">仅在论文节点（type=entity 且带 paper 标签）中，按站内互链总数（无向度数）排序，优先浏览与其他条目连接最多的核心论文。</p>
+            <p class="section-subtitle">按论文节点之间的站内互链总数（无向度数）排序，优先浏览与其他条目连接最多的核心论文。</p>
             <div id="roadmapPaperRelatedList" class="card-grid data-loading">
               <article class="card skeleton-card"><p>正在加载论文互链统计…</p></article>
             </div>


### PR DESCRIPTION
## 摘要

roadmap 页「论文互链枢纽 · Top 10」的副标题在桌面端会「提前换行」：首行末尾留出空白、文字折到第二行。本 PR 收紧文案修复该视觉问题。

根因不是宽度限制（`max-width` 在 roadmap 页已被 `.detail-content-main .section-subtitle` 覆盖为 `none`），而是全局 `.section-subtitle` 的 `word-break: keep-all` —— 整段 CJK 分句不可断行。原文案过长，第二分句在首行末尾放不下便整体折到次行，首行右侧因此留白。改为与同级「全站互链枢纽」副标题等长、同结构的措辞后，桌面端单行排满、自然收尾。

- 改前：`仅在论文节点（type=entity 且带 paper 标签）中，按站内互链总数（无向度数）排序，优先浏览与其他条目连接最多的核心论文。`
- 改后：`按论文节点之间的站内互链总数（无向度数）排序，优先浏览与其他条目连接最多的核心论文。`

「仅限论文节点」的语义由「论文节点之间」保留；仅去掉了 `type=entity 且带 paper 标签` 这段实现细节术语。改动仅 1 行 HTML（`docs/roadmap.html`）。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `PYTHONPATH=scripts python3 -m unittest tests.test_roadmap_page` 通过
- [x] 本地静态站桌面端（1280px）headless 截图：副标题由 2 行 → 1 行，与「全站互链枢纽」一致，无提前换行
- [ ] `make ci-preflight`：N/A（仅 docs HTML 文案改动，不涉及 wiki/导出链）

### 验证截图

``&lt;img alt="论文互链枢纽副标题修复后单行渲染" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/fixed-paper-subtitle.png" /&gt;``

## 相关 Issue

无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011VVSYQj2Y752T55rLmrFYA)_