### PR TITLE
feat(ux): 节点类型双语标签与更新记录中文类型

### DIFF
--- a/docs/change-log.html
+++ b/docs/change-log.html
@@ -46,6 +46,7 @@
     </div>
   </footer>
 
+  <script src="wiki-type-labels.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -203,6 +203,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script defer src="vendor/d3.min.js"></script>
+  <script src="wiki-type-labels.js"></script>
   <script defer src="graph-tooltip.js"></script>
   <script defer src="graph-node-size.js"></script>
   <script defer src="topic-filters.js"></script>

--- a/docs/graph-tooltip.js
+++ b/docs/graph-tooltip.js
@@ -107,13 +107,16 @@
     return s;
   }
 
-  var GRAPH_NODE_TYPE_LABEL = {
-    concept: '概念', method: '方法', task: '任务',
-    entity: '工具', comparison: '对比', query: 'Query',
-    formalization: '形式化', overview: '总览', reference: '参考',
-    roadmap: '路线', roadmap_page: '路线',
-    '': 'Wiki'
-  };
+  function formatNodeTypeLabel(typeKey, typeLabels) {
+    if (typeLabels) {
+      return typeLabels[typeKey] || typeKey || '知识页';
+    }
+    var api = window.RNWikiTypeLabels;
+    if (api && api.formatBilingual) {
+      return api.formatBilingual(typeKey);
+    }
+    return typeKey || '知识页';
+  }
 
   var GRAPH_NODE_TYPE_COLOR = {
     concept: '#60a5fa', method: '#34d399', task: '#f472b6',
@@ -206,9 +209,8 @@
     var html = '';
     if (opts.showType !== false) {
       var typeKey = opts.type != null ? opts.type : '';
-      var typeLabels = opts.typeLabels || GRAPH_NODE_TYPE_LABEL;
       var typeColors = opts.typeColors || GRAPH_NODE_TYPE_COLOR;
-      var typeLabel = typeLabels[typeKey] || typeKey || 'Wiki';
+      var typeLabel = formatNodeTypeLabel(typeKey, opts.typeLabels);
       var badgeColor = opts.badgeColor != null ? opts.badgeColor
         : (opts.communityColor
           || typeColors[typeKey] || typeColors[''] || '#64748b');
@@ -249,7 +251,7 @@
     bindOutsideDismiss: bindGraphTooltipOutsideDismiss,
     isMetadataOnlySummary: isMetadataOnlySummary,
     formatTooltipSummary: formatTooltipSummary,
-    GRAPH_NODE_TYPE_LABEL: GRAPH_NODE_TYPE_LABEL,
+    formatNodeTypeLabel: formatNodeTypeLabel,
     GRAPH_NODE_TYPE_COLOR: GRAPH_NODE_TYPE_COLOR,
     shortenCommunityLabel: shortenCommunityLabel,
     COMMUNITY_COLORS_FALLBACK: COMMUNITY_COLORS_FALLBACK,

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1810,6 +1810,7 @@
   <!-- ── D3.js + 3D 图谱 ── -->
   <script src="vendor/d3.min.js"></script>
   <script src="vendor/3d-force-graph.min.js"></script>
+  <script src="wiki-type-labels.js"></script>
   <script src="main.js"></script>
   <script src="graph-tooltip.js"></script>
   <script src="graph-node-size.js"></script>
@@ -1832,27 +1833,14 @@
       roadmap_page:  '#22d3ee',
       '':            '#64748b',
     };
-    const TYPE_LABEL = {
-      concept: '概念', method: '方法', task: '任务',
-      entity: '工具', comparison: '对比', query: 'Query',
-      formalization: '形式化', overview: '总览', reference: '参考',
-      roadmap: '路线', roadmap_page: '路线',
-      '': 'Wiki',
-    };
     const TYPE_LEGEND_ORDER = [
       'concept', 'method', 'task', 'formalization', 'comparison',
       'entity', 'query', 'overview', 'reference', 'roadmap_page',
     ];
-    const TYPE_LEGEND_EN = {
-      concept: 'Concept', method: 'Method', task: 'Task',
-      formalization: 'Formalization', comparison: 'Comparison',
-      entity: 'Entity', query: 'Query', overview: 'Overview',
-      reference: 'Reference', roadmap_page: 'Roadmap',
-    };
     function formatTypeLegendLabel(type) {
-      const zh = TYPE_LABEL[type] || type;
-      const en = TYPE_LEGEND_EN[type] || type;
-      return zh + ' (' + en + ')';
+      const api = window.RNWikiTypeLabels;
+      if (api && api.formatBilingual) return api.formatBilingual(type);
+      return type || '知识页';
     }
     const TYPE_FILTER_OPTIONS = TYPE_LEGEND_ORDER.map((type) => ({
       value: type,
@@ -2389,7 +2377,6 @@
       if (!window.RNGraphTooltip?.buildMetaBadgesHtml) return '';
       return window.RNGraphTooltip.buildMetaBadgesHtml({
         type: d.type || '',
-        typeLabels: TYPE_LABEL,
         typeColors: TYPE_COLOR,
         badgeColor: metaBadgeColor(d),
       });
@@ -3027,7 +3014,6 @@
       if (window.RNGraphTooltip?.buildNodeTooltipHtml) {
         return window.RNGraphTooltip.buildNodeTooltipHtml({
           type: d.type || '',
-          typeLabels: TYPE_LABEL,
           typeColors: TYPE_COLOR,
           badgeColor: metaBadgeColor(d),
           title: info.title || d.label,

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,6 +114,7 @@
     </div>
   </footer>
 
+  <script src="wiki-type-labels.js"></script>
   <script src="main.js"></script>
   <script src="graph-tooltip.js"></script>
   <script src="graph-node-size.js"></script>

--- a/docs/main.js
+++ b/docs/main.js
@@ -272,17 +272,12 @@
     if (html) mount.innerHTML = html;
   }
 
-  var WIKI_TYPE_LABEL_HOME = {
-    concept: '概念',
-    method: '方法',
-    task: '任务',
-    comparison: '对比',
-    entity: '工具/平台',
-    query: 'Query',
-    formalization: '形式化',
-    overview: '总览',
-    reference: '参考'
-  };
+  function wikiTypeLabel(type, context) {
+    var api = window.RNWikiTypeLabels;
+    if (!api) return type ? String(type) : '知识页';
+    if (context === 'updates') return api.formatChinese(type);
+    return api.formatBilingual(type);
+  }
 
   // ── 首页知识节点活跃度热力图（GitHub 风格，数据源 exports/wiki-activity.json）──
   var HOME_HEATMAP_DAY_MS = 24 * 60 * 60 * 1000;
@@ -452,7 +447,7 @@
       var maxRows = Math.min(items.length, 5);
       for (var cri = 0; cri < maxRows; cri++) {
         var rowMeta = items[cri];
-        var rowType = WIKI_TYPE_LABEL_HOME[rowMeta.type] || (rowMeta.type ? String(rowMeta.type) : 'Wiki');
+        var rowType = wikiTypeLabel(rowMeta.type, mount.hasAttribute('data-compact') ? 'node' : 'updates');
         compactRows +=
           '<li class="home-latest-row"><span class="home-latest-row-date">' +
           escapeHtml(rowMeta.recency ? String(rowMeta.recency) : '') +
@@ -499,7 +494,7 @@
     }
 
     function renderTimelineItem(meta, folded) {
-      var typeLabel = WIKI_TYPE_LABEL_HOME[meta.type] || (meta.type ? String(meta.type) : 'Wiki');
+      var typeLabel = wikiTypeLabel(meta.type, 'updates');
       return (
         '<li class="updates-item' + (folded ? ' updates-item-folded' : '') + '">' +
         renderActionBadgeCell(meta.action, 'updates-badge-cell') +
@@ -2739,7 +2734,7 @@
   }
 
   function buildInternalLinkCardMeta(page, id, options) {
-    var typeLabel = (page && page.type) || (options && options.defaultType) || 'detail_page';
+    var typeLabel = wikiTypeLabel((page && page.type) || (options && options.defaultType) || 'detail_page', 'node');
     var extra = options && typeof options.metaExtra === 'function' ? options.metaExtra(id, page) : '';
     return extra ? typeLabel + ' · ' + extra : typeLabel;
   }
@@ -3124,7 +3119,7 @@
       if (!items.length) { section.hidden = true; return; }
       section.hidden = false;
       listEl.innerHTML = items.map(function (n) {
-        var typeLabel = WIKI_TYPE_LABEL_HOME[n.type] || (n.type ? String(n.type) : 'Wiki');
+        var typeLabel = wikiTypeLabel(n.type, 'node');
         return (
           '<a class="detail-recent-ingest-item" href="' + escapeHtml(detailHref(n.detail_id)) + '">' +
           '<span class="detail-recent-ingest-date">' + escapeHtml(String(n.recency)) + '</span>' +
@@ -4500,7 +4495,7 @@
         detailCardsHtml += '<article class="card data-card">' +
             '  <div>' +
             '    <h3><a href="' + escapeHtml(detailHref(detailPage.id)) + '">' + escapeHtml(detailPage.title || detailPage.id) + '</a></h3>' +
-            '    <p class="card-meta">' + escapeHtml(detailPage.type || 'detail_page') + '</p>' +
+            '    <p class="card-meta">' + escapeHtml(wikiTypeLabel(detailPage.type || 'detail_page', 'node')) + '</p>' +
             '    <p>' + escapeHtml(detailPage.summary || '暂无摘要') + '</p>' +
             '    <p class="data-submeta"><code>' + escapeHtml(detailPage.path || detailPage.id || '') + '</code></p>' +
             '  </div>' +
@@ -4895,7 +4890,10 @@
     function buildResultCardHtml(item, queryTokens) {
       var detailUrl = 'detail.html?id=' + encodeURIComponent(item.id);
       var graphUrl = 'graph.html?focus=' + encodeURIComponent(item.id);
-      var typeLabel = item.page_type || (item.path ? item.path.split('/').slice(1, 3).join(' / ') : '');
+      var typeLabel = wikiTypeLabel(item.page_type, 'node');
+      if (!typeLabel && item.path) {
+        typeLabel = item.path.split('/').slice(1, 3).join(' / ');
+      }
 
       var tagLine = '';
       var itemTags = item.tags || [];

--- a/docs/module.html
+++ b/docs/module.html
@@ -152,6 +152,7 @@
     </div>
   </footer>
 
+  <script src="wiki-type-labels.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -167,6 +167,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script src="wiki-type-labels.js"></script>
   <script defer src="main.js"></script>
 </body>
 </html>

--- a/docs/tech-map.html
+++ b/docs/tech-map.html
@@ -165,6 +165,7 @@
     </div>
   </footer>
 
+  <script src="wiki-type-labels.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/docs/wiki-type-labels.js
+++ b/docs/wiki-type-labels.js
@@ -1,0 +1,63 @@
+/**
+ * Wiki 节点类型展示标签（中文 / 英文双语与纯中文）。
+ * - 节点类型 UI：formatBilingual → 「概念 (Concept)」
+ * - 更新记录时间线：formatChinese → 「概念」
+ */
+(function () {
+  var ZH = {
+    concept: '概念',
+    method: '方法',
+    task: '任务',
+    comparison: '对比',
+    entity: '实体',
+    query: '查询',
+    formalization: '形式化',
+    overview: '总览',
+    reference: '参考',
+    roadmap: '路线',
+    roadmap_page: '路线',
+    detail_page: '详情页',
+    '': '知识页'
+  };
+
+  var EN = {
+    concept: 'Concept',
+    method: 'Method',
+    task: 'Task',
+    comparison: 'Comparison',
+    entity: 'Entity',
+    query: 'Query',
+    formalization: 'Formalization',
+    overview: 'Overview',
+    reference: 'Reference',
+    roadmap: 'Roadmap',
+    roadmap_page: 'Roadmap',
+    detail_page: 'Detail Page',
+    '': 'Wiki'
+  };
+
+  function normalizeType(type) {
+    if (type == null || type === '') return '';
+    return String(type);
+  }
+
+  function formatChinese(type) {
+    var key = normalizeType(type);
+    return ZH[key] || (key ? key : ZH['']);
+  }
+
+  function formatBilingual(type) {
+    var key = normalizeType(type);
+    var zh = formatChinese(key);
+    var en = EN[key] || (key ? key : EN['']);
+    if (!en || zh === en) return zh;
+    return zh + ' (' + en + ')';
+  }
+
+  window.RNWikiTypeLabels = {
+    ZH: ZH,
+    EN: EN,
+    formatChinese: formatChinese,
+    formatBilingual: formatBilingual
+  };
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 新增共享模块 `docs/wiki-type-labels.js`，统一 wiki 节点类型的中文/英文映射
- **节点类型**展示统一为「中文 (English)」格式（图谱图例/浮窗、搜索卡片、详情页关联项、首页最新节点等）
- **更新记录**（`change-log.html` 时间线）的类型标签改为纯中文（如「概念」「查询」「实体」）

## 变更文件
- `docs/wiki-type-labels.js`（新建）
- `docs/graph-tooltip.js`、`docs/graph.html`、`docs/main.js`
- 各静态页补充 `wiki-type-labels.js` 脚本引用

## 验证
- `make lint-js` 通过
- 本地静态站截图：更新记录时间线显示纯中文类型；图谱「按类型」图例显示「概念 (Concept)」等双语格式

## 验证截图
![更新记录纯中文类型标签](https://cursor.com/artifacts/c/art-e3449420-63ae-4081-8991-065db03c233e)
![图谱按类型双语图例](https://cursor.com/artifacts/c/art-c6a003cf-87d3-43c4-aca3-839a7a3d51f4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be512ad3-c3a7-42fc-b36a-356d3b916296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be512ad3-c3a7-42fc-b36a-356d3b916296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

