### PR TITLE
style(ux): 移动端最新知识节点保持三列网格对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -465,14 +465,12 @@ body.sponsor-dialog-open {
 }
 .home-latest-row { display: contents; }
 .home-latest-row-date, .home-latest-row-type { color: var(--text-muted); font-size: .85rem; white-space: nowrap; }
-.home-latest-row > a { min-width: 0; }
+.home-latest-row > a { min-width: 0; overflow-wrap: anywhere; }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
-  /* 窄屏：三列并排会挤压标题，退化为「日期 · 类型」一行 + 标题一行 */
-  .home-latest-list, .home-latest-row { display: block; }
-  .home-latest-row + .home-latest-row { margin-top: 14px; }
-  .home-latest-row-type::before { content: ' · '; }
-  .home-latest-row > a { display: block; margin-top: 2px; }
+  /* 窄屏：保持三列 grid 跨行对齐，仅收紧间距与字号 */
+  .home-latest-list { column-gap: 10px; row-gap: 8px; }
+  .home-latest-row-date, .home-latest-row-type { font-size: .78rem; }
 }
 .home-latest-wiki-intro { margin-bottom: 20px; }
 /* change-log 更新时间线（参考论文笔记站 updates.html：左轨道 + 日期圆点 + 条目行 + 超量折叠） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

首页「最新知识节点」紧凑列表在桌面端已使用三列 grid（日期 / 类型 / 标题）跨行对齐，但 `≤860px` 媒体查询会退化为 block 两行布局，导致移动端列无法对齐。本 PR 移除该退化逻辑，与更新记录页 `updates-item` 的处理一致：移动端同样保持分列，仅收紧间距与字号。

## 变更

- `docs/style.css`：删除窄屏下 `.home-latest-list` / `.home-latest-row` 的 `display: block` 与「日期 · 类型」合并样式
- 窄屏保留 `grid-template-columns: max-content max-content 1fr`，`column-gap` 16→10px，元数据字号略缩小
- 标题链增加 `overflow-wrap: anywhere`，长标题在第三列内换行而不撑破对齐

## 验证

- 本地 `390×844` 视口截图：日期、类型、标题三列纵向对齐，长标题在第三列内换行
- 仅 CSS 改动，未涉及 wiki / 派生索引

## 验证截图

![移动端最新知识节点三列对齐](https://cursor.com/artifacts/c/art-d78c4d6c-34cf-444a-b3ed-21ec6cff3a97)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff911198-a552-47cc-9eb0-0bfea6bcab9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff911198-a552-47cc-9eb0-0bfea6bcab9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

