### PR TITLE
feat(ux): 首页 3D 图谱预览增加常驻节点悬浮文字

### DIFF
--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -36,6 +36,11 @@
     };
   }
 
+  function miniNodeLabelText(d) {
+    var text = String(d.label || d.id);
+    return text.length > 12 ? text.slice(0, 12) + '…' : text;
+  }
+
   function tooltipSummary(raw) {
     return window.RNGraphTooltip && window.RNGraphTooltip.formatTooltipSummary
       ? window.RNGraphTooltip.formatTooltipSummary(raw, 100)
@@ -296,6 +301,9 @@
     var graph3d = null;
     var loading3d = false;
     var lastPointer3d = { clientX: 0, clientY: 0 };
+    var labelLayer3d = null;
+    var labelEls3d = new Map();
+    var labelTickBound = false;
 
     function trackPointer3d(ev) {
       lastPointer3d.clientX = ev.clientX;
@@ -323,11 +331,77 @@
       });
     }
 
+    function ensureLabelLayer3d() {
+      if (!wrap3d) return null;
+      if (labelLayer3d) return labelLayer3d;
+      labelLayer3d = document.createElement('div');
+      labelLayer3d.className = 'mini-graph-3d-labels';
+      labelLayer3d.setAttribute('aria-hidden', 'true');
+      wrap3d.appendChild(labelLayer3d);
+      return labelLayer3d;
+    }
+
+    function buildLabelEls3d() {
+      var layer = ensureLabelLayer3d();
+      if (!layer) return;
+      labelEls3d.clear();
+      layer.innerHTML = '';
+      var theme = miniGraphTheme();
+      nodes.forEach(function (d) {
+        var el = document.createElement('div');
+        el.className = 'mini-graph-3d-label';
+        el.textContent = miniNodeLabelText(d);
+        el.style.color = theme.label;
+        layer.appendChild(el);
+        labelEls3d.set(d.id, el);
+      });
+    }
+
+    function syncLabelPositions3d() {
+      if (!graph3d || wrap3d.hidden || !labelLayer3d) return;
+      var graphNodes = graph3d.graphData().nodes || [];
+      graphNodes.forEach(function (d) {
+        var el = labelEls3d.get(d.id);
+        if (!el || d.x == null || d.y == null) return;
+        var coords = graph3d.graph2ScreenCoords(d.x, d.y, d.z != null ? d.z : 0);
+        if (!coords || !isFinite(coords.x) || !isFinite(coords.y)) {
+          el.style.visibility = 'hidden';
+          return;
+        }
+        el.style.visibility = 'visible';
+        el.style.left = coords.x + 'px';
+        el.style.top = coords.y + 'px';
+      });
+    }
+
+    function bindLabelTick3d() {
+      if (labelTickBound || !graph3d) return;
+      labelTickBound = true;
+      graph3d.onEngineTick(syncLabelPositions3d);
+    }
+
+    function refreshMiniGraph3dLabels() {
+      if (!labelLayer3d) return;
+      var theme = miniGraphTheme();
+      labelEls3d.forEach(function (el) {
+        el.style.color = theme.label;
+      });
+    }
+
+    function hideLabelLayer3d() {
+      if (labelLayer3d) labelLayer3d.style.display = 'none';
+    }
+
+    function showLabelLayer3d() {
+      if (labelLayer3d) labelLayer3d.style.display = '';
+    }
+
     function applyMode3dTheme() {
       if (!graph3d) return;
       var theme = miniGraphTheme();
       graph3d.backgroundColor(theme.background);
       graph3d.linkColor(function () { return miniGraphTheme().edge3d; });
+      refreshMiniGraph3dLabels();
     }
 
     function setModeButtons(mode) {
@@ -392,6 +466,9 @@
           window.location.href = 'graph.html?focus=' + encodeURIComponent(d.id);
         })
         .graphData({ nodes: nodes3d, links: links3d });
+      buildLabelEls3d();
+      bindLabelTick3d();
+      syncLabelPositions3d();
       wrap3d.addEventListener('mousemove', trackPointer3d);
       bindMiniGraph3dTooltipDismiss();
       // 力模拟稳定后一次性取景填满容器（与 2D sim.on('end') 的自动 fit 对齐）；
@@ -401,7 +478,9 @@
         if (fitted3d) return;
         fitted3d = true;
         graph3d.zoomToFit(600, 40);
+        syncLabelPositions3d();
       });
+      window.requestAnimationFrame(syncLabelPositions3d);
       var controls3d = graph3d.controls();
       if (controls3d) {
         controls3d.autoRotate = true;
@@ -416,7 +495,9 @@
       wrap3d.hidden = false;
       setModeButtons('3d');
       if (graph3d) {
+        showLabelLayer3d();
         graph3d.resumeAnimation();
+        syncLabelPositions3d();
         return;
       }
       if (typeof window.ForceGraph3D === 'function') {
@@ -443,6 +524,7 @@
     function show2d() {
       hideTooltip();
       pinnedNode = null;
+      hideLabelLayer3d();
       wrap3d.hidden = true;
       miniSvg.style.display = '';
       setModeButtons('2d');
@@ -458,6 +540,7 @@
         graph3d
           .width(miniWrap.clientWidth || 700)
           .height(miniWrap.clientHeight || 480);
+        syncLabelPositions3d();
       });
     }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -426,6 +426,22 @@ body.sponsor-dialog-open {
 /* 首页图谱预览 2D / 3D 切换（3D 画布懒加载，容器与 SVG 同位叠放） */
 #mini-graph-3d { position: absolute; inset: 0; }
 #mini-graph-3d[hidden] { display: none; }
+.mini-graph-3d-labels {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 2;
+}
+.mini-graph-3d-label {
+  position: absolute;
+  font-size: 10px;
+  line-height: 1.2;
+  text-align: center;
+  white-space: nowrap;
+  transform: translate(-50%, 10px);
+  user-select: none;
+}
 .mini-graph-mode { position: absolute; top: 12px; right: 16px; display: flex; gap: 4px; z-index: 3; }
 .mini-graph-mode-btn {
   font-size: .72rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页知识图谱预览切到 **3D** 时，在节点旁显示与 2D 一致的截断标签（最长 12 字 + `…`）
- 使用 HTML 叠加层 + `graph2ScreenCoords` 每帧同步位置，随自动旋转/力模拟保持跟随
- 深浅主题切换时同步刷新标签颜色

## 验证
- 本地 `make export graph` 后启动静态站，切换首页预览至 3D，节点标签可见且随旋转移动
- 2D 悬浮预览卡片行为保持不变

## 验证截图
![首页 3D 图谱预览节点悬浮文字](https://cursor.com/artifacts/c/art-b3a36d3b-cfc0-407e-83fb-3d581ced9137)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c3582e-3920-4a6a-8307-91260921489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c3582e-3920-4a6a-8307-91260921489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

