### PR TITLE
feat(ux): 路线页新增按 L 等级串联的知识地图（tree 指令式流程图）

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2193,17 +2193,6 @@
     return '';
   }
 
-  /** L 等级徽标与配色：L0（冷蓝）→ L7（暖橙）的连续色阶，凸显不同 L 等级。 */
-  function roadmapKmapLevelMeta(stageId) {
-    var badge = String(stageId || '').toUpperCase() || '·';
-    var match = /(-?\d+)/.exec(String(stageId || ''));
-    if (match == null) return { badge: badge, color: 'var(--accent)' };
-    var lvl = parseInt(match[1], 10);
-    var t = Math.max(0, Math.min(7, lvl)) / 7;
-    var hue = Math.round(205 - t * 190);
-    return { badge: badge, color: 'hsl(' + hue + ', 66%, 52%)' };
-  }
-
   /**
    * 路线页「知识地图」：把各 L 阶段与其相关知识节点串成 tree 指令式竖向流程图。
    * 不用力导向节点图，风格对齐详情页知识地图面板；仅在含 ≥2 个阶段的路线（如主路线）出现。
@@ -2237,11 +2226,11 @@
       var title = String(stage.title || '');
       var related = Array.isArray(stage.related_items) ? stage.related_items : [];
       totalNodes += related.length;
-      var lvl = roadmapKmapLevelMeta(stage.id);
-      var chapterHref = '#' + slugifyHeading(lvl.badge + ' ' + title);
-      parts.push('<li class="roadmap-kmap-stage" style="--kmap-lvl-color:' + lvl.color + ';">');
+      var badge = String(stage.id || '').toUpperCase() || '·';
+      var chapterHref = '#' + slugifyHeading(badge + ' ' + title);
+      parts.push('<li class="roadmap-kmap-stage">');
       parts.push('<a class="roadmap-kmap-stage-head" href="' + escapeHtml(chapterHref) + '">');
-      parts.push('<span class="roadmap-kmap-badge">' + escapeHtml(lvl.badge) + '</span>');
+      parts.push('<span class="roadmap-kmap-badge">' + escapeHtml(badge) + '</span>');
       parts.push('<span class="roadmap-kmap-stage-title">' + escapeHtml(title) + '</span>');
       parts.push('<span class="roadmap-kmap-stage-count">' + escapeHtml(String(related.length)) + '</span>');
       parts.push('</a>');

--- a/docs/main.js
+++ b/docs/main.js
@@ -2157,6 +2157,134 @@
     syncRoadmapStagesMetaHref(roadmapPage);
   }
 
+  // 节点类型配色兜底：roadmap.html 未加载 graph-tooltip.js，需自带一份与图谱一致的类型色。
+  var ROADMAP_KMAP_TYPE_COLOR = {
+    concept: '#60a5fa', method: '#34d399', task: '#f472b6',
+    entity: '#fbbf24', comparison: '#c084fc', query: '#94a3b8',
+    formalization: '#fb923c', overview: '#64748b', reference: '#64748b',
+    roadmap: '#22d3ee', roadmap_page: '#22d3ee', '': '#64748b'
+  };
+
+  // 站内 path 前缀 → 图谱细粒度节点类型（与知识图谱 / 详情页知识地图同一套配色）。
+  var ROADMAP_KMAP_PATH_TYPE = [
+    ['wiki/concepts/', 'concept'],
+    ['wiki/methods/', 'method'],
+    ['wiki/tasks/', 'task'],
+    ['wiki/comparisons/', 'comparison'],
+    ['wiki/formalizations/', 'formalization'],
+    ['wiki/overviews/', 'overview'],
+    ['wiki/queries/', 'query'],
+    ['wiki/entities/', 'entity'],
+    ['roadmap/', 'roadmap']
+  ];
+
+  /** 从相关项的 path（回退到 id / 粗类型）推断细粒度节点类型，用于知识地图节点配色。 */
+  function roadmapKmapNodeType(page, id) {
+    var path = String((page && page.path) || '');
+    for (var i = 0; i < ROADMAP_KMAP_PATH_TYPE.length; i++) {
+      if (path.indexOf(ROADMAP_KMAP_PATH_TYPE[i][0]) !== -1) return ROADMAP_KMAP_PATH_TYPE[i][1];
+    }
+    var sid = String(id || '');
+    if (path.indexOf('references/') !== -1 || sid.indexOf('reference-') === 0) return 'reference';
+    if (sid.indexOf('entity-') === 0) return 'entity';
+    var coarse = (page && page.type) || '';
+    if (coarse === 'entity_page') return 'entity';
+    if (coarse === 'roadmap_page') return 'roadmap';
+    return '';
+  }
+
+  /** L 等级徽标与配色：L0（冷蓝）→ L7（暖橙）的连续色阶，凸显不同 L 等级。 */
+  function roadmapKmapLevelMeta(stageId) {
+    var badge = String(stageId || '').toUpperCase() || '·';
+    var match = /(-?\d+)/.exec(String(stageId || ''));
+    if (match == null) return { badge: badge, color: 'var(--accent)' };
+    var lvl = parseInt(match[1], 10);
+    var t = Math.max(0, Math.min(7, lvl)) / 7;
+    var hue = Math.round(205 - t * 190);
+    return { badge: badge, color: 'hsl(' + hue + ', 66%, 52%)' };
+  }
+
+  /**
+   * 路线页「知识地图」：把各 L 阶段与其相关知识节点串成 tree 指令式竖向流程图。
+   * 不用力导向节点图，风格对齐详情页知识地图面板；仅在含 ≥2 个阶段的路线（如主路线）出现。
+   */
+  function renderRoadmapKnowledgeMap(roadmapPage, roadmapId, detailPages) {
+    var wrap = document.getElementById('roadmapKnowledgeMapWrap');
+    var treeEl = document.getElementById('roadmapKnowledgeMapTree');
+    var metaEl = document.getElementById('roadmapKnowledgeMapMeta');
+    var graphLink = document.getElementById('roadmapKnowledgeMapGraphLink');
+    if (!wrap || !treeEl) return;
+    var stages = Array.isArray(roadmapPage.stages) ? roadmapPage.stages : [];
+    if (stages.length < 2) {
+      wrap.hidden = true;
+      treeEl.innerHTML = '';
+      return;
+    }
+    var typeColors =
+      (window.RNGraphTooltip && window.RNGraphTooltip.GRAPH_NODE_TYPE_COLOR) || ROADMAP_KMAP_TYPE_COLOR;
+    var typeLabelOf =
+      (window.RNWikiTypeLabels && window.RNWikiTypeLabels.formatChinese) || function () { return ''; };
+
+    var totalNodes = 0;
+    var parts = [];
+    parts.push('<div class="roadmap-kmap-root">');
+    parts.push('<span class="roadmap-kmap-root-icon" aria-hidden="true">🚀</span>');
+    parts.push('<span class="roadmap-kmap-root-label">' + escapeHtml(roadmapPage.title || roadmapId) + '</span>');
+    parts.push('</div>');
+    parts.push('<ul class="roadmap-kmap-tree">');
+    for (var s = 0; s < stages.length; s++) {
+      var stage = stages[s];
+      var title = String(stage.title || '');
+      var related = Array.isArray(stage.related_items) ? stage.related_items : [];
+      totalNodes += related.length;
+      var lvl = roadmapKmapLevelMeta(stage.id);
+      var chapterHref = '#' + slugifyHeading(lvl.badge + ' ' + title);
+      parts.push('<li class="roadmap-kmap-stage" style="--kmap-lvl-color:' + lvl.color + ';">');
+      parts.push('<a class="roadmap-kmap-stage-head" href="' + escapeHtml(chapterHref) + '">');
+      parts.push('<span class="roadmap-kmap-badge">' + escapeHtml(lvl.badge) + '</span>');
+      parts.push('<span class="roadmap-kmap-stage-title">' + escapeHtml(title) + '</span>');
+      parts.push('<span class="roadmap-kmap-stage-count">' + escapeHtml(String(related.length)) + '</span>');
+      parts.push('</a>');
+      if (related.length) {
+        parts.push('<ul class="roadmap-kmap-leaves">');
+        for (var k = 0; k < related.length; k++) {
+          var rid = related[k];
+          var page = detailPages[rid] || {};
+          var href = page.type === 'roadmap_page' ? roadmapHref(rid) : detailHref(rid);
+          var nodeType = roadmapKmapNodeType(page, rid);
+          var color = typeColors[nodeType] || typeColors[''] || '#64748b';
+          var typeLabel = typeLabelOf(nodeType);
+          var tip = typeLabel + (page.summary ? ' · ' + page.summary : '');
+          parts.push('<li class="roadmap-kmap-leaf">');
+          parts.push(
+            '<a class="roadmap-kmap-leaf-a" href="' + escapeHtml(href) + '"' +
+              (tip ? ' title="' + escapeHtml(tip) + '"' : '') + '>'
+          );
+          parts.push('<span class="roadmap-kmap-dot" style="background:' + color + ';" aria-hidden="true"></span>');
+          parts.push('<span class="roadmap-kmap-leaf-label">' + escapeHtml(page.title || rid) + '</span>');
+          if (typeLabel) {
+            parts.push('<span class="roadmap-kmap-leaf-type">' + escapeHtml(typeLabel) + '</span>');
+          }
+          parts.push('</a>');
+          parts.push('</li>');
+        }
+        parts.push('</ul>');
+      }
+      parts.push('</li>');
+    }
+    parts.push('</ul>');
+    treeEl.innerHTML = parts.join('');
+
+    if (metaEl) metaEl.textContent = stages.length + ' 个阶段 · ' + totalNodes + ' 个知识节点';
+    if (graphLink) {
+      var roadmapDetail = detailPages[roadmapId] || {};
+      var focus = roadmapDetail.path || roadmapPage.path || roadmapPage.id || roadmapId;
+      graphLink.href = 'graph.html?focus=' + encodeURIComponent(focus);
+      graphLink.hidden = false;
+    }
+    wrap.hidden = false;
+  }
+
   function renderDetailMath(container) {
     if (!container || typeof window.renderMathInElement !== 'function') return;
     window.renderMathInElement(container, {
@@ -4129,6 +4257,7 @@
         renderInternalLinks(paperRelatedEl, [], detailPages, hubErr);
       });
     renderRoadmapFlowSection(roadmapPage, roadmapId, detailPages);
+    renderRoadmapKnowledgeMap(roadmapPage, roadmapId, detailPages);
     renderRoadmapMarkdownBody(roadmapPage, roadmapId, siteData, detailPages);
 
     var graphLink = document.getElementById('roadmapGraphLink');

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -58,6 +58,16 @@
             </div>
           </aside>
         </div>
+        <aside id="roadmapKnowledgeMapWrap" class="detail-mini-map roadmap-kmap-wrap" aria-label="知识地图：按 L 等级串联的路线节点" hidden>
+          <div class="detail-mini-map-head">
+            <h3>知识地图</h3>
+            <span id="roadmapKnowledgeMapMeta" class="detail-mini-map-meta">正在读取路线节点…</span>
+          </div>
+          <div id="roadmapKnowledgeMapTree" class="roadmap-kmap" role="tree" aria-label="按 L 等级串联的路线知识节点"></div>
+          <div class="detail-mini-map-foot">
+            <a id="roadmapKnowledgeMapGraphLink" class="detail-mini-map-all-link" href="graph.html" hidden>在知识图谱中查看 →</a>
+          </div>
+        </aside>
       </div>
     </section>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -2472,7 +2472,8 @@ button.home-wiki-heatmap-cell.is-active {
   height: 1.3rem;
   padding: 0 0.4rem;
   border-radius: 6px;
-  background: var(--kmap-lvl-color, var(--accent));
+  /* 各 L 等级统一强调色：靠 L0…L7 数字区分层级，让类型色圆点成为唯一语义色 */
+  background: hsl(205, 66%, 48%);
   color: #fff;
   font-size: 0.72rem;
   font-weight: 700;

--- a/docs/style.css
+++ b/docs/style.css
@@ -2371,6 +2371,157 @@ button.home-wiki-heatmap-cell.is-active {
       var(--roadmap-vtree-summary-gap, 0.5rem)
   );
 }
+
+/* ── 路线页「知识地图」：按 L 等级串联的 tree 指令式竖向流程图 ──
+   复用详情页知识地图面板外框（.detail-mini-map），内部为带连接线的树，
+   节点=类型配色圆点+链接，不用力导向节点图。 */
+.roadmap-kmap-wrap {
+  margin-top: 4px;
+  /* hero 是 grid：item 默认 min-width:auto 会被树的 min-content 撑破容器，须允许收缩 */
+  min-width: 0;
+}
+.roadmap-kmap {
+  --kmap-line: var(--border-strong, var(--border));
+  --kmap-indent: 1.3rem;
+  --kmap-row: 1.95rem;
+  --kmap-stub: 0.55rem;
+  background: var(--bg);
+  border-radius: 8px;
+  padding: 12px 16px 14px;
+  max-height: 460px;
+  overflow: auto;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+.roadmap-kmap-root {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: var(--kmap-row);
+  font-weight: 700;
+  font-size: 0.98rem;
+}
+.roadmap-kmap-root-icon {
+  font-size: 1.05rem;
+}
+.roadmap-kmap-root-label {
+  min-width: 0;
+  word-break: break-word;
+}
+.roadmap-kmap-tree,
+.roadmap-kmap-leaves {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 var(--kmap-indent);
+}
+/* tree 连接线：竖线 │ + 拐角横线 ├─ / └─（末项竖线只画到拐角） */
+.roadmap-kmap-stage,
+.roadmap-kmap-leaf {
+  position: relative;
+}
+.roadmap-kmap-stage::before,
+.roadmap-kmap-leaf::before {
+  content: "";
+  position: absolute;
+  left: calc(-1 * var(--kmap-indent) + var(--kmap-stub));
+  top: 0;
+  height: 100%;
+  border-left: 1.5px solid var(--kmap-line);
+}
+.roadmap-kmap-stage:last-child::before,
+.roadmap-kmap-leaf:last-child::before {
+  height: calc(var(--kmap-row) / 2);
+}
+.roadmap-kmap-stage::after,
+.roadmap-kmap-leaf::after {
+  content: "";
+  position: absolute;
+  left: calc(-1 * var(--kmap-indent) + var(--kmap-stub));
+  top: calc(var(--kmap-row) / 2);
+  width: calc(var(--kmap-indent) - var(--kmap-stub) - 0.35rem);
+  border-top: 1.5px solid var(--kmap-line);
+}
+.roadmap-kmap-stage-head,
+.roadmap-kmap-leaf-a {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: var(--kmap-row);
+  padding: 0 0.4rem;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--text);
+}
+.roadmap-kmap-stage-head {
+  font-weight: 600;
+}
+.roadmap-kmap-stage-head:hover,
+.roadmap-kmap-leaf-a:hover {
+  background: var(--bg-alt);
+}
+.roadmap-kmap-stage-head:hover .roadmap-kmap-stage-title,
+.roadmap-kmap-leaf-a:hover .roadmap-kmap-leaf-label {
+  color: var(--accent);
+}
+.roadmap-kmap-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.15rem;
+  height: 1.3rem;
+  padding: 0 0.4rem;
+  border-radius: 6px;
+  background: var(--kmap-lvl-color, var(--accent));
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.roadmap-kmap-stage-title {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+.roadmap-kmap-stage-count {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-alt);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+.roadmap-kmap-dot {
+  flex-shrink: 0;
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--bg);
+}
+.roadmap-kmap-leaf-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roadmap-kmap-leaf-type {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+@media (max-width: 640px) {
+  .roadmap-kmap {
+    --kmap-indent: 1.1rem;
+    max-height: 380px;
+    font-size: 0.86rem;
+  }
+  .roadmap-kmap-leaf-type {
+    display: none;
+  }
+}
+
 /* 嵌入正文各 L 章节下的单阶段「速览」块（与顶部整块二选一） */
 .roadmap-stage-embed-wrap {
   margin: 12px 0 22px;


### PR DESCRIPTION
在 roadmap 详情页 hero 区新增「知识地图」面板，参考详情页知识地图面板风格，
但以 ubuntu tree 指令式竖向树状流程图取代力导向节点图：以各 L 阶段为一级目录、
阶段相关知识节点为叶子，用 │ ├─ └─ 连接线串联；节点按图谱类型配色，
阶段徽标按 L 等级冷→暖渐变凸显不同等级；点击阶段标题跳转正文对应 L 章节。
仅在含 ≥2 阶段的路线（主路线）显示；深浅色与移动端均已适配。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015rc4qshdyCY9nNEFR7RN6L