### PR TITLE
fix(ux): 收起至30天时不再自动滚回顶部

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -714,11 +714,6 @@
         currentWindowDays = TIMELINE_WINDOW_DAYS;
         timelineShowAll = false;
         refreshTimelineBody();
-        var collapseScrollTarget = document.getElementById('change-log-heading') ||
-          document.getElementById('change-log-section');
-        if (collapseScrollTarget && collapseScrollTarget.scrollIntoView) {
-          collapseScrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
         return;
       }
       var backTopBtn = ev.target.closest('button.updates-timeline-back-top');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复更新记录页「收起至 30 天」点击后会自动滚回页面顶部的问题。
- 收起操作现在仅重置时间线窗口，保持当前滚动位置；需要回到顶部时仍使用右侧常驻的「回到顶部」按钮。

## 验证
- `node --check docs/main.js` 通过
- 行为变更：移除 `collapseDaysBtn` 处理中的 `scrollIntoView` 调用

## 关联
- 承接已合并的 #944（更新记录展开/收起与回到顶部按钮）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd97665e-9db2-4328-ae40-34c5eb376078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd97665e-9db2-4328-ae40-34c5eb376078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

