### PR TITLE
docs: Add "main" and "twist2" to lint allowlist

### DIFF
--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -90,6 +90,7 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
     "md",
     "http",
     "https",
+    "main",
 }
 
 # 高频术语但「已在 entities/ 或非同名 stem 的 methods 页有恰当归属」，
@@ -103,6 +104,7 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
 #   locomotion → tasks/locomotion.md（+ humanoid-/hybrid-locomotion，任务域，归 tasks）
 #   loco-manipulation → tasks/loco-manipulation.md（移动操作，任务域，归 tasks）
 #   step       → entities/step2urdf.md（CAD 交换格式，已在 concepts/text-to-cad.md 引介）
+#   twist2     → entities/paper-twist2.md（具体系统/论文，归 entities）
 MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "amp",
     "g1",
@@ -113,6 +115,7 @@ MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "locomotion",
     "loco-manipulation",
     "step",
+    "twist2",
 }
 
 # 仅用于信息提示、不计入 lint 失败总数的检查 key

--- a/wiki/methods/π0-policy.md
+++ b/wiki/methods/π0-policy.md
@@ -2,7 +2,7 @@
 type: method
 tags: [vla, foundation-policy, deepmind, flow-matching, manipulation]
 status: complete
-updated: 2026-06-04
+updated: 2026-07-04
 related:
   - ./vla.md
   - ./pi07-policy.md


### PR DESCRIPTION
## 摘要

补充两个词条到 lint 脚本的允许列表：
- `main`：添加到 `ALLOWED_STEMS`（协议/格式类）
- `twist2`：添加到 `MISSING_CONCEPT_COVERED_ELSEWHERE`（已在 entities/paper-twist2.md 归属）

同时修正 π0-policy.md 的更新日期（2026-06-04 → 2026-07-04）。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [ ] 知识入库（ingest / wiki 内容）
- [ ] 前端（`docs/`）
- [ ] 其他

## 验证

- [x] `make ci-preflight`（脚本改动）

## 相关 Issue

无

https://claude.ai/code/session_015AZuMk5nzWXQJZSXLPwm8Q