### PR TITLE
feat(ux): roadmap 详情页 hero 新增 L 阶段知识地图流程图

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2166,69 +2166,65 @@
     return 'rmStageExit';
   }
 
-  function mermaidSafeNodeId(raw) {
-    return String(raw || '').replace(/[^a-zA-Z0-9_]/g, '_');
-  }
-
-  function escapeMermaidLabelText(text) {
-    return String(text || '')
-      .replace(/&/g, '&amp;')
-      .replace(/"/g, '&quot;');
-  }
-
-  function buildRoadmapKnowledgeMapMermaidSource(stages, detailPages, contentEl) {
+  function buildRoadmapKnowledgeMapTreeHTML(stages, detailPages, contentEl, roadmapTitle) {
     if (!stages || stages.length < 2) return null;
-    var lines = ['flowchart TB'];
-    lines.push('  classDef rmStageIntro fill:#0d4f5c,stroke:#00d4ff,stroke-width:2px,color:#fff');
-    lines.push('  classDef rmStageFoundation fill:#14291f,stroke:#4ade80,color:#e8ffe8');
-    lines.push('  classDef rmStageControl fill:#2b2614,stroke:#fbbf24,color:#fff8e6');
-    lines.push('  classDef rmStageLearning fill:#241a2e,stroke:#c084fc,color:#f3e8ff');
-    lines.push('  classDef rmStageDeploy fill:#142433,stroke:#38bdf8,color:#e0f2fe');
-    lines.push('  classDef rmStageExit fill:#2a1515,stroke:#f87171,color:#ffe4e6');
-    lines.push('  classDef rmStageDefault fill:#1a1a1a,stroke:#64748b,color:#ddd');
-    lines.push('  classDef rmWikiNode fill:#12171c,stroke:#475569,color:#cbd5e1');
-
-    var prevTailId = '';
+    var maxWikiPerStage = 3;
     var wikiCount = 0;
-    var maxWikiPerStage = 2;
+    var parts = [];
+    var rootLabel = String(roadmapTitle || '技术路线').trim();
+    if (rootLabel.length > 56) rootLabel = rootLabel.slice(0, 54) + '…';
+    parts.push('<div class="rm-kmtree" role="tree">');
+    parts.push('<div class="rm-kmtree-row rm-kmtree-row--root" role="treeitem" aria-level="1">');
+    parts.push('<span class="rm-kmtree-prefix" aria-hidden="true"></span>');
+    parts.push('<span class="rm-kmtree-label">' + escapeHtml(rootLabel) + '</span>');
+    parts.push('</div>');
+
     var i;
     for (i = 0; i < stages.length; i++) {
       var stage = stages[i];
-      var sid = normalizeRoadmapStageId(stage.id);
-      var stageNodeId = 'rm_st_' + mermaidSafeNodeId(sid);
+      var isLastStage = i === stages.length - 1;
+      var stageBranch = isLastStage ? '└── ' : '├── ';
+      var childIndent = isLastStage ? '    ' : '│   ';
       var stageLabel = formatRoadmapStageDisplayId(stage.id) + ' · ' + String(stage.title || '').trim();
-      if (stageLabel.length > 44) stageLabel = stageLabel.slice(0, 42) + '…';
+      if (stageLabel.length > 52) stageLabel = stageLabel.slice(0, 50) + '…';
       var stageHref = findRoadmapStageHeadingId(stage, contentEl);
       stageHref = stageHref ? ('#' + stageHref) : '#roadmap-content';
       var stageBand = roadmapStageColorBand(stage.id);
-      var stageMermaidLabel = '"<a href=\'' + stageHref + '\'><b>' +
-        escapeMermaidLabelText(stageLabel) + '</b></a>"';
-      lines.push('  ' + stageNodeId + '[' + stageMermaidLabel + ']:::' + stageBand);
 
-      if (prevTailId) {
-        lines.push('  ' + prevTailId + ' --> ' + stageNodeId);
-      }
-      prevTailId = stageNodeId;
+      parts.push('<div class="rm-kmtree-row rm-kmtree-row--stage" role="treeitem" aria-level="2" data-band="' +
+        escapeHtml(stageBand.replace('rmStage', '').toLowerCase()) + '">');
+      parts.push('<span class="rm-kmtree-prefix" aria-hidden="true">' + stageBranch + '</span>');
+      parts.push('<a class="rm-kmtree-label" href="' + escapeHtml(stageHref) + '">' + escapeHtml(stageLabel) + '</a>');
+      parts.push('</div>');
 
       var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, maxWikiPerStage) : [];
+      if (!related.length) {
+        parts.push('<div class="rm-kmtree-row rm-kmtree-row--empty" role="treeitem" aria-level="3">');
+        parts.push('<span class="rm-kmtree-prefix" aria-hidden="true">' + childIndent + '└── </span>');
+        parts.push('<span class="rm-kmtree-label">（本阶段暂无抽取链接）</span>');
+        parts.push('</div>');
+        continue;
+      }
       var k;
       for (k = 0; k < related.length; k++) {
         var rid = related[k];
         var page = detailPages[rid] || {};
-        var wikiId = 'rm_w_' + mermaidSafeNodeId(sid) + '_' + k;
         var wikiTitle = page.title || rid;
-        if (wikiTitle.length > 24) wikiTitle = wikiTitle.slice(0, 22) + '…';
+        if (wikiTitle.length > 42) wikiTitle = wikiTitle.slice(0, 40) + '…';
         var wikiHref = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
-        var wikiLabel = '"<a href=\'' + wikiHref + '\'>' + escapeMermaidLabelText(wikiTitle) + '</a>"';
-        lines.push('  ' + wikiId + '[' + wikiLabel + ']:::rmWikiNode');
-        lines.push('  ' + prevTailId + ' --> ' + wikiId);
-        prevTailId = wikiId;
+        var isLastChild = k === related.length - 1;
+        var wikiBranch = childIndent + (isLastChild ? '└── ' : '├── ');
+        parts.push('<div class="rm-kmtree-row rm-kmtree-row--wiki" role="treeitem" aria-level="3">');
+        parts.push('<span class="rm-kmtree-prefix" aria-hidden="true">' + wikiBranch + '</span>');
+        parts.push('<a class="rm-kmtree-label" href="' + escapeHtml(wikiHref) + '">' + escapeHtml(wikiTitle) + '</a>');
+        parts.push('</div>');
         wikiCount += 1;
       }
     }
 
+    parts.push('</div>');
     return {
-      source: lines.join('\n'),
+      html: parts.join(''),
       stageCount: stages.length,
       wikiCount: wikiCount
     };
@@ -2236,25 +2232,29 @@
 
   function renderRoadmapKnowledgeMap(roadmapPage, detailPages, contentEl) {
     var wrap = document.getElementById('roadmapKnowledgeMapWrap');
-    var host = document.getElementById('roadmapKnowledgeMapMermaid');
+    var host = document.getElementById('roadmapKnowledgeMapTree');
     var metaEl = document.getElementById('roadmapKnowledgeMapMeta');
     var flowLink = document.getElementById('roadmapKnowledgeMapFlowLink');
-    if (!wrap || !host) return Promise.resolve();
+    if (!wrap || !host) return;
     var stages = Array.isArray(roadmapPage && roadmapPage.stages) ? roadmapPage.stages : [];
     if (stages.length < 2) {
       wrap.hidden = true;
       host.innerHTML = '';
-      return Promise.resolve();
+      return;
     }
-    var built = buildRoadmapKnowledgeMapMermaidSource(stages, detailPages, contentEl);
-    if (!built || !built.source) {
+    var built = buildRoadmapKnowledgeMapTreeHTML(
+      stages,
+      detailPages,
+      contentEl,
+      (roadmapPage && roadmapPage.title) || ''
+    );
+    if (!built || !built.html) {
       wrap.hidden = true;
       host.innerHTML = '';
-      return Promise.resolve();
+      return;
     }
     wrap.hidden = false;
-    host.className = 'mermaid roadmap-knowledge-map-mermaid';
-    host.textContent = built.source;
+    host.innerHTML = built.html;
     if (metaEl) {
       metaEl.textContent = built.stageCount + ' 个 L 阶段 · ' + built.wikiCount + ' 个知识节点';
     }
@@ -2272,11 +2272,6 @@
         flowLink.textContent = '展开阶段详情 →';
       }
     }
-    return renderDetailMermaid(wrap).then(function () {
-      patchMermaidSvgLabelOverflow(wrap);
-      enhanceMermaidZoomTargets(wrap);
-      bindMermaidZoom(wrap);
-    });
   }
 
   function renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages) {

--- a/docs/main.js
+++ b/docs/main.js
@@ -2143,6 +2143,142 @@
     if (sub) sub.hidden = !show;
   }
 
