### PR TITLE
feat(ux): 更新记录页增加收起至30天与回到顶部按钮

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -619,19 +619,18 @@
       if (!allGroups.length) return '';
       var isExpanded = showAll || windowDays > TIMELINE_WINDOW_DAYS;
       var canExpandMore = !showAll && visibleGroups.length < allGroups.length;
-      if (!canExpandMore && !isExpanded) return '';
-      var buttons = [];
+      var leftButtons = [];
       if (canExpandMore) {
-        buttons.push('<button type="button" class="btn-secondary updates-timeline-more-days">再展开 30 天</button>');
-        buttons.push('<button type="button" class="btn-secondary updates-timeline-show-all">展开全部记录</button>');
+        leftButtons.push('<button type="button" class="btn-secondary updates-timeline-more-days">再展开 30 天</button>');
+        leftButtons.push('<button type="button" class="btn-secondary updates-timeline-show-all">展开全部记录</button>');
       }
       if (isExpanded) {
-        buttons.push('<button type="button" class="btn-secondary updates-timeline-collapse-days">收起至 30 天</button>');
-        buttons.push('<button type="button" class="btn-secondary updates-timeline-back-top">回到顶部</button>');
+        leftButtons.push('<button type="button" class="btn-secondary updates-timeline-collapse-days">收起至 30 天</button>');
       }
       return (
         '<div class="updates-timeline-actions" role="group" aria-label="更新记录导航">' +
-        buttons.join('') +
+        '<div class="updates-timeline-actions-start">' + leftButtons.join('') + '</div>' +
+        '<button type="button" class="btn-secondary updates-timeline-back-top">回到顶部</button>' +
         '</div>'
       );
     }
@@ -786,6 +785,10 @@
         ' <button type="button" class="btn-secondary btn-inline home-wiki-heatmap-clear">清除筛选</button></p>' +
         '<div class="updates-timeline-days">' +
         renderTimelineDay(dateKey, dayNodes, total, filterStats) +
+        '</div>' +
+        '<div class="updates-timeline-actions" role="group" aria-label="更新记录导航">' +
+        '<div class="updates-timeline-actions-start"></div>' +
+        '<button type="button" class="btn-secondary updates-timeline-back-top">回到顶部</button>' +
         '</div>';
     }
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -615,12 +615,23 @@
       return '<p class="data-meta home-latest-wiki-intro">' + escapeHtml(introParts.join(' · ')) + '</p>';
     }
 
-    function renderTimelineActions(visibleGroups, allGroups, showAll) {
-      if (!allGroups.length || showAll || visibleGroups.length >= allGroups.length) return '';
+    function renderTimelineActions(visibleGroups, allGroups, windowDays, showAll) {
+      if (!allGroups.length) return '';
+      var isExpanded = showAll || windowDays > TIMELINE_WINDOW_DAYS;
+      var canExpandMore = !showAll && visibleGroups.length < allGroups.length;
+      if (!canExpandMore && !isExpanded) return '';
+      var buttons = [];
+      if (canExpandMore) {
+        buttons.push('<button type="button" class="btn-secondary updates-timeline-more-days">再展开 30 天</button>');
+        buttons.push('<button type="button" class="btn-secondary updates-timeline-show-all">展开全部记录</button>');
+      }
+      if (isExpanded) {
+        buttons.push('<button type="button" class="btn-secondary updates-timeline-collapse-days">收起至 30 天</button>');
+        buttons.push('<button type="button" class="btn-secondary updates-timeline-back-top">回到顶部</button>');
+      }
       return (
-        '<div class="updates-timeline-actions" role="group" aria-label="展开更多更新记录">' +
-        '<button type="button" class="btn-secondary updates-timeline-more-days">再展开 30 天</button>' +
-        '<button type="button" class="btn-secondary updates-timeline-show-all">展开全部记录</button>' +
+        '<div class="updates-timeline-actions" role="group" aria-label="更新记录导航">' +
+        buttons.join('') +
         '</div>'
       );
     }
@@ -641,7 +652,7 @@
           { added: tg.addedCount || 0, maintained: tg.maintainedCount || 0 }
         );
       }
