### PR TITLE
fix(ux): 触屏 3D 选中节点旋转后保持连线高亮

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -864,8 +864,11 @@
           if (onNodeClick) onNodeClick(src, ev || lastPointer);
         })
         .onNodeHover(function (node) {
-          hoverNodeId = node ? node.id : null;
-          refreshAppearance();
+          // 侧栏/触屏选中态由 sidebarNodeId 驱动；旋转视角时 hover 会短暂落空，不能覆盖持久高亮。
+          if (!sidebarNodeId) {
+            hoverNodeId = node ? node.id : null;
+            refreshAppearance();
+          }
           var src = node ? (resolveSourceNode(node.id) || node) : null;
           if (onNodeHover) onNodeHover(src, lastPointer);
         })

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2239,9 +2239,11 @@
             if (pinnedNode === d) {
               pinnedNode = null;
               hideTooltip();
+              clearGraph3DMobileHighlight();
             } else {
               pinnedNode = d;
               showTooltip(ev, d);
+              syncGraph3DMobileHighlight(d);
             }
           } else {
             openSidebar(d);
@@ -2324,6 +2326,7 @@
         }
         graph3dView.show();
         graph3dView.syncFilters();
+        if (isMobile && pinnedNode) syncGraph3DMobileHighlight(pinnedNode);
         // 不在切换时自动适配：仅首次力布局结束后由 graph-3d 自动适配一次，
         // 之后只有用户点「适配屏幕」按钮才适配。
       } else {
@@ -3082,6 +3085,7 @@
           setTimeout(() => {
             pinnedNode = null;
             hideTooltip();
+            clearGraph3DMobileHighlight();
           }, 100);
         }
       }
@@ -4322,8 +4326,8 @@
       };
     }
 
