### PR TITLE
fix(ux): 修复详情页元信息 hidden 行多占 grid gap 导致空行

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -907,6 +907,10 @@ button.home-wiki-heatmap-cell.is-active {
   align-items: center;
   gap: 6px 8px;
 }
+/* hidden 行若仍参与 grid/flex 布局会多占一行 gap（如「所属专题」未命中时） */
+.detail-meta-item[hidden] {
+  display: none !important;
+}
 .detail-meta-item strong {
   font-weight: 650;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「页面元信息」在「所属社区」与「所属机构」之间出现额外空行，视觉上像未对齐。
- 根因：中间的「所属专题」行在未命中专题时带 `hidden`，但 `.detail-meta-item { display: flex }` 覆盖了 `[hidden]` 的默认 `display: none`，该行仍参与 CSS Grid 布局并多占一行 `gap`（8px + 8px）。
- 修复：为 `.detail-meta-item[hidden]` 显式设置 `display: none !important`，使隐藏行完全脱离网格。

## 验证
- 本地 Puppeteer 复现（390px 视口，`wiki-entities-hands-on-rl-book`）：修复前 community→institution 间距 16px，修复后各行均为 8px。
- 路线页 `roadmap.html` 复用同一 `.detail-meta-item` 样式，一并受益。

## 验证截图
![动手学强化学习详情页元信息间距修复后](https://cursor.com/artifacts/c/art-764d25bb-b243-4931-b4dd-2f58b560ed06)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea32b44a-6af5-4d96-a397-06f0ae619eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea32b44a-6af5-4d96-a397-06f0ae619eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

