### PR TITLE
feat(ux): 路线章节底部新增「收起本章」按钮（收起并回到章节标题行）

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1878,6 +1878,25 @@
       while (body.lastChild && body.lastChild.nodeType === 1 && body.lastChild.tagName === 'HR') {
         body.removeChild(body.lastChild);
       }
+      // 长章节读到底后不必滑回标题：正文末尾提供「收起本章」，收起并把视口带回章节标题行。
+      var foot = document.createElement('div');
+      foot.className = 'roadmap-major-section-foot';
+      var collapseBtn = document.createElement('button');
+      collapseBtn.type = 'button';
+      collapseBtn.className = 'roadmap-major-section-collapse';
+      collapseBtn.textContent = '↑ 收起本章';
+      collapseBtn.addEventListener('click', function () {
+        var section = this.closest('details.roadmap-major-section');
+        if (!section) return;
+        section.open = false;
+        var summaryEl = section.querySelector(':scope > summary');
+        if (summaryEl) summaryEl.focus({ preventScroll: true });
+        // 收起后正文大幅塌缩，全局 scroll-behavior:smooth 的动画会与 scroll anchoring
+        // 相互干扰导致落点漂移，这里强制瞬时定位回章节标题行。
+        section.scrollIntoView({ block: 'start', behavior: 'instant' });
+      });
+      foot.appendChild(collapseBtn);
+      body.appendChild(foot);
     }
   }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -2268,6 +2268,8 @@ button.home-wiki-heatmap-cell.is-active {
   border-radius: 12px;
   background: var(--surface-strong, var(--bg-alt));
   overflow: hidden;
+  /* 底部「收起本章」收起后 scrollIntoView 回到标题行，与全站锚点跳转同款头部避让 */
+  scroll-margin-top: 96px;
 }
 .roadmap-major-section-summary {
   display: flex;
@@ -2312,6 +2314,28 @@ button.home-wiki-heatmap-cell.is-active {
 }
 .roadmap-major-section-body > :first-child {
   margin-top: 0.85rem;
+}
+/* 章节正文末尾「收起本章」按钮（视觉对齐 change-log 的 .updates-day-more 胶囊按钮） */
+.roadmap-major-section-foot {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+}
+.roadmap-major-section-collapse {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 4px 16px;
+  font-size: 0.8rem;
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.roadmap-major-section-collapse:hover {
+  color: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 /* 路线正文时间线（wrapRoadmapTimelineSections）：左侧轨道 + 章节节点，
    视觉对齐 change-log 更新时间线；章节 details 展开/收起不受影响 */


### PR DESCRIPTION
## 摘要

衔接 #939 的路线页时间线改造：长章节展开读到底后，此前必须滑回章节顶部才能点标题收起。本 PR 在每个章节正文末尾新增「↑ 收起本章」按钮，点击后收起章节并把视口瞬时带回章节标题行（含 sticky 头部避让），键盘焦点同步移回章节标题。

- `docs/main.js`：`wrapRoadmapCollapsibleMajorHeadings` 为每个章节 body 末尾追加按钮；点击处理为 收起 → 焦点回 summary（`preventScroll`）→ `scrollIntoView` 回标题行。
- `docs/style.css`：按钮复用 change-log 页 `.updates-day-more` 胶囊按钮视觉；`.roadmap-major-section` 增加与全站锚点一致的 `scroll-margin-top: 96px`。
- 关键修复：站点全局 `scroll-behavior: smooth` 下，收起时上万像素的高度塌缩会与平滑滚动动画、浏览器 scroll anchoring 互相干扰，落点漂移不定（实测 ±200px 且不可复现）；改用 `behavior: 'instant'` 后落点稳定。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] `npm run lint:js` 无告警
- [x] `make ci-preflight` 通过（12/12）
- [x] headless Chromium 交互断言：15/15 章节 body 末尾均有按钮；从 L4 章节底部（视口滚过标题 8800px 处）点击 → `details.open === false`、焦点落在 summary、章节标题稳定回到视口上部（top +172px，两次独立运行一致）
- [x] 展开/收起往返、章节内 Mermaid 补渲染不受影响；纵深路线页（同一渲染路径）同样生效

## 验证截图

截图已在 Claude Code 会话内发送给仓库所有者（本环境无法向 PR 正文上传图片），本地留存于 `.cursor-artifacts/screenshots/`（已 gitignore）：

- `collapse-btn-before.png`：L4 章节展开态底部的「↑ 收起本章」胶囊按钮（位于自测题/参考答案之后）
- `collapse-btn-after.png`：点击后章节收起，视口回到 L4 标题行（sticky 头部之下，带焦点框提示）

## 相关 Issue

无（延续 #939 的路线页时间线改造）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LskS2RfkMwHMJUwaK8Mdq

---
_Generated by [Claude Code](https://claude.ai/code/session_011LskS2RfkMwHMJUwaK8Mdq)_