### PR TITLE
feat: V27 P0 接触/力控/操作概念页交叉链路巡检 V1

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v27.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v27.md
@@ -24,8 +24,8 @@
 
 ## P0: 自动化与工具链深度强化 (Engineering)
 
-- [ ] **接触/力控/操作概念页交叉链路巡检 V1**：
-    - [ ] `scripts/lint_wiki.py` 新增 `_check_contact_control_crosslink`：对 `tags` 含 `contact` / `force-control` / `impedance` / `manipulation` / `tactile` 的 `concepts/` 概念页，检查正文是否回链到「接触力旋量闭环」专题枢纽（`contact-wrench-closed-loop` / `topic-contact-force-control`，缺失给 INFO 级 `contact_control_crosslink` 提示，不阻塞 CI），枢纽页自身豁免；写入 lint 报告基线快照（`exports/lint-report.md`）；新增 `tests/test_lint_wiki_contact_control_crosslink.py` 用例覆盖（列表式/内联式 tag、有/无回链、枢纽豁免、INFO 不计失败）。
+- [x] **接触/力控/操作概念页交叉链路巡检 V1**：
+    - [x] `scripts/lint_wiki.py` 新增 `_check_contact_control_crosslink`：对 `tags` 含 `contact` / `force-control` / `impedance` / `manipulation` / `tactile`（子串匹配派生标签）的 `concepts/` 概念页，检查正文是否回链到「接触力旋量闭环」专题枢纽（`contact-wrench-closed-loop` / `topic-contact-force-control`，缺失给 INFO 级 `contact_control_crosslink` 提示，不阻塞 CI），枢纽页自身豁免；已写入 lint 报告基线快照（`exports/lint-report.md`，当前 10 页 backlog）；新增 `tests/test_lint_wiki_contact_control_crosslink.py` 用例覆盖（列表式/内联式 tag、有/无回链、双枢纽、枢纽豁免、INFO 不计失败）。
 
 ## P1: 接触力旋量闭环知识链专题 (Quality)
 
@@ -51,7 +51,7 @@
 
 ## 验收标准 (Definition of DoD)
 
-- [ ] `make lint`: 0 errors（新引入的 `contact_control_crosslink_check` 为 INFO 级，不阻塞 CI）。
+- [~] `make lint`: 0 errors（新引入的 `contact_control_crosslink` 为 INFO 级，不阻塞 CI）——已达成 0 errors + 14 条信息型预警。
 - [ ] 知识图谱节点数 **≥ 1525**，边数 **≥ 10260**（见 `exports/graph-stats.json`）。
 - [ ] 事实库扩展至 **≥ 220 条**（重点补 力控带宽 / 阻抗导纳 / 视触觉时延 矛盾检测规则）。
 - [ ] `community_quality_warning` 保持 `false` 且 `largest_community_ratio ≤ 0.25`。

--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-07-02] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **4** 条信息型预警）：
+共发现 **0** 个问题（另含 **14** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -107,5 +107,17 @@
 
 ### 💡 动力学/仿真/物理概念页缺回链「仿真物理保真度」专题枢纽（信息型，不阻塞 CI）（0 个）
 - 无
+
+### 💡 接触/力控/操作概念页缺回链「接触力旋量闭环」专题枢纽（信息型，不阻塞 CI）（10 个）
+- wiki/concepts/contact-rich-manipulation.md
+- wiki/concepts/dexterous-kinematics.md
+- wiki/concepts/embodied-data-cleaning.md
+- wiki/concepts/footstep-planning.md
+- wiki/concepts/foundation-policy.md
+- wiki/concepts/open-x-embodiment.md
+- wiki/concepts/physics-fidelity-sim2real-gap.md
+- wiki/concepts/state-estimation.md
+- wiki/concepts/tactile-sensing.md
+- wiki/concepts/whole-body-coordination.md
 
 📊 Sources 覆盖率：1523/1552 (98%) wiki/entity 页有 ingest 来源

--- a/log.md
+++ b/log.md
@@ -1,5 +1,7 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-07-02] lint | scripts/lint_wiki.py 新增 `_check_contact_control_crosslink`（V27 P0）——接触/力控/操作概念页交叉链路巡检 V1，INFO 级不阻塞 CI，回链「接触力旋量闭环」枢纽（contact-wrench-closed-loop / topic-contact-force-control）；新增 tests/test_lint_wiki_contact_control_crosslink.py（7 例）；刷新 exports/lint-report.md 基线（10 页 backlog，0 errors）
+
 ## [2026-07-02] ingest | sources/papers/flying_knots_arxiv_2602_21302.md — Flying Knots Task-Level ILC 可变形绳操作；wiki/entities/paper-flying-knots.md、wiki/entities/flying-knots-public.md；交叉更新 manipulation、contact-rich-manipulation
 
 ## [2026-07-02] ingest | sources/repos/robot_retargeter.md — robot_retargeter SMPL-X/多机型 mink 重定向；wiki/entities/robot-retargeter.md；交叉更新 motion-retargeting、motion-retargeting-pipeline、soma-retargeter、amass

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -124,6 +124,7 @@ INFO_ONLY_KEYS: set[str] = {
     "dataset_missing_metadata",
     "stale_claims",
     "physics_concept_crosslink",
+    "contact_control_crosslink",
 }
 
 
