### PR TITLE
revert(ux): 移除 3D 图谱常驻悬浮文字标签

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -170,22 +170,6 @@
     var resolveSourceNode = opts.resolveSourceNode || function (id) {
       return sourceNodes.find(function (n) { return n.id === id; });
     };
-    var getNodeLabelText = opts.getNodeLabelText || function (d) {
-      return d.label || d.id;
-    };
-    var getNodeLabelFontSize = opts.getNodeLabelFontSize || function () { return 10; };
-    var getNodeLabelColor = opts.getNodeLabelColor || function () {
-      return isDark() ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.5)';
-    };
-    var getNodeLabelOpacity = opts.getNodeLabelOpacity || function () { return 0.85; };
-    var isNodeLabelHub = opts.isNodeLabelHub || function () { return false; };
-
-    var labelLayer = null;
-    var labelEls = new Map();
-    var labelTickBound = false;
-    var labelsLayoutReady = false;
-    var baselineCameraDist = null;
-    var cameraZoomInteracted = false;
 
     var nodes3d = sourceNodes.map(cloneNodeFor3D);
     var sidebarNodeId = null;
@@ -230,148 +214,6 @@
 
     function backgroundColor() {
       return isDark() ? '#0d1117' : '#eef2f7';
-    }
-
-    function getCameraDistance() {
-      if (!graph || typeof graph.cameraPosition !== 'function') return null;
-      var cam = graph.cameraPosition();
-      if (!cam || !cam.lookAt) return null;
-      var dx = cam.x - cam.lookAt.x;
-      var dy = cam.y - cam.lookAt.y;
-      var dz = cam.z - cam.lookAt.z;
-      return Math.sqrt(dx * dx + dy * dy + dz * dz);
-    }
-
-    function getLabelZoomFactor() {
-      var dist = getCameraDistance();
-      if (!dist || !baselineCameraDist) return 1;
-      return baselineCameraDist / dist;
-    }
-
-    function captureBaselineCameraDist() {
-      var dist = getCameraDistance();
-      if (dist && isFinite(dist)) baselineCameraDist = dist;
-    }
-
-    function ensureLabelLayer() {
-      if (labelLayer) return labelLayer;
-      labelLayer = document.createElement('div');
-      labelLayer.className = 'graph-3d-labels';
-      labelLayer.setAttribute('aria-hidden', 'true');
-      container.appendChild(labelLayer);
-      return labelLayer;
-    }
-
-    function buildLabelEls() {
-      var layer = ensureLabelLayer();
-      if (!layer) return;
-      labelEls.clear();
-      layer.innerHTML = '';
-      sourceNodes.forEach(function (src) {
-        var el = document.createElement('div');
-        el.className = 'graph-3d-label';
-        el.textContent = getNodeLabelText(src);
-        layer.appendChild(el);
-        labelEls.set(src.id, el);
-      });
-      syncLabelStyles();
-    }
-
-    function effectiveLabelOpacity(d) {
-      if (container.hidden || timelineActive() || nodeHiddenByFilter(d)) return 0;
-      if (!labelsLayoutReady) return 0;
-      var src = resolveSourceNode(d.id) || d;
-      var base = getNodeLabelOpacity(src, getLabelZoomFactor(), labelsLayoutReady, cameraZoomInteracted);
-      if (base <= 0) return 0;
-      return base * nodeOpacityFor(d);
-    }
-
-    function syncLabelStyles() {
-      if (!labelLayer) return;
-      var color = getNodeLabelColor();
-      labelEls.forEach(function (el, id) {
-        var d = nodeById.get(id);
-        if (!d) return;
-        var src = resolveSourceNode(id) || d;
-        el.textContent = getNodeLabelText(src);
-        el.style.color = color;
-        el.style.fontSize = getNodeLabelFontSize(src) + 'px';
-        el.classList.toggle('is-topic-hub', !!isNodeLabelHub(src));
-        var opacity = effectiveLabelOpacity(d);
-        el.style.opacity = String(opacity);
-        el.style.visibility = opacity > 0.02 ? 'visible' : 'hidden';
-      });
-    }
-
-    function syncLabelPositions() {
-      if (!graph || container.hidden || !labelLayer) return;
-      var dist = getCameraDistance();
-      if (baselineCameraDist && dist && Math.abs(dist - baselineCameraDist) > baselineCameraDist * 0.04) {
-        cameraZoomInteracted = true;
-      }
-      var graphNodes = graph.graphData().nodes || [];
-      graphNodes.forEach(function (d) {
-        var el = labelEls.get(d.id);
-        if (!el || d.x == null || d.y == null) return;
-        var z = d.z != null ? d.z : 0;
-        var src = resolveSourceNode(d.id) || d;
-        var center = graph.graph2ScreenCoords(d.x, d.y, z);
-        if (!center || !isFinite(center.x) || !isFinite(center.y)) {
-          el.style.visibility = 'hidden';
-          return;
-        }
-        var rimY = getNodeRadius(src) + 13;
-        var bottom = graph.graph2ScreenCoords(d.x, d.y + rimY, z);
-        var topY = bottom && isFinite(bottom.y) ? bottom.y : center.y + 12;
-        el.style.left = center.x + 'px';
-        el.style.top = topY + 'px';
-        var opacity = effectiveLabelOpacity(d);
-        el.style.opacity = String(opacity);
-        el.style.visibility = opacity > 0.02 ? 'visible' : 'hidden';
-      });
-    }
-
-    function bindLabelTick() {
-      if (labelTickBound || !graph) return;
-      labelTickBound = true;
-      graph.onEngineTick(function () {
-        maybeMarkLabelsLayoutReady();
-        syncLabelPositions();
-        syncLabelStyles();
-      });
-    }
-
-    function resetLabelsLayoutState() {
-      labelsLayoutReady = false;
-      baselineCameraDist = null;
-      cameraZoomInteracted = false;
-      syncLabelStyles();
-    }
-
-    function markLabelsLayoutReady() {
-      labelsLayoutReady = true;
-      captureBaselineCameraDist();
-      syncLabelPositions();
-      syncLabelStyles();
-    }
-
-    function maybeMarkLabelsLayoutReady() {
-      if (labelsLayoutReady || !graph) return;
-      if (typeof graph.d3Alpha === 'function' && graph.d3Alpha() > 0.02) return;
-      markLabelsLayoutReady();
-    }
-
-    function showLabelLayer() {
-      if (labelLayer) labelLayer.style.display = '';
-    }
-
-    function hideLabelLayer() {
-      if (labelLayer) labelLayer.style.display = 'none';
-    }
-
-    function syncLabels() {
-      syncLabelPositions();
-      syncLabelStyles();
     }
 
     function buildLinks() {
@@ -631,7 +473,6 @@
         .linkOpacity(function (l) { return linkOpacityFor(l); })
         .linkVisibility(function (l) { return linkVisibleFor(l); });
       updateNodeMeshes();
-      syncLabels();
     }
 
     // pop-in 期间逐帧刷新节点 mesh 缩放，让「激活」放大过程平滑（由 3d-force-graph 的渲染环负责出图）。
