### PR TITLE
fix(wiki): GPU 云四实体页 ingest 日志补全以修复新增标签

### DIFF
--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,5 +1,5 @@
 // Robotics Notebooks Service Worker — 离线缓存支持
-const CACHE_NAME = 'robotics-wiki-2026-07-04';
+const CACHE_NAME = 'robotics-wiki-2026-07-05';
 const ASSETS_TO_CACHE = [
   '/Robotics_Notebooks/',
   '/Robotics_Notebooks/index.html',

--- a/log.md
+++ b/log.md
@@ -60,7 +60,7 @@
 
 ## [2026-07-02] ingest | sources/sites/runpod.md 等 — 国外 GPU 云六平台入库；wiki/comparisons/international-gpu-cloud-platforms.md；交叉更新 china-gpu-cloud-platforms、simulator-selection-guide、isaac-lab
 
-## [2026-07-02] ingest | sources/sites/matpool.md、featurize.md、gpushare.md、ai-galaxy.md — 扩展国内 GPU 云平台实体；wiki/comparisons/china-gpu-cloud-platforms.md 统一选型对比；移除 autodl-vs-gpufree
+## [2026-07-02] ingest | sources/sites/matpool.md、featurize.md、gpushare.md、ai-galaxy.md — 扩展国内 GPU 云平台实体；wiki/entities/matpool.md、wiki/entities/featurize.md、wiki/entities/gpushare.md、wiki/entities/ai-galaxy.md；wiki/comparisons/china-gpu-cloud-platforms.md 统一选型对比；移除 autodl-vs-gpufree
 
 ## [2026-07-02] ingest | sources/sites/autodl.md、sources/sites/gpufree.md — AutoDL 与算力自由 GPU 云入库；wiki/entities/autodl.md、wiki/entities/gpufree.md；交叉更新 wiki/entities/isaac-lab.md、wiki/queries/simulator-selection-guide.md
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在 `2026-07-02` GPU 云 ingest 日志中显式写出四实体页路径，补齐「新增/维护」标签。

## 变更

`log.md` 第 63 行补充：

- `wiki/entities/matpool.md`
- `wiki/entities/featurize.md`
- `wiki/entities/gpushare.md`
- `wiki/entities/ai-galaxy.md`

## 效果

| 日期 | 标签 |
|------|------|
| 2026-07-02 | **新增**（4 个实体页） |
| 2026-06-12 / 06-17 | **维护**（此前 glob 误匹配） |

全库无标签节点：**0 / 6439**

## 验证

- `make ci-preflight` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-720a8b22-b0bd-4cfe-8cc2-3c4c97adfc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-720a8b22-b0bd-4cfe-8cc2-3c4c97adfc62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

