### PR TITLE
fix(ux): 移动端更新记录底部按钮改为纵向全宽排列

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -584,6 +584,28 @@ body.sponsor-dialog-open {
   margin-left: auto;
   flex-shrink: 0;
 }
+@media (max-width: 640px) {
+  .updates-timeline-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .updates-timeline-actions-start {
+    flex-direction: column;
+    width: 100%;
+    gap: 8px;
+  }
+  .updates-timeline-actions .btn-secondary {
+    width: 100%;
+    padding: 10px 16px;
+    font-size: 0.88rem;
+  }
+  .updates-timeline-back-top {
+    margin-left: 0;
+  }
+}
 /* 首页「最新知识节点」活跃度热力图（GitHub 风格布局；色阶取站点主题蓝
    （--accent 同色相，暗档最亮≈--accent-hover），已过顺序色板校验：
    亮度单调、相邻 ΔL ≥ 0.06、最浅档对底色 ≥ 2:1） */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

更新记录页（`change-log.html`）底部「再展开 30 天 / 展开全部记录 / 收起至 30 天 / 回到顶部」在窄屏下原先横向挤在一行，观感拥挤。本 PR 在 `max-width: 640px` 下改为纵向全宽按钮，并略收紧内边距与字号。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [ ] `make ci-preflight`（若改动 wiki/导出链）— N/A，仅 CSS
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest` — N/A
- [x] 本地 `change-log.html` 390px 视口截图，底部按钮纵向排列正常

## 验证截图

![移动端更新记录底部按钮纵向排列](https://cursor.com/artifacts/c/art-433c0e96-23bd-4c8a-9858-0d39fdade667)

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccb61af7-fa42-402a-b587-f87169106c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccb61af7-fa42-402a-b587-f87169106c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