+  function normalizeRoadmapStageId(stageId) {
+    return String(stageId || '').toLowerCase().replace(/−/g, '-');
+  }
+
+  function formatRoadmapStageDisplayId(stageId) {
+    var norm = normalizeRoadmapStageId(stageId);
+    if (norm === 'l-1') return 'L−1';
+    return norm.toUpperCase();
+  }
+
+  function roadmapStageColorBand(stageId) {
+    var norm = normalizeRoadmapStageId(stageId);
+    if (norm === 'l-1') return 'rmStageIntro';
+    var m = /^l(\d+)/.exec(norm);
+    if (!m) return 'rmStageDefault';
+    var major = parseInt(m[1], 10);
+    if (major <= 3) return 'rmStageFoundation';
+    if (major === 4) return 'rmStageControl';
+    if (major === 5) return 'rmStageLearning';
+    if (major === 6) return 'rmStageDeploy';
+    return 'rmStageExit';
+  }
+
+  function mermaidSafeNodeId(raw) {
+    return String(raw || '').replace(/[^a-zA-Z0-9_]/g, '_');
+  }
+
+  function escapeMermaidLabelText(text) {
+    return String(text || '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function buildRoadmapKnowledgeMapMermaidSource(stages, detailPages, contentEl) {
+    if (!stages || stages.length < 2) return null;
+    var lines = ['flowchart TB'];
+    lines.push('  classDef rmStageIntro fill:#0d4f5c,stroke:#00d4ff,stroke-width:2px,color:#fff');
+    lines.push('  classDef rmStageFoundation fill:#14291f,stroke:#4ade80,color:#e8ffe8');
+    lines.push('  classDef rmStageControl fill:#2b2614,stroke:#fbbf24,color:#fff8e6');
+    lines.push('  classDef rmStageLearning fill:#241a2e,stroke:#c084fc,color:#f3e8ff');
+    lines.push('  classDef rmStageDeploy fill:#142433,stroke:#38bdf8,color:#e0f2fe');
+    lines.push('  classDef rmStageExit fill:#2a1515,stroke:#f87171,color:#ffe4e6');
+    lines.push('  classDef rmStageDefault fill:#1a1a1a,stroke:#64748b,color:#ddd');
+    lines.push('  classDef rmWikiNode fill:#12171c,stroke:#475569,color:#cbd5e1');
+
+    var prevTailId = '';
+    var wikiCount = 0;
+    var maxWikiPerStage = 2;
+    var i;
+    for (i = 0; i < stages.length; i++) {
+      var stage = stages[i];
+      var sid = normalizeRoadmapStageId(stage.id);
+      var stageNodeId = 'rm_st_' + mermaidSafeNodeId(sid);
+      var stageLabel = formatRoadmapStageDisplayId(stage.id) + ' · ' + String(stage.title || '').trim();
+      if (stageLabel.length > 44) stageLabel = stageLabel.slice(0, 42) + '…';
+      var stageHref = findRoadmapStageHeadingId(stage, contentEl);
+      stageHref = stageHref ? ('#' + stageHref) : '#roadmap-content';
+      var stageBand = roadmapStageColorBand(stage.id);
+      var stageMermaidLabel = '"<a href=\'' + stageHref + '\'><b>' +
+        escapeMermaidLabelText(stageLabel) + '</b></a>"';
+      lines.push('  ' + stageNodeId + '[' + stageMermaidLabel + ']:::' + stageBand);
+
+      if (prevTailId) {
+        lines.push('  ' + prevTailId + ' --> ' + stageNodeId);
+      }
+      prevTailId = stageNodeId;
+
+      var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, maxWikiPerStage) : [];
+      var k;
+      for (k = 0; k < related.length; k++) {
+        var rid = related[k];
+        var page = detailPages[rid] || {};
+        var wikiId = 'rm_w_' + mermaidSafeNodeId(sid) + '_' + k;
+        var wikiTitle = page.title || rid;
+        if (wikiTitle.length > 24) wikiTitle = wikiTitle.slice(0, 22) + '…';
+        var wikiHref = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
+        var wikiLabel = '"<a href=\'' + wikiHref + '\'>' + escapeMermaidLabelText(wikiTitle) + '</a>"';
+        lines.push('  ' + wikiId + '[' + wikiLabel + ']:::rmWikiNode');
+        lines.push('  ' + prevTailId + ' --> ' + wikiId);
+        prevTailId = wikiId;
+        wikiCount += 1;
+      }
+    }
+
+    return {
+      source: lines.join('\n'),
+      stageCount: stages.length,
+      wikiCount: wikiCount
+    };
+  }
+
+  function renderRoadmapKnowledgeMap(roadmapPage, detailPages, contentEl) {
+    var wrap = document.getElementById('roadmapKnowledgeMapWrap');
+    var host = document.getElementById('roadmapKnowledgeMapMermaid');
+    var metaEl = document.getElementById('roadmapKnowledgeMapMeta');
+    var flowLink = document.getElementById('roadmapKnowledgeMapFlowLink');
+    if (!wrap || !host) return Promise.resolve();
+    var stages = Array.isArray(roadmapPage && roadmapPage.stages) ? roadmapPage.stages : [];
+    if (stages.length < 2) {
+      wrap.hidden = true;
+      host.innerHTML = '';
+      return Promise.resolve();
+    }
+    var built = buildRoadmapKnowledgeMapMermaidSource(stages, detailPages, contentEl);
+    if (!built || !built.source) {
+      wrap.hidden = true;
+      host.innerHTML = '';
+      return Promise.resolve();
+    }
+    wrap.hidden = false;
+    host.className = 'mermaid roadmap-knowledge-map-mermaid';
+    host.textContent = built.source;
+    if (metaEl) {
+      metaEl.textContent = built.stageCount + ' 个 L 阶段 · ' + built.wikiCount + ' 个知识节点';
+    }
+    if (flowLink) {
+      var flowSection = document.getElementById('roadmap-flow');
+      var firstStageHref = findRoadmapStageHeadingId(stages[0], contentEl);
+      if (flowSection && !flowSection.hidden) {
+        flowLink.href = '#roadmap-flow';
+        flowLink.textContent = '展开阶段速览 →';
+      } else if (firstStageHref) {
+        flowLink.href = '#' + firstStageHref;
+        flowLink.textContent = '展开阶段详情 →';
+      } else {
+        flowLink.href = '#roadmap-content';
+        flowLink.textContent = '展开阶段详情 →';
+      }
+    }
+    return renderDetailMermaid(wrap).then(function () {
+      patchMermaidSvgLabelOverflow(wrap);
+      enhanceMermaidZoomTargets(wrap);
+      bindMermaidZoom(wrap);
+    });
+  }
+
   function renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages) {
     var flowRoot = document.getElementById('roadmapFlowMermaidRoot');
     var stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
@@ -4057,6 +4193,8 @@
       if (breadcrumb) removeLoadingState(breadcrumb);
       setRoadmapFlowChromeVisible(false);
       setRoadmapContentChromeVisible(false);
+      var knowledgeMapEmpty = document.getElementById('roadmapKnowledgeMapWrap');
+      if (knowledgeMapEmpty) knowledgeMapEmpty.hidden = true;
       var flowRootEmpty = document.getElementById('roadmapFlowMermaidRoot');
       if (flowRootEmpty) flowRootEmpty.innerHTML = '';
       var contentRootEmpty = document.getElementById('roadmapContent');
@@ -4130,6 +4268,7 @@
       });
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
     renderRoadmapMarkdownBody(roadmapPage, roadmapId, siteData, detailPages);
