### PR TITLE
fix(ux): 窄屏下更新记录条目改为分行展示

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -479,9 +479,30 @@ body.sponsor-dialog-open {
 .home-latest-row > a { min-width: 0; overflow-wrap: anywhere; }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
-  /* 窄屏：保持三列 grid 跨行对齐，仅收紧间距与字号 */
-  .home-latest-list { column-gap: 10px; row-gap: 8px; }
+  /* 窄屏：每条记录独立换行，不再跨行列对齐 */
+  .home-latest-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .home-latest-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 8px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+  }
+  .home-latest-row:last-child { border-bottom: none; padding-bottom: 0; }
   .home-latest-row-date, .home-latest-row-type { font-size: .78rem; }
+  .home-latest-row-badge,
+  .updates-badge-cell { min-width: 0; }
+  .home-latest-row-badge.updates-badge-cell--empty,
+  .updates-badge-cell--empty { display: none; }
+  .home-latest-row > a {
+    flex: 1 1 100%;
+    width: 100%;
+  }
 }
 .home-latest-wiki-intro { margin-bottom: 20px; }
 /* change-log 更新时间线（参考论文笔记站 updates.html：左轨道 + 日期圆点 + 条目行 + 超量折叠） */
@@ -550,6 +571,25 @@ body.sponsor-dialog-open {
   grid-column: 3;
   min-width: 0;
   overflow-wrap: anywhere;
+}
+@media (max-width: 860px) {
+  /* 窄屏：标签/类型与标题分行，取消跨条目列对齐 */
+  .updates-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 8px;
+    padding: 4px 0;
+  }
+  .updates-badge-cell,
+  .updates-item-type,
+  .updates-item-link { grid-column: unset; }
+  .updates-badge-cell { min-width: 0; }
+  .updates-badge-cell--empty { display: none; }
+  .updates-item-link {
+    flex: 1 1 100%;
+    width: 100%;
+  }
 }
 .updates-day.is-folded .updates-item-folded { display: none; }
 .updates-day-more {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 屏幕宽度 ≤860px 时，**更新记录**（`change-log.html`）时间线条目与首页「最新知识节点」紧凑列表不再保持跨行 grid 列对齐
- 每条记录改为：第一行显示日期/标签/类型（可换行），第二行独占标题链接，避免窄屏横向挤压

## 验证
- 本地 `make export graph` 后于 390px 视口预览 `change-log.html` 与 `index.html`
- 条目 `display: flex`，标题 `flex-basis: 100%` 独占新行

## 验证截图
![更新记录页窄屏分行布局](https://cursor.com/artifacts/c/art-bcbe5308-c711-422b-ab5d-10de3ec341ed)
![首页最新知识节点窄屏分行布局](https://cursor.com/artifacts/c/art-20d67ac6-5a95-4956-8187-a16e575292c0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b25dfb4-e8c8-4115-b98a-5ebf8e463e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b25dfb4-e8c8-4115-b98a-5ebf8e463e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

