### PR TITLE
fix(ux): 无标签时保持更新记录列对齐

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -423,6 +423,24 @@
       items = [homeStats.latest_wiki_node];
     }
 
+    function renderActionBadge(action) {
+      if (action === 'added') {
+        return '<span class="updates-badge updates-badge-added">新增</span>';
+      }
+      if (action === 'maintained') {
+        return '<span class="updates-badge">维护</span>';
+      }
+      return '';
+    }
+
+    function renderActionBadgeCell(action, cellClass) {
+      var badge = renderActionBadge(action);
+      if (badge) {
+        return '<span class="' + cellClass + '">' + badge + '</span>';
+      }
+      return '<span class="' + cellClass + ' updates-badge-cell--empty" aria-hidden="true"></span>';
+    }
+
     // 首页紧凑模式（mount 带 data-compact）：只列最近 5 条单行记录；
     // 完整时间线与活跃度热力图迁至 change-log.html
     if (mount.hasAttribute('data-compact')) {
@@ -435,17 +453,11 @@
       for (var cri = 0; cri < maxRows; cri++) {
         var rowMeta = items[cri];
         var rowType = WIKI_TYPE_LABEL_HOME[rowMeta.type] || (rowMeta.type ? String(rowMeta.type) : 'Wiki');
-        var rowBadge = '';
-        if (rowMeta.action === 'added') {
-          rowBadge = '<span class="updates-badge updates-badge-added">新增</span>';
-        } else if (rowMeta.action === 'maintained') {
-          rowBadge = '<span class="updates-badge">维护</span>';
-        }
         compactRows +=
           '<li class="home-latest-row"><span class="home-latest-row-date">' +
           escapeHtml(rowMeta.recency ? String(rowMeta.recency) : '') +
           '</span>' +
-          (rowBadge ? '<span class="home-latest-row-badge">' + rowBadge + '</span>' : '') +
+          renderActionBadgeCell(rowMeta.action, 'home-latest-row-badge') +
           '<span class="home-latest-row-type">' +
           escapeHtml(rowType) +
           '</span><a href="' +
@@ -464,16 +476,6 @@
     var TIMELINE_FOLD_LIMIT = 14; // 超过则折叠
     var TIMELINE_FOLD_SHOW = 12;  // 折叠时先显示的条数
     var activityDays = wikiActivity && Array.isArray(wikiActivity.days) ? wikiActivity.days : [];
-
-    function renderActionBadge(action) {
-      if (action === 'added') {
-        return '<span class="updates-badge updates-badge-added">新增</span>';
-      }
-      if (action === 'maintained') {
-        return '<span class="updates-badge">维护</span>';
-      }
-      return '';
-    }
 
     function countActionStats(metas) {
       var added = 0;
@@ -498,10 +500,9 @@
 
     function renderTimelineItem(meta, folded) {
       var typeLabel = WIKI_TYPE_LABEL_HOME[meta.type] || (meta.type ? String(meta.type) : 'Wiki');
-      var badgeHtml = renderActionBadge(meta.action);
       return (
         '<li class="updates-item' + (folded ? ' updates-item-folded' : '') + '">' +
-        (badgeHtml || '<span class="updates-item-badge-spacer" aria-hidden="true"></span>') +
+        renderActionBadgeCell(meta.action, 'updates-badge-cell') +
         '<span class="updates-item-type">' + escapeHtml(typeLabel) + '</span>' +
         '<a class="updates-item-link" href="' + escapeHtml(detailHref(meta.detail_id)) + '">' +
         escapeHtml(meta.label || meta.detail_id) +

--- a/docs/style.css
+++ b/docs/style.css
@@ -458,14 +458,24 @@ body.sponsor-dialog-open {
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: max-content max-content max-content 1fr;
+  --updates-badge-col-width: 3.25rem;
+  grid-template-columns: max-content var(--updates-badge-col-width) max-content 1fr;
   column-gap: 12px;
   row-gap: 10px;
   align-items: baseline;
 }
 .home-latest-row { display: contents; }
 .home-latest-row-date, .home-latest-row-type { color: var(--text-muted); font-size: .85rem; white-space: nowrap; }
+.home-latest-row-badge,
+.updates-badge-cell {
+  display: inline-flex;
+  align-items: baseline;
+  min-width: var(--updates-badge-col-width, 3.25rem);
+  flex-shrink: 0;
+}
 .home-latest-row-badge .updates-badge { vertical-align: baseline; }
+.updates-badge-cell--empty,
+.home-latest-row-badge.updates-badge-cell--empty { min-height: 1.25em; }
 .home-latest-row > a { min-width: 0; overflow-wrap: anywhere; }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
@@ -500,10 +510,10 @@ body.sponsor-dialog-open {
   box-shadow: 0 0 0 3px var(--bg);
 }
 .updates-day-meta { font-size: .78rem; font-weight: 400; color: var(--text-muted); margin-left: .55rem; }
-.updates-day-list { list-style: none; margin: 8px 0 0; padding: 0; }
+.updates-day-list { list-style: none; margin: 8px 0 0; padding: 0; --updates-badge-col-width: 3.25rem; }
 .updates-item {
   display: grid;
-  grid-template-columns: max-content max-content 1fr;
+  grid-template-columns: var(--updates-badge-col-width, 3.25rem) max-content 1fr;
   column-gap: 10px;
   align-items: baseline;
   font-size: .93rem;
@@ -511,7 +521,6 @@ body.sponsor-dialog-open {
   padding: 2px 0;
 }
 .updates-badge {
-  grid-column: 1;
   font-size: .66rem;
   line-height: 1.5;
   padding: 0 .55rem;
@@ -529,11 +538,6 @@ body.sponsor-dialog-open {
 }
 [data-theme="light"] .updates-badge-added {
   background: rgba(42, 108, 180, 0.08);
-}
-.updates-item-badge-spacer {
-  grid-column: 1;
-  display: inline-block;
-  width: 2.4em;
 }
 .updates-item-type {
   grid-column: 2;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

更新记录时间线与首页紧凑列表：当条目没有「新增/维护」标签时，仍保留固定宽度的标签列占位，避免类型列与标题列错位。

## 变更

- `docs/main.js`：`renderActionBadgeCell()` 无标签时输出空占位格
- `docs/style.css`：标签列固定 `3.25rem`，首页四列 grid 与 change-log 三列 grid 对齐

## 验证

- 仅前端样式/渲染改动，无 wiki 内容变更

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-720a8b22-b0bd-4cfe-8cc2-3c4c97adfc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-720a8b22-b0bd-4cfe-8cc2-3c4c97adfc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

