### PR TITLE
fix(ux): 增强 3D 选中节点连线高亮加粗可见度

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -69,6 +69,24 @@
     return /^Sphere(Buffer)?Geometry$/i.test(geometry.type);
   }
 
+  function isCylinderGeometryType(geometry) {
+    if (!geometry || !geometry.type) return false;
+    return /^Cylinder(Buffer)?Geometry$/i.test(geometry.type);
+  }
+
+  /** three-forcegraph 连线可能是 Group 包裹的 Cylinder mesh，缩放必须落在圆柱体上。 */
+  function resolveLinkCylinderMesh(linkObj) {
+    if (!linkObj) return null;
+    if (linkObj.isMesh && linkObj.geometry && isCylinderGeometryType(linkObj.geometry)) return linkObj;
+    if (linkObj.children && linkObj.children.length) {
+      for (var i = 0; i < linkObj.children.length; i++) {
+        var ch = linkObj.children[i];
+        if (ch.isMesh && ch.geometry && isCylinderGeometryType(ch.geometry)) return ch;
+      }
+    }
+    return linkObj.isMesh ? linkObj : null;
+  }
+
   function captureBundledThreeFromMesh(obj) {
     return {
       SphereGeometry: obj.geometry.constructor,
@@ -312,13 +330,13 @@
       if (sidebarNodeId && edgeHighlightsWithNode) {
         var ref = l._ref;
         if (!ref) return 0.08;
-        if (!filtered) return edgeHighlightsWithNode(ref, sidebarNodeId) ? 0.55 : 0.08;
+        if (!filtered) return edgeHighlightsWithNode(ref, sidebarNodeId) ? 0.88 : 0.06;
         if (!visible.has(s) || !visible.has(t)) return 0.08;
-        return edgeHighlightsWithNode(ref, sidebarNodeId) ? 0.55 : 0.08;
+        return edgeHighlightsWithNode(ref, sidebarNodeId) ? 0.88 : 0.06;
       }
       if (hoverNodeId) {
         var eRef = l._ref;
-        if (eRef && edgeHighlightsWithNode) return edgeHighlightsWithNode(eRef, hoverNodeId) ? 0.45 : 0.1;
+        if (eRef && edgeHighlightsWithNode) return edgeHighlightsWithNode(eRef, hoverNodeId) ? 0.68 : 0.1;
       }
       if (!filtered) return 0.06;
       if (!visible.has(s) || !visible.has(t)) return 0.03;
@@ -344,7 +362,8 @@
     }
 
     function linkBaseWidth() {
-      return getLinkWidth() * 0.3;
+      // 3D 世界坐标下节点球体半径约 11–40；基准连线需与节点同量级才可见。
+      return getLinkWidth() * 0.5;
     }
 
     // 期望连线宽度（高亮连线除染色外再加粗）。实际粗细不靠 linkWidth 访问器生效——
@@ -354,11 +373,11 @@
       var base = linkBaseWidth();
       if (sidebarNodeId) {
         var ref = l._ref;
-        if (ref && edgeHighlightsWithNode && edgeHighlightsWithNode(ref, sidebarNodeId)) return base * 3.5;
+        if (ref && edgeHighlightsWithNode && edgeHighlightsWithNode(ref, sidebarNodeId)) return base * 12;
       }
       if (hoverNodeId) {
         var eRef = l._ref;
-        if (eRef && edgeHighlightsWithNode && edgeHighlightsWithNode(eRef, hoverNodeId)) return base * 3;
+        if (eRef && edgeHighlightsWithNode && edgeHighlightsWithNode(eRef, hoverNodeId)) return base * 8;
       }
       return base;
     }
@@ -425,13 +444,15 @@
     // 在这里按「期望宽度 / 基准宽度」设置 mesh 半径轴(x/y)缩放；返回 falsy 让库继续做默认定位
     // （只写 scale.z 长度 + lookAt 朝向），两者互不干扰，加粗即可稳定保留、且无需重建几何或重排布局。
     function linkScaleUpdate(obj, _coords, link) {
+      var mesh = resolveLinkCylinderMesh(obj);
+      if (!mesh) return false;
       var mult = 1;
       if (sidebarNodeId || hoverNodeId) {
         var base = linkBaseWidth();
         if (base > 0) mult = linkWidthFor(link) / base;
       }
-      obj.scale.x = mult;
-      obj.scale.y = mult;
+      mesh.scale.x = mult;
+      mesh.scale.y = mult;
       return false;
     }
 

--- a/scripts/verify_graph_3d_link_thickness.cjs
+++ b/scripts/verify_graph_3d_link_thickness.cjs
@@ -1,4 +1,4 @@
-// Verify PR #867: selected/hovered 3D links thicken via linkPositionUpdate (mesh x/y scale).
+// Verify 3D selected/hovered links thicken via linkPositionUpdate (mesh x/y scale).
 // Also records a short MP4 comparing sidebar closed vs open.
 // Usage: node scripts/verify_graph_3d_link_thickness.cjs [baseUrl] [outDir]
 const puppeteer = require('puppeteer-core');