-      var actionsHtml = renderTimelineActions(visibleGroups, allGroups, showAll);
+      var actionsHtml = renderTimelineActions(visibleGroups, allGroups, windowDays, showAll);
       return introHtml + '<div class="updates-timeline-days">' + daysHtml + '</div>' + actionsHtml;
     }
 
@@ -697,6 +708,30 @@
       if (showAllBtn) {
         timelineShowAll = true;
         refreshTimelineBody();
+        return;
+      }
+      var collapseDaysBtn = ev.target.closest('button.updates-timeline-collapse-days');
+      if (collapseDaysBtn) {
+        currentWindowDays = TIMELINE_WINDOW_DAYS;
+        timelineShowAll = false;
+        refreshTimelineBody();
+        var collapseScrollTarget = document.getElementById('change-log-heading') ||
+          document.getElementById('change-log-section');
+        if (collapseScrollTarget && collapseScrollTarget.scrollIntoView) {
+          collapseScrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        return;
+      }
+      var backTopBtn = ev.target.closest('button.updates-timeline-back-top');
+      if (backTopBtn) {
+        var scrollTarget = document.getElementById('change-log-heading') ||
+          document.getElementById('change-log-section') ||
+          document.querySelector('.site-header');
+        if (scrollTarget && scrollTarget.scrollIntoView) {
+          scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } else {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
         return;
       }
       var moreBtn = ev.target.closest('button.updates-day-more');

--- a/docs/style.css
+++ b/docs/style.css
@@ -567,9 +567,22 @@ body.sponsor-dialog-open {
 .updates-timeline-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
   margin-top: 18px;
   padding-left: 18px;
+  padding-right: 18px;
+}
+.updates-timeline-actions-start {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.updates-timeline-back-top {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 /* 首页「最新知识节点」活跃度热力图（GitHub 风格布局；色阶取站点主题蓝
    （--accent 同色相，暗档最亮≈--accent-hover），已过顺序色板校验：

--- a/scripts/screenshot_pr_changelog_3d.cjs
+++ b/scripts/screenshot_pr_changelog_3d.cjs
@@ -83,6 +83,8 @@ async function waitChangeLogReady(page) {
         dayCount: document.querySelectorAll('.updates-day').length,
         hasMoreBtn: !!document.querySelector('.updates-timeline-more-days'),
         hasAllBtn: !!document.querySelector('.updates-timeline-show-all'),
+        hasCollapseBtn: !!document.querySelector('.updates-timeline-collapse-days'),
+        hasBackTopBtn: !!document.querySelector('.updates-timeline-back-top'),
       }));
       const out = path.join(outDir, 'change-log-default-30d.png');
       await page.screenshot({ path: out, fullPage: true });
@@ -102,6 +104,8 @@ async function waitChangeLogReady(page) {
         intro: document.querySelector('.home-latest-wiki-intro')?.textContent?.trim() || '',
         dayCount: document.querySelectorAll('.updates-day').length,
         hasActions: !!document.querySelector('.updates-timeline-actions'),
+        hasCollapseBtn: !!document.querySelector('.updates-timeline-collapse-days'),
+        hasBackTopBtn: !!document.querySelector('.updates-timeline-back-top'),
       }));
       const out = path.join(outDir, 'change-log-expanded-all.png');
       await page.screenshot({ path: out, fullPage: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 更新记录页（`change-log.html`）在时间线展开超过默认 30 天窗口或「展开全部记录」后，底部操作区新增 **收起至 30 天** 按钮。
- **回到顶部** 按钮始终显示（含默认 30 天视图与热力图单日筛选），并通过 `margin-left: auto` 靠右对齐；左侧保留展开/收起按钮。

## 验证
- `node --check docs/main.js` 通过
- 本地静态站预览：默认 30 天视图即显示右对齐「回到顶部」；展开全部后左侧为「收起至 30 天」，右侧仍为「回到顶部」

## 验证截图
![更新记录默认 30 天窗口，回到顶部靠右](https://cursor.com/artifacts/c/art-fdee0402-5a8b-4d5b-8148-e5034b048a45)
![更新记录展开全部后收起与回到顶部](https://cursor.com/artifacts/c/art-1af53114-91a9-4cb3-a056-382b883dc721)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd97665e-9db2-4328-ae40-34c5eb376078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd97665e-9db2-4328-ae40-34c5eb376078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