@@ -281,6 +282,7 @@ def _empty_results() -> dict[str, Any]:
         "dataset_missing_metadata": [],
         "stale_claims": [],
         "physics_concept_crosslink": [],
+        "contact_control_crosslink": [],
         "_ingest_covered": 0,
         "_ingest_total": 0,
     }
@@ -1172,6 +1174,56 @@ def _check_physics_concept_crosslink(pages: list[Path], results: dict[str, Any])
             results["physics_concept_crosslink"].append(str(rel))
 
 
+# 接触力控专题枢纽页：接触/力控/阻抗/操作/触觉概念页应回链至少一个，形成力旋量闭环链路
+CONTACT_FORCE_CONTROL_HUBS: tuple[str, ...] = (
+    "contact-wrench-closed-loop",
+    "topic-contact-force-control",
+)
+
+# 关键词以子串方式匹配 tag，覆盖 force-control / impedance-control / tactile-sensing /
+# contact-rich 等派生标签，避免精确匹配漏掉常见变体
+CONTACT_CONTROL_TAG_KEYWORDS: tuple[str, ...] = (
+    "contact",
+    "force-control",
+    "impedance",
+    "manipulation",
+    "tactile",
+)
+
+
+def _check_contact_control_crosslink(pages: list[Path], results: dict[str, Any]) -> None:
+    """V27: 接触/力控/操作概念页交叉链路巡检 V1（信息型，不阻塞 CI）。
+
+    对 frontmatter ``tags`` 含 ``contact`` / ``force-control`` / ``impedance`` /
+    ``manipulation`` / ``tactile``（以子串方式匹配派生标签）的 ``wiki/concepts/*``
+    概念页，检查正文是否回链到「接触力旋量闭环」专题枢纽页
+    （``contact-wrench-closed-loop`` / ``topic-contact-force-control``）。缺失回链
+    作为 INFO 级提示写入 lint 报告，沉淀接触力旋量闭环知识链的交叉链路基线，不计入
+    lint 失败总数。枢纽页自身豁免。
+    """
+    for page in pages:
+        rel = page.relative_to(REPO_ROOT)
+        parts = rel.parts
+        if len(parts) < 3 or parts[0] != "wiki" or parts[1] != "concepts":
+            continue
+        if page.stem in CONTACT_FORCE_CONTROL_HUBS:
+            continue
+
+        content = page.read_text(encoding="utf-8")
+        fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+        fm_block = fm_match.group(1) if fm_match else ""
+        # tags 既支持列表式（- contact），也支持内联式 [contact, ...]
+        tags = _frontmatter_tags(fm_block)
+        inline = re.search(r"^tags:\s*\[([^\]]*)\]", fm_block, re.MULTILINE)
+        if inline:
+            tags |= {t.strip().lower() for t in inline.group(1).split(",")}
+        if not any(kw in tag for tag in tags for kw in CONTACT_CONTROL_TAG_KEYWORDS):
+            continue
+
+        if not any(hub in content for hub in CONTACT_FORCE_CONTROL_HUBS):
+            results["contact_control_crosslink"].append(str(rel))
+
+
 def _check_tool_institutions(pages: list[Path], results: dict[str, Any]) -> None:
     """entities/ 软件工具页须能派生至少一个所属机构（见 schema/institutions.json）。"""
     from bump_institution_tags import (
@@ -1261,6 +1313,7 @@ def lint() -> dict[str, Any]:
     _check_dataset_entity_metadata(pages, results)
     _check_stale_claims(pages, results)
     _check_physics_concept_crosslink(pages, results)
+    _check_contact_control_crosslink(pages, results)
     _check_tool_institutions(pages, results)
 
     return results
@@ -1360,6 +1413,11 @@ def format_report(results: dict[str, Any]) -> str:
         (
             "physics_concept_crosslink",
             "动力学/仿真/物理概念页缺回链「仿真物理保真度」专题枢纽（信息型，不阻塞 CI）",
+            "💡",
+        ),
+        (
+            "contact_control_crosslink",
+            "接触/力控/操作概念页缺回链「接触力旋量闭环」专题枢纽（信息型，不阻塞 CI）",
             "💡",
         ),
     ]