@@ -947,7 +788,6 @@
         // 用基于节点数据坐标的安全 fit：库自带 zoomToFit 在场景对象尚未生成时
         // （getGraphBbox 返回 null）会静默 no-op，首次切换易停在未取景的相机上。
         zoomFitToNodes(duration);
-        markLabelsLayoutReady();
       }
       if (typeof graph.onEngineStop === 'function') {
         graph.onEngineStop(function () { runFit(); });
@@ -1082,11 +922,8 @@
     return {
       show: function () {
         container.hidden = false;
-        showLabelLayer();
         syncPositionsFromSource();
         ensureGraph();
-        buildLabelEls();
-        bindLabelTick();
         syncViewport();
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
@@ -1108,13 +945,11 @@
           });
           scheduleInitialFit(650);
           firstShowKick();
-          syncLabels();
         });
       },
 
       hide: function () {
         pauseRenderLoop();
-        hideLabelLayer();
         container.hidden = true;
       },
 
@@ -1129,7 +964,6 @@
       resize: function () {
         if (container.hidden) return;
         syncViewport();
-        syncLabels();
       },
 
       syncFilters: function () {
@@ -1140,7 +974,6 @@
       // timelineBegin：进入时序模式，按时间顺序的 node id 列表初始化；先清空力模拟子集（0 个节点）。
       timelineBegin: function (orderedIds) {
         if (!graph) return;
-        resetLabelsLayoutState();
         timelineSnapshot = nodes3d.map(function (n) {
           return { n: n, x: n.x, y: n.y, z: n.z };
         });
@@ -1183,8 +1016,6 @@
       timelineFit: function (ms) {
         if (timelineRevealedIds === null) return;
         zoomFitToNodes(ms == null ? 500 : ms, function (n) { return timelineRevealedIds.has(n.id); });
-        captureBaselineCameraDist();
-        syncLabels();
       },
 
       // timelineEnd：退出时序模式 —— 还原进入前全图位置，恢复完整 graphData 并重排收敛。
@@ -1206,13 +1037,11 @@
         graph.graphData({ nodes: nodes3d, links: buildLinks() });
         refreshAppearance();
         reheatAfterGraphData();
-        markLabelsLayoutReady();
       },
 
       refreshColors: function () {
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
-        syncLabels();
       },
 
       updateForces: function () {
@@ -1229,7 +1058,6 @@
       },
 
       restartSimulation: function () {
-        resetLabelsLayoutState();
         if (customMeshesInstalled) {
           resetNodePositionsInPlace();
           this.updateForces();
@@ -1243,17 +1071,11 @@
 
       fitToScreen: function (ms) {
         zoomFitToNodes(ms == null ? 650 : ms);
-        captureBaselineCameraDist();
-        cameraZoomInteracted = false;
-        syncLabels();
       },
 
       fitToVisible: function (ms) {
         var visible = getVisibleNodeIds();
         zoomFitToNodes(ms == null ? 650 : ms, function (n) { return visible.has(n.id); });
-        captureBaselineCameraDist();
-        cameraZoomInteracted = false;
-        syncLabels();
       },
 
       focusNode: function (node, ms) {
@@ -1266,10 +1088,6 @@
           n3,
           ms == null ? 700 : ms
         );
-        window.setTimeout(function () {
-          cameraZoomInteracted = true;
-          syncLabels();
-        }, (ms == null ? 700 : ms) + 40);
       },
 
       applySidebarHighlight: function (d, direct, secondary) {
@@ -1293,9 +1111,6 @@
         window.removeEventListener('error', reviveRenderLoopOnError);
         if (graph && graph._destructor) graph._destructor();
         graph = null;
-        labelLayer = null;
-        labelEls.clear();
-        labelTickBound = false;
         container.replaceChildren();
       },
     };

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -282,25 +282,6 @@
     }
     #graph-canvas-3d[hidden] { display: none !important; }
     #graph-canvas-3d .scene-nav-info { display: none !important; }
