### PR TITLE
feat: Add wiki activity heatmap to homepage with daily node filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,11 @@ docs/sitemap.xml
 docs/exports/index-v1.json
 docs/exports/site-data-v1.json
 docs/exports/link-graph.json
+docs/exports/wiki-activity.json
 exports/index-v1.json
 exports/site-data-v1.json
 exports/link-graph.json
+exports/wiki-activity.json
 
 # Cloud Agent 本地验证截图与临时 HTML（勿提交）
 .cursor-artifacts/

--- a/docs/main.js
+++ b/docs/main.js
@@ -270,6 +270,8 @@
 
   // ── 首页知识节点活跃度热力图（GitHub 风格，数据源 exports/wiki-activity.json）──
   var HOME_HEATMAP_DAY_MS = 24 * 60 * 60 * 1000;
+  // GitHub 同款固定一年窗口：53 周列，最新周在最右，无数据日期为空格
+  var HOME_HEATMAP_WEEKS = 53;
   // 周一为第一行，仅标注 一/三/五 三行（与 GitHub Mon/Wed/Fri 一致）
   var HOME_HEATMAP_WEEKDAY_LABELS = ['一', '', '三', '', '五', '', ''];
 
@@ -310,7 +312,6 @@
   function buildHomeWikiHeatmapHtml(days) {
     var countByDate = {};
     var counts = [];
-    var minMs = Infinity;
     var maxMs = -Infinity;
     for (var i = 0; i < days.length; i++) {
       var day = days[i];
@@ -319,14 +320,15 @@
       if (ms === null || count <= 0) continue;
       countByDate[day.date] = count;
       counts.push(count);
-      if (ms < minMs) minMs = ms;
       if (ms > maxMs) maxMs = ms;
     }
     if (!counts.length) return '';
     var thresholds = homeHeatmapThresholds(counts);
-    // getUTCDay() 0=周日 → 周一对齐的行号 (day+6)%7
-    var startMs = minMs - ((new Date(minMs).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
-    var endMs = maxMs + (6 - (new Date(maxMs).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
+    // getUTCDay() 0=周日 → 周一对齐的行号 (day+6)%7；
+    // 窗口固定 53 周，以最新数据所在周为最右列
+    var lastWeekStartMs = maxMs - ((new Date(maxMs).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
+    var startMs = lastWeekStartMs - (HOME_HEATMAP_WEEKS - 1) * 7 * HOME_HEATMAP_DAY_MS;
+    var endMs = lastWeekStartMs + 6 * HOME_HEATMAP_DAY_MS;
 
     var cellsHtml = '';
     var monthsHtml = '';
@@ -347,7 +349,8 @@
       monthsHtml += '<span>' + monthLabel + '</span>';
       for (var row = 0; row < 7; row++) {
         var dayMs = weekMs + row * HOME_HEATMAP_DAY_MS;
-        if (dayMs < minMs || dayMs > maxMs) {
+        if (dayMs > maxMs) {
+          // 仅未来日期留白；历史上无节点的日期与 GitHub 一样渲染为空格
           cellsHtml += '<span class="home-wiki-heatmap-cell is-pad" aria-hidden="true"></span>';
           continue;
         }

--- a/docs/main.js
+++ b/docs/main.js
@@ -268,7 +268,132 @@
     reference: '参考'
   };
 
-  function renderLatestWikiNode(homeStats) {
+  // ── 首页知识节点活跃度热力图（GitHub 风格，数据源 exports/wiki-activity.json）──
+  var HOME_HEATMAP_DAY_MS = 24 * 60 * 60 * 1000;
+  // 周一为第一行，仅标注 一/三/五 三行（与 GitHub Mon/Wed/Fri 一致）
+  var HOME_HEATMAP_WEEKDAY_LABELS = ['一', '', '三', '', '五', '', ''];
+
+  function homeHeatmapParseDate(value) {
+    var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value || ''));
+    if (!m) return null;
+    var ms = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+    return isNaN(ms) ? null : ms;
+  }
+
+  function homeHeatmapIsoDate(ms) {
+    var d = new Date(ms);
+    var mm = String(d.getUTCMonth() + 1);
+    var dd = String(d.getUTCDate());
+    if (mm.length < 2) mm = '0' + mm;
+    if (dd.length < 2) dd = '0' + dd;
+    return d.getUTCFullYear() + '-' + mm + '-' + dd;
+  }
+
+  // 非零日计数的四分位阈值：档位对离群的批量维护日保持稳健
+  function homeHeatmapThresholds(counts) {
+    var sorted = counts.slice().sort(function (a, b) { return a - b; });
+    function pick(ratio) {
+      var idx = Math.min(sorted.length - 1, Math.floor(ratio * sorted.length));
+      return sorted[idx];
+    }
+    return [pick(0.25), pick(0.5), pick(0.75)];
+  }
+
+  function homeHeatmapLevel(count, thresholds) {
+    if (!count) return 0;
+    if (count <= thresholds[0]) return 1;
+    if (count <= thresholds[1]) return 2;
+    if (count <= thresholds[2]) return 3;
+    return 4;
+  }
+
+  function buildHomeWikiHeatmapHtml(days) {
+    var countByDate = {};
+    var counts = [];
+    var minMs = Infinity;
+    var maxMs = -Infinity;
+    for (var i = 0; i < days.length; i++) {
+      var day = days[i];
+      var ms = homeHeatmapParseDate(day && day.date);
+      var count = day && typeof day.count === 'number' ? day.count : 0;
+      if (ms === null || count <= 0) continue;
+      countByDate[day.date] = count;
+      counts.push(count);
+      if (ms < minMs) minMs = ms;
+      if (ms > maxMs) maxMs = ms;
+    }
+    if (!counts.length) return '';
+    var thresholds = homeHeatmapThresholds(counts);
+    // getUTCDay() 0=周日 → 周一对齐的行号 (day+6)%7
+    var startMs = minMs - ((new Date(minMs).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
+    var endMs = maxMs + (6 - (new Date(maxMs).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
+
+    var cellsHtml = '';
+    var monthsHtml = '';
+    var prevMonth = -1;
+    var lastLabelWeek = -2;
+    var week = 0;
+    for (var weekMs = startMs; weekMs <= endMs; weekMs += 7 * HOME_HEATMAP_DAY_MS, week++) {
+      var month = new Date(weekMs).getUTCMonth();
+      var monthLabel = '';
+      if (month !== prevMonth) {
+        // 距上一个标签不足 2 列时跳过，避免文字重叠
+        if (week - lastLabelWeek >= 2) {
+          monthLabel = String(month + 1) + '月';
+          lastLabelWeek = week;
+        }
+        prevMonth = month;
+      }
+      monthsHtml += '<span>' + monthLabel + '</span>';
+      for (var row = 0; row < 7; row++) {
+        var dayMs = weekMs + row * HOME_HEATMAP_DAY_MS;
+        if (dayMs < minMs || dayMs > maxMs) {
+          cellsHtml += '<span class="home-wiki-heatmap-cell is-pad" aria-hidden="true"></span>';
+          continue;
+        }
+        var iso = homeHeatmapIsoDate(dayMs);
+        var dayCount = countByDate[iso] || 0;
+        if (!dayCount) {
+          cellsHtml +=
+            '<span class="home-wiki-heatmap-cell" data-level="0" title="' +
+            iso + '：0 个节点"></span>';
+          continue;
+        }
+        var tip = iso + '：' + dayCount + ' 个节点';
+        cellsHtml +=
+          '<button type="button" class="home-wiki-heatmap-cell" data-level="' +
+          homeHeatmapLevel(dayCount, thresholds) +
+          '" data-date="' + iso + '" title="' + tip +
+          '" aria-pressed="false" aria-label="' + tip + '，点击筛选"></button>';
+      }
+    }
+
+    var weekdaysHtml = '';
+    for (var w = 0; w < 7; w++) {
+      weekdaysHtml += '<span>' + HOME_HEATMAP_WEEKDAY_LABELS[w] + '</span>';
+    }
+    var legendCells = '';
+    for (var lv = 0; lv <= 4; lv++) {
+      legendCells += '<span class="home-wiki-heatmap-cell" data-level="' + lv + '"></span>';
+    }
+    return (
+      '<div class="home-wiki-heatmap">' +
+      '<div class="home-wiki-heatmap-scroll">' +
+      '<div class="home-wiki-heatmap-inner">' +
+      '<div class="home-wiki-heatmap-months" aria-hidden="true">' + monthsHtml + '</div>' +
+      '<div class="home-wiki-heatmap-body">' +
+      '<div class="home-wiki-heatmap-weekdays" aria-hidden="true">' + weekdaysHtml + '</div>' +
+      '<div class="home-wiki-heatmap-grid" role="group" aria-label="按日期筛选知识节点">' +
+      cellsHtml +
+      '</div></div></div></div>' +
+      '<div class="home-wiki-heatmap-legend">' +
+      '<span class="home-wiki-heatmap-legend-hint">点击方格筛选当日节点</span>' +
+      '<span>少</span>' + legendCells + '<span>多</span>' +
+      '</div></div>'
+    );
+  }
+
+  function renderLatestWikiNode(homeStats, wikiActivity) {
     var mount = document.getElementById('homeLatestWikiModule');
     if (!mount) return;
     mount.classList.remove('data-loading');
@@ -278,43 +403,6 @@
     } else if (homeStats && homeStats.latest_wiki_node && homeStats.latest_wiki_node.detail_id) {
       items = [homeStats.latest_wiki_node];
     }
-    if (!items.length || !items[0].detail_id) {
-      mount.innerHTML = '<p class="data-meta">暂无「最近更新」数据。</p>';
-      return;
-    }
-    var first = items[0];
-    var fromLog = first.source === 'log.md';
-    var dateStr = first.recency ? String(first.recency) : '';
-
-    var groups = [];
-    var groupIndex = {};
-    items.forEach(function (meta) {
-      var dateKey = meta && meta.recency ? String(meta.recency) : '';
-      if (!(dateKey in groupIndex)) {
-        groupIndex[dateKey] = groups.length;
-        groups.push({ date: dateKey, items: [] });
-      }
-      groups[groupIndex[dateKey]].items.push(meta);
-    });
-
-    var introParts = [];
-    if (fromLog && groups.length > 1) {
-      var lastDate = groups[groups.length - 1].date || dateStr;
-      var dateRange = lastDate && dateStr && lastDate !== dateStr ? (lastDate + ' → ' + dateStr) : dateStr;
-      if (dateRange) introParts.push(dateRange);
-      introParts.push('维护日志时间线');
-      introParts.push(String(items.length) + ' 个节点 / ' + String(groups.length) + ' 天');
-    } else {
-      if (dateStr) introParts.push(dateStr);
-      if (fromLog) {
-        introParts.push('维护日志');
-        if (items.length > 1) introParts.push(String(items.length) + ' 个节点');
-      } else {
-        introParts.push('按页面更新时间');
-      }
-    }
-    var introHtml =
-      '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(introParts.join(' · ')) + '</p>';
 
     function renderCard(meta, includeDate) {
       var typeLabel = WIKI_TYPE_LABEL_HOME[meta.type] || (meta.type ? String(meta.type) : 'Wiki');
@@ -333,36 +421,144 @@
       );
     }
 
-    var bodyHtml;
-    if (fromLog && groups.length > 1) {
-      bodyHtml = '';
-      for (var gi = 0; gi < groups.length; gi++) {
-        var group = groups[gi];
-        var groupCards = '';
-        for (var ci = 0; ci < group.items.length; ci++) {
-          groupCards += renderCard(group.items[ci], false);
-        }
-        var dateLabel = group.date
-          ? escapeHtml(group.date) + ' · ' + String(group.items.length) + ' 项'
-          : String(group.items.length) + ' 项';
-        bodyHtml += (
-          '<section class="home-latest-wiki-timeline-group">' +
-          '<h3 class="home-latest-wiki-timeline-date">' + dateLabel + '</h3>' +
-          '<div class="home-latest-wiki-cards card-grid home-latest-wiki-grid">' + groupCards + '</div>' +
-          '</section>'
-        );
-      }
-      bodyHtml = '<div class="home-latest-wiki-timeline">' + bodyHtml + '</div>';
+    var defaultBodyHtml;
+    if (!items.length || !items[0].detail_id) {
+      defaultBodyHtml = '<p class="data-meta">暂无「最近更新」数据。</p>';
     } else {
-      var itemsCards = '';
-      for (var j = 0; j < items.length; j++) {
-        itemsCards += renderCard(items[j], !fromLog);
+      var first = items[0];
+      var fromLog = first.source === 'log.md';
+      var dateStr = first.recency ? String(first.recency) : '';
+
+      var groups = [];
+      var groupIndex = {};
+      items.forEach(function (meta) {
+        var dateKey = meta && meta.recency ? String(meta.recency) : '';
+        if (!(dateKey in groupIndex)) {
+          groupIndex[dateKey] = groups.length;
+          groups.push({ date: dateKey, items: [] });
+        }
+        groups[groupIndex[dateKey]].items.push(meta);
+      });
+
+      var introParts = [];
+      if (fromLog && groups.length > 1) {
+        var lastDate = groups[groups.length - 1].date || dateStr;
+        var dateRange = lastDate && dateStr && lastDate !== dateStr ? (lastDate + ' → ' + dateStr) : dateStr;
+        if (dateRange) introParts.push(dateRange);
+        introParts.push('维护日志时间线');
+        introParts.push(String(items.length) + ' 个节点 / ' + String(groups.length) + ' 天');
+      } else {
+        if (dateStr) introParts.push(dateStr);
+        if (fromLog) {
+          introParts.push('维护日志');
+          if (items.length > 1) introParts.push(String(items.length) + ' 个节点');
+        } else {
+          introParts.push('按页面更新时间');
+        }
       }
-      var wrapClass =
-        items.length > 1 ? 'home-latest-wiki-cards card-grid home-latest-wiki-grid' : 'home-latest-wiki-cards';
-      bodyHtml = '<div class="' + wrapClass + '">' + itemsCards + '</div>';
+      var introHtml =
+        '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(introParts.join(' · ')) + '</p>';
+
+      var bodyHtml;
+      if (fromLog && groups.length > 1) {
+        bodyHtml = '';
+        for (var gi = 0; gi < groups.length; gi++) {
+          var group = groups[gi];
+          var groupCards = '';
+          for (var ci = 0; ci < group.items.length; ci++) {
+            groupCards += renderCard(group.items[ci], false);
+          }
+          var dateLabel = group.date
+            ? escapeHtml(group.date) + ' · ' + String(group.items.length) + ' 项'
+            : String(group.items.length) + ' 项';
+          bodyHtml += (
+            '<section class="home-latest-wiki-timeline-group">' +
+            '<h3 class="home-latest-wiki-timeline-date">' + dateLabel + '</h3>' +
+            '<div class="home-latest-wiki-cards card-grid home-latest-wiki-grid">' + groupCards + '</div>' +
+            '</section>'
+          );
+        }
+        bodyHtml = '<div class="home-latest-wiki-timeline">' + bodyHtml + '</div>';
+      } else {
+        var itemsCards = '';
+        for (var j = 0; j < items.length; j++) {
+          itemsCards += renderCard(items[j], !fromLog);
+        }
+        var wrapClass =
+          items.length > 1 ? 'home-latest-wiki-cards card-grid home-latest-wiki-grid' : 'home-latest-wiki-cards';
+        bodyHtml = '<div class="' + wrapClass + '">' + itemsCards + '</div>';
+      }
+      defaultBodyHtml = introHtml + bodyHtml;
     }
-    mount.innerHTML = introHtml + bodyHtml;
+
+    var activityDays = wikiActivity && Array.isArray(wikiActivity.days) ? wikiActivity.days : [];
+    var heatmapHtml = activityDays.length ? buildHomeWikiHeatmapHtml(activityDays) : '';
+    mount.innerHTML = heatmapHtml + '<div class="home-latest-wiki-body">' + defaultBodyHtml + '</div>';
+    if (!heatmapHtml) return;
+
+    var bodyMount = mount.querySelector('.home-latest-wiki-body');
+    var grid = mount.querySelector('.home-wiki-heatmap-grid');
+    var scrollWrap = mount.querySelector('.home-wiki-heatmap-scroll');
+    if (scrollWrap) scrollWrap.scrollLeft = scrollWrap.scrollWidth; // 默认停在最新日期
+
+    var nodesByDate = {};
+    var totalByDate = {};
+    for (var ai = 0; ai < activityDays.length; ai++) {
+      var dayEntry = activityDays[ai];
+      if (!dayEntry || !dayEntry.date) continue;
+      nodesByDate[dayEntry.date] = Array.isArray(dayEntry.nodes) ? dayEntry.nodes : [];
+      totalByDate[dayEntry.date] = typeof dayEntry.count === 'number' ? dayEntry.count : 0;
+    }
+
+    var activeDate = '';
+
+    function setActiveCell(dateKey) {
+      var cells = grid.querySelectorAll('button.home-wiki-heatmap-cell');
+      for (var ci2 = 0; ci2 < cells.length; ci2++) {
+        var isActive = !!dateKey && cells[ci2].getAttribute('data-date') === dateKey;
+        cells[ci2].classList.toggle('is-active', isActive);
+        cells[ci2].setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      }
+    }
+
+    function clearHeatmapFilter() {
+      activeDate = '';
+      setActiveCell('');
+      bodyMount.innerHTML = defaultBodyHtml;
+    }
+
+    function applyHeatmapFilter(dateKey) {
+      var dayNodes = nodesByDate[dateKey] || [];
+      if (!dayNodes.length) return;
+      activeDate = dateKey;
+      setActiveCell(dateKey);
+      var total = totalByDate[dateKey] || dayNodes.length;
+      var filterIntro = [dateKey, '维护日志', String(total) + ' 个节点'];
+      if (dayNodes.length < total) filterIntro.push('仅展示前 ' + dayNodes.length + ' 项');
+      var cardsHtml = '';
+      for (var ni = 0; ni < dayNodes.length; ni++) {
+        cardsHtml += renderCard(dayNodes[ni], false);
+      }
+      bodyMount.innerHTML =
+        '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(filterIntro.join(' · ')) +
+        ' <button type="button" class="btn-secondary btn-inline home-wiki-heatmap-clear">清除筛选</button></p>' +
+        '<div class="home-latest-wiki-cards card-grid home-latest-wiki-grid">' + cardsHtml + '</div>';
+    }
+
+    grid.addEventListener('click', function (ev) {
+      var cell = ev.target.closest('button.home-wiki-heatmap-cell');
+      if (!cell) return;
+      var dateKey = cell.getAttribute('data-date') || '';
+      if (!dateKey) return;
+      if (dateKey === activeDate) {
+        clearHeatmapFilter();
+      } else {
+        applyHeatmapFilter(dateKey);
+      }
+    });
+    bodyMount.addEventListener('click', function (ev) {
+      if (ev.target.closest('.home-wiki-heatmap-clear')) clearHeatmapFilter();
+    });
   }
 
   function moduleHref(id) {
@@ -4273,14 +4469,25 @@
   }
 
   if (homeStatsRoot) {
-    fetch('exports/home-stats.json')
+    var homeStatsFetch = fetch('exports/home-stats.json').then(function (response) {
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      return response.json();
+    });
+    // 热力图数据可缺席（本地未 make graph 时降级为无热力图，不影响时间线）
+    var wikiActivityFetch = fetch('exports/wiki-activity.json')
       .then(function (response) {
         if (!response.ok) throw new Error('HTTP ' + response.status);
         return response.json();
       })
-      .then(function (stats) {
+      .catch(function (error) {
+        console.warn('Wiki activity sync failed:', error);
+        return null;
+      });
+    Promise.all([homeStatsFetch, wikiActivityFetch])
+      .then(function (results) {
+        var stats = results[0];
         renderHomeStats(stats, stats.coverage ? (stats.coverage.covered + '/' + stats.coverage.total) : '');
-        renderLatestWikiNode(stats);
+        renderLatestWikiNode(stats, results[1]);
       })
       .catch(function (error) {
         console.warn('Home stats sync failed:', error);

--- a/docs/style.css
+++ b/docs/style.css
@@ -434,6 +434,91 @@ body.sponsor-dialog-open {
   letter-spacing: -.01em;
   margin: 0;
 }
+/* 首页「最新知识节点」活跃度热力图（GitHub 风格；绿阶已过顺序色板校验：
+   亮度单调、相邻 ΔL ≥ 0.06、最浅档对底色 ≥ 2:1） */
+.home-wiki-heatmap {
+  --hm-cell: 12px;
+  --hm-gap: 3px;
+  --hm-level-0: #2c2c2e;
+  --hm-level-1: #155a36;
+  --hm-level-2: #1f8047;
+  --hm-level-3: #2aa65a;
+  --hm-level-4: #39d353;
+  --hm-cell-line: rgba(255, 255, 255, 0.06);
+  margin-bottom: 20px;
+}
+[data-theme="light"] .home-wiki-heatmap {
+  --hm-level-0: #ebedf0;
+  --hm-level-1: #62c672;
+  --hm-level-2: #3ba14f;
+  --hm-level-3: #2a7d3e;
+  --hm-level-4: #1b5a2e;
+  --hm-cell-line: rgba(27, 31, 36, 0.06);
+}
+.home-wiki-heatmap-scroll { overflow-x: auto; padding: 2px; }
+.home-wiki-heatmap-inner { width: max-content; }
+.home-wiki-heatmap-months {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: calc(var(--hm-cell) + var(--hm-gap));
+  margin-left: calc(24px + var(--hm-gap));
+  height: 18px;
+  font-size: .68rem;
+  color: var(--text-muted);
+}
+.home-wiki-heatmap-months span { white-space: nowrap; }
+.home-wiki-heatmap-body { display: flex; gap: var(--hm-gap); }
+.home-wiki-heatmap-weekdays {
+  display: grid;
+  grid-template-rows: repeat(7, var(--hm-cell));
+  row-gap: var(--hm-gap);
+  width: 24px;
+  font-size: .62rem;
+  line-height: var(--hm-cell);
+  color: var(--text-muted);
+}
+.home-wiki-heatmap-grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, var(--hm-cell));
+  grid-auto-columns: var(--hm-cell);
+  gap: var(--hm-gap);
+}
+.home-wiki-heatmap-cell {
+  width: var(--hm-cell);
+  height: var(--hm-cell);
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: var(--hm-level-0);
+  box-shadow: inset 0 0 0 1px var(--hm-cell-line);
+}
+.home-wiki-heatmap-cell[data-level="1"] { background: var(--hm-level-1); }
+.home-wiki-heatmap-cell[data-level="2"] { background: var(--hm-level-2); }
+.home-wiki-heatmap-cell[data-level="3"] { background: var(--hm-level-3); }
+.home-wiki-heatmap-cell[data-level="4"] { background: var(--hm-level-4); }
+.home-wiki-heatmap-cell.is-pad { visibility: hidden; }
+button.home-wiki-heatmap-cell { cursor: pointer; }
+button.home-wiki-heatmap-cell:hover,
+button.home-wiki-heatmap-cell:focus-visible {
+  outline: 1px solid var(--border-strong);
+  outline-offset: 1px;
+}
+button.home-wiki-heatmap-cell.is-active {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.home-wiki-heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--hm-gap);
+  margin-top: 8px;
+  font-size: .68rem;
+  color: var(--text-muted);
+}
+.home-wiki-heatmap-legend .home-wiki-heatmap-cell { flex-shrink: 0; }
+.home-wiki-heatmap-legend-hint { margin-right: auto; }
+.home-wiki-heatmap-clear { margin-left: 8px; vertical-align: middle; }
 .section-subtitle {
   color: var(--text-muted);
   font-size: .97rem;

--- a/docs/style.css
+++ b/docs/style.css
@@ -457,7 +457,8 @@ body.sponsor-dialog-open {
   --hm-cell-line: rgba(27, 31, 36, 0.06);
 }
 .home-wiki-heatmap-scroll { overflow-x: auto; padding: 2px; }
-.home-wiki-heatmap-inner { width: max-content; }
+/* 容器有富余时整体贴右（最新日期对齐右缘）；溢出时由 scrollLeft 锚定最右 */
+.home-wiki-heatmap-inner { width: max-content; margin-left: auto; }
 .home-wiki-heatmap-months {
   display: grid;
   grid-auto-flow: column;

--- a/docs/style.css
+++ b/docs/style.css
@@ -438,7 +438,7 @@ body.sponsor-dialog-open {
    （--accent 同色相，暗档最亮≈--accent-hover），已过顺序色板校验：
    亮度单调、相邻 ΔL ≥ 0.06、最浅档对底色 ≥ 2:1） */
 .home-wiki-heatmap {
-  --hm-cell: 12px;
+  --hm-cell-min: 8px; /* 格子宽度下限：低于则容器横向滚动 */
   --hm-gap: 3px;
   --hm-level-0: #2c2c2e;
   --hm-level-1: #1d4f8c;
@@ -457,38 +457,43 @@ body.sponsor-dialog-open {
   --hm-cell-line: rgba(27, 31, 36, 0.06);
 }
 .home-wiki-heatmap-scroll { overflow-x: auto; padding: 2px; }
-/* 容器有富余时整体贴右（最新日期对齐右缘）；溢出时由 scrollLeft 锚定最右 */
-.home-wiki-heatmap-inner { width: max-content; margin-left: auto; }
+/* 流式适配容器宽度：53 列 minmax(下限, 1fr) 均分整行；
+   窄屏格子到下限后由 min-width 撑开、scrollLeft 锚定最右 */
+.home-wiki-heatmap-inner { min-width: max-content; }
 .home-wiki-heatmap-months {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: calc(var(--hm-cell) + var(--hm-gap));
+  grid-auto-columns: minmax(var(--hm-cell-min), 1fr);
+  gap: var(--hm-gap);
   margin-left: calc(24px + var(--hm-gap));
   height: 18px;
   font-size: .68rem;
   color: var(--text-muted);
 }
-.home-wiki-heatmap-months span { white-space: nowrap; }
+/* width:0 让标签不参与 1fr 轨道尺寸计算（fr 等宽会被最宽标签整体撑大），
+   文字从所在列起点向右溢出显示 */
+.home-wiki-heatmap-months span { white-space: nowrap; width: 0; overflow: visible; }
 .home-wiki-heatmap-body { display: flex; gap: var(--hm-gap); }
 .home-wiki-heatmap-weekdays {
   display: grid;
-  grid-template-rows: repeat(7, var(--hm-cell));
+  grid-template-rows: repeat(7, 1fr);
   row-gap: var(--hm-gap);
+  align-items: center;
   width: 24px;
   font-size: .62rem;
-  line-height: var(--hm-cell);
   color: var(--text-muted);
 }
 .home-wiki-heatmap-grid {
+  flex: 1;
+  min-width: 0;
   display: grid;
   grid-auto-flow: column;
-  grid-template-rows: repeat(7, var(--hm-cell));
-  grid-auto-columns: var(--hm-cell);
+  grid-template-rows: repeat(7, auto);
+  grid-auto-columns: minmax(var(--hm-cell-min), 1fr);
   gap: var(--hm-gap);
 }
 .home-wiki-heatmap-cell {
-  width: var(--hm-cell);
-  height: var(--hm-cell);
+  aspect-ratio: 1 / 1;
   padding: 0;
   border: 0;
   border-radius: 3px;
@@ -519,7 +524,7 @@ button.home-wiki-heatmap-cell.is-active {
   font-size: .68rem;
   color: var(--text-muted);
 }
-.home-wiki-heatmap-legend .home-wiki-heatmap-cell { flex-shrink: 0; }
+.home-wiki-heatmap-legend .home-wiki-heatmap-cell { width: 12px; height: 12px; flex-shrink: 0; }
 .home-wiki-heatmap-legend-hint { margin-right: auto; }
 .home-wiki-heatmap-clear { margin-left: 8px; vertical-align: middle; }
 .section-subtitle {

--- a/docs/style.css
+++ b/docs/style.css
@@ -434,25 +434,26 @@ body.sponsor-dialog-open {
   letter-spacing: -.01em;
   margin: 0;
 }
-/* 首页「最新知识节点」活跃度热力图（GitHub 风格；绿阶已过顺序色板校验：
+/* 首页「最新知识节点」活跃度热力图（GitHub 风格布局；色阶取站点主题蓝
+   （--accent 同色相，暗档最亮≈--accent-hover），已过顺序色板校验：
    亮度单调、相邻 ΔL ≥ 0.06、最浅档对底色 ≥ 2:1） */
 .home-wiki-heatmap {
   --hm-cell: 12px;
   --hm-gap: 3px;
   --hm-level-0: #2c2c2e;
-  --hm-level-1: #155a36;
-  --hm-level-2: #1f8047;
-  --hm-level-3: #2aa65a;
-  --hm-level-4: #39d353;
+  --hm-level-1: #1d4f8c;
+  --hm-level-2: #2a6cb4;
+  --hm-level-3: #4b8fd9;
+  --hm-level-4: #7fb6f0;
   --hm-cell-line: rgba(255, 255, 255, 0.06);
   margin-bottom: 20px;
 }
 [data-theme="light"] .home-wiki-heatmap {
   --hm-level-0: #ebedf0;
-  --hm-level-1: #62c672;
-  --hm-level-2: #3ba14f;
-  --hm-level-3: #2a7d3e;
-  --hm-level-4: #1b5a2e;
+  --hm-level-1: #6faede;
+  --hm-level-2: #3f8ad2;
+  --hm-level-3: #1a6cbe;
+  --hm-level-4: #084d99;
   --hm-cell-line: rgba(27, 31, 36, 0.06);
 }
 .home-wiki-heatmap-scroll { overflow-x: auto; padding: 2px; }
@@ -504,8 +505,9 @@ button.home-wiki-heatmap-cell:focus-visible {
   outline: 1px solid var(--border-strong);
   outline-offset: 1px;
 }
+/* 选中描边用文本色而非 --accent：蓝阶格子上蓝描边难以分辨 */
 button.home-wiki-heatmap-cell.is-active {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--text);
   outline-offset: 1px;
 }
 .home-wiki-heatmap-legend {

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -11,6 +11,7 @@ const ASSETS_TO_CACHE = [
   '/Robotics_Notebooks/exports/site-data-v1.json',
   '/Robotics_Notebooks/exports/index-v1.json',
   '/Robotics_Notebooks/exports/graph-stats.json',
+  '/Robotics_Notebooks/exports/wiki-activity.json',
 ];
 
 self.addEventListener('install', (event) => {

--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -10,6 +10,9 @@ generate_link_graph.py — Wiki 内链图谱生成工具
 structural / query 等均可）；latest_wiki_node 为当日列表首项（兼容旧字段）。
 若无日志命中则回退到 frontmatter / mtime 的 recency，列表仅一项。
 
+另写入 exports/wiki-activity.json（首页热力图数据源）：不限时间窗口，按同一套
+路径解析规则汇总 log.md 全量日志的每日 wiki 节点（同日去重、跨日可重复）。
+
 输出格式：
   {
     "nodes": [
@@ -49,6 +52,7 @@ REPO_ROOT = Path(__file__).parent.parent
 WIKI_DIR = REPO_ROOT / "wiki"
 OUT_PATH = REPO_ROOT / "exports" / "link-graph.json"
 STATS_PATH = REPO_ROOT / "exports" / "graph-stats.json"
+ACTIVITY_PATH = REPO_ROOT / "exports" / "wiki-activity.json"
 LOG_MD_PATH = REPO_ROOT / "log.md"
 # log.md 正文中出现的 wiki 相对路径（允许省略 .md，匹配至非标点为止）
 WIKI_PATH_IN_LOG = re.compile(r"wiki/(?:[\w./-]+/)+[\w./-]+(?:\.md)?", re.IGNORECASE)
@@ -245,6 +249,9 @@ LATEST_NODES_DEFAULT = 20
 LATEST_NODES_CAP = 30
 LATEST_NODES_WINDOW_DAYS = 30
 LATEST_NODES_ENV_VAR = "GRAPH_LATEST_NODES_MAX"
+# wiki-activity.json：单日节点列表上限（count 保留真实值；批量维护日 glob
+# 可展开出上千节点，全量导出会拖垮首页热力图筛选的加载与渲染）。
+ACTIVITY_NODES_PER_DAY_CAP = 30
 
 
 def wiki_recency_date(content: str, page: Path) -> date:
@@ -419,6 +426,68 @@ def latest_wiki_nodes_from_log(
                 log_date=log_date,
             )
     return out[:max_items]
+
+
+def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """从 log.md 全量日志汇总每日出现的 wiki 节点（首页热力图按日期筛选用）。
+
+    与 latest_wiki_nodes_from_log 使用同一套路径解析与校验规则，但不限时间
+    窗口：同一日期的多个日志块合并、同日去重（跨日可重复出现），仅保留仓库
+    现存且在图谱节点中的路径。返回按日期升序的
+    ``[{date, count, nodes: [{detail_id, label, type}]}]``，无节点的日期不输出；
+    count 为当日真实节点数，nodes 仅保留出现顺序前 ACTIVITY_NODES_PER_DAY_CAP 项。
+    """
+    if not LOG_MD_PATH.is_file():
+        return []
+    sections = _log_sections(LOG_MD_PATH.read_text(encoding="utf-8"))
+    node_by_id: dict[str, dict[str, Any]] = {str(n["id"]): n for n in nodes}
+    seen_by_date: dict[str, set[str]] = {}
+    metas_by_date: dict[str, list[dict[str, Any]]] = {}
+
+    for chunk in sections:
+        date_m = re.match(r"^## \[(\d{4}-\d{2}-\d{2})\]", chunk)
+        if not date_m:
+            continue
+        log_date = date_m.group(1)
+        try:
+            date.fromisoformat(log_date)
+        except ValueError:
+            continue
+        seen = seen_by_date.setdefault(log_date, set())
+        day_out = metas_by_date.setdefault(log_date, [])
+        for m in WIKI_GLOB_IN_LOG.finditer(chunk):
+            for rel in _expand_wiki_glob(m.group(1)):
+                _append_latest_node(
+                    rel, node_by_id=node_by_id, seen=seen, out=day_out, log_date=log_date
+                )
+        for m in WIKI_PATH_IN_LOG.finditer(chunk):
+            rel = _normalize_wiki_rel_from_log_match(m.group(0))
+            if "*" in rel:
+                for expanded in _expand_wiki_glob(rel):
+                    _append_latest_node(
+                        expanded, node_by_id=node_by_id, seen=seen, out=day_out, log_date=log_date
+                    )
+                continue
+            _append_latest_node(
+                rel, node_by_id=node_by_id, seen=seen, out=day_out, log_date=log_date
+            )
+
+    days: list[dict[str, Any]] = []
+    for log_date in sorted(metas_by_date):
+        metas = metas_by_date[log_date]
+        if not metas:
+            continue
+        days.append(
+            {
+                "date": log_date,
+                "count": len(metas),
+                "nodes": [
+                    {"detail_id": m["detail_id"], "label": m["label"], "type": m["type"]}
+                    for m in metas[:ACTIVITY_NODES_PER_DAY_CAP]
+                ],
+            }
+        )
+    return days
 
 
 def resolve_latest_nodes_max(cli_value: int | None) -> int:
@@ -1163,6 +1232,17 @@ def main() -> None:
     print(
         f"✅ graph-stats.json: {len(orphans)} orphans, "
         f"top hub='{hub_list[0]['label'] if hub_list else '-'}' → {STATS_PATH.relative_to(REPO_ROOT)}"
+    )
+
+    activity_days = wiki_activity_from_log(nodes)
+    activity = {"generated_at": stats["generated_at"], "days": activity_days}
+    ACTIVITY_PATH.write_text(
+        json.dumps(activity, ensure_ascii=False, separators=(",", ":")), encoding="utf-8"
+    )
+    print(
+        f"✅ wiki-activity.json: {len(activity_days)} days, "
+        f"{sum(d['count'] for d in activity_days)} node refs "
+        f"→ {ACTIVITY_PATH.relative_to(REPO_ROOT)}"
     )
 
 

--- a/scripts/graph_exports_sync.py
+++ b/scripts/graph_exports_sync.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-GRAPH_EXPORT_FILES: tuple[str, ...] = ("link-graph.json", "graph-stats.json", "home-stats.json")
+GRAPH_EXPORT_FILES: tuple[str, ...] = (
+    "link-graph.json",
+    "graph-stats.json",
+    "home-stats.json",
+    "wiki-activity.json",
+)
 
 
 def repo_root() -> Path:

--- a/tests/test_generate_link_graph_wiki_activity.py
+++ b/tests/test_generate_link_graph_wiki_activity.py
@@ -1,0 +1,126 @@
+"""wiki_activity_from_log：首页热力图按日活动数据（全量日志、同日去重）单元测试。"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import generate_link_graph as glg
+
+
+def _node(rel_path: str, label: str = "", type_: str = "concept") -> dict[str, object]:
+    return {"id": rel_path, "label": label or rel_path, "type": type_}
+
+
+def _wiki_path_for(rel: str) -> Path:
+    return glg.REPO_ROOT / rel
+
+
+class WikiActivityFromLogTest(unittest.TestCase):
+    """覆盖按日聚合、同日多块合并去重、升序输出与节点瘦身字段。"""
+
+    def setUp(self) -> None:
+        # 选仓库中真实存在的 wiki 路径，避免与文件存在性校验冲突。
+        self.existing_paths: list[str] = []
+        for candidate in [
+            "wiki/concepts/sim2real.md",
+            "wiki/concepts/system-identification.md",
+            "wiki/tasks/locomotion.md",
+            "wiki/methods/reinforcement-learning.md",
+        ]:
+            if _wiki_path_for(candidate).is_file():
+                self.existing_paths.append(candidate)
+        if len(self.existing_paths) < 3:
+            self.skipTest("仓库中可用 wiki 节点不足以执行测试")
+        self.nodes = [_node(rel) for rel in self.existing_paths]
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self._fake_log_path = Path(self._tmpdir.name) / "log.md"
+
+    def _write_log(self, blocks: list[tuple[str, list[str]]]) -> None:
+        chunks: list[str] = []
+        for log_date, paths in blocks:
+            lines = [f"## [{log_date}] ingest"]
+            for p in paths:
+                lines.append(f"- 接入 {p}")
+            chunks.append("\n".join(lines) + "\n")
+        self._fake_log_path.write_text("\n".join(chunks), encoding="utf-8")
+
+    def _patched_log(self):
+        return mock.patch.object(glg, "LOG_MD_PATH", self._fake_log_path)
+
+    def test_days_sorted_ascending_across_full_history(self) -> None:
+        old_date = "2025-01-01"  # 远早于 latest_wiki_nodes 的 30 天窗口，仍应保留
+        self._write_log(
+            [
+                ("2026-05-28", self.existing_paths[:1]),
+                (old_date, self.existing_paths[1:2]),
+            ]
+        )
+        with self._patched_log():
+            out = glg.wiki_activity_from_log(self.nodes)
+        self.assertEqual([d["date"] for d in out], [old_date, "2026-05-28"])
+        self.assertEqual([d["count"] for d in out], [1, 1])
+
+    def test_same_day_blocks_merge_and_dedupe(self) -> None:
+        self._write_log(
+            [
+                ("2026-05-28", self.existing_paths[:2]),
+                ("2026-05-28", self.existing_paths[1:3]),  # 与上一块重叠 1 条
+            ]
+        )
+        with self._patched_log():
+            out = glg.wiki_activity_from_log(self.nodes)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["count"], 3)
+        detail_ids = [n["detail_id"] for n in out[0]["nodes"]]
+        self.assertEqual(len(detail_ids), len(set(detail_ids)))
+
+    def test_same_node_can_repeat_across_days(self) -> None:
+        self._write_log(
+            [
+                ("2026-05-28", self.existing_paths[:1]),
+                ("2026-05-27", self.existing_paths[:1]),
+            ]
+        )
+        with self._patched_log():
+            out = glg.wiki_activity_from_log(self.nodes)
+        self.assertEqual([d["count"] for d in out], [1, 1])
+
+    def test_node_payload_is_slim(self) -> None:
+        self._write_log([("2026-05-28", self.existing_paths[:1])])
+        with self._patched_log():
+            out = glg.wiki_activity_from_log(self.nodes)
+        node = out[0]["nodes"][0]
+        self.assertEqual(set(node), {"detail_id", "label", "type"})
+
+    def test_nodes_capped_per_day_but_count_stays_real(self) -> None:
+        cap = glg.ACTIVITY_NODES_PER_DAY_CAP
+        many = sorted(
+            str(p.relative_to(glg.REPO_ROOT)).replace("\\", "/") for p in glg.WIKI_DIR.rglob("*.md")
+        )[: cap + 5]
+        if len(many) <= cap:
+            self.skipTest("仓库 wiki 页面数不足以覆盖单日上限")
+        nodes = [_node(rel) for rel in many]
+        self._write_log([("2026-05-28", many)])
+        with self._patched_log():
+            out = glg.wiki_activity_from_log(nodes)
+        self.assertEqual(out[0]["count"], len(many))
+        self.assertEqual(len(out[0]["nodes"]), cap)
+
+    def test_unknown_paths_and_empty_days_are_dropped(self) -> None:
+        self._write_log(
+            [
+                ("2026-05-28", ["wiki/concepts/definitely-not-a-page.md"]),
+                ("2026-05-27", self.existing_paths[:1]),
+            ]
+        )
+        with self._patched_log():
+            out = glg.wiki_activity_from_log(self.nodes)
+        self.assertEqual([d["date"] for d in out], ["2026-05-27"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 摘要

为首页「最新知识节点」模块新增 GitHub 风格的活跃度热力图，展示 log.md 全量日志中每日维护的节点数。用户可点击热力图方格按日期筛选节点列表，再次点击同一格或「清除筛选」恢复默认时间线。热力图数据源为新增的 `exports/wiki-activity.json`，由 `generate_link_graph.py` 从日志全量汇总生成。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他

## 主要改动

### 前端（`docs/main.js` 和 `docs/style.css`）
- **热力图渲染**：新增 `buildHomeWikiHeatmapHtml()`，生成 GitHub 同款固定 53 周年度网格（周列 × 星期行，周一起始，标注 一/三/五 与月份）；历史上无节点的日期渲染为灰色空格，仅未来日期留白
- **流式宽度适配**：53 列 `minmax(8px, 1fr)` 均分整行、格子 `aspect-ratio` 保持正方形并随容器缩放；窄屏到 8px 下限后横向滚动并自动锚定最右（最新日期）
- **强度分级**：非零日计数按四分位阈值分 1-4 级（`homeHeatmapThresholds()`），对批量维护日等离群值稳健
- **交互**：点击方格筛选当日节点卡片（选中格描边高亮 + `aria-pressed`，悬停 tooltip 显示当日节点数）；批量维护日提示「仅展示前 30 项」；再次点击或「清除筛选」恢复
- **数据加载**：`renderLatestWikiNode()` 接收 `wikiActivity` 参数，与 `home-stats.json` 并行拉取；数据缺席时优雅降级为原时间线
- **样式**：新增 `.home-wiki-heatmap*` 系列类，色阶取站点主题蓝（`--accent` 同色相，暗色最亮档 ≈ `--accent-hover`），明暗两套均通过顺序色板校验（亮度单调、相邻 ΔL ≥ 0.06、最浅档对底色 ≥ 2:1）；选中描边用文本色以免与蓝阶格子混淆

### 后端脚本（`scripts/generate_link_graph.py`）
- **新增** `wiki_activity_from_log()`：复用 `latest_wiki_nodes_from_log()` 同一套路径解析/校验规则，但不限 30 天窗口；同日多块合并去重、跨日可重复；单日节点列表封顶 `ACTIVITY_NODES_PER_DAY_CAP=30`（`count` 保留真实值）
- **输出**：`exports/wiki-activity.json`（`{generated_at, days: [{date, count, nodes}]}`，当前 63 天 / 137KB，gzip 约 26KB）

### 测试（`tests/test_generate_link_graph_wiki_activity.py`）
- 新增 6 例单元测试：日期升序全历史、同日合并去重、跨日重复、节点字段瘦身、单日封顶与真实计数分离、无效路径剔除

### 配置与部署
- **`.gitignore`**：新增 `exports/wiki-activity.json` 与 `docs/exports/wiki-activity.json`（与 `link-graph.json` 同策略：不入库，部署时由 pages.yml 现有步骤生成，本地 `make graph` 产出）
- **`graph_exports_sync.py`**：`GRAPH_EXPORT_FILES` 加入 `wiki-activity.json`
- **`sw.js`**：预缓存列表加入 `wiki-activity.json`

## 验证

- `make ci-preflight` 通过（12/12）
- 全仓 pytest 通过（含新增 6 例）；`ruff check` / `ruff format` / ESLint 通过
- 本地静态站 Playwright 实测 14 项交互检查全过（流式宽度调整后复测）：371 格网格、满宽正方形格子、桌面无横向溢出、渲染位置、点击筛选、封顶提示、清除恢复、同格二次点击取消、滚动锚定最新周、`aria-pressed` 状态；另测 375px 窄屏（8px 下限格子 + 横向滚动锚定最右）

## 验证截图

热力图特写（53 周年度窗口铺满容器宽度，无节点日期为空格，蓝阶与站点 `--accent` 同色相）：

``&lt;img alt="热力图特写（暗色）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/heatmap-closeup-dark.png" /&gt;``

暗色主题默认视图：

``&lt;img alt="首页热力图默认视图（暗色）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/heatmap-default-dark.png" /&gt;``

点击 2026-06-25 后的筛选视图（74 个节点，展示前 30 项 + 清除筛选按钮）：

``&lt;img alt="按日期筛选视图（暗色）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/heatmap-filtered-dark.png" /&gt;``

亮色主题默认视图：

``&lt;img alt="首页热力图默认视图（亮色）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/heatmap-default-light.png" /&gt;``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148T1szGkNgwuTd2EMnP8vc