### PR TITLE
feat(ux): git 提交记录兜底更新记录新增/维护标签

### DIFF
--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -40,6 +40,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 from collections import Counter, defaultdict
 from datetime import date, timedelta
 from pathlib import Path
@@ -319,6 +320,7 @@ def _append_latest_node(
     out: list[dict[str, Any]],
     log_date: str,
     first_log_dates: dict[str, str] | None = None,
+    git_added_dates: dict[str, str] | None = None,
 ) -> None:
     if not rel.startswith("wiki/") or rel in seen or "*" in rel:
         return
@@ -338,7 +340,7 @@ def _append_latest_node(
         "source": "log.md",
     }
     if first_log_dates is not None:
-        action = _wiki_node_action(rel, log_date, first_log_dates)
+        action = _wiki_node_action(rel, log_date, first_log_dates, git_added_dates)
         if action:
             entry["action"] = action
     out.append(entry)
@@ -457,9 +459,119 @@ def wiki_first_log_dates(nodes: list[dict[str, Any]]) -> dict[str, str]:
     return first_dates
 
 
-def _wiki_node_action(rel: str, log_date: str, first_log_dates: dict[str, str]) -> str | None:
-    """Classify a log-day wiki touch as ``added`` or ``maintained``."""
+_GIT_LOG_BOUNDARY = "\x01"
+_WIKI_GIT_ADDED_DATES_CACHE: dict[str, str] | None = None
+
+
+def _iter_wiki_md_paths() -> list[str]:
+    return sorted(
+        str(p.relative_to(REPO_ROOT)).replace("\\", "/")
+        for p in WIKI_DIR.rglob("*.md")
+        if p.is_file()
+    )
+
+
+def wiki_git_added_dates(*, force_refresh: bool = False) -> dict[str, str]:
+    """Map ``wiki/...md`` → ISO committer date of first git add (fallback for action tags).
+
+    Single ``git log --name-status`` pass over ``wiki/``; rename-aware. Used only when
+    ``wiki_first_log_dates`` has no ingest/structural entry for a path (e.g. nodes
+    mentioned in ``query`` / ``lint`` blocks).
+    """
+    global _WIKI_GIT_ADDED_DATES_CACHE
+    if not force_refresh and _WIKI_GIT_ADDED_DATES_CACHE is not None:
+        return _WIKI_GIT_ADDED_DATES_CACHE
+
+    current_paths = _iter_wiki_md_paths()
+    if not current_paths:
+        _WIKI_GIT_ADDED_DATES_CACHE = {}
+        return _WIKI_GIT_ADDED_DATES_CACHE
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(REPO_ROOT),
+                "-c",
+                "core.quotepath=false",
+                "log",
+                "--topo-order",
+                "--no-merges",
+                f"--format={_GIT_LOG_BOUNDARY}%cs",
+                "--name-status",
+                "--",
+                "wiki",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            _WIKI_GIT_ADDED_DATES_CACHE = {}
+            return _WIKI_GIT_ADDED_DATES_CACHE
+    except (subprocess.SubprocessError, OSError):
+        _WIKI_GIT_ADDED_DATES_CACHE = {}
+        return _WIKI_GIT_ADDED_DATES_CACHE
+
+    alias = {p: p for p in current_paths}
+    added_date: dict[str, str] = {}
+    date_str: str | None = None
+
+    for line in result.stdout.splitlines():
+        if line.startswith(_GIT_LOG_BOUNDARY):
+            date_str = line[1:].strip() or None
+            continue
+        if not date_str or "\t" not in line:
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        if not status:
+            continue
+        kind = status[0]
+
+        if kind in ("R", "C") and len(parts) >= 3:
+            old, new = parts[1], parts[2]
+            cur = alias.get(new)
+            if cur is None:
+                continue
+            if kind == "R":
+                if new != old:
+                    del alias[new]
+                alias[old] = cur
+            else:
+                added_date[cur] = date_str
+                del alias[new]
+        elif len(parts) >= 2:
+            path = parts[1]
+            cur = alias.get(path)
+            if cur is None:
+                continue
+            if kind == "D":
+                del alias[path]
+                continue
+            if kind == "A":
+                added_date[cur] = date_str
+
+    _WIKI_GIT_ADDED_DATES_CACHE = added_date
+    return added_date
+
+
+def _wiki_node_action(
+    rel: str,
+    log_date: str,
+    first_log_dates: dict[str, str],
+    git_added_dates: dict[str, str] | None = None,
+) -> str | None:
+    """Classify a log-day wiki touch as ``added`` or ``maintained``.
+
+    Prefer ``wiki_first_log_dates`` (ingest/structural); fall back to git first-add
+    when the path only appears in query/lint/etc. blocks.
+    """
     first_day = first_log_dates.get(rel)
+    if first_day is None and git_added_dates:
+        first_day = git_added_dates.get(rel)
     if not first_day:
         return None
     return "added" if first_day == log_date else "maintained"
