### PR TITLE
fix(ux): 路线图页面误走 detail.html 时自动重定向

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1891,6 +1891,16 @@
     return sid.toUpperCase();
   }
 
+  /** 路线正文时间线左侧节点：L0 / S0 等层级徽标，无匹配则返回空串（显示圆点）。 */
+  function parseRoadmapTimelineNodeLabel(headingText) {
+    var text = String(headingText || '').trim();
+    var layerMatch = /^\s*(L\s*[−–-]?\s*\d+(?:\.\d+)?)/.exec(text);
+    if (layerMatch) return layerMatch[1].replace(/\s+/g, '');
+    var stageMatch = /^\s*Stage\s+(\d+)/i.exec(text);
+    if (stageMatch) return 'S' + stageMatch[1];
+    return '';
+  }
+
   function buildRoadmapStageRowHTML(stage, index, roadmapId, detailPages, options) {
     var opts = options || {};
     var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
@@ -2029,10 +2039,10 @@
       node.className = 'roadmap-timeline-node';
       node.setAttribute('aria-hidden', 'true');
       var h2 = sections[i].querySelector(':scope > summary > h2');
-      var stageMatch = /^\s*(L\s*[−–-]?\s*\d+(?:\.\d+)?)/.exec((h2 && h2.textContent) || '');
-      if (stageMatch) {
+      var timelineLabel = parseRoadmapTimelineNodeLabel((h2 && h2.textContent) || '');
+      if (timelineLabel) {
         node.classList.add('roadmap-timeline-node-stage');
-        node.textContent = stageMatch[1].replace(/\s+/g, '');
+        node.textContent = timelineLabel;
       } else {
         node.classList.add('roadmap-timeline-node-dot');
       }
@@ -2222,6 +2232,23 @@
    * 路线页「知识地图」：把各 L 阶段与其相关知识节点串成 tree 指令式竖向流程图。
    * 不用力导向节点图，风格对齐详情页知识地图面板；仅在含 ≥2 个阶段的路线（如主路线）出现。
    */
+  function collectDepthBranchRoadmaps(roadmapPage, detailPages) {
+    var out = [];
+    var seen = {};
+    var related = Array.isArray(roadmapPage.related_items) ? roadmapPage.related_items : [];
+    var i;
+    for (i = 0; i < related.length; i++) {
+      var rid = related[i];
+      if (seen[rid]) continue;
+      var page = detailPages[rid] || {};
+      if (page.type !== 'roadmap_page') continue;
+      if (String(rid).indexOf('roadmap-depth-') !== 0) continue;
+      seen[rid] = true;
+      out.push(rid);
+    }
+    return out;
+  }
+
   function renderRoadmapKnowledgeMap(roadmapPage, roadmapId, detailPages) {
     var wrap = document.getElementById('roadmapKnowledgeMapWrap');
     var treeEl = document.getElementById('roadmapKnowledgeMapTree');
@@ -2286,10 +2313,48 @@
       }
       parts.push('</li>');
     }
+    var depthBranches = roadmapId === 'roadmap-motion-control'
+      ? collectDepthBranchRoadmaps(roadmapPage, detailPages)
+      : [];
+    var stageCount = stages.length;
+    if (depthBranches.length) {
+      stageCount += 1;
+      totalNodes += depthBranches.length;
+      parts.push('<li class="roadmap-kmap-stage roadmap-kmap-stage-depth">');
+      parts.push('<a class="roadmap-kmap-stage-head" href="#depth-optional-index">');
+      parts.push('<span class="roadmap-kmap-badge">纵深</span>');
+      parts.push('<span class="roadmap-kmap-stage-title">可选纵深路线</span>');
+      parts.push('<span class="roadmap-kmap-stage-count">' + escapeHtml(String(depthBranches.length)) + '</span>');
+      parts.push('</a>');
+      parts.push('<ul class="roadmap-kmap-leaves">');
+      for (var d = 0; d < depthBranches.length; d++) {
+        var depthId = depthBranches[d];
+        var depthPage = detailPages[depthId] || {};
+        var depthHref = roadmapHref(depthId);
+        var depthType = roadmapKmapNodeType(depthPage, depthId);
+        var depthColor = typeColors[depthType] || typeColors[''] || '#64748b';
+        var depthTypeLabel = typeLabelOf(depthType);
+        var depthTip = depthTypeLabel + (depthPage.summary ? ' · ' + depthPage.summary : '');
+        parts.push('<li class="roadmap-kmap-leaf">');
+        parts.push(
+          '<a class="roadmap-kmap-leaf-a" href="' + escapeHtml(depthHref) + '"' +
+            (depthTip ? ' title="' + escapeHtml(depthTip) + '"' : '') + '>'
+        );
+        parts.push('<span class="roadmap-kmap-dot" style="background:' + depthColor + ';" aria-hidden="true"></span>');
+        parts.push('<span class="roadmap-kmap-leaf-label">' + escapeHtml(depthPage.title || depthId) + '</span>');
+        if (depthTypeLabel) {
+          parts.push('<span class="roadmap-kmap-leaf-type">' + escapeHtml(depthTypeLabel) + '</span>');
+        }
+        parts.push('</a>');
+        parts.push('</li>');
+      }
+      parts.push('</ul>');
+      parts.push('</li>');
+    }
     parts.push('</ul>');
     treeEl.innerHTML = parts.join('');
 
-    if (metaEl) metaEl.textContent = stages.length + ' 个阶段 · ' + totalNodes + ' 个知识节点';
+    if (metaEl) metaEl.textContent = stageCount + ' 个阶段 · ' + totalNodes + ' 个知识节点';
     if (graphLink) {
       var roadmapDetail = detailPages[roadmapId] || {};
       var focus = roadmapDetail.path || roadmapPage.path || roadmapPage.id || roadmapId;

--- a/docs/main.js
+++ b/docs/main.js
@@ -253,6 +253,24 @@
     return 'detail.html?id=' + encodeURIComponent(id);
   }
 
+  function pageHref(id, detailPages) {
+    if (!id) return '';
+    var page = detailPages && detailPages[id];
+    if (page && page.type === 'roadmap_page') return roadmapHref(id);
+    return detailHref(id);
+  }
+
+  function isRoadmapPageId(id, detailPages, hints) {
+    if (!id) return false;
+    var page = detailPages && detailPages[id];
+    if (page && page.type === 'roadmap_page') return true;
+    var hint = hints || {};
+    if (hint.type === 'roadmap_page') return true;
+    if (hint.page_type === 'roadmap') return true;
+    var path = hint.path || id;
+    return String(path).indexOf('roadmap/') === 0 || String(id).indexOf('roadmap-') === 0;
+  }
+
   // 首页热门主题 chips：数据来自 home-stats.json 的 top_communities（图谱社区规模 Top-N，
   // 随 make graph 演化）；数据缺席时保留 index.html 内的静态兜底 chips 不动
   function renderHotTopics(homeStats) {
@@ -3193,16 +3211,24 @@
     return raw || '';
   }
 
-  function buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId) {
+  function buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId, detailPages) {
     var summary = formatGraphTooltipSummary(d.summary);
     var communityColor = d.community ? nodeFill(d) : '';
     var linkHtml;
     if (d.isCurrent) {
       linkHtml = '<div class="tt-summary">当前页面</div>';
     } else {
-      var pid = pathToId[d.id];
-      var href = pid ? detailHref(pid) : ('graph.html?focus=' + encodeURIComponent(d.id));
-      var linkText = pid ? '打开详情页 →' : '在完整图谱中查看 →';
+      var pid = pathToId[d.id] || d.detail_id;
+      var href;
+      var linkText;
+      if (pid) {
+        var roadmapNode = isRoadmapPageId(pid, detailPages, { type: d.type, path: d.id });
+        href = roadmapNode ? roadmapHref(pid) : detailHref(pid);
+        linkText = roadmapNode ? '打开路线页 →' : '打开详情页 →';
+      } else {
+        href = 'graph.html?focus=' + encodeURIComponent(d.id);
+        linkText = '在完整图谱中查看 →';
+      }
       linkHtml = '<a class="tt-link" href="' + escapeHtml(href) + '">' + escapeHtml(linkText) + '</a>';
     }
     if (window.RNGraphTooltip && window.RNGraphTooltip.buildNodeTooltipHtml) {
@@ -3710,20 +3736,20 @@
               hoverTip.clearPin();
               hoverTip.hide();
             } else {
-              hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId));
+              hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId, detailPages));
             }
             return;
           }
           if (d.isCurrent) return;