-    .graph-3d-labels {
-      position: absolute;
-      inset: 0;
-      pointer-events: none;
-      overflow: hidden;
-      z-index: 3;
-    }
-    .graph-3d-label {
-      position: absolute;
-      text-align: center;
-      white-space: nowrap;
-      transform: translate(-50%, 0);
-      user-select: none;
-      transition: opacity .15s;
-      pointer-events: none;
-    }
-    .graph-3d-label.is-topic-hub {
-      font-weight: 700;
-    }
 
     /* dot-grid overlay (CSS only) */
     #graph-wrap::before {
@@ -739,7 +720,6 @@
     [data-theme="light"] .topic-intro-text { color: rgba(15, 23, 42, 0.68); }
     [data-theme="light"] .topic-intro-link { color: #1659b4; }
     [data-theme="light"] .node-topic-hub .node-label { fill: rgba(15, 23, 42, 0.88) !important; }
-    [data-theme="light"] .graph-3d-label.is-topic-hub { color: rgba(15, 23, 42, 0.88) !important; }
     [data-theme="light"] .toolbar-sep { background: rgba(0,0,0,0.1); }
     [data-theme="light"] #graph-node-count { color: rgba(0,0,0,0.38); }
     [data-theme="light"] #graph-back {
@@ -2242,11 +2222,6 @@
         edgeHighlightsWithNode,
         getChargeStrength: () => chargeStrength,
         getMagneticConfig: getMagneticConfig3D,
-        getNodeLabelText: (d) => d._info.title || d.label,
-        getNodeLabelFontSize: scaledFontSize,
-        getNodeLabelColor: labelFill,
-        getNodeLabelOpacity: computeNodeLabelOpacity,
-        isNodeLabelHub: isCurrentTopicHub,
         onNodeClick: (d, ev) => {
           if (timelinePlaying) return;
           if (isMobile) {
@@ -2383,21 +2358,6 @@
     }
     function labelFill() {
       return isDark() ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.5)';
-    }
-
-    function nodeLabelVisible(d) {
-      return nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
-        && nodeMatchesSearch(d) && nodeMatchesTopic(d) && nodeMatchesInstitutionFilter(d);
-    }
-
-    function computeNodeLabelOpacity(d, zoomK, labelsReady, cameraMoved) {
-      if (!labelsReady || timelineAnimating) return 0;
-      if (!nodeLabelVisible(d)) return 0;
-      const hub = isCurrentTopicHub(d);
-      if (searchQuery || hub) return 0.92;
-      if (!cameraMoved) return 0.85;
-      const k = zoomK != null ? zoomK : 1;
-      return k > 0.6 ? Math.min(1, (k - 0.6) * 2.5) : 0;
     }
 
     const HEALTH_COLORS = ['#f87171', '#fb923c', '#facc15', '#4ade80'];

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -36,11 +36,6 @@
     };
   }
 