--- a/tests/test_lint_wiki_contact_control_crosslink.py
+++ b/tests/test_lint_wiki_contact_control_crosslink.py
@@ -1,0 +1,97 @@
+"""Tests for V27 lint check: 接触/力控/操作概念页交叉链路巡检（信息型）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import lint_wiki as lw
+
+
+def _setup_wiki(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setattr(lw, "REPO_ROOT", tmp_path)
+    wiki = tmp_path / "wiki"
+    (wiki / "concepts").mkdir(parents=True)
+    return wiki
+
+
+def _run(pages: list[Path]) -> dict:
+    results = lw._empty_results()
+    lw._check_contact_control_crosslink(pages, results)
+    return results
+
+
+def test_concept_with_hub_backlink_passes(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "concepts" / "impedance-control.md"
+    page.write_text(
+        "---\ntype: concept\ntags: [control, impedance-control, force-control]\n---\n"
+        "阻抗控制在接触力旋量闭环链路中的定位，见 "
+        "[端到端 Query](../queries/contact-wrench-closed-loop.md)。\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["contact_control_crosslink"] == []
+
+
+def test_inline_tag_concept_without_hub_is_flagged(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "concepts" / "contact-rich-manipulation.md"
+    page.write_text(
+        "---\ntype: concept\ntags: [manipulation, contact, force-control]\n---\n"
+        "接触丰富操作正文，未回链任何力控枢纽。\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["contact_control_crosslink"] == ["wiki/concepts/contact-rich-manipulation.md"]
+
+
+def test_list_style_tag_concept_flagged(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "concepts" / "tactile-sensing.md"
+    page.write_text(
+        "---\ntype: concept\ntags:\n  - perception\n  - tactile-sensing\n---\n触觉感知正文。\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["contact_control_crosslink"] == ["wiki/concepts/tactile-sensing.md"]
+
+
+def test_topic_hub_backlink_also_passes(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "concepts" / "force-control-basics.md"
+    page.write_text(
+        "---\ntype: concept\ntags: [control, manipulation, force-control]\n---\n"
+        "力控基础，见专题 [接触力控](../overview/topic-contact-force-control.md)。\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["contact_control_crosslink"] == []
+
+
+def test_untagged_concept_is_ignored(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "concepts" / "diffusion-policy.md"
+    page.write_text(
+        "---\ntype: concept\ntags: [imitation-learning, generative]\n---\n与接触力控无关。\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["contact_control_crosslink"] == []
+
+
+def test_hub_pages_exempt_from_self_check(tmp_path: Path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    page = wiki / "concepts" / "contact-wrench-closed-loop.md"
+    page.write_text(
+        "---\ntype: concept\ntags: [contact, force-control]\n---\n枢纽页自身无需自链。\n",
+        encoding="utf-8",
+    )
+    results = _run([page])
+    assert results["contact_control_crosslink"] == []
+
+
+def test_info_only_does_not_count_toward_failing_total() -> None:
+    results = lw._empty_results()
+    results["contact_control_crosslink"].append("wiki/concepts/contact-rich-manipulation.md")
+    assert lw._failing_total(results) == 0
+    assert lw._info_total(results) == 1


### PR DESCRIPTION
## 摘要

实现 V27 P0 任务：新增 `_check_contact_control_crosslink` lint 检查，对 `tags` 含 `contact` / `force-control` / `impedance` / `manipulation` / `tactile` 的概念页，检查正文是否回链到「接触力旋量闭环」专题枢纽页（`contact-wrench-closed-loop` / `topic-contact-force-control`）。缺失回链作为 INFO 级提示，不阻塞 CI。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### 核心实现

1. **`scripts/lint_wiki.py`**
   - 新增 `CONTACT_FORCE_CONTROL_HUBS` 常量：定义两个枢纽页标识符
   - 新增 `CONTACT_CONTROL_TAG_KEYWORDS` 常量：定义关键词列表，支持子串匹配派生标签（如 `force-control` 匹配 `impedance-control`）
   - 新增 `_check_contact_control_crosslink()` 函数：
     - 遍历 `wiki/concepts/` 下的概念页
     - 解析 frontmatter 的 `tags`（支持列表式和内联式两种格式）
     - 检查 tag 是否包含关键词（子串匹配）
     - 检查正文是否包含枢纽页标识符
     - 缺失回链时添加到 `contact_control_crosslink` 结果列表
     - 枢纽页自身豁免检查
   - 在 `lint()` 主函数中调用新增检查
   - 在 `_empty_results()` 中初始化结果字段
   - 在 `format_report()` 中添加 INFO 级报告项

2. **`tests/test_lint_wiki_contact_control_crosslink.py`**（新增）
   - 7 个测试用例覆盖：
     - 有回链的概念页通过检查
     - 无回链的概念页被标记
     - 列表式和内联式 tag 格式均支持
     - 双枢纽页（`contact-wrench-closed-loop` 和 `topic-contact-force-control`）均可作为有效回链
     - 枢纽页自身豁免
     - INFO 级结果不计入失败总数

3. **`exports/lint-report.md`**
   - 刷新基线快照：新增 10 页 backlog（当前缺回链的概念页）
   - 信息型预警总数从 4 增至 14

4. **`docs/checklists/tech-stack-next-phase-checklist-v27.md`**
   - 标记任务完成（`[x]`）
   - 更新验收标准说明：已达成 0 errors + 14 条信息型预警

5. **`log.md`**
   - 记录本次改动

## 验证

- [x] `make test`：7 个新增测试全部通过
- [x] `make lint`：0 errors，新增 14 条 INFO 级预警（不阻塞 CI）
- [x] 代码逻辑验证：
  - 子串匹配关键词正确处理派生标签
  - 列表式/内联式 tag 格式均被正

https://claude.ai/code/session_01Dq1bNk4SzDp3B8qmmNoLNw