-          var pid = pathToId[d.id];
-          if (pid) window.location.href = detailHref(pid);
+          var pid = pathToId[d.id] || d.detail_id;
+          if (pid) window.location.href = pageHref(pid, detailPages);
         })
         .on('mouseenter', function (ev, d) {
           if (hoverTip.isMobile) return;
           window.d3.select(this).select('circle')
             .attr('fill-opacity', 1)
             .attr('r', function (node) { return detailMiniNodeRadius(node, 1.3); });
-          hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId));
+          hoverTip.show(ev, d, buildGraphNodeTooltipHtml(d, nodeFill, communityLabelMap, pathToId, detailPages));
         })
         .on('mousemove', function (ev) {
           if (hoverTip.isMobile && hoverTip.getPinned()) return;
@@ -3802,6 +3828,13 @@
     const params = new URLSearchParams(window.location.search);
     const detailId = params.get('id') || '';
     const detailPage = resolveDetailPage(detailId, detailPages);
+
+    if (detailPage && detailPage.type === 'roadmap_page') {
+      var roadmapTarget = roadmapHref(detailId);
+      if (window.location.hash) roadmapTarget += window.location.hash;
+      window.location.replace(roadmapTarget);
+      return;
+    }
 
     const titleEl = document.getElementById('detailTitle');
     const summaryEl = document.getElementById('detailSummary');
@@ -5162,7 +5195,10 @@
     }
 
     function buildResultCardHtml(item, queryTokens) {
-      var detailUrl = 'detail.html?id=' + encodeURIComponent(item.id);
+      var resultId = item.id;
+      var detailUrl = isRoadmapPageId(resultId, null, item)
+        ? roadmapHref(resultId)
+        : ('detail.html?id=' + encodeURIComponent(resultId));
       var graphUrl = 'graph.html?focus=' + encodeURIComponent(item.id);
       var typeLabel = wikiTypeLabel(item.page_type, 'node');
       if (!typeLabel && item.path) {

--- a/docs/main.js
+++ b/docs/main.js
@@ -1884,6 +1884,13 @@
    * One roadmap stage row (li > details): related wiki / roadmap links.
    * Used by the vertical tree and by per-L–chapter embeds on roadmap pages.
    */
+  function formatRoadmapStageBadge(stageId) {
+    var sid = String(stageId || '').toLowerCase();
+    var stageNum = /^stage-(\d+)$/.exec(sid);
+    if (stageNum) return 'S' + stageNum[1];
+    return sid.toUpperCase();
+  }
+
   function buildRoadmapStageRowHTML(stage, index, roadmapId, detailPages, options) {
     var opts = options || {};
     var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
@@ -1902,7 +1909,7 @@
       parts.push('<span class="roadmap-vtree-step" aria-hidden="true">' + escapeHtml(String(index + 1)) + '</span>');
     }
     parts.push(
-      '<span class="roadmap-vtree-heading">' + escapeHtml(sid.toUpperCase() + ' · ' + title) + '</span>'
+      '<span class="roadmap-vtree-heading">' + escapeHtml(formatRoadmapStageBadge(sid) + ' · ' + title) + '</span>'
     );
     parts.push('<span class="roadmap-vtree-count">' + escapeHtml(String(related.length)) + ' 条</span>');
     parts.push('</summary>');
@@ -2244,8 +2251,8 @@
       var title = String(stage.title || '');
       var related = Array.isArray(stage.related_items) ? stage.related_items : [];
       totalNodes += related.length;
-      var badge = String(stage.id || '').toUpperCase() || '·';
-      var chapterHref = '#' + slugifyHeading(badge + ' ' + title);
+      var badge = formatRoadmapStageBadge(stage.id) || '·';
+      var chapterHref = '#' + slugifyHeading(stage.heading || (badge + ' ' + title));
       parts.push('<li class="roadmap-kmap-stage">');
       parts.push('<a class="roadmap-kmap-stage-head" href="' + escapeHtml(chapterHref) + '">');
       parts.push('<span class="roadmap-kmap-badge">' + escapeHtml(badge) + '</span>');

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -506,10 +506,27 @@ def parse_roadmap_stages(text: str, current_path: Path) -> List[Dict[str, Any]]:
         stages.append(current)
 
     for line in text.splitlines():
-        m = re.match(r"##\s+(L\d+(?:\.\d+)?)\s+(.+)", line.strip())
-        if m:
+        stripped = line.strip()
+        stage_match = re.match(r"##\s+Stage\s+(\d+)\s+(.+)", stripped, re.IGNORECASE)
+        layer_match = re.match(r"##\s+(L\d+(?:\.\d+)?)\s+(.+)", stripped)
+        if stage_match:
             flush_current()
-            current = {"id": m.group(1).lower(), "title": m.group(2).strip()}
+            stage_num = stage_match.group(1)
+            title = stage_match.group(2).strip()
+            current = {
+                "id": f"stage-{stage_num}",
+                "title": title,
+                "heading": stripped[3:].strip(),
+            }
+            section_lines = []
+            continue
+        if layer_match:
+            flush_current()
+            current = {
+                "id": layer_match.group(1).lower(),
+                "title": layer_match.group(2).strip(),
+                "heading": stripped[3:].strip(),
+            }
             section_lines = []
             continue
         if current:

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -961,6 +961,17 @@ def generate_sitemap(
             }
         )
 
+    roadmap_page_items = [item for item in items if item.get("type") == "roadmap_page"]
+    for item in roadmap_page_items:
+        item_id = item.get("id", "")
+        urls.append(
+            {
+                "loc": f"{base_url}/docs/roadmap.html?id={item_id}",
+                "priority": "0.8",
+                "changefreq": "monthly",
+            }
+        )
+
     sitemap_lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',

--- a/tests/test_detail_page.py
+++ b/tests/test_detail_page.py
@@ -36,6 +36,12 @@ class DetailPageScaffoldTests(unittest.TestCase):
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
 
+    def test_detail_page_redirects_roadmap_pages_to_roadmap_html(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("detailPage.type === 'roadmap_page'", content)
+        self.assertIn("window.location.replace(roadmapTarget)", content)
+        self.assertIn("function pageHref", content)
+
     def test_institution_badges_link_to_graph_institution_filter(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         self.assertIn("graph.html?institution=", content)

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -43,6 +43,11 @@ class RoadmapPageTests(unittest.TestCase):
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
 
+    def test_search_results_link_roadmap_pages_to_roadmap_html(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("isRoadmapPageId(resultId, null, item)", content)
+        self.assertIn("roadmapHref(resultId)", content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -48,6 +48,17 @@ class RoadmapPageTests(unittest.TestCase):
         self.assertIn("isRoadmapPageId(resultId, null, item)", content)
         self.assertIn("roadmapHref(resultId)", content)
 
+    def test_timeline_shows_stage_labels_for_depth_roadmaps(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("function parseRoadmapTimelineNodeLabel", content)
+        self.assertIn("Stage\\s+(\\d+)", content)
+
+    def test_main_roadmap_knowledge_map_includes_depth_branches(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("function collectDepthBranchRoadmaps", content)
+        self.assertIn("roadmap-kmap-stage-depth", content)
+        self.assertIn("#depth-optional-index", content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_roadmap_stages_export.py
+++ b/tests/test_roadmap_stages_export.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+from export_minimal import ROOT, parse_roadmap_stages
+
+MOTION_CONTROL = ROOT / "roadmap" / "motion-control.md"
+DEPTH_SAFE_CONTROL = ROOT / "roadmap" / "depth-safe-control.md"
+DEPTH_RL_LOCOMOTION = ROOT / "roadmap" / "depth-rl-locomotion.md"
+
+
+class RoadmapStagesExportTests(unittest.TestCase):
+    def test_motion_control_parses_layer_stages(self) -> None:
+        stages = parse_roadmap_stages(MOTION_CONTROL.read_text(encoding="utf-8"), MOTION_CONTROL)
+        self.assertGreaterEqual(len(stages), 8)
+        self.assertEqual(stages[0]["id"], "l0")
+        self.assertIn("heading", stages[0])
+        self.assertIn("数学与编程基础", stages[0]["heading"])
+
+    def test_depth_safe_control_parses_stage_sections(self) -> None:
+        stages = parse_roadmap_stages(DEPTH_SAFE_CONTROL.read_text(encoding="utf-8"), DEPTH_SAFE_CONTROL)
+        self.assertEqual(len(stages), 4)
+        self.assertEqual(stages[0]["id"], "stage-0")
+        self.assertEqual(stages[-1]["id"], "stage-3")
+        self.assertGreater(len(stages[1].get("related_items", [])), 0)
+
+    def test_depth_rl_locomotion_parses_six_stages(self) -> None:
+        stages = parse_roadmap_stages(DEPTH_RL_LOCOMOTION.read_text(encoding="utf-8"), DEPTH_RL_LOCOMOTION)
+        self.assertEqual(len(stages), 6)
+        self.assertEqual(stages[0]["id"], "stage-0")
+        self.assertEqual(stages[-1]["id"], "stage-5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roadmap_stages_export.py
+++ b/tests/test_roadmap_stages_export.py
@@ -1,5 +1,4 @@
 import unittest
-from pathlib import Path
 
 from export_minimal import ROOT, parse_roadmap_stages
 

--- a/tests/test_roadmap_stages_export.py
+++ b/tests/test_roadmap_stages_export.py
@@ -16,14 +16,18 @@ class RoadmapStagesExportTests(unittest.TestCase):
         self.assertIn("数学与编程基础", stages[0]["heading"])
 
     def test_depth_safe_control_parses_stage_sections(self) -> None:
-        stages = parse_roadmap_stages(DEPTH_SAFE_CONTROL.read_text(encoding="utf-8"), DEPTH_SAFE_CONTROL)
+        stages = parse_roadmap_stages(
+            DEPTH_SAFE_CONTROL.read_text(encoding="utf-8"), DEPTH_SAFE_CONTROL
+        )
         self.assertEqual(len(stages), 4)
         self.assertEqual(stages[0]["id"], "stage-0")
         self.assertEqual(stages[-1]["id"], "stage-3")
         self.assertGreater(len(stages[1].get("related_items", [])), 0)
 
     def test_depth_rl_locomotion_parses_six_stages(self) -> None:
-        stages = parse_roadmap_stages(DEPTH_RL_LOCOMOTION.read_text(encoding="utf-8"), DEPTH_RL_LOCOMOTION)
+        stages = parse_roadmap_stages(
+            DEPTH_RL_LOCOMOTION.read_text(encoding="utf-8"), DEPTH_RL_LOCOMOTION
+        )
         self.assertEqual(len(stages), 6)
         self.assertEqual(stages[0]["id"], "stage-0")
         self.assertEqual(stages[-1]["id"], "stage-5")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- **CI 修复**：移除 `tests/test_roadmap_stages_export.py` 未使用的 `Path` 导入（Ruff F401）；对该文件执行 `ruff format`（Ruff format check 失败）。
- **纵深路线时间线**：`parseRoadmapTimelineNodeLabel` 识别 `## Stage N` 标题，正文时间线左侧显示 S0/S1… 徽标。
- **主路线纵深连接**：知识地图新增「纵深 · 可选纵深路线」分支，固定展示全部 4 条 `roadmap-depth-*` 页面。
- **路由修复**：`detail.html?id=roadmap-...` 自动重定向到 `roadmap.html`；搜索/迷你图谱链接同步修正；`parse_roadmap_stages` 支持 `## Stage N` 格式。

## 验证
- `make ci-test` 本地通过（291 tests）
- GitHub Actions Tests / Wiki Lint / Search & Export Quality Check 均已绿

## 验证截图
![主路线知识地图纵深分支](https://cursor.com/artifacts/c/art-c22afcbc-6af2-435a-8c9e-7e346accad30)
![纵深路线正文时间线 Stage 标签](https://cursor.com/artifacts/c/art-3882ae27-00d0-44d0-98be-a446f750ab91)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6478e9e-7eae-4837-982c-46bc2022ea11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6478e9e-7eae-4837-982c-46bc2022ea11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