@@ -42,8 +42,8 @@ async function sampleLinkScales(page, label) {
     return {
       label,
       cylinders: scales.length,
-      thick35: scales.filter((s) => s.x >= 3.4 && s.x <= 3.6).length,
-      thick3: scales.filter((s) => s.x >= 2.9 && s.x <= 3.1).length,
+      thick12: scales.filter((s) => s.x >= 11.9 && s.x <= 12.1).length,
+      thick8: scales.filter((s) => s.x >= 7.9 && s.x <= 8.1).length,
       unit: scales.filter((s) => Math.abs(s.x - 1) < 0.05).length,
       maxX: scales.reduce((m, s) => Math.max(m, s.x), 0),
       sidebarOpen: document.getElementById('sidebar')?.classList.contains('open'),
@@ -127,7 +127,7 @@ function framesToMp4(frameDir, outMp4, fps) {
     await sleep(6000);
     await hideLoading(page);
     const baseline = await sampleLinkScales(page, 'baseline-no-sidebar');
-    baseline.pass = baseline.maxX <= 1.1 && baseline.thick35 === 0;
+    baseline.pass = baseline.maxX <= 1.1 && baseline.thick12 === 0;
     report.cases.push(baseline);
     await page.screenshot({ path: path.join(outDir, 'graph-3d-link-baseline.png') });
 
@@ -137,7 +137,7 @@ function framesToMp4(frameDir, outMp4, fps) {
     }
     await captureFrames(page, framesDir, 4, 500);
 
-    // Case 2: open sidebar via ?focus= (selected node links should scale x/y to 3.5)
+    // Case 2: open sidebar via ?focus= (selected node links should scale x/y to 12)
     await page.goto(urlWith({ view: '3d', focus: focusId }), { waitUntil: 'domcontentloaded', timeout: 120000 });
     await page.waitForFunction(() => {
       const el = document.getElementById('graph-loading');
@@ -146,7 +146,7 @@ function framesToMp4(frameDir, outMp4, fps) {
     await sleep(7000);
     await hideLoading(page);
     const focused = await sampleLinkScales(page, 'sidebar-focus');
-    focused.pass = focused.thick35 > 0 && focused.unit > 0 && focused.maxX >= 3.4;
+    focused.pass = focused.thick12 > 0 && focused.unit > 0 && focused.maxX >= 11.9;
     report.cases.push(focused);
     await page.screenshot({ path: path.join(outDir, 'graph-3d-link-focused.png') });
     await captureFrames(page, framesDir, 8, 500);
@@ -155,7 +155,7 @@ function framesToMp4(frameDir, outMp4, fps) {
     await page.click('#sb-close');
     await sleep(2500);
     const cleared = await sampleLinkScales(page, 'sidebar-closed');
-    cleared.pass = cleared.maxX <= 1.1 && cleared.thick35 === 0;
+    cleared.pass = cleared.maxX <= 1.1 && cleared.thick12 === 0;
     report.cases.push(cleared);
     await captureFrames(page, framesDir, 4, 500);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 3D 图谱选中节点（侧栏打开）时连线「只染色、看不出加粗」的问题
- 根因：节点球体世界半径约 11–40，而连线基准宽度仅 `0.3`，即便 `linkPositionUpdate` 做了 3.5× 缩放，有效半径仍约 1，在全图视角下肉眼不可辨
- 调整：提高基准宽度与不透明度，选中/悬停分别使用 12× / 8× 半径缩放，并确保缩放落在 Cylinder mesh 上

## 改动
- `docs/graph-3d.js`
  - `linkBaseWidth`: `0.3` → `0.5`
  - 选中连线宽度倍数 `3.5` → `12`，悬停 `3` → `8`
  - 选中/悬停不透明度对齐 2D（0.88 / 0.68）
  - 新增 `resolveLinkCylinderMesh`，`linkScaleUpdate` 对圆柱体 mesh 做 x/y 缩放
- `scripts/verify_graph_3d_link_thickness.cjs`：更新自动化断言阈值（12×）

## 验证
- `node scripts/verify_graph_3d_link_thickness.cjs` 三阶段全部通过（无侧栏 → `?focus=` 选中 → 关闭侧栏）
- 选中态 243 条邻接连线 `scale.x = 12`，关闭侧栏后恢复为 1

## 验证截图
[3D 全图视角：选中 Sim2Real 节点后邻接连线加粗高亮](https://cursor.com/agents/bc-179856e0-8516-4d98-9578-e8a747054262/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-3d-link-focused.png)

[3D 近景：选中节点放射状加粗连线](https://cursor.com/agents/bc-179856e0-8516-4d98-9578-e8a747054262/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-3d-selected-links-highlight.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-179856e0-8516-4d98-9578-e8a747054262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-179856e0-8516-4d98-9578-e8a747054262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

