### PR TITLE
fix(ux): 更新记录热力图 PC 端宽度适配，消除横向滚动条

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -691,10 +691,19 @@ body.sponsor-dialog-open {
   --hm-level-4: #084d99;
   --hm-cell-line: rgba(27, 31, 36, 0.06);
 }
-.home-wiki-heatmap-scroll { overflow-x: auto; padding: 2px; }
+.home-wiki-heatmap-scroll {
+  width: 100%;
+  overflow-x: auto;
+  padding: 2px;
+  box-sizing: border-box;
+}
 /* 流式适配容器宽度：53 列 minmax(下限, 1fr) 均分整行；
    窄屏格子到下限后由 min-width 撑开、scrollLeft 锚定最右 */
-.home-wiki-heatmap-inner { min-width: max-content; }
+.home-wiki-heatmap-inner {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
 .home-wiki-heatmap-months {
   display: grid;
   grid-template-columns: repeat(var(--hm-weeks), minmax(var(--hm-cell-min), 1fr));
@@ -761,6 +770,24 @@ button.home-wiki-heatmap-cell.is-active {
 .home-wiki-heatmap-legend .home-wiki-heatmap-cell { width: 12px; height: 12px; flex-shrink: 0; }
 .home-wiki-heatmap-legend-hint { margin-right: auto; }
 .home-wiki-heatmap-clear { margin-left: 8px; vertical-align: middle; }
+/* PC：热力图在内容区内完整放下，隐藏横向滚动；列宽用 calc 均分避免 fr 子像素溢出 */
+@media (min-width: 680px) {
+  .home-wiki-heatmap-scroll { overflow-x: hidden; }
+  .home-wiki-heatmap-months,
+  .home-wiki-heatmap-grid {
+    --hm-col-width: calc((100% - (var(--hm-weeks) - 1) * var(--hm-gap)) / var(--hm-weeks));
+    grid-template-columns: repeat(var(--hm-weeks), var(--hm-col-width));
+  }
+  .home-wiki-heatmap-cell {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 1 / 1;
+  }
+}
+/* 极窄屏：格子到下限后恢复横向滚动，默认锚定最右（最新日期） */
+@media (max-width: 679px) {
+  .home-wiki-heatmap-inner { min-width: max-content; }
+}
 .section-subtitle {
   color: var(--text-muted);
   font-size: .97rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 `change-log.html` 更新记录页活跃度热力图在 PC 端出现横向滚动条的问题
- 根因：内层 `min-width: max-content` 与 53 列 `fr` 子像素舍入导致内容比容器宽约 1px，配合 `overflow-x: auto` 始终显示滚动条
- 桌面端（≥680px）改为流式 `width: 100%`、列宽 `calc` 均分，并隐藏横向溢出；极窄屏仍保留横向滚动与 8px 格子下限

## 验证
- `pytest tests/test_home_heatmap_window.py --no-cov` 通过
- `npm run lint:js` 通过
- 本地 1280px 视口截图：热力图完整显示、无横向滚动条

## 验证截图
![更新记录页热力图 PC 端无横向滚动条](https://cursor.com/artifacts/c/art-23741927-c047-49ec-8db0-cb0cb96cd3fd)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23688b8b-6681-4c5c-98fe-83094bf9bd72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23688b8b-6681-4c5c-98fe-83094bf9bd72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

