### PR TITLE
fix(ux): 修复首页「最新知识节点」grid 列错位

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -493,13 +493,13 @@
           renderActionBadgeCell(rowMeta.action, 'home-latest-row-badge') +
           '<span class="home-latest-row-type">' +
           escapeHtml(rowType) +
-          '</span><a href="' +
+          '</span><span class="home-latest-row-main"><a href="' +
           escapeHtml(detailHref(rowMeta.detail_id)) +
           '">' +
           escapeHtml(rowMeta.label || rowMeta.detail_id) +
           '</a>' +
           renderItemSuffix(rowMeta) +
-          '</li>';
+          '</span></li>';
       }
       mount.innerHTML =
         '<ul class="home-latest-list">' + compactRows + '</ul>' +

--- a/docs/style.css
+++ b/docs/style.css
@@ -476,7 +476,14 @@ body.sponsor-dialog-open {
 .home-latest-row-badge .updates-badge { vertical-align: baseline; }
 .updates-badge-cell--empty,
 .home-latest-row-badge.updates-badge-cell--empty { min-height: 1.25em; }
-.home-latest-row > a { min-width: 0; overflow-wrap: anywhere; }
+.home-latest-row-main {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.home-latest-row-main > a { min-width: 0; overflow-wrap: anywhere; }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
   /* 窄屏：每条记录独立换行，不再跨行列对齐 */
@@ -499,7 +506,7 @@ body.sponsor-dialog-open {
   .updates-badge-cell { min-width: 0; }
   .home-latest-row-badge.updates-badge-cell--empty,
   .updates-badge-cell--empty { display: none; }
-  .home-latest-row > a {
+  .home-latest-row-main {
     flex: 1 1 100%;
     width: 100%;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复首页「最新知识节点」紧凑列表在加入 ⭐️ / 社区后缀后列对齐炸裂的问题
- 根因：`.home-latest-row` 使用 `display: contents` 参与 4 列 grid，但链接后的后缀 span 成为额外 grid 子项，挤占下一行格子
- 将标题链接与后缀包入 `.home-latest-row-main` 容器（与 change-log 时间线的 `.updates-item-main` 一致），恢复「日期 | 标签 | 类型 | 标题+后缀」四列布局

## 验证
- `make lint-js` 通过
- 本地静态站 `#home-latest-wiki-section` 截图确认 5 条记录列对齐正常

## 验证截图
![首页最新知识节点修复后](https://cursor.com/artifacts/c/art-1f9dc3e3-3edb-4fb9-867c-4fa02308d54f)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-614cff2a-2cd4-448c-83eb-ab9683e4448b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-614cff2a-2cd4-448c-83eb-ab9683e4448b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