-  function miniNodeLabelText(d) {
-    var text = String(d.label || d.id);
-    return text.length > 12 ? text.slice(0, 12) + '…' : text;
-  }
-
   function tooltipSummary(raw) {
     return window.RNGraphTooltip && window.RNGraphTooltip.formatTooltipSummary
       ? window.RNGraphTooltip.formatTooltipSummary(raw, 100)
@@ -301,9 +296,6 @@
     var graph3d = null;
     var loading3d = false;
     var lastPointer3d = { clientX: 0, clientY: 0 };
-    var labelLayer3d = null;
-    var labelEls3d = new Map();
-    var labelTickBound = false;
 
     function trackPointer3d(ev) {
       lastPointer3d.clientX = ev.clientX;
@@ -331,77 +323,11 @@
       });
     }
 
-    function ensureLabelLayer3d() {
-      if (!wrap3d) return null;
-      if (labelLayer3d) return labelLayer3d;
-      labelLayer3d = document.createElement('div');
-      labelLayer3d.className = 'mini-graph-3d-labels';
-      labelLayer3d.setAttribute('aria-hidden', 'true');
-      wrap3d.appendChild(labelLayer3d);
-      return labelLayer3d;
-    }
-
-    function buildLabelEls3d() {
-      var layer = ensureLabelLayer3d();
-      if (!layer) return;
-      labelEls3d.clear();
-      layer.innerHTML = '';
-      var theme = miniGraphTheme();
-      nodes.forEach(function (d) {
-        var el = document.createElement('div');
-        el.className = 'mini-graph-3d-label';
-        el.textContent = miniNodeLabelText(d);
-        el.style.color = theme.label;
-        layer.appendChild(el);
-        labelEls3d.set(d.id, el);
-      });
-    }
-
-    function syncLabelPositions3d() {
-      if (!graph3d || wrap3d.hidden || !labelLayer3d) return;
-      var graphNodes = graph3d.graphData().nodes || [];
-      graphNodes.forEach(function (d) {
-        var el = labelEls3d.get(d.id);
-        if (!el || d.x == null || d.y == null) return;
-        var coords = graph3d.graph2ScreenCoords(d.x, d.y, d.z != null ? d.z : 0);
-        if (!coords || !isFinite(coords.x) || !isFinite(coords.y)) {
-          el.style.visibility = 'hidden';
-          return;
-        }
-        el.style.visibility = 'visible';
-        el.style.left = coords.x + 'px';
-        el.style.top = coords.y + 'px';
-      });
-    }
-
-    function bindLabelTick3d() {
-      if (labelTickBound || !graph3d) return;
-      labelTickBound = true;
-      graph3d.onEngineTick(syncLabelPositions3d);
-    }
-
-    function refreshMiniGraph3dLabels() {
-      if (!labelLayer3d) return;
-      var theme = miniGraphTheme();
-      labelEls3d.forEach(function (el) {
-        el.style.color = theme.label;
-      });
-    }
-
-    function hideLabelLayer3d() {
-      if (labelLayer3d) labelLayer3d.style.display = 'none';
-    }
-
-    function showLabelLayer3d() {
-      if (labelLayer3d) labelLayer3d.style.display = '';
-    }
-
     function applyMode3dTheme() {
       if (!graph3d) return;
       var theme = miniGraphTheme();
       graph3d.backgroundColor(theme.background);
       graph3d.linkColor(function () { return miniGraphTheme().edge3d; });
-      refreshMiniGraph3dLabels();
     }
 
     function setModeButtons(mode) {
@@ -466,9 +392,6 @@
           window.location.href = 'graph.html?focus=' + encodeURIComponent(d.id);
         })
         .graphData({ nodes: nodes3d, links: links3d });
