### PR TITLE
fix(ux): 修复图谱侧边栏论文阅读笔记错误链接

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3091,8 +3091,72 @@
       return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
     }
 
-    function isSafeUrl(url) {
+    const NOTEBOOK_SITE_PREFIX = 'imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/';
+
+    function normalizeSourceLinkEntry(entry) {
+      if (entry == null) return { label: '', url: '' };
+      if (typeof entry === 'string') return { label: entry, url: entry };
+      return {
+        label: String((entry && entry.label) || (entry && entry.url) || ''),
+        url: String((entry && entry.url) || '')
+      };
+    }
+
+    function isPaperNotebookHtmlUrl(url) {
       if (!url) return false;
+      const base = String(url).split('#')[0].split('?')[0];
+      return base.includes(NOTEBOOK_SITE_PREFIX) && /\.html$/i.test(base);
+    }
+
+    function cleanPaperNotebookLabel(label, url, fallbackTitle) {
+      let text = String(label || '').trim();
+      text = text.replace(/^机器人论文阅读笔记[:：]\s*/u, '');
+      text = text.replace(/^[深读笔记论]+[:：<\s]+/u, '').replace(/[<>]+$/g, '').trim();
+      if (!text || text.length < 3) {
+        const stem = decodeURIComponent(String(url).split('/').pop().replace(/\.html$/i, ''));
+        text = stem.replace(/__+/g, ': ').replace(/[_-]+/g, ' ').trim();
+      }
+      if (!text && fallbackTitle) text = String(fallbackTitle);
+      return text || '论文阅读笔记';
+    }
+
+    function collectPaperNotebookLinks(item) {
+      if (!item) return [];
+      const seen = new Set();
+      const out = [];
+      function push(url, label) {
+        if (!isPaperNotebookHtmlUrl(url) || !isSafeUrl(url)) return;
+        const key = String(url).split('#')[0].split('?')[0];
+        if (seen.has(key)) return;
+        seen.add(key);
+        out.push({ url: key, label: cleanPaperNotebookLabel(label, key, item.title) });
+      }
+      const mapped = item.paper_notebook_links;
+      if (Array.isArray(mapped)) {
+        mapped.forEach(entry => {
+          const norm = normalizeSourceLinkEntry(entry);
+          push(norm.url, norm.label);
+        });
+      }
+      (item.source_links || []).forEach(entry => {
+        const norm = normalizeSourceLinkEntry(entry);
+        push(norm.url, norm.label);
+      });
+      const content = item.content_markdown || '';
+      const mdRe = /\[机器人论文阅读笔记[:：]([^\]]+)\]\((https:\/\/imchong\.github\.io\/Humanoid_Robot_Learning_Paper_Notebooks\/papers\/[^)]+\.html)\)/gi;
+      let match;
+      while ((match = mdRe.exec(content)) !== null) {
+        push(match[2], match[1]);
+      }
+      const bareRe = /https:\/\/imchong\.github\.io\/Humanoid_Robot_Learning_Paper_Notebooks\/papers\/[^\s)<>"']+\.html/gi;
+      while ((match = bareRe.exec(content)) !== null) {
+        push(match[0], '');
+      }
+      return out.slice(0, 6);
+    }
+
+    function isSafeUrl(url) {
+      if (!url || (typeof url !== 'string' && typeof url !== 'number')) return false;
       // eslint-disable-next-line no-control-regex
     let s = String(url).replace(/[\x00-\x1F\x7F-\x9F]/g, '').trim();
       s = s.replace(/&#x([0-9a-f]+);?/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
@@ -4370,16 +4434,10 @@
         sbRelSec.hidden = true;
       }
 
-      const paperLinks = (item?.source_links || []).filter(function (entry) {
-        const url = typeof entry === 'string' ? entry : (entry && entry.url) || '';
-        return String(url).includes('Humanoid_Robot_Learning_Paper_Notebooks');
-      });
+      const paperLinks = collectPaperNotebookLinks(item);
       if (paperLinks.length) {
-        sbPaperList.innerHTML = paperLinks.slice(0, 6).map((url, idx) => {
-          if (!isSafeUrl(url)) return '';
-          const stem = decodeURIComponent(String(url).split('/').pop().replace(/\.html$/, ''));
-          const label = stem.replace(/[_-]+/g, ' ').trim() || `论文阅读笔记 ${idx + 1}`;
-          return `<li><a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a></li>`;
+        sbPaperList.innerHTML = paperLinks.map(link => {
+          return `<li><a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(link.label)}</a></li>`;
         }).join('');
         sbPaperSec.hidden = false;
       } else {

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-
 from build_search_index import generate_search_index
 from search_indexing import parse_frontmatter, strip_frontmatter
 from utils.paths import path_to_id
@@ -554,8 +553,13 @@ def build_wiki_paper_notebook_link_index() -> dict[str, dict[str, str]]:
     if not PAPER_NOTEBOOK_INDEX_PATH.exists() or not PAPER_NOTEBOOK_FULL_MAP_PATH.exists():
         return {}
 
-    papers = {entry["dir"]: entry for entry in json.loads(PAPER_NOTEBOOK_INDEX_PATH.read_text(encoding="utf-8"))}
-    overrides = yaml.safe_load(PAPER_NOTEBOOK_FULL_MAP_PATH.read_text(encoding="utf-8")).get("overrides", {})
+    papers = {
+        entry["dir"]: entry
+        for entry in json.loads(PAPER_NOTEBOOK_INDEX_PATH.read_text(encoding="utf-8"))
+    }
+    overrides = yaml.safe_load(PAPER_NOTEBOOK_FULL_MAP_PATH.read_text(encoding="utf-8")).get(
+        "overrides", {}
+    )
     out: dict[str, dict[str, str]] = {}
     for paper_dir, wiki_paths in overrides.items():
         paper = papers.get(paper_dir)
@@ -613,7 +617,9 @@ def attach_paper_notebook_links(
     items: list[dict[str, Any]],
     wiki_link_index: dict[str, dict[str, str]] | None = None,
 ) -> None:
-    index = wiki_link_index if wiki_link_index is not None else build_wiki_paper_notebook_link_index()
+    index = (
+        wiki_link_index if wiki_link_index is not None else build_wiki_paper_notebook_link_index()
+    )
     for item in items:
         links = collect_paper_notebook_links(item, index)
         if links:

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List
 
+import yaml
+
 from build_search_index import generate_search_index
 from search_indexing import parse_frontmatter, strip_frontmatter
 from utils.paths import path_to_id
@@ -18,6 +20,21 @@ DOCS_OUTPUT = ROOT / "docs" / "exports" / "index-v1.json"
 DOCS_SITE_OUTPUT = ROOT / "docs" / "exports" / "site-data-v1.json"
 SITEMAP_OUTPUT = ROOT / "docs" / "sitemap.xml"
 BASE_URL = "https://imchong.github.io/Robotics_Notebooks"
+SCHEMA_DIR = ROOT / "schema"
+PAPER_NOTEBOOK_INDEX_PATH = SCHEMA_DIR / "paper-notebook-index.json"
+PAPER_NOTEBOOK_FULL_MAP_PATH = SCHEMA_DIR / "paper-notebook-wiki-full-map.yml"
+PAPER_NOTEBOOK_SITE_PREFIX = (
+    "https://imchong.github.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/"
+)
+PAPER_NOTEBOOK_HTML_RE = re.compile(
+    r"https://imchong\.github\.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/[^\s)<>\"']+\.html",
+    re.IGNORECASE,
+)
+PAPER_NOTEBOOK_MD_LINK_RE = re.compile(
+    r"\[机器人论文阅读笔记[:：]([^\]]+)\]"
+    r"\((https://imchong\.github\.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/[^)]+\.html)\)",
+    re.IGNORECASE,
+)
 
 
 def build_ingest_index() -> Dict[str, str]:
@@ -503,6 +520,106 @@ def parse_roadmap_stages(text: str, current_path: Path) -> List[Dict[str, Any]]:
     return stages
 
 
+def _paper_notebook_short_label(title: str) -> str:
+    title = title.strip()
+    if title.lower().startswith("[website],"):
+        title = title.split(",", 1)[1].strip()
+    if title.startswith("[") and "]" in title:
+        title = title[1 : title.index("]")].strip()
+    label = title.split(":")[0].split("(")[0].strip()
+    return label or title.strip()
+
+
+def _clean_paper_notebook_label(label: str, url: str, fallback_title: str = "") -> str:
+    text = label.strip()
+    text = re.sub(r"^机器人论文阅读笔记[:：]\s*", "", text)
+    text = re.sub(r"^[深读笔记论]+[:：<\s]+", "", text)
+    text = text.strip("<> ").strip()
+    if not text or len(text) < 3:
+        stem = url.rsplit("/", 1)[-1].removesuffix(".html")
+        text = stem.replace("__", ": ").replace("_", " ").strip()
+    if not text:
+        text = _paper_notebook_short_label(fallback_title)
+    return text or "论文阅读笔记"
+
+
+def _is_paper_notebook_html_url(url: str) -> bool:
+    if not url:
+        return False
+    base = url.split("#", 1)[0].split("?", 1)[0]
+    return base.startswith(PAPER_NOTEBOOK_SITE_PREFIX) and base.endswith(".html")
+
+
+def build_wiki_paper_notebook_link_index() -> dict[str, dict[str, str]]:
+    if not PAPER_NOTEBOOK_INDEX_PATH.exists() or not PAPER_NOTEBOOK_FULL_MAP_PATH.exists():
+        return {}
+
+    papers = {entry["dir"]: entry for entry in json.loads(PAPER_NOTEBOOK_INDEX_PATH.read_text(encoding="utf-8"))}
+    overrides = yaml.safe_load(PAPER_NOTEBOOK_FULL_MAP_PATH.read_text(encoding="utf-8")).get("overrides", {})
+    out: dict[str, dict[str, str]] = {}
+    for paper_dir, wiki_paths in overrides.items():
+        paper = papers.get(paper_dir)
+        if not paper:
+            continue
+        url = str(paper.get("url") or "")
+        if not _is_paper_notebook_html_url(url):
+            continue
+        label = _paper_notebook_short_label(str(paper.get("title") or paper_dir))
+        for wiki_path in wiki_paths:
+            path = wiki_path if str(wiki_path).startswith("wiki/") else f"wiki/{wiki_path}"
+            out[path] = {"url": url, "label": label}
+    return out
+
+
+def collect_paper_notebook_links(
+    item: dict[str, Any],
+    wiki_link_index: dict[str, dict[str, str]] | None = None,
+) -> list[dict[str, str]]:
+    path = str(item.get("path") or "")
+    content = str(item.get("content_markdown") or "")
+    title = str(item.get("title") or "")
+    results: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    def push(url: str, label: str = "") -> None:
+        if not _is_paper_notebook_html_url(url):
+            return
+        key = url.split("#", 1)[0].split("?", 1)[0]
+        if key in seen:
+            return
+        seen.add(key)
+        results.append({"url": key, "label": _clean_paper_notebook_label(label, key, title)})
+
+    if wiki_link_index and path in wiki_link_index:
+        mapped = wiki_link_index[path]
+        push(str(mapped.get("url") or ""), str(mapped.get("label") or ""))
+
+    for entry in item.get("source_links", []):
+        if isinstance(entry, dict):
+            push(str(entry.get("url") or ""), str(entry.get("label") or ""))
+        else:
+            push(str(entry), str(entry))
+
+    for match in PAPER_NOTEBOOK_MD_LINK_RE.finditer(content):
+        push(match.group(2), match.group(1))
+
+    for match in PAPER_NOTEBOOK_HTML_RE.finditer(content):
+        push(match.group(0), "")
+
+    return results[:6]
+
+
+def attach_paper_notebook_links(
+    items: list[dict[str, Any]],
+    wiki_link_index: dict[str, dict[str, str]] | None = None,
+) -> None:
+    index = wiki_link_index if wiki_link_index is not None else build_wiki_paper_notebook_link_index()
+    for item in items:
+        links = collect_paper_notebook_links(item, index)
+        if links:
+            item["paper_notebook_links"] = links
+
+
 def build_item(path: Path) -> dict[str, Any]:
     text = read_text(path)
     fm = parse_frontmatter(text)
@@ -859,6 +976,7 @@ def main() -> None:
     global _INGEST_INDEX
     _INGEST_INDEX = build_ingest_index()
     items = [build_item(p) for p in collect_paths()]
+    attach_paper_notebook_links(items)
     payload = {
         "version": "v1",
         "generated_mode": "script",

--- a/tests/test_paper_notebook_links_export.py
+++ b/tests/test_paper_notebook_links_export.py
@@ -1,0 +1,48 @@
+import unittest
+from pathlib import Path
+
+from export_minimal import (
+    attach_paper_notebook_links,
+    build_item,
+    collect_paper_notebook_links,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ZEROWBC = ROOT / "wiki" / "entities" / "paper-notebook-zerowbc.md"
+VMP = ROOT / "wiki" / "entities" / "paper-notebook-vmp.md"
+PLANNED = (
+    ROOT
+    / "wiki"
+    / "entities"
+    / "paper-notebook-a-21-dof-humanoid-dexterous-hand-with-hybrid-sma.md"
+)
+
+
+class PaperNotebookLinksExportTests(unittest.TestCase):
+    def test_collect_paper_notebook_links_prefers_notebook_html(self) -> None:
+        item = build_item(ZEROWBC)
+        links = collect_paper_notebook_links(item)
+        self.assertEqual(len(links), 1)
+        self.assertTrue(links[0]["url"].endswith(".html"))
+        self.assertIn("ZeroWBC", links[0]["label"])
+        self.assertNotIn("progress.json", links[0]["url"])
+
+    def test_collect_paper_notebook_links_ignores_github_progress_json(self) -> None:
+        item = build_item(VMP)
+        links = collect_paper_notebook_links(item)
+        self.assertEqual(links, [])
+
+    def test_planned_stub_without_notebook_html_has_no_links(self) -> None:
+        item = build_item(PLANNED)
+        links = collect_paper_notebook_links(item)
+        self.assertEqual(links, [])
+
+    def test_attach_paper_notebook_links_writes_index_field(self) -> None:
+        item = build_item(ZEROWBC)
+        attach_paper_notebook_links([item])
+        self.assertIn("paper_notebook_links", item)
+        self.assertEqual(len(item["paper_notebook_links"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 graph 视图侧边栏中，论文笔记节点「打开详情页」上方「论文阅读笔记」区块的错误链接：

- `source_links` 导出为对象后，旧逻辑把整个 entry 当 URL 使用，导致 `href="[object Object]"`。
- 过滤器匹配 `Humanoid_Robot_Learning_Paper_Notebooks` 子串，误把 `github.com/.../progress.json` 等元数据链当成深读笔记。

本次改动：

1. **`docs/graph.html`**：新增 `collectPaperNotebookLinks()`，只保留 `imchong.github.io/.../papers/*.html` 深读页，正确解析 `label`/`url`，并加固 `isSafeUrl` 拒绝非字符串。
2. **`scripts/export_minimal.py`**：导出时为索引项写入 `paper_notebook_links`（来自 full-map、正文 markdown 与合法 `source_links`），供侧栏优先消费。
3. **`tests/test_paper_notebook_links_export.py`**：覆盖 ZeroWBC 正常链、VMP/progress.json 误链过滤、计划 stub 空链。

## 验证

- `make ci-preflight` 通过
- `PYTHONPATH=scripts python3 -m unittest tests.test_paper_notebook_links_export -v` 通过
- 本地 `graph.html?focus=wiki/entities/paper-notebook-zerowbc.md` 侧栏「论文阅读笔记」显示 **ZeroWBC** 并指向笔记站 HTML

## 验证截图

[图谱侧边栏论文阅读笔记链接修复（ZeroWBC）](https://cursor.com/agents/bc-c961a8b7-0088-4126-b2a7-186fca79cbd9/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-paper-notebook-sidebar.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c961a8b7-0088-4126-b2a7-186fca79cbd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c961a8b7-0088-4126-b2a7-186fca79cbd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

