### PR TITLE
style(ux): 主页最新知识节点列表三列网格对齐

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -416,10 +416,11 @@
       for (var cri = 0; cri < maxRows; cri++) {
         var rowMeta = items[cri];
         var rowType = WIKI_TYPE_LABEL_HOME[rowMeta.type] || (rowMeta.type ? String(rowMeta.type) : 'Wiki');
-        var rowLead = rowMeta.recency ? String(rowMeta.recency) + ' · ' + rowType : rowType;
         compactRows +=
-          '<li class="home-latest-row"><span class="home-latest-row-meta">' +
-          escapeHtml(rowLead) +
+          '<li class="home-latest-row"><span class="home-latest-row-date">' +
+          escapeHtml(rowMeta.recency ? String(rowMeta.recency) : '') +
+          '</span><span class="home-latest-row-type">' +
+          escapeHtml(rowType) +
           '</span><a href="' +
           escapeHtml(detailHref(rowMeta.detail_id)) +
           '">' +

--- a/docs/style.css
+++ b/docs/style.css
@@ -423,12 +423,29 @@ body.sponsor-dialog-open {
   background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0)), var(--bg-alt);
 }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
-/* 首页「最新知识节点」紧凑模式：单行记录列表（完整时间线见 change-log.html） */
-.home-latest-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 10px; }
-.home-latest-row { display: flex; align-items: baseline; gap: 12px; }
+/* 首页「最新知识节点」紧凑模式：单行记录列表（完整时间线见 change-log.html）。
+   整表共用一个 grid（行内容 display:contents 提升为格子），日期/类型/标题三列跨行对齐 */
+.home-latest-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: max-content max-content 1fr;
+  column-gap: 16px;
+  row-gap: 10px;
+  align-items: baseline;
+}
+.home-latest-row { display: contents; }
+.home-latest-row-date, .home-latest-row-type { color: var(--text-muted); font-size: .85rem; white-space: nowrap; }
 .home-latest-row > a { min-width: 0; }
-.home-latest-row-meta { color: var(--text-muted); font-size: .85rem; white-space: nowrap; flex-shrink: 0; }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
+@media (max-width: 860px) {
+  /* 窄屏：三列并排会挤压标题，退化为「日期 · 类型」一行 + 标题一行 */
+  .home-latest-list, .home-latest-row { display: block; }
+  .home-latest-row + .home-latest-row { margin-top: 14px; }
+  .home-latest-row-type::before { content: ' · '; }
+  .home-latest-row > a { display: block; margin-top: 2px; }
+}
 .home-latest-wiki-intro { margin-bottom: 20px; }
 .home-latest-wiki-card h3 { margin-top: 4px; }
 .home-latest-wiki-timeline { display: grid; gap: 20px; }


### PR DESCRIPTION
## 摘要

#913 的跟进微调：主页「最新知识节点」紧凑列表原先每行是独立 flex，「日期 · 类型」合并在一个 span 里，类型字数不同（工具/平台 vs 方法）导致标题列起点参差。本 PR 改为整表共用一个三列 grid（行元素 `display: contents`），日期 / 类型 / 标题三列跨行严格对齐。

- 渲染侧：合并 span 拆为独立的日期、类型两个格子（`main.js` 紧凑分支）
- 布局侧：`.home-latest-list` 改 `grid-template-columns: max-content max-content 1fr`；≤860px 窄屏退化为「日期 · 类型」+ 标题两行，避免三列挤压标题（断点与主页现有移动端断点一致）

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `npx eslint docs/main.js` 0 报错
- [x] 静态站实测（Chromium）：桌面 5 行的类型列左缘全部 x=350、标题列全部 x=424，逐像素对齐；移动端 390px 宽下退化排版正常、「·」分隔符间距正确
- [ ] `make ci-preflight`：N/A（仅 main.js + style.css，不涉及 wiki/导出链；两文件均非生成产物）

## 相关 Issue

无（承接 #913 的会话内反馈）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx7S8zgZk5wWTZWzN8M9Jt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx7S8zgZk5wWTZWzN8M9Jt)_