-      buildLabelEls3d();
-      bindLabelTick3d();
-      syncLabelPositions3d();
       wrap3d.addEventListener('mousemove', trackPointer3d);
       bindMiniGraph3dTooltipDismiss();
       // 力模拟稳定后一次性取景填满容器（与 2D sim.on('end') 的自动 fit 对齐）；
@@ -478,9 +401,7 @@
         if (fitted3d) return;
         fitted3d = true;
         graph3d.zoomToFit(600, 40);
-        syncLabelPositions3d();
       });
-      window.requestAnimationFrame(syncLabelPositions3d);
       var controls3d = graph3d.controls();
       if (controls3d) {
         controls3d.autoRotate = true;
@@ -495,9 +416,7 @@
       wrap3d.hidden = false;
       setModeButtons('3d');
       if (graph3d) {
-        showLabelLayer3d();
         graph3d.resumeAnimation();
-        syncLabelPositions3d();
         return;
       }
       if (typeof window.ForceGraph3D === 'function') {
@@ -524,7 +443,6 @@
     function show2d() {
       hideTooltip();
       pinnedNode = null;
-      hideLabelLayer3d();
       wrap3d.hidden = true;
       miniSvg.style.display = '';
       setModeButtons('2d');
@@ -540,7 +458,6 @@
         graph3d
           .width(miniWrap.clientWidth || 700)
           .height(miniWrap.clientHeight || 480);
-        syncLabelPositions3d();
       });
     }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -426,22 +426,6 @@ body.sponsor-dialog-open {
 /* 首页图谱预览 2D / 3D 切换（3D 画布懒加载，容器与 SVG 同位叠放） */
 #mini-graph-3d { position: absolute; inset: 0; }
 #mini-graph-3d[hidden] { display: none; }
-.mini-graph-3d-labels {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: 2;
-}
-.mini-graph-3d-label {
-  position: absolute;
-  font-size: 10px;
-  line-height: 1.2;
-  text-align: center;
-  white-space: nowrap;
-  transform: translate(-50%, 10px);
-  user-select: none;
-}
 .mini-graph-mode { position: absolute; top: 12px; right: 16px; display: flex; gap: 4px; z-index: 3; }
 .mini-graph-mode-btn {
   font-size: .72rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 移除首页 mini-graph 3D 预览与知识图谱页 3D 视图的 HTML 悬浮文字标签
- 3D 仍保留节点悬浮预览卡片（tooltip）与 2D 标签，仅去掉 3D 常驻文字叠加层

## 验证
- Revert #931、#932 对应提交，相关 `labelLayer` / `graph-3d-label` / `mini-graph-3d-label` 代码已全部清除
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c3582e-3920-4a6a-8307-91260921489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c3582e-3920-4a6a-8307-91260921489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