+    renderRoadmapKnowledgeMap(roadmapPage, detailPages, document.getElementById('roadmapContent'));
 
     var graphLink = document.getElementById('roadmapGraphLink');
     if (graphLink) {

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -58,6 +58,16 @@
             </div>
           </aside>
         </div>
+        <aside id="roadmapKnowledgeMapWrap" class="detail-mini-map roadmap-knowledge-map" aria-label="知识地图 L 阶段流程图" hidden>
+          <div class="detail-mini-map-head">
+            <h3>知识地图（L 阶段流程）</h3>
+            <span id="roadmapKnowledgeMapMeta" class="detail-mini-map-meta">正在生成分阶段流程图…</span>
+          </div>
+          <div id="roadmapKnowledgeMapMermaid" class="roadmap-knowledge-map-mermaid-host" aria-live="polite"></div>
+          <div class="detail-mini-map-foot">
+            <a id="roadmapKnowledgeMapFlowLink" class="detail-mini-map-all-link" href="#roadmap-content">展开阶段详情 →</a>
+          </div>
+        </aside>
       </div>
     </section>
 

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -58,12 +58,12 @@
             </div>
           </aside>
         </div>
-        <aside id="roadmapKnowledgeMapWrap" class="detail-mini-map roadmap-knowledge-map" aria-label="知识地图 L 阶段流程图" hidden>
+        <aside id="roadmapKnowledgeMapWrap" class="detail-mini-map roadmap-knowledge-map" aria-label="知识地图 L 阶段树状图" hidden>
           <div class="detail-mini-map-head">
-            <h3>知识地图（L 阶段流程）</h3>
-            <span id="roadmapKnowledgeMapMeta" class="detail-mini-map-meta">正在生成分阶段流程图…</span>
+            <h3>知识地图（L 阶段树）</h3>
+            <span id="roadmapKnowledgeMapMeta" class="detail-mini-map-meta">正在生成阶段树…</span>
           </div>
-          <div id="roadmapKnowledgeMapMermaid" class="roadmap-knowledge-map-mermaid-host" aria-live="polite"></div>
+          <div id="roadmapKnowledgeMapTree" class="roadmap-knowledge-map-tree-host" aria-live="polite"></div>
           <div class="detail-mini-map-foot">
             <a id="roadmapKnowledgeMapFlowLink" class="detail-mini-map-all-link" href="#roadmap-content">展开阶段详情 →</a>
           </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -2233,30 +2233,72 @@ button.home-wiki-heatmap-cell.is-active {
 .search-tier-heading.search-tier-exact { color:var(--accent, #1659b4); }
 .search-tier-heading .data-meta { font-weight:400; opacity:.75; margin-left:4px; }
 
-/* --- Roadmap hero: L-stage knowledge map (Mermaid flowchart) --- */
+/* --- Roadmap hero: L-stage knowledge map (tree / ubuntu tree style) --- */
 .roadmap-knowledge-map {
   margin-top: 0.25rem;
 }
-.roadmap-knowledge-map-mermaid-host {
+.roadmap-knowledge-map-tree-host {
   overflow-x: auto;
-  padding: 4px 0 8px;
-  min-height: 120px;
+  padding: 6px 4px 10px;
+  max-height: min(72vh, 640px);
+  overflow-y: auto;
 }
-.roadmap-knowledge-map-mermaid-host .mermaid {
+.rm-kmtree {
+  font-family: var(--font-mono, ui-monospace, "Cascadia Code", "Fira Code", Menlo, Consolas, monospace);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  min-width: min-content;
+}
+.rm-kmtree-row {
   display: flex;
-  justify-content: center;
-  margin: 0;
+  align-items: baseline;
+  gap: 0;
+  white-space: nowrap;
 }
-.roadmap-knowledge-map-mermaid-host svg {
-  max-width: none;
+.rm-kmtree-prefix {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  opacity: 0.72;
+  user-select: none;
 }
-.roadmap-knowledge-map-mermaid-host .node a {
-  color: inherit;
+.rm-kmtree-label {
+  flex: 0 0 auto;
+  min-width: 0;
   text-decoration: none;
 }
-.roadmap-knowledge-map-mermaid-host .node a:hover {
+.rm-kmtree-row--root .rm-kmtree-label {
+  font-weight: 600;
+  color: var(--text);
+}
+.rm-kmtree-row--stage .rm-kmtree-label {
+  font-weight: 600;
+}
+.rm-kmtree-row--stage[data-band="intro"] .rm-kmtree-label { color: #00d4ff; }
+.rm-kmtree-row--stage[data-band="foundation"] .rm-kmtree-label { color: #4ade80; }
+.rm-kmtree-row--stage[data-band="control"] .rm-kmtree-label { color: #fbbf24; }
+.rm-kmtree-row--stage[data-band="learning"] .rm-kmtree-label { color: #c084fc; }
+.rm-kmtree-row--stage[data-band="deploy"] .rm-kmtree-label { color: #38bdf8; }
+.rm-kmtree-row--stage[data-band="exit"] .rm-kmtree-label { color: #f87171; }
+.rm-kmtree-row--stage[data-band="default"] .rm-kmtree-label { color: var(--text); }
+.rm-kmtree-row--stage .rm-kmtree-label:hover,
+.rm-kmtree-row--wiki .rm-kmtree-label:hover {
   text-decoration: underline;
 }
+.rm-kmtree-row--wiki .rm-kmtree-label {
+  font-weight: 400;
+  color: var(--accent);
+}
+.rm-kmtree-row--empty .rm-kmtree-label {
+  font-weight: 400;
+  color: var(--text-muted);
+  font-style: italic;
+}
+[data-theme="light"] .rm-kmtree-row--stage[data-band="intro"] .rm-kmtree-label { color: #0e7490; }
+[data-theme="light"] .rm-kmtree-row--stage[data-band="foundation"] .rm-kmtree-label { color: #15803d; }
+[data-theme="light"] .rm-kmtree-row--stage[data-band="control"] .rm-kmtree-label { color: #b45309; }
+[data-theme="light"] .rm-kmtree-row--stage[data-band="learning"] .rm-kmtree-label { color: #7e22ce; }
+[data-theme="light"] .rm-kmtree-row--stage[data-band="deploy"] .rm-kmtree-label { color: #0369a1; }
+[data-theme="light"] .rm-kmtree-row--stage[data-band="exit"] .rm-kmtree-label { color: #b91c1c; }
 
 /* --- Roadmap page: vertical tree --- */
 .roadmap-flow-section {

--- a/docs/style.css
+++ b/docs/style.css
@@ -2233,6 +2233,31 @@ button.home-wiki-heatmap-cell.is-active {
 .search-tier-heading.search-tier-exact { color:var(--accent, #1659b4); }
 .search-tier-heading .data-meta { font-weight:400; opacity:.75; margin-left:4px; }
 
+/* --- Roadmap hero: L-stage knowledge map (Mermaid flowchart) --- */
+.roadmap-knowledge-map {
+  margin-top: 0.25rem;
+}
+.roadmap-knowledge-map-mermaid-host {
+  overflow-x: auto;
+  padding: 4px 0 8px;
+  min-height: 120px;
+}
+.roadmap-knowledge-map-mermaid-host .mermaid {
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+.roadmap-knowledge-map-mermaid-host svg {
+  max-width: none;
+}
+.roadmap-knowledge-map-mermaid-host .node a {
+  color: inherit;
+  text-decoration: none;
+}
+.roadmap-knowledge-map-mermaid-host .node a:hover {
+  text-decoration: underline;
+}
+
 /* --- Roadmap page: vertical tree --- */
 .roadmap-flow-section {
   padding-bottom: 0;

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -506,10 +506,11 @@ def parse_roadmap_stages(text: str, current_path: Path) -> List[Dict[str, Any]]:
         stages.append(current)
 
     for line in text.splitlines():
-        m = re.match(r"##\s+(L\d+(?:\.\d+)?)\s+(.+)", line.strip())
+        m = re.match(r"##\s+(L(?:[−\-]\d+|\d+(?:\.\d+)?))\s+(.+)", line.strip())
         if m:
             flush_current()
-            current = {"id": m.group(1).lower(), "title": m.group(2).strip()}
+            stage_id = m.group(1).lower().replace("−", "-")
+            current = {"id": stage_id, "title": m.group(2).strip()}
             section_lines = []
             continue
         if current:

--- a/tests/test_roadmap_hero_export.py
+++ b/tests/test_roadmap_hero_export.py
@@ -7,6 +7,7 @@ from export_minimal import (
     extract_labeled_bullets,
     extract_roadmap_hero,
     extract_summary,
+    parse_roadmap_stages,
     strip_labeled_section,
 )
 
@@ -47,6 +48,14 @@ class RoadmapHeroExportTests(unittest.TestCase):
         out = strip_labeled_section(sample.split("\n", 1)[1], ROADMAP_HERO_LABEL)
         self.assertNotIn("首屏导读", out)
         self.assertIn("**摘要**", out)
+
+    def test_parse_roadmap_stages_includes_l_minus_one(self) -> None:
+        stages = parse_roadmap_stages(self.text, MOTION_CONTROL)
+        ids = [stage["id"] for stage in stages]
+        self.assertEqual(ids[0], "l-1")
+        self.assertIn("l0", ids)
+        self.assertIn("l7", ids)
+        self.assertGreaterEqual(len(ids), 9)
 
 
 if __name__ == "__main__":

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -17,7 +17,7 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapMetaStages"',
             'id="roadmapFlowMermaidRoot"',
             'id="roadmapKnowledgeMapWrap"',
-            'id="roadmapKnowledgeMapMermaid"',
+            'id="roadmapKnowledgeMapTree"',
             'id="roadmapRelatedList"',
             'id="roadmapPaperRelatedList"',
             'id="roadmapContent"',
@@ -42,7 +42,8 @@ class RoadmapPageTests(unittest.TestCase):
             "bindSelftestMermaidRerender",
             "roadmap-stage-entry-embed",
             "renderRoadmapKnowledgeMap",
-            "buildRoadmapKnowledgeMapMermaidSource",
+            "buildRoadmapKnowledgeMapTreeHTML",
+            "rm-kmtree",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -16,6 +16,8 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapMetaUpdated"',
             'id="roadmapMetaStages"',
             'id="roadmapFlowMermaidRoot"',
+            'id="roadmapKnowledgeMapWrap"',
+            'id="roadmapKnowledgeMapMermaid"',
             'id="roadmapRelatedList"',
             'id="roadmapPaperRelatedList"',
             'id="roadmapContent"',
@@ -39,6 +41,8 @@ class RoadmapPageTests(unittest.TestCase):
             "findRoadmapStageEntryAnchor",
             "bindSelftestMermaidRerender",
             "roadmap-stage-entry-embed",
+            "renderRoadmapKnowledgeMap",
+            "buildRoadmapKnowledgeMapMermaidSource",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在 `roadmap.html` 详情页 hero 区新增「知识地图（L 阶段树）」，参考 detail 页知识地图位置，但**不使用 D3 节点图**，也**不用 Mermaid 方框流程图**，而是采用 **Ubuntu `tree` 命令风格**的垂直树状布局：

```
主路线：运动控制算法工程师成长路线
├── L−1 · 序言
│   ├── Modern Robotics
│   └── Locomotion
├── L0 · 数学与编程基础
│   ├── 线性代数
│   └── SE(3)
...
└── L7 · 出口
```

- L 阶段为父节点（按 L 带分色），每阶段下挂最多 3 个 `related_items` 知识子节点
- 使用 `├──` / `└──` / `│` 前缀 + 等宽字体，纵向展开
- 点击阶段 → 正文锚点；点击子节点 → 详情页

## 验证

- `make ci-preflight` 通过
- 本地 `roadmap.html?id=roadmap-motion-control` 树状图渲染正常

## 验证截图

![roadmap 知识地图 tree 布局](https://cursor.com/artifacts/c/art-d2f7bbd2-f914-40a7-9418-7dca2ebfbc4b)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61255735-207d-4c56-ac28-19d283b4c174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61255735-207d-4c56-ac28-19d283b4c174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

