### PR TITLE
Add timeline visualization for roadmap sections

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1881,6 +1881,40 @@
     }
   }
 
+  /**
+   * 路线正文：把 wrapRoadmapCollapsibleMajorHeadings 产出的章节折叠块包进竖向时间线容器
+   * （左侧轨道 + 章节节点：L−1…L7 显示层级徽标、其余章节为圆点，视觉对齐 change-log 更新时间线），
+   * details 展开/收起交互保持不变。须在 wrapRoadmapCollapsibleMajorHeadings 之后调用，
+   * 此时全部章节 details 已是相邻兄弟节点。
+   */
+  function wrapRoadmapTimelineSections(container) {
+    if (!container) return;
+    var sections = Array.from(container.querySelectorAll(':scope > details.roadmap-major-section'));
+    if (!sections.length) return;
+    var wrap = document.createElement('div');
+    wrap.className = 'roadmap-timeline';
+    sections[0].parentNode.insertBefore(wrap, sections[0]);
+    var i;
+    for (i = 0; i < sections.length; i++) {
+      var item = document.createElement('div');
+      item.className = 'roadmap-timeline-item';
+      var node = document.createElement('span');
+      node.className = 'roadmap-timeline-node';
+      node.setAttribute('aria-hidden', 'true');
+      var h2 = sections[i].querySelector(':scope > summary > h2');
+      var stageMatch = /^\s*(L\s*[−–-]?\s*\d+(?:\.\d+)?)/.exec((h2 && h2.textContent) || '');
+      if (stageMatch) {
+        node.classList.add('roadmap-timeline-node-stage');
+        node.textContent = stageMatch[1].replace(/\s+/g, '');
+      } else {
+        node.classList.add('roadmap-timeline-node-dot');
+      }
+      item.appendChild(node);
+      item.appendChild(sections[i]);
+      wrap.appendChild(item);
+    }
+  }
+
   /** 路线章节折叠展开后，对刚打开的 section 内未渲染/失败的 Mermaid 再跑一次。 */
   function bindRoadmapSectionMermaidRerender(container) {
     if (!container || container.getAttribute('data-roadmap-mermaid-toggle-bound') === '1') return;
@@ -4043,6 +4077,7 @@
         clearRoadmapStandaloneFlowSection();
       }
       wrapRoadmapCollapsibleMajorHeadings(contentEl);
+      wrapRoadmapTimelineSections(contentEl);
       bindRoadmapSectionMermaidRerender(contentEl);
       bindSelftestMermaidRerender(contentEl);
       renderDetailMermaid(contentEl);

--- a/docs/style.css
+++ b/docs/style.css
@@ -2313,6 +2313,71 @@ button.home-wiki-heatmap-cell.is-active {
 .roadmap-major-section-body > :first-child {
   margin-top: 0.85rem;
 }
+/* 路线正文时间线（wrapRoadmapTimelineSections）：左侧轨道 + 章节节点，
+   视觉对齐 change-log 更新时间线；章节 details 展开/收起不受影响 */
+.roadmap-timeline {
+  position: relative;
+  padding-left: 46px;
+}
+.roadmap-timeline::before {
+  content: '';
+  position: absolute;
+  left: 16px;
+  top: 14px;
+  bottom: 20px;
+  width: 2px;
+  background: var(--border);
+  border-radius: 1px;
+}
+.roadmap-timeline-item {
+  position: relative;
+}
+.roadmap-timeline-node {
+  position: absolute;
+  left: -29px;
+  transform: translateX(-50%);
+  z-index: 1;
+  box-shadow: 0 0 0 3px var(--bg);
+}
+.roadmap-timeline-node-stage {
+  top: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 21px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+.roadmap-timeline-node-dot {
+  top: 0.85rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+@media (max-width: 640px) {
+  .roadmap-timeline {
+    padding-left: 38px;
+  }
+  .roadmap-timeline::before {
+    left: 12px;
+  }
+  .roadmap-timeline-node {
+    left: -25px;
+  }
+  .roadmap-timeline-node-stage {
+    min-width: 28px;
+    height: 19px;
+    font-size: 0.62rem;
+  }
+}
 .roadmap-flow-details,
 .roadmap-stage-flow-details {
   margin-bottom: 1rem;


### PR DESCRIPTION
## 摘要

为路线图正文章节添加竖向时间线视觉效果，左侧轨道配合章节节点（L−1…L7 显示层级徽标、其余为圆点），视觉对齐 change-log 更新时间线。章节 details 展开/收起交互保持不变。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### CSS 变更（`docs/style.css`）
- 新增 `.roadmap-timeline` 容器样式：左侧 46px 内边距，竖向轨道线（2px 宽）
- 新增 `.roadmap-timeline-item` 包装单个章节
- 新增 `.roadmap-timeline-node` 节点基础样式（绝对定位、阴影）
- 新增 `.roadmap-timeline-node-stage` 层级徽标样式（圆角胶囊、白字、强调色背景）
- 新增 `.roadmap-timeline-node-dot` 圆点样式（12px 圆形）
- 响应式调整（≤640px）：减小内边距、节点尺寸

### JavaScript 变更（`docs/main.js`）
- 新增 `wrapRoadmapTimelineSections()` 函数：
  - 遍历所有 `details.roadmap-major-section` 元素
  - 创建时间线容器并包装各章节
  - 通过正则匹配章节标题中的 `L−1…L7` 层级标记
  - 匹配到层级标记则显示徽标，否则显示圆点
  - 保留原有 details 交互逻辑
- 在 `wrapRoadmapCollapsibleMajorHeadings()` 之后调用该函数

## 验证

- [x] `make ci-preflight`（仅前端改动，无 wiki 内容变更）
- 静态站 roadmap 页面渲染正常，时间线视觉效果符合预期

https://claude.ai/code/session_011LskS2RfkMwHMJUwaK8Mdq