@@ -495,6 +607,7 @@ def latest_wiki_nodes_from_log(
     cutoff_date = target_date - timedelta(days=max(window_days - 1, 0))
     node_by_id: dict[str, dict[str, Any]] = {str(n["id"]): n for n in nodes}
     first_log_dates = wiki_first_log_dates(nodes)
+    git_added_dates = wiki_git_added_dates()
     seen: set[str] = set()
     out: list[dict[str, Any]] = []
 
@@ -520,6 +633,7 @@ def latest_wiki_nodes_from_log(
                     out=out,
                     log_date=log_date,
                     first_log_dates=first_log_dates,
+                    git_added_dates=git_added_dates,
                 )
         for m in WIKI_PATH_IN_LOG.finditer(chunk):
             rel = _normalize_wiki_rel_from_log_match(m.group(0))
@@ -532,6 +646,7 @@ def latest_wiki_nodes_from_log(
                         out=out,
                         log_date=log_date,
                         first_log_dates=first_log_dates,
+                        git_added_dates=git_added_dates,
                     )
                 continue
             _append_latest_node(
@@ -541,6 +656,7 @@ def latest_wiki_nodes_from_log(
                 out=out,
                 log_date=log_date,
                 first_log_dates=first_log_dates,
+                git_added_dates=git_added_dates,
             )
     return out[:max_items]
 
@@ -559,6 +675,7 @@ def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     sections = _log_sections(LOG_MD_PATH.read_text(encoding="utf-8"))
     node_by_id: dict[str, dict[str, Any]] = {str(n["id"]): n for n in nodes}
     first_log_dates = wiki_first_log_dates(nodes)
+    git_added_dates = wiki_git_added_dates()
     seen_by_date: dict[str, set[str]] = {}
     metas_by_date: dict[str, list[dict[str, Any]]] = {}
 
@@ -582,6 +699,7 @@ def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     out=day_out,
                     log_date=log_date,
                     first_log_dates=first_log_dates,
+                    git_added_dates=git_added_dates,
                 )
         for m in WIKI_PATH_IN_LOG.finditer(chunk):
             rel = _normalize_wiki_rel_from_log_match(m.group(0))
@@ -594,6 +712,7 @@ def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
                         out=day_out,
                         log_date=log_date,
                         first_log_dates=first_log_dates,
+                        git_added_dates=git_added_dates,
                     )
                 continue
             _append_latest_node(
@@ -603,6 +722,7 @@ def wiki_activity_from_log(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 out=day_out,
                 log_date=log_date,
                 first_log_dates=first_log_dates,
+                git_added_dates=git_added_dates,
             )
 
     days: list[dict[str, Any]] = []

--- a/tests/test_wiki_first_log_dates.py
+++ b/tests/test_wiki_first_log_dates.py
@@ -86,6 +86,39 @@ class WikiFirstLogDatesTest(unittest.TestCase):
         )
         self.assertIsNone(glg._wiki_node_action("wiki/tasks/unknown.md", "2026-05-28", first_dates))
 
+    def test_git_fallback_when_log_has_no_first_date(self) -> None:
+        git_dates = {"wiki/concepts/sim2real.md": "2026-04-10"}
+        rel = "wiki/concepts/sim2real.md"
+        self.assertEqual(
+            glg._wiki_node_action(rel, "2026-04-10", {}, git_dates),
+            "added",
+        )
+        self.assertEqual(
+            glg._wiki_node_action(rel, "2026-05-01", {}, git_dates),
+            "maintained",
+        )
+
+    def test_log_first_date_takes_priority_over_git(self) -> None:
+        rel = self.existing_paths[0]
+        self.assertEqual(
+            glg._wiki_node_action(
+                rel,
+                "2026-05-28",
+                {rel: "2026-05-28"},
+                {rel: "2026-04-01"},
+            ),
+            "added",
+        )
+        self.assertEqual(
+            glg._wiki_node_action(
+                rel,
+                "2026-05-28",
+                {rel: "2026-05-01"},
+                {rel: "2026-05-28"},
+            ),
+            "maintained",
+        )
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_wiki_git_added_dates.py
+++ b/tests/test_wiki_git_added_dates.py
@@ -1,0 +1,38 @@
+"""wiki_git_added_dates：git 首次入库日期（action 标签兜底数据源）。"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import generate_link_graph as glg
+
+
+class WikiGitAddedDatesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        glg._WIKI_GIT_ADDED_DATES_CACHE = None
+        self.addCleanup(lambda: setattr(glg, "_WIKI_GIT_ADDED_DATES_CACHE", None))
+
+    def test_collects_first_add_date(self) -> None:
+        log_text = (
+            f"{glg._GIT_LOG_BOUNDARY}2026-05-28\n"
+            "M\twiki/concepts/sim2real.md\n"
+            f"{glg._GIT_LOG_BOUNDARY}2026-05-01\n"
+            "A\twiki/concepts/sim2real.md\n"
+        )
+        paths = ["wiki/concepts/sim2real.md"]
+
+        def fake_run(*_args, **_kwargs):
+            return mock.Mock(returncode=0, stdout=log_text)
+
+        with (
+            mock.patch.object(glg, "_iter_wiki_md_paths", return_value=paths),
+            mock.patch("generate_link_graph.subprocess.run", side_effect=fake_run),
+        ):
+            out = glg.wiki_git_added_dates(force_refresh=True)
+
+        self.assertEqual(out["wiki/concepts/sim2real.md"], "2026-05-01")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

对更新记录中**没有「新增/维护」标签**的节点，增加 git 提交历史兜底判定。

## 背景

约 17% 的时间线条目（1091/6434）无标签，原因是它们只出现在 `query` / `lint` / `feat` 等日志块，未进入 `ingest`/`structural` 的首次出现统计。git 提交记录仍可判断该文件首次入库日。

## 判定规则（混合）

1. **优先** `log.md` 中 `ingest`/`structural` 的首次出现日
2. **兜底** `git log --name-status wiki` 的首次 `A`（add）日期
3. 当日 = 首次日 → 新增；否则 → 维护

## 效果

- 无标签节点：1091 → **8**（0.1%）
- 剩余 8 个为 git 历史中找不到首次入库的路径

## 验证

- `make ci-test` 通过（263 tests）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-720a8b22-b0bd-4cfe-8cc2-3c4c97adfc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-720a8b22-b0bd-4cfe-8cc2-3c4c97adfc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

