### PR TITLE
fix(ux): 修复首次 2D→3D 切换时 3D 图谱节点不显示

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -525,19 +525,24 @@
     function resumeRenderLoop() {
       if (!graph) return;
       // 3d-force-graph 在 kapsule 的防抖 digest 里才创建 WebGL renderer 并由 init 自启渲染环。
-      // 主线程繁忙时本函数（经 afterGraphDataApplied 的 2×rAF 调度）可能早于该 digest 跑完，
+      // 主线程繁忙时本函数（经 afterGraphDataApplied 调度）可能早于该 digest 跑完，
       // 此刻 renderer 尚未就绪；若仍 resumeAnimation，会让库内部 _animationCycle 在对象未就绪时
       // 同步抛错——且抛错发生在 requestAnimationFrame 重排之前 → 渲染环被永久中断、整屏黑屏。
       // 故 renderer 未就绪时推迟到下一帧重试（有上限兜底）；待库 init digest 建好 renderer 并自启
       // 渲染环后，这里再 resumeAnimation 也只是无害的 no-op。
       if (typeof graph.renderer === 'function' && !graph.renderer()) {
-        if (resumeDeferrals++ < 120) window.requestAnimationFrame(resumeRenderLoop);
+        if (resumeDeferrals++ < 180) window.requestAnimationFrame(resumeRenderLoop);
         return;
       }
-      resumeDeferrals = 0;
-      // 只恢复渲染环，不再把 alphaTarget 钉在 0.25（那会让力模拟永不收敛、一直微抖）。
-      // alphaTarget 保持 0，配合 reheat 的 alpha=1 实现「冲一下→自然衰减到静止」。
-      if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
+      // renderer 已就绪但 graphData digest 可能尚未把 layout 赋给 forceGraph；此时
+      // _animationCycle → forceGraph.tickFrame → layout.tick() 仍会同步抛错并永久中断 rAF。
+      // 捕获后推迟重试，直到 layout 建好（首次 2D→3D 切换、主线程繁忙时常见）。
+      try {
+        if (typeof graph.resumeAnimation === 'function') graph.resumeAnimation();
+        resumeDeferrals = 0;
+      } catch (_resumeErr) {
+        if (resumeDeferrals++ < 180) window.requestAnimationFrame(resumeRenderLoop);
+      }
     }
 
     // 渲染环自愈：万一 3d-force-graph 的 _animationCycle 仍在内部对象（renderObjs / forceGraph）
@@ -783,9 +788,25 @@
     var graph = null;
 
     function afterGraphDataApplied(fn) {
-      window.requestAnimationFrame(function () {
-        window.requestAnimationFrame(fn);
-      });
+      // graphData 经 kapsule 防抖 digest 异步落地；2×rAF 在 2D 力模拟刚停、1500+ 节点
+      // 首次进 3D 时不足以等到 renderer/layout 就绪。轮询 renderer 后再回调，配合
+      // resumeRenderLoop 的 try/catch 重试，避免 layout.tick 抢跑导致渲染环永久中断。
+      var attempts = 0;
+      function wait() {
+        attempts += 1;
+        if (!graph) {
+          if (attempts < 240) window.requestAnimationFrame(wait);
+          else fn();
+          return;
+        }
+        if (typeof graph.renderer === 'function' && !graph.renderer()) {
+          if (attempts < 240) window.requestAnimationFrame(wait);
+          else fn();
+          return;
+        }
+        fn();
+      }
+      window.requestAnimationFrame(wait);
     }
 
     function bindGraphInstance() {

--- a/scripts/verify_graph_loading_2d3d.cjs
+++ b/scripts/verify_graph_loading_2d3d.cjs
@@ -152,7 +152,9 @@ function isLoadingDismissed(st) {
     report.cases.push(case1);
     await page.screenshot({ path: path.join(outDir, 'graph-loading-2d-ready.png') });
 
-    // Case 2: switch to 3D — loading stays dismissed, 3D canvas shown
+    // Case 2: switch to 3D — loading stays dismissed, 3D canvas shown, no render-loop crash
+    const pageErrors = [];
+    page.on('pageerror', (e) => pageErrors.push(String(e.message || e)));
     await clickViewMode(page, '3d');
     await sleep(2500);
     const after3dSwitch = await loadingState(page);
@@ -163,8 +165,9 @@ function isLoadingDismissed(st) {
       view3dActive: view3d.btn3dActive && !view3d.btn2dActive,
       has3dCanvas: view3d.has3dCanvas,
       svgHidden: view3d.svgDisplay === 'none',
+      noTickCrash: !pageErrors.some((m) => m.includes("reading 'tick'")),
     };
-    case2.pass = case2.loadingDismissed && is3dViewActive(view3d);
+    case2.pass = case2.loadingDismissed && is3dViewActive(view3d) && case2.noTickCrash;
     report.cases.push(case2);
     await page.screenshot({ path: path.join(outDir, 'graph-loading-3d-switched.png') });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复知识图谱页**第一次**从 2D 切换到 3D 时画布空白、节点不显示的问题。

**根因：** `graphData()` 经 3d-force-graph 的 kapsule 防抖 digest 异步落地；`afterGraphDataApplied` 仅用 2×`requestAnimationFrame` 就调用 `resumeAnimation()`。此时 WebGL `renderer` 可能已就绪，但内部力布局 `layout` 尚未赋值。`_animationCycle → forceGraph.tickFrame → layout.tick()` 同步抛错，且发生在下一帧 `rAF` 重排之前，导致渲染环**永久中断**（表现为整屏空白；切回 2D 再进 3D 因实例已初始化而恢复正常）。

## 改动

- **`docs/graph-3d.js`**
  - `resumeRenderLoop`：`resumeAnimation()` 外包 `try/catch`，`layout` 未就绪时推迟到下一帧重试（最多 180 帧）。
  - `afterGraphDataApplied`：改为轮询直到 `renderer` 就绪后再回调，减少抢跑。
- **`scripts/verify_graph_loading_2d3d.cjs`**：Case 2 增加 `layout.tick` 崩溃回归检测。

## 验证

- `node scripts/verify_graph_loading_2d3d.cjs http://127.0.0.1:8765/graph.html` 全绿（含首次 2D→3D，无 `reading 'tick'` 报错）
- 本地 Puppeteer：首次 2D→3D 切换 6s 后截图节点正常渲染，console 无 pageerror

## 验证截图

[首次 2D→3D 切换后 3D 节点正常显示](https://cursor.com/agents/bc-e5a0415b-6192-4310-ad97-4fc004624130/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-3d-first-switch-fix.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5a0415b-6192-4310-ad97-4fc004624130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5a0415b-6192-4310-ad97-4fc004624130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

