### PR TITLE
fix(ux): 长标题时社区标签紧跟节点名不换行

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -477,13 +477,13 @@ body.sponsor-dialog-open {
 .updates-badge-cell--empty,
 .home-latest-row-badge.updates-badge-cell--empty { min-height: 1.25em; }
 .home-latest-row-main {
-  display: flex;
-  align-items: baseline;
-  gap: 0.55rem;
   min-width: 0;
-  flex-wrap: wrap;
 }
-.home-latest-row-main > a { min-width: 0; overflow-wrap: anywhere; }
+.home-latest-row-main > a { overflow-wrap: anywhere; }
+.home-latest-row-main > .updates-item-opensource,
+.home-latest-row-main > .updates-item-cat {
+  margin-left: 0.55rem;
+}
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
   /* 窄屏：每条记录独立换行，不再跨行列对齐 */
@@ -576,26 +576,21 @@ body.sponsor-dialog-open {
 }
 .updates-item-main {
   grid-column: 3;
-  display: flex;
-  align-items: baseline;
-  gap: 0.55rem;
   min-width: 0;
-  flex-wrap: wrap;
 }
 .updates-item-link {
-  min-width: 0;
   overflow-wrap: anywhere;
 }
 .updates-item-opensource {
-  flex: none;
   line-height: 1;
+  margin-left: 0.55rem;
 }
 .updates-item-cat {
-  flex: none;
   font-size: .72rem;
   color: var(--text-muted);
   opacity: .85;
   white-space: nowrap;
+  margin-left: 0.55rem;
 }
 @media (max-width: 860px) {
   /* 窄屏：标签/类型与标题分行，取消跨条目列对齐 */

--- a/docs/style.css
+++ b/docs/style.css
@@ -479,10 +479,12 @@ body.sponsor-dialog-open {
 .home-latest-row-main {
   min-width: 0;
 }
-.home-latest-row-main > a { overflow-wrap: anywhere; }
-.home-latest-row-main > .updates-item-opensource,
-.home-latest-row-main > .updates-item-cat {
-  margin-left: 0.55rem;
+.home-latest-row-main > a {
+  overflow-wrap: anywhere;
+  padding-right: 0.55rem;
+}
+.home-latest-row-main > .updates-item-opensource {
+  padding-right: 0.55rem;
 }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
@@ -580,17 +582,17 @@ body.sponsor-dialog-open {
 }
 .updates-item-link {
   overflow-wrap: anywhere;
+  padding-right: 0.55rem;
 }
 .updates-item-opensource {
   line-height: 1;
-  margin-left: 0.55rem;
+  padding-right: 0.55rem;
 }
 .updates-item-cat {
   font-size: .72rem;
   color: var(--text-muted);
   opacity: .85;
   white-space: nowrap;
-  margin-left: 0.55rem;
 }
 @media (max-width: 860px) {
   /* 窄屏：标签/类型与标题分行，取消跨条目列对齐 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复「最新知识节点」与「更新记录」中，节点标题过长时社区标签被 flex 换行挤到独立一行的问题
- 将 `.home-latest-row-main` / `.updates-item-main` 改为内联文本流，社区标签紧跟标题末尾
- 间距从社区标签的 `margin-left` 改为标题链接的 `padding-right`：换行时空格留在节点名后，社区标签新行不再出现前导空白

## 变更
- `docs/style.css`：标题链接与 `.updates-item-opensource` 使用 `padding-right` 控制间距；移除 `.updates-item-cat` 的 `margin-left`

## 验证
- 移动端视口（390px）本地预览：长标题 KEMO 条目社区标签紧跟标题，换行后标签行无前导空格
- 首页紧凑列表与 change-log 完整时间线均已覆盖

## 验证截图
![首页最新知识节点移动端](https://cursor.com/artifacts/c/art-a71b94df-bbc7-469b-a5b7-e33c0df08930)
![更新记录页移动端](https://cursor.com/artifacts/c/art-0c33b494-584a-4668-8c7f-75071d0d56c8)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5769bf12-3cae-489e-8f64-9810c39805d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5769bf12-3cae-489e-8f64-9810c39805d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

