### PR TITLE
fix(ux): 更新记录热力图固定 53 周滑动窗口

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -302,6 +302,24 @@
     return d.getUTCFullYear() + '-' + mm + '-' + dd;
   }
 
+  function homeHeatmapTodayUtcMs() {
+    var now = new Date();
+    return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  }
+
+  function homeHeatmapWeekStartMs(ms) {
+    return ms - ((new Date(ms).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
+  }
+
+  // 固定 53 周窗口：右缘对齐「今天」所在周（GitHub 同款），左缘随日历推进同步滑出
+  function homeHeatmapWindowBounds(anchorMs) {
+    var lastWeekStartMs = homeHeatmapWeekStartMs(anchorMs);
+    return {
+      startMs: lastWeekStartMs - (HOME_HEATMAP_WEEKS - 1) * 7 * HOME_HEATMAP_DAY_MS,
+      endMs: lastWeekStartMs + 6 * HOME_HEATMAP_DAY_MS
+    };
+  }
+
   // 非零日计数的四分位阈值：档位对离群的批量维护日保持稳健
   function homeHeatmapThresholds(counts) {
     var sorted = counts.slice().sort(function (a, b) { return a - b; });
@@ -322,24 +340,25 @@
 
   function buildHomeWikiHeatmapHtml(days) {
     var countByDate = {};
-    var counts = [];
-    var maxMs = -Infinity;
+    var hasActivity = false;
+    var todayMs = homeHeatmapTodayUtcMs();
+    var bounds = homeHeatmapWindowBounds(todayMs);
+    var startMs = bounds.startMs;
+    var endMs = bounds.endMs;
+    var windowCounts = [];
     for (var i = 0; i < days.length; i++) {
       var day = days[i];
       var ms = homeHeatmapParseDate(day && day.date);
       var count = day && typeof day.count === 'number' ? day.count : 0;
       if (ms === null || count <= 0) continue;
-      countByDate[day.date] = count;
-      counts.push(count);
-      if (ms > maxMs) maxMs = ms;
+      hasActivity = true;
+      if (ms >= startMs && ms <= endMs) {
+        countByDate[day.date] = count;
+        windowCounts.push(count);
+      }
     }
-    if (!counts.length) return '';
-    var thresholds = homeHeatmapThresholds(counts);
-    // getUTCDay() 0=周日 → 周一对齐的行号 (day+6)%7；
-    // 窗口固定 53 周，以最新数据所在周为最右列
-    var lastWeekStartMs = maxMs - ((new Date(maxMs).getUTCDay() + 6) % 7) * HOME_HEATMAP_DAY_MS;
-    var startMs = lastWeekStartMs - (HOME_HEATMAP_WEEKS - 1) * 7 * HOME_HEATMAP_DAY_MS;
-    var endMs = lastWeekStartMs + 6 * HOME_HEATMAP_DAY_MS;
+    if (!hasActivity) return '';
+    var thresholds = homeHeatmapThresholds(windowCounts.length ? windowCounts : [1]);
 
     var cellsHtml = '';
     var monthsHtml = '';
@@ -360,7 +379,7 @@
       monthsHtml += '<span>' + monthLabel + '</span>';
       for (var row = 0; row < 7; row++) {
         var dayMs = weekMs + row * HOME_HEATMAP_DAY_MS;
-        if (dayMs > maxMs) {
+        if (dayMs > todayMs) {
           // 仅未来日期留白；历史上无节点的日期与 GitHub 一样渲染为空格
           cellsHtml += '<span class="home-wiki-heatmap-cell is-pad" aria-hidden="true"></span>';
           continue;
@@ -397,7 +416,8 @@
       '<div class="home-wiki-heatmap-months" aria-hidden="true">' + monthsHtml + '</div>' +
       '<div class="home-wiki-heatmap-body">' +
       '<div class="home-wiki-heatmap-weekdays" aria-hidden="true">' + weekdaysHtml + '</div>' +
-      '<div class="home-wiki-heatmap-grid" role="group" aria-label="按日期筛选知识节点">' +
+      '<div class="home-wiki-heatmap-grid" data-week-count="' + HOME_HEATMAP_WEEKS +
+      '" role="group" aria-label="按日期筛选知识节点">' +
       cellsHtml +
       '</div></div></div></div>' +
       '<div class="home-wiki-heatmap-legend">' +

--- a/docs/style.css
+++ b/docs/style.css
@@ -650,6 +650,7 @@ body.sponsor-dialog-open {
    （--accent 同色相，暗档最亮≈--accent-hover），已过顺序色板校验：
    亮度单调、相邻 ΔL ≥ 0.06、最浅档对底色 ≥ 2:1） */
 .home-wiki-heatmap {
+  --hm-weeks: 53;
   --hm-cell-min: 8px; /* 格子宽度下限：低于则容器横向滚动 */
   --hm-gap: 3px;
   --hm-level-0: #2c2c2e;
@@ -674,8 +675,7 @@ body.sponsor-dialog-open {
 .home-wiki-heatmap-inner { min-width: max-content; }
 .home-wiki-heatmap-months {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(var(--hm-cell-min), 1fr);
+  grid-template-columns: repeat(var(--hm-weeks), minmax(var(--hm-cell-min), 1fr));
   gap: var(--hm-gap);
   margin-left: calc(24px + var(--hm-gap));
   height: 18px;
@@ -701,7 +701,7 @@ body.sponsor-dialog-open {
   display: grid;
   grid-auto-flow: column;
   grid-template-rows: repeat(7, auto);
-  grid-auto-columns: minmax(var(--hm-cell-min), 1fr);
+  grid-template-columns: repeat(var(--hm-weeks), minmax(var(--hm-cell-min), 1fr));
   gap: var(--hm-gap);
 }
 .home-wiki-heatmap-cell {

--- a/tests/test_home_heatmap_window.py
+++ b/tests/test_home_heatmap_window.py
@@ -1,0 +1,71 @@
+"""更新记录热力图：固定 53 周滑动窗口（右缘锚定 UTC 今天）回归测试。"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN_JS = ROOT / "docs" / "main.js"
+WIKI_ACTIVITY = ROOT / "docs" / "exports" / "wiki-activity.json"
+
+_NODE_SNIPPET = r"""
+const fs = require('fs');
+const code = fs.readFileSync(process.argv[1], 'utf8');
+const start = code.indexOf('var HOME_HEATMAP_DAY_MS');
+const end = code.indexOf('function renderLatestWikiNode');
+const vm = require('vm');
+const sandbox = {};
+vm.runInNewContext(code.slice(start, end), sandbox);
+const days = JSON.parse(fs.readFileSync(process.argv[2], 'utf8')).days;
+const html = sandbox.buildHomeWikiHeatmapHtml(days);
+const gridMatch = html.match(/home-wiki-heatmap-grid[^>]*>([\s\S]*?)<\/div><\/div><\/div><\/div>/);
+const gridHtml = gridMatch ? gridMatch[1] : '';
+const gridCells = (gridHtml.match(/home-wiki-heatmap-cell/g) || []).length;
+const weekAttr = html.match(/data-week-count="(\d+)"/);
+const todayMs = sandbox.homeHeatmapTodayUtcMs();
+const bounds = sandbox.homeHeatmapWindowBounds(todayMs);
+const weekMs = [];
+for (let w = bounds.startMs; w <= bounds.endMs; w += sandbox.HOME_HEATMAP_DAY_MS * 7) weekMs.push(w);
+console.log(JSON.stringify({
+  gridCells,
+  weekAttr: weekAttr ? Number(weekAttr[1]) : null,
+  weeks: weekMs.length,
+  start: new Date(bounds.startMs).toISOString().slice(0, 10),
+  end: new Date(bounds.endMs).toISOString().slice(0, 10),
+}));
+"""
+
+
+def _run_node() -> dict:
+    if not WIKI_ACTIVITY.is_file():
+        raise FileNotFoundError(
+            "docs/exports/wiki-activity.json missing; run `make export graph` first"
+        )
+    proc = subprocess.run(
+        ["node", "-e", _NODE_SNIPPET, str(MAIN_JS), str(WIKI_ACTIVITY)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout.strip())
+
+
+def test_home_heatmap_fixed_53_week_window() -> None:
+    out = _run_node()
+    assert out["weeks"] == 53
+    assert out["weekAttr"] == 53
+    assert out["gridCells"] == 53 * 7
+
+
+def test_home_heatmap_window_ends_on_today_week() -> None:
+    out = _run_node()
+    proc = subprocess.run(
+        ["node", "-e", "const n=new Date(); console.log(n.toISOString().slice(0,10));"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    today = proc.stdout.strip()
+    assert today <= out["end"]

--- a/tests/test_home_heatmap_window.py
+++ b/tests/test_home_heatmap_window.py
@@ -8,17 +8,23 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MAIN_JS = ROOT / "docs" / "main.js"
-WIKI_ACTIVITY = ROOT / "docs" / "exports" / "wiki-activity.json"
+
+# CI 不生成 gitignore 的 wiki-activity.json；用合成日数据验证窗口逻辑。
+_SAMPLE_DAYS = [
+    {"date": "2026-04-24", "count": 3},
+    {"date": "2026-06-01", "count": 5},
+    {"date": "2026-07-07", "count": 2},
+]
 
 _NODE_SNIPPET = r"""
 const fs = require('fs');
 const code = fs.readFileSync(process.argv[1], 'utf8');
+const days = JSON.parse(process.argv[2]);
 const start = code.indexOf('var HOME_HEATMAP_DAY_MS');
 const end = code.indexOf('function renderLatestWikiNode');
 const vm = require('vm');
 const sandbox = {};
 vm.runInNewContext(code.slice(start, end), sandbox);
-const days = JSON.parse(fs.readFileSync(process.argv[2], 'utf8')).days;
 const html = sandbox.buildHomeWikiHeatmapHtml(days);
 const gridMatch = html.match(/home-wiki-heatmap-grid[^>]*>([\s\S]*?)<\/div><\/div><\/div><\/div>/);
 const gridHtml = gridMatch ? gridMatch[1] : '';
@@ -32,19 +38,17 @@ console.log(JSON.stringify({
   gridCells,
   weekAttr: weekAttr ? Number(weekAttr[1]) : null,
   weeks: weekMs.length,
+  today: new Date(todayMs).toISOString().slice(0, 10),
   start: new Date(bounds.startMs).toISOString().slice(0, 10),
   end: new Date(bounds.endMs).toISOString().slice(0, 10),
 }));
 """
 
 
-def _run_node() -> dict:
-    if not WIKI_ACTIVITY.is_file():
-        raise FileNotFoundError(
-            "docs/exports/wiki-activity.json missing; run `make export graph` first"
-        )
+def _run_node(days: list[dict[str, object]] | None = None) -> dict:
+    payload = json.dumps(days if days is not None else _SAMPLE_DAYS)
     proc = subprocess.run(
-        ["node", "-e", _NODE_SNIPPET, str(MAIN_JS), str(WIKI_ACTIVITY)],
+        ["node", "-e", _NODE_SNIPPET, str(MAIN_JS), payload],
         check=True,
         capture_output=True,
         text=True,
@@ -61,11 +65,11 @@ def test_home_heatmap_fixed_53_week_window() -> None:
 
 def test_home_heatmap_window_ends_on_today_week() -> None:
     out = _run_node()
-    proc = subprocess.run(
-        ["node", "-e", "const n=new Date(); console.log(n.toISOString().slice(0,10));"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    today = proc.stdout.strip()
-    assert today <= out["end"]
+    assert out["today"] <= out["end"]
+
+
+def test_home_heatmap_window_not_data_span() -> None:
+    """短跨度合成数据也不应退化为 min→max 全量列数（旧版约 12 周）。"""
+    out = _run_node(_SAMPLE_DAYS)
+    assert out["weeks"] == 53
+    assert out["gridCells"] == 53 * 7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

更新记录页（`change-log.html`）的活跃度热力图此前在数据跨度变长时会不断向右追加列、左侧起点不随时间滑出，整体越来越宽。

本次改为 **GitHub 同款固定 53 周滑动窗口**：
- 右缘锚定 **UTC 今天** 所在周（不再锚定最后一条日志日期）
- 日历推进时左缘同步滑出超出窗口的旧日期
- CSS 用 `repeat(53, …)` 锁定列数，防止列数随数据增长

## 验证

- `make ci-preflight` 通过
- 新增 `tests/test_home_heatmap_window.py`：断言 53 周 / 371 格固定窗口

## 验证截图

![更新记录页热力图固定 53 周窗口](https://cursor.com/artifacts/c/art-6d62bf94-5a80-4472-9b24-32dc26d88de8)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ba59553-4e0d-422a-a603-82e3910f8858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ba59553-4e0d-422a-a603-82e3910f8858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

