### PR TITLE
feat(ux): 更新记录全量时间线与首页 3D 图谱悬浮卡片

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -518,84 +518,150 @@
       return { groups: groups, totalNodes: totalNodes };
     }
 
-    var defaultBodyHtml;
-    var timelineFromActivity = buildTimelineGroupsFromActivity(activityDays);
-    if (timelineFromActivity.groups.length) {
-      var activityGroups = timelineFromActivity.groups;
-      var oldestDate = activityDays[0] && activityDays[0].date ? activityDays[0].date : '';
-      var newestDate = activityDays[activityDays.length - 1] && activityDays[activityDays.length - 1].date
-        ? activityDays[activityDays.length - 1].date
-        : '';
-      var activityIntroParts = [];
-      if (oldestDate && newestDate && oldestDate !== newestDate) {
-        activityIntroParts.push(oldestDate + ' → ' + newestDate);
-      } else if (newestDate) {
-        activityIntroParts.push(newestDate);
+    function subtractCalendarDays(dateStr, days) {
+      var parts = String(dateStr || '').split('-');
+      if (parts.length !== 3) return dateStr;
+      var d = new Date(Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2])));
+      d.setUTCDate(d.getUTCDate() - days);
+      return d.toISOString().slice(0, 10);
+    }
+
+    function countTimelineGroupNodes(groups) {
+      var sum = 0;
+      for (var cgi = 0; cgi < groups.length; cgi++) {
+        var g = groups[cgi];
+        sum += typeof g.totalCount === 'number' ? g.totalCount : (g.items ? g.items.length : 0);
       }
-      activityIntroParts.push('维护日志时间线');
-      activityIntroParts.push(
-        String(timelineFromActivity.totalNodes) + ' 个节点 / ' + String(activityGroups.length) + ' 天'
-      );
-      var activityIntroHtml =
-        '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(activityIntroParts.join(' · ')) + '</p>';
-      var activityDaysHtml = '';
-      for (var agi = 0; agi < activityGroups.length; agi++) {
-        var activityGroup = activityGroups[agi];
-        activityDaysHtml += renderTimelineDay(
-          activityGroup.date,
-          activityGroup.items,
-          activityGroup.totalCount
+      return sum;
+    }
+
+    function filterTimelineGroupsByWindow(groups, windowDays, showAll) {
+      if (!groups.length || showAll) return groups.slice();
+      var newest = groups[0].date;
+      if (!newest) return groups.slice();
+      var cutoff = subtractCalendarDays(newest, Math.max(windowDays - 1, 0));
+      var filtered = [];
+      for (var fgi = 0; fgi < groups.length; fgi++) {
+        if (groups[fgi].date >= cutoff) filtered.push(groups[fgi]);
+      }
+      return filtered;
+    }
+
+    function buildTimelineIntro(visibleGroups, allGroups, windowDays, showAll) {
+      if (!visibleGroups.length) {
+        return '<p class="data-meta">暂无「最近更新」数据。</p>';
+      }
+      var newest = visibleGroups[0].date || '';
+      var oldestVisible = visibleGroups[visibleGroups.length - 1].date || newest;
+      var introParts = [];
+      if (oldestVisible && newest && oldestVisible !== newest) {
+        introParts.push(oldestVisible + ' → ' + newest);
+      } else if (newest) {
+        introParts.push(newest);
+      }
+      introParts.push('维护日志时间线');
+      var visibleNodes = countTimelineGroupNodes(visibleGroups);
+      if (showAll || visibleGroups.length >= allGroups.length) {
+        introParts.push(String(visibleNodes) + ' 个节点 / ' + String(allGroups.length) + ' 天');
+      } else {
+        introParts.push(
+          '显示最近 ' + String(windowDays) + ' 天 · ' +
+          String(visibleNodes) + ' 个节点 / ' + String(visibleGroups.length) + ' 天' +
+          '（共 ' + String(allGroups.length) + ' 天）'
         );
       }
-      defaultBodyHtml = activityIntroHtml + '<div class="updates-timeline-days">' + activityDaysHtml + '</div>';
-    } else if (!items.length || !items[0].detail_id) {
-      defaultBodyHtml = '<p class="data-meta">暂无「最近更新」数据。</p>';
-    } else {
-      var first = items[0];
-      var fromLog = first.source === 'log.md';
-      var dateStr = first.recency ? String(first.recency) : '';
+      return '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(introParts.join(' · ')) + '</p>';
+    }
 
-      var groups = [];
-      var groupIndex = {};
+    function renderTimelineActions(visibleGroups, allGroups, showAll) {
+      if (!allGroups.length || showAll || visibleGroups.length >= allGroups.length) return '';
+      return (
+        '<div class="updates-timeline-actions" role="group" aria-label="展开更多更新记录">' +
+        '<button type="button" class="btn-secondary updates-timeline-more-days">再展开 30 天</button>' +
+        '<button type="button" class="btn-secondary updates-timeline-show-all">展开全部记录</button>' +
+        '</div>'
+      );
+    }
+
+    function renderTimelineBody(allGroups, windowDays, showAll) {
+      if (!allGroups.length) {
+        return '<p class="data-meta">暂无「最近更新」数据。</p>';
+      }
+      var visibleGroups = filterTimelineGroupsByWindow(allGroups, windowDays, showAll);
+      var introHtml = buildTimelineIntro(visibleGroups, allGroups, windowDays, showAll);
+      var daysHtml = '';
+      for (var tgi = 0; tgi < visibleGroups.length; tgi++) {
+        var tg = visibleGroups[tgi];
+        daysHtml += renderTimelineDay(tg.date, tg.items, tg.totalCount);
+      }
+      var actionsHtml = renderTimelineActions(visibleGroups, allGroups, showAll);
+      return introHtml + '<div class="updates-timeline-days">' + daysHtml + '</div>' + actionsHtml;
+    }
+
+    var TIMELINE_WINDOW_DAYS = 30;
+    var TIMELINE_WINDOW_STEP = 30;
+    var timelineFromActivity = buildTimelineGroupsFromActivity(activityDays);
+    var allTimelineGroups = [];
+    if (timelineFromActivity.groups.length) {
+      allTimelineGroups = timelineFromActivity.groups;
+    } else if (items.length && items[0].detail_id) {
+      var fallbackGroups = [];
+      var fallbackIndex = {};
       items.forEach(function (meta) {
         var dateKey = meta && meta.recency ? String(meta.recency) : '';
-        if (!(dateKey in groupIndex)) {
-          groupIndex[dateKey] = groups.length;
-          groups.push({ date: dateKey, items: [] });
+        if (!(dateKey in fallbackIndex)) {
+          fallbackIndex[dateKey] = fallbackGroups.length;
+          fallbackGroups.push({ date: dateKey, items: [], totalCount: 0 });
         }
-        groups[groupIndex[dateKey]].items.push(meta);
+        fallbackGroups[fallbackIndex[dateKey]].items.push(meta);
+        fallbackGroups[fallbackIndex[dateKey]].totalCount = fallbackGroups[fallbackIndex[dateKey]].items.length;
       });
-
-      var introParts = [];
-      if (fromLog && groups.length > 1) {
-        var lastDate = groups[groups.length - 1].date || dateStr;
-        var dateRange = lastDate && dateStr && lastDate !== dateStr ? (lastDate + ' → ' + dateStr) : dateStr;
-        if (dateRange) introParts.push(dateRange);
-        introParts.push('维护日志时间线');
-        introParts.push(String(items.length) + ' 个节点 / ' + String(groups.length) + ' 天');
-      } else {
-        if (dateStr) introParts.push(dateStr);
-        if (fromLog) {
-          introParts.push('维护日志');
-          if (items.length > 1) introParts.push(String(items.length) + ' 个节点');
-        } else {
-          introParts.push('按页面更新时间');
-        }
-      }
-      var introHtml =
-        '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(introParts.join(' · ')) + '</p>';
-
-      var daysHtml = '';
-      for (var gi = 0; gi < groups.length; gi++) {
-        daysHtml += renderTimelineDay(groups[gi].date, groups[gi].items);
-      }
-      defaultBodyHtml = introHtml + '<div class="updates-timeline-days">' + daysHtml + '</div>';
+      allTimelineGroups = fallbackGroups;
     }
+
+    var currentWindowDays = TIMELINE_WINDOW_DAYS;
+    var timelineShowAll = false;
+    var defaultBodyHtml = renderTimelineBody(allTimelineGroups, currentWindowDays, timelineShowAll);
     var heatmapHtml = activityDays.length ? buildHomeWikiHeatmapHtml(activityDays) : '';
     mount.innerHTML = heatmapHtml + '<div class="home-latest-wiki-body">' + defaultBodyHtml + '</div>';
-    if (!heatmapHtml) return;
 
     var bodyMount = mount.querySelector('.home-latest-wiki-body');
+    var activeDate = '';
+    var clearHeatmapFilter = null;
+
+    function refreshTimelineBody() {
+      if (activeDate) return;
+      defaultBodyHtml = renderTimelineBody(allTimelineGroups, currentWindowDays, timelineShowAll);
+      bodyMount.innerHTML = defaultBodyHtml;
+    }
+
+    bodyMount.addEventListener('click', function (ev) {
+      if (ev.target.closest('.home-wiki-heatmap-clear')) {
+        if (clearHeatmapFilter) clearHeatmapFilter();
+        return;
+      }
+      var moreDaysBtn = ev.target.closest('button.updates-timeline-more-days');
+      if (moreDaysBtn) {
+        if (!timelineShowAll) currentWindowDays += TIMELINE_WINDOW_STEP;
+        refreshTimelineBody();
+        return;
+      }
+      var showAllBtn = ev.target.closest('button.updates-timeline-show-all');
+      if (showAllBtn) {
+        timelineShowAll = true;
+        refreshTimelineBody();
+        return;
+      }
+      var moreBtn = ev.target.closest('button.updates-day-more');
+      if (moreBtn) {
+        var daySection = moreBtn.closest('.updates-day');
+        if (daySection) daySection.classList.remove('is-folded');
+        moreBtn.parentNode.removeChild(moreBtn);
+      }
+    });
+
+    if (!heatmapHtml) return;
+
     var grid = mount.querySelector('.home-wiki-heatmap-grid');
     var scrollWrap = mount.querySelector('.home-wiki-heatmap-scroll');
     if (scrollWrap) scrollWrap.scrollLeft = scrollWrap.scrollWidth; // 默认停在最新日期
@@ -609,8 +675,6 @@
       totalByDate[dayEntry.date] = typeof dayEntry.count === 'number' ? dayEntry.count : 0;
     }
 
-    var activeDate = '';
-
     function setActiveCell(dateKey) {
       var cells = grid.querySelectorAll('button.home-wiki-heatmap-cell');
       for (var ci2 = 0; ci2 < cells.length; ci2++) {
@@ -620,11 +684,12 @@
       }
     }
 
-    function clearHeatmapFilter() {
+    function clearHeatmapFilterImpl() {
       activeDate = '';
       setActiveCell('');
       bodyMount.innerHTML = defaultBodyHtml;
     }
+    clearHeatmapFilter = clearHeatmapFilterImpl;
 
     function applyHeatmapFilter(dateKey) {
       var dayNodes = nodesByDate[dateKey] || [];
@@ -645,21 +710,9 @@
       var dateKey = cell.getAttribute('data-date') || '';
       if (!dateKey) return;
       if (dateKey === activeDate) {
-        clearHeatmapFilter();
+        clearHeatmapFilterImpl();
       } else {
         applyHeatmapFilter(dateKey);
-      }
-    });
-    bodyMount.addEventListener('click', function (ev) {
-      if (ev.target.closest('.home-wiki-heatmap-clear')) {
-        clearHeatmapFilter();
-        return;
-      }
-      var moreBtn = ev.target.closest('button.updates-day-more');
-      if (moreBtn) {
-        var daySection = moreBtn.closest('.updates-day');
-        if (daySection) daySection.classList.remove('is-folded');
-        moreBtn.parentNode.removeChild(moreBtn);
       }
     });
   }

--- a/docs/main.js
+++ b/docs/main.js
@@ -455,6 +455,7 @@
     // 时间线条目 / 单日区块（参考论文笔记站 updates.html：左轨道 + 日期圆点 + 条目行 + 超量折叠）
     var TIMELINE_FOLD_LIMIT = 14; // 超过则折叠
     var TIMELINE_FOLD_SHOW = 12;  // 折叠时先显示的条数
+    var activityDays = wikiActivity && Array.isArray(wikiActivity.days) ? wikiActivity.days : [];
 
     function renderTimelineItem(meta, folded) {
       var typeLabel = WIKI_TYPE_LABEL_HOME[meta.type] || (meta.type ? String(meta.type) : 'Wiki');
@@ -489,8 +490,65 @@
       );
     }
 