-    function openSidebar(d) {
-      // V19: 高亮当前节点及 2-hop 邻居
+    /** 侧栏/3D 选中高亮：当前节点的一跳与二跳邻居集合 */
+    function buildSidebarNeighborSets(d) {
       const direct = new Set();
       const secondary = new Set();
       edges.forEach(e => {
@@ -4336,7 +4340,25 @@
         if (direct.has(sId) && tId !== d.id) secondary.add(tId);
         if (direct.has(tId) && sId !== d.id) secondary.add(sId);
       });
+      return { direct, secondary };
+    }
 
+    /** 触屏 3D：固定卡片选中态写入持久高亮（不依赖 hover，旋转视角不会丢） */
+    function syncGraph3DMobileHighlight(d) {
+      if (!isMobile || !graph3dView || !is3DView() || !d) return;
+      const { direct, secondary } = buildSidebarNeighborSets(d);
+      graph3dView.applySidebarHighlight(d, direct, secondary);
+    }
+
+    function clearGraph3DMobileHighlight() {
+      if (!graph3dView || !is3DView()) return;
+      if (sidebar.classList.contains('open')) return;
+      graph3dView.clearSidebarHighlight();
+    }
+
+    function openSidebar(d) {
+      // V19: 高亮当前节点及 2-hop 邻居
+      const { direct, secondary } = buildSidebarNeighborSets(d);
       sidebarFocusIds = new Set([d.id, ...direct]);
 
       hideTooltip();
@@ -4496,6 +4518,7 @@
       if (!isMobile || !pinnedNode) return false;
       pinnedNode = null;
       hideTooltip();
+      clearGraph3DMobileHighlight();
       return true;
     }
 

--- a/scripts/verify_graph_3d_touch_highlight.cjs
+++ b/scripts/verify_graph_3d_touch_highlight.cjs
@@ -1,0 +1,144 @@
+// Verify 3D selected-node highlight survives touch orbit drag (mobile viewport).
+// Usage: node scripts/verify_graph_3d_touch_highlight.cjs [baseUrl] [outDir]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+const baseUrl = process.argv[2] || 'http://127.0.0.1:8765/graph.html';
+const outDir = path.resolve(process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots'));
+const focusId = 'wiki/concepts/sim2real.md';
+const chromeArgs = [
+  '--no-sandbox',
+  '--disable-dev-shm-usage',
+  '--window-size=390,844',
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
+];
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function urlWith(params) {
+  const u = new URL(baseUrl);
+  Object.entries(params).forEach(([k, v]) => u.searchParams.set(k, v));
+  return u.toString();
+}
+
+async function sampleLinkScales(page) {
+  return page.evaluate(() => {
+    const g = window.__fg3dInstances && window.__fg3dInstances[window.__fg3dInstances.length - 1];
+    if (!g || !g.scene) return { error: 'no ForceGraph3D instance' };
+    const scene = g.scene();
+    const scales = [];
+    scene.traverse((o) => {
+      if (o.isMesh && o.geometry?.type?.includes('Cylinder')) {
+        scales.push({ x: o.scale.x, y: o.scale.y });
+      }
+    });
+    return {
+      cylinders: scales.length,
+      thick12: scales.filter((s) => s.x >= 11.9 && s.x <= 12.1).length,
+      maxX: scales.reduce((m, s) => Math.max(m, s.x), 0),
+      isMobile: window.matchMedia('(hover: none) and (pointer: coarse)').matches,
+    };
+  });
+}
+
+(async () => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const exe = process.env.PUPPETEER_EXECUTABLE_PATH
+    || (fs.existsSync('/usr/local/bin/google-chrome') ? '/usr/local/bin/google-chrome' : 'google-chrome');
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: chromeArgs,
+    defaultViewport: { width: 390, height: 844, deviceScaleFactor: 2, isMobile: true, hasTouch: true },
+  });
+
+  const report = { cases: [], ok: false };
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 390, height: 844, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+
+    await page.evaluateOnNewDocument(() => {
+      const orig = window.matchMedia.bind(window);
+      window.matchMedia = (q) => {
+        if (q === '(hover: none) and (pointer: coarse)') {
+          return { matches: true, media: q, addListener() {}, removeListener() {}, addEventListener() {}, removeEventListener() {}, dispatchEvent() { return true; } };
+        }
+        return orig(q);
+      };
+    });
+
+    await page.evaluateOnNewDocument(() => {
+      window.__fg3dInstances = [];
+      const hook = () => {
+        if (!window.ForceGraph3D || window.__fgHooked) return;
+        window.__fgHooked = true;
+        const Orig = window.ForceGraph3D;
+        function Wrapped(el) {
+          const inst = Orig(el);
+          window.__fg3dInstances.push(inst);
+          return inst;
+        }
+        Wrapped.prototype = Orig.prototype;
+        Object.assign(Wrapped, Orig);
+        window.ForceGraph3D = Wrapped;
+      };
+      const t = setInterval(() => { hook(); if (window.__fgHooked) clearInterval(t); }, 5);
+    });
+
+    // Case 1: mobile viewport + focus selection (persistent sidebarNodeId highlight)
+    await page.goto(urlWith({ view: '3d', focus: focusId }), { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-loading');
+      return !el || el.hidden || el.classList.contains('is-hidden');
+    }, { timeout: 90000 });
+    await sleep(8000);
+    await page.evaluate(() => {
+      const el = document.getElementById('graph-loading');
+      if (el) { el.hidden = true; el.classList.add('is-hidden'); el.style.display = 'none'; }
+    });
+
+    const before = await sampleLinkScales(page);
+    before.label = 'before-orbit';
+    before.pass = before.thick12 > 0 && before.maxX >= 11.9;
+    report.cases.push(before);
+
+    const canvas = await page.$('#graph-canvas-3d canvas');
+    const box = await canvas.boundingBox();
+    const cx = box.x + box.width * 0.52;
+    const cy = box.y + box.height * 0.48;
+
+    await page.touchscreen.touchStart(cx, cy);
+    await sleep(60);
+    await page.touchscreen.touchMove(cx + 110, cy - 70);
+    await sleep(60);
+    await page.touchscreen.touchMove(cx - 80, cy + 90);
+    await sleep(60);
+    await page.touchscreen.touchEnd();
+    await sleep(2000);
+
+    const after = await sampleLinkScales(page);
+    after.label = 'after-orbit';
+    after.pass = after.thick12 > 0 && after.maxX >= 11.9;
+    report.cases.push(after);
+
+    await page.screenshot({ path: path.join(outDir, 'graph-3d-touch-highlight-after-rotate.png') });
+
+    report.ok = report.cases.every((c) => c.pass);
+    const outJson = path.join(outDir, 'graph-3d-touch-highlight-verify.json');
+    fs.writeFileSync(outJson, JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复触屏 3D 选中节点后，单指旋转视角高亮立即消失的问题
- 根因：移动端点击只固定 tooltip，3D 高亮依赖 `hoverNodeId`；旋转时 hover 落空即 `refreshAppearance()` 清掉加粗/染色
- 方案：触屏选中时写入 `applySidebarHighlight` 持久态（与 PC 侧栏同源），旋转不再依赖 hover；`sidebarNodeId` 已设时忽略 hover 刷新

## 改动
- `docs/graph.html`：抽取 `buildSidebarNeighborSets`；新增 `syncGraph3DMobileHighlight` / `clearGraph3DMobileHighlight`；触屏 3D 点选/取消/切视图时同步持久高亮
- `docs/graph-3d.js`：`sidebarNodeId` 存在时不再用 hover 驱动 `refreshAppearance`
- `scripts/verify_graph_3d_touch_highlight.cjs`：移动端视口 + 触摸拖拽后断言高亮连线 `scale.x=12` 仍在

## 同分支一并包含
- #878 的 3D 选中连线加粗可见度增强（基准宽度与 12× 倍数）

## 验证
- `node scripts/verify_graph_3d_touch_highlight.cjs` 通过（旋转前/后 `thick12=243`）
- `node scripts/verify_graph_3d_link_thickness.cjs` 通过

## 验证截图
[触屏旋转后 3D 选中连线高亮仍保留](https://cursor.com/agents/bc-179856e0-8516-4d98-9578-e8a747054262/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-3d-touch-highlight-after-rotate.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-179856e0-8516-4d98-9578-e8a747054262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-179856e0-8516-4d98-9578-e8a747054262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