+    function buildTimelineGroupsFromActivity(days) {
+      var groups = [];
+      var totalNodes = 0;
+      for (var ai = days.length - 1; ai >= 0; ai--) {
+        var dayEntry = days[ai];
+        if (!dayEntry || !dayEntry.date) continue;
+        var dayNodes = Array.isArray(dayEntry.nodes) ? dayEntry.nodes : [];
+        if (!dayNodes.length) continue;
+        var metas = [];
+        for (var ni = 0; ni < dayNodes.length; ni++) {
+          var nodeMeta = dayNodes[ni];
+          if (!nodeMeta || !nodeMeta.detail_id) continue;
+          metas.push({
+            detail_id: nodeMeta.detail_id,
+            label: nodeMeta.label || nodeMeta.detail_id,
+            type: nodeMeta.type || '',
+            recency: dayEntry.date,
+            source: 'log.md'
+          });
+        }
+        if (!metas.length) continue;
+        var dayCount = typeof dayEntry.count === 'number' ? dayEntry.count : metas.length;
+        totalNodes += dayCount;
+        groups.push({ date: dayEntry.date, items: metas, totalCount: dayCount });
+      }
+      return { groups: groups, totalNodes: totalNodes };
+    }
+
     var defaultBodyHtml;
-    if (!items.length || !items[0].detail_id) {
+    var timelineFromActivity = buildTimelineGroupsFromActivity(activityDays);
+    if (timelineFromActivity.groups.length) {
+      var activityGroups = timelineFromActivity.groups;
+      var oldestDate = activityDays[0] && activityDays[0].date ? activityDays[0].date : '';
+      var newestDate = activityDays[activityDays.length - 1] && activityDays[activityDays.length - 1].date
+        ? activityDays[activityDays.length - 1].date
+        : '';
+      var activityIntroParts = [];
+      if (oldestDate && newestDate && oldestDate !== newestDate) {
+        activityIntroParts.push(oldestDate + ' → ' + newestDate);
+      } else if (newestDate) {
+        activityIntroParts.push(newestDate);
+      }
+      activityIntroParts.push('维护日志时间线');
+      activityIntroParts.push(
+        String(timelineFromActivity.totalNodes) + ' 个节点 / ' + String(activityGroups.length) + ' 天'
+      );
+      var activityIntroHtml =
+        '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(activityIntroParts.join(' · ')) + '</p>';
+      var activityDaysHtml = '';
+      for (var agi = 0; agi < activityGroups.length; agi++) {
+        var activityGroup = activityGroups[agi];
+        activityDaysHtml += renderTimelineDay(
+          activityGroup.date,
+          activityGroup.items,
+          activityGroup.totalCount
+        );
+      }
+      defaultBodyHtml = activityIntroHtml + '<div class="updates-timeline-days">' + activityDaysHtml + '</div>';
+    } else if (!items.length || !items[0].detail_id) {
       defaultBodyHtml = '<p class="data-meta">暂无「最近更新」数据。</p>';
     } else {
       var first = items[0];
@@ -533,8 +591,6 @@
       }
       defaultBodyHtml = introHtml + '<div class="updates-timeline-days">' + daysHtml + '</div>';
     }
-
-    var activityDays = wikiActivity && Array.isArray(wikiActivity.days) ? wikiActivity.days : [];
     var heatmapHtml = activityDays.length ? buildHomeWikiHeatmapHtml(activityDays) : '';
     mount.innerHTML = heatmapHtml + '<div class="home-latest-wiki-body">' + defaultBodyHtml + '</div>';
     if (!heatmapHtml) return;

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -295,6 +295,33 @@
     var wrap3d = document.getElementById('mini-graph-3d');
     var graph3d = null;
     var loading3d = false;
+    var lastPointer3d = { clientX: 0, clientY: 0 };
+
+    function trackPointer3d(ev) {
+      lastPointer3d.clientX = ev.clientX;
+      lastPointer3d.clientY = ev.clientY;
+    }
+
+    function showTooltip3d(d) {
+      showTooltip(lastPointer3d, d, nodeFill, communityLabelMap);
+    }
+
+    function bindMiniGraph3dTooltipDismiss() {
+      if (!window.RNGraphTooltip || !wrap3d) return;
+      var tooltipApi = {
+        isMobile: isMobile,
+        getPinned: function() { return pinnedNode; },
+        clearPin: function() { pinnedNode = null; },
+        hide: hideTooltip
+      };
+      window.RNGraphTooltip.bindBlankDismiss(wrap3d, tooltipApi, {
+        tooltipEl: tooltip
+      });
+      window.RNGraphTooltip.bindOutsideDismiss(wrap3d, tooltipApi, {
+        tooltipEl: tooltip,
+        dismissRootEl: document.querySelector('main')
+      });
+    }
 
     function applyMode3dTheme() {
       if (!graph3d) return;
@@ -320,7 +347,14 @@
       // 独立节点/边副本：2D d3 力模拟已把 edges 的端点替换为节点对象引用，
       // 且节点带 x/y/vx/vy 等模拟状态，直接共享会与 3D 力模拟争用
       var nodes3d = nodes.map(function (n) {
-        return { id: n.id, label: n.label, type: n.type, community: n.community, _degree: n._degree };
+        return {
+          id: n.id,
+          label: n.label,
+          type: n.type,
+          community: n.community,
+          summary: n.summary || '',
+          _degree: n._degree
+        };
       });
       var links3d = edges.map(function (e) {
         return {
@@ -338,13 +372,28 @@
         .cooldownTime(4000)
         .nodeColor(function (d) { return nodeFill(d); })
         .nodeVal(function (d) { return Math.max(1, d._degree); })
-        .nodeLabel(function (d) { return escapeHtml(d.label || d.id); })
         .linkColor(function () { return miniGraphTheme().edge3d; })
         .linkOpacity(0.35)
+        .onNodeHover(function (node) {
+          if (isMobile) return;
+          if (node) showTooltip3d(node);
+          else hideTooltip();
+        })
         .onNodeClick(function (d) {
+          if (isMobile) {
+            if (pinnedNode === d) {
+              pinnedNode = null;
+              hideTooltip();
+            } else {
+              showTooltip3d(d);
+            }
+            return;
+          }
           window.location.href = 'graph.html?focus=' + encodeURIComponent(d.id);
         })
         .graphData({ nodes: nodes3d, links: links3d });
+      wrap3d.addEventListener('mousemove', trackPointer3d);
+      bindMiniGraph3dTooltipDismiss();
       // 力模拟稳定后一次性取景填满容器（与 2D sim.on('end') 的自动 fit 对齐）；
       // 只做首次，避免用户拖拽节点触发的后续 engineStop 抢走相机
       var fitted3d = false;
@@ -392,6 +441,8 @@
     }
 
     function show2d() {
+      hideTooltip();
+      pinnedNode = null;
       wrap3d.hidden = true;
       miniSvg.style.display = '';
       setModeButtons('2d');

--- a/docs/style.css
+++ b/docs/style.css
@@ -503,15 +503,26 @@ body.sponsor-dialog-open {
 .updates-day-meta { font-size: .78rem; font-weight: 400; color: var(--text-muted); margin-left: .55rem; }
 .updates-day-list { list-style: none; margin: 8px 0 0; padding: 0; }
 .updates-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 10px;
   align-items: baseline;
-  gap: 10px;
   font-size: .93rem;
   line-height: 1.6;
   padding: 2px 0;
 }
-.updates-item-type { flex: none; font-size: .72rem; color: var(--text-muted); white-space: nowrap; min-width: 4.5em; }
-.updates-item-link { min-width: 0; }
+.updates-item-type {
+  grid-column: 1;
+  font-size: .72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  min-width: 4.5em;
+}
+.updates-item-link {
+  grid-column: 2;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .updates-day.is-folded .updates-item-folded { display: none; }
 .updates-day-more {
   display: inline-block;
@@ -525,8 +536,12 @@ body.sponsor-dialog-open {
   cursor: pointer;
 }
 .updates-day-more:hover { color: var(--accent-hover); border-color: var(--accent-hover); }
-@media (max-width: 860px) {
-  .updates-item { flex-wrap: wrap; row-gap: 2px; }
+.updates-timeline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+  padding-left: 18px;
 }
 /* 首页「最新知识节点」活跃度热力图（GitHub 风格布局；色阶取站点主题蓝
    （--accent 同色相，暗档最亮≈--accent-hover），已过顺序色板校验：

--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -249,9 +249,8 @@ LATEST_NODES_DEFAULT = 20
 LATEST_NODES_CAP = 30
 LATEST_NODES_WINDOW_DAYS = 30
 LATEST_NODES_ENV_VAR = "GRAPH_LATEST_NODES_MAX"
-# wiki-activity.json：单日节点列表上限（count 保留真实值；批量维护日 glob
-# 可展开出上千节点，全量导出会拖垮首页热力图筛选的加载与渲染）。
-ACTIVITY_NODES_PER_DAY_CAP = 30
+# wiki-activity.json：按日导出全部节点（count 与 nodes 长度一致）。
+# 更新记录页与热力图筛选依赖全量日志时间线；单日条目过多时由前端折叠展示。
 
 
 def wiki_recency_date(content: str, page: Path) -> date:
@@ -435,7 +434,7 @@ def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     窗口：同一日期的多个日志块合并、同日去重（跨日可重复出现），仅保留仓库
     现存且在图谱节点中的路径。返回按日期升序的
     ``[{date, count, nodes: [{detail_id, label, type}]}]``，无节点的日期不输出；
-    count 为当日真实节点数，nodes 仅保留出现顺序前 ACTIVITY_NODES_PER_DAY_CAP 项。
+    count 为当日节点数，nodes 为当日全部节点（出现顺序）。
     """
     if not LOG_MD_PATH.is_file():
         return []
@@ -483,7 +482,7 @@ def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "count": len(metas),
                 "nodes": [
                     {"detail_id": m["detail_id"], "label": m["label"], "type": m["type"]}
-                    for m in metas[:ACTIVITY_NODES_PER_DAY_CAP]
+                    for m in metas
                 ],
             }
         )

--- a/scripts/screenshot_pr_changelog_3d.cjs
+++ b/scripts/screenshot_pr_changelog_3d.cjs
@@ -1,0 +1,179 @@
+// PR verification: change-log 30-day window + homepage mini-graph 3D hover tooltip.
+// Usage: node scripts/screenshot_pr_changelog_3d.cjs [port] [outDir]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+const CHROME_CANDIDATES = [
+  process.env.PUPPETEER_EXECUTABLE_PATH,
+  process.env.CHROME_PATH,
+  '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  '/usr/local/bin/google-chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+].filter(Boolean);
+const exe = CHROME_CANDIDATES.find((p) => fs.existsSync(p));
+if (!exe) {
+  console.error('No Chrome/Chromium found.');
+  process.exit(1);
+}
+
+const chromeArgs = [
+  '--no-sandbox',
+  '--disable-gpu',
+  '--disable-dev-shm-usage',
+  '--window-size=1440,1200',
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
+];
+
+const d3Local = path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js');
+const d3Body = fs.existsSync(d3Local) ? fs.readFileSync(d3Local) : null;
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function setupPage(page) {
+  await page.setViewport({ width: 1440, height: 1200, deviceScaleFactor: 1 });
+  if (d3Body) {
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      const u = req.url();
+      if (u.includes('cdn.jsdelivr.net/npm/d3')) {
+        req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+      } else {
+        req.continue();
+      }
+    });
+  }
+}
+
+async function waitChangeLogReady(page) {
+  await page.waitForFunction(() => {
+    const mount = document.getElementById('homeLatestWikiModule');
+    return mount && !mount.classList.contains('data-loading') && mount.querySelector('.updates-day');
+  }, { timeout: 120000 });
+}
+
+(async () => {
+  const port = process.argv[2] || '8765';
+  const outDir = path.resolve(process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots'));
+  fs.mkdirSync(outDir, { recursive: true });
+  const base = `http://127.0.0.1:${port}`;
+  const shots = [];
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: chromeArgs,
+  });
+
+  try {
+    // 1) change-log — default 30-day window + action buttons
+    {
+      const page = await browser.newPage();
+      await setupPage(page);
+      await page.goto(`${base}/change-log.html`, { waitUntil: 'networkidle2', timeout: 120000 });
+      await waitChangeLogReady(page);
+      const meta = await page.evaluate(() => ({
+        intro: document.querySelector('.home-latest-wiki-intro')?.textContent?.trim() || '',
+        dayCount: document.querySelectorAll('.updates-day').length,
+        hasMoreBtn: !!document.querySelector('.updates-timeline-more-days'),
+        hasAllBtn: !!document.querySelector('.updates-timeline-show-all'),
+      }));
+      const out = path.join(outDir, 'change-log-default-30d.png');
+      await page.screenshot({ path: out, fullPage: true });
+      shots.push({ page: 'change-log default', out, meta });
+      await page.close();
+    }
+
+    // 2) change-log — expand all
+    {
+      const page = await browser.newPage();
+      await setupPage(page);
+      await page.goto(`${base}/change-log.html`, { waitUntil: 'networkidle2', timeout: 120000 });
+      await waitChangeLogReady(page);
+      await page.click('.updates-timeline-show-all');
+      await sleep(400);
+      const meta = await page.evaluate(() => ({
+        intro: document.querySelector('.home-latest-wiki-intro')?.textContent?.trim() || '',
+        dayCount: document.querySelectorAll('.updates-day').length,
+        hasActions: !!document.querySelector('.updates-timeline-actions'),
+      }));
+      const out = path.join(outDir, 'change-log-expanded-all.png');
+      await page.screenshot({ path: out, fullPage: true });
+      shots.push({ page: 'change-log all', out, meta });
+      await page.close();
+    }
+
+    // 3) index — mini-graph 3D hover tooltip
+    {
+      const page = await browser.newPage();
+      await setupPage(page);
+      await page.goto(`${base}/index.html`, { waitUntil: 'networkidle2', timeout: 120000 });
+      await page.waitForSelector('#miniGraphMode3d', { timeout: 60000 });
+      await page.click('#miniGraphMode3d');
+      await page.waitForFunction(() => {
+        const wrap = document.getElementById('mini-graph-3d');
+        return wrap && !wrap.hidden && wrap.querySelector('canvas');
+      }, { timeout: 120000 });
+      await sleep(8000);
+
+      const canvasBox = await page.evaluate(() => {
+        const canvas = document.querySelector('#mini-graph-3d canvas');
+        if (!canvas) return null;
+        const r = canvas.getBoundingClientRect();
+        return { x: r.x, y: r.y, width: r.width, height: r.height };
+      });
+      if (!canvasBox) throw new Error('3D canvas not found');
+
+      let tooltipVisible = false;
+      const gridX = 7;
+      const gridY = 7;
+      for (let gy = 1; gy < gridY && !tooltipVisible; gy++) {
+        for (let gx = 1; gx < gridX && !tooltipVisible; gx++) {
+          const x = canvasBox.x + (canvasBox.width * gx) / gridX;
+          const y = canvasBox.y + (canvasBox.height * gy) / gridY;
+          await page.mouse.move(x, y);
+          await sleep(350);
+          tooltipVisible = await page.evaluate(() => {
+            const tip = document.getElementById('mini-graph-tooltip');
+            return !!(tip && !tip.classList.contains('hidden') && tip.textContent.trim());
+          });
+        }
+      }
+
+      const tooltipMeta = await page.evaluate(() => {
+        const tip = document.getElementById('mini-graph-tooltip');
+        return {
+          visible: !!(tip && !tip.classList.contains('hidden')),
+          hasTitle: !!tip?.querySelector('.tt-title'),
+          hasLink: !!tip?.querySelector('.tt-link'),
+          text: tip?.textContent?.trim().slice(0, 120) || '',
+        };
+      });
+
+      const section = await page.$('#mini-graph-section');
+      const out = path.join(outDir, 'index-mini-graph-3d-tooltip.png');
+      if (section) {
+        await section.screenshot({ path: out });
+      } else {
+        await page.screenshot({ path: out });
+      }
+      shots.push({ page: 'index 3d tooltip', out, meta: { tooltipVisible, tooltipMeta, canvasBox } });
+      await page.close();
+    }
+
+    const reportPath = path.join(outDir, 'pr-changelog-3d-verify.json');
+    fs.writeFileSync(reportPath, JSON.stringify({ ok: true, shots }, null, 2));
+    console.log(JSON.stringify({ ok: true, shots, reportPath }, null, 2));
+  } finally {
+    await browser.close();
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test_generate_link_graph_wiki_activity.py
+++ b/tests/test_generate_link_graph_wiki_activity.py
@@ -96,19 +96,18 @@ class WikiActivityFromLogTest(unittest.TestCase):
         node = out[0]["nodes"][0]
         self.assertEqual(set(node), {"detail_id", "label", "type"})
 
-    def test_nodes_capped_per_day_but_count_stays_real(self) -> None:
-        cap = glg.ACTIVITY_NODES_PER_DAY_CAP
+    def test_nodes_export_all_entries_and_count_matches(self) -> None:
         many = sorted(
             str(p.relative_to(glg.REPO_ROOT)).replace("\\", "/") for p in glg.WIKI_DIR.rglob("*.md")
-        )[: cap + 5]
-        if len(many) <= cap:
-            self.skipTest("仓库 wiki 页面数不足以覆盖单日上限")
+        )[:35]
+        if len(many) < 10:
+            self.skipTest("仓库 wiki 页面数不足以覆盖多日节点导出")
         nodes = [_node(rel) for rel in many]
         self._write_log([("2026-05-28", many)])
         with self._patched_log():
             out = glg.wiki_activity_from_log(nodes)
         self.assertEqual(out[0]["count"], len(many))
-        self.assertEqual(len(out[0]["nodes"]), cap)
+        self.assertEqual(len(out[0]["nodes"]), len(many))
 
     def test_unknown_paths_and_empty_days_are_dropped(self) -> None:
         self._write_log(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- **更新记录页**（`change-log.html`）：时间线基于 `wiki-activity.json` 全量日志；**默认仅显示最近 30 个日历日**，底部提供「再展开 30 天」「展开全部记录」。
- **列对齐**：每条记录 grid 双列（类型 | 链接），长标题换行保持在链接列内。
- **数据导出**：`wiki-activity.json` 全量导出每日节点。
- **首页 3D 预览**：对齐 2D 悬浮预览卡片。

## 验证

- `make ci-preflight` 通过
- `node scripts/screenshot_pr_changelog_3d.cjs` 本地截图验证通过

## 验证截图

### 更新记录 — 默认最近 30 天（含展开按钮）

![更新记录默认显示最近30天](https://cursor.com/artifacts/c/art-0a069785-4deb-44d1-8827-bef9f8c1a5ca)

### 更新记录 — 展开全部（63 天）

![更新记录展开全部63天](https://cursor.com/artifacts/c/art-bd438bef-64ce-485a-b381-ade8550285a3)

### 首页 — 3D 预览节点悬浮卡片

![首页3D预览节点悬浮卡片](https://cursor.com/artifacts/c/art-781de4cf-15dd-4250-b8cc-73ba35c9c283)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c93caf7-1b9e-4d3c-8e6c-262f32a64bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c93caf7-1b9e-4d3c-8e6c-262f32a64bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

