### PR TITLE
fix(ux): 移动端图谱 focus 入口改用底部浮窗

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -633,6 +633,16 @@
       }
     }
 
+    /* 触屏设备：节点详情用底部固定浮窗，不展示右侧侧边栏 */
+    @media (hover: none) and (pointer: coarse) {
+      #graph-sidebar {
+        display: none !important;
+      }
+      #graph-wrap.sidebar-open {
+        right: 0 !important;
+      }
+    }
+
     @media (max-width: 480px) {
       #graph-search {
         width: 90px;
@@ -4526,6 +4536,18 @@
 
     sbClose.addEventListener('click', closeSidebar);
 
+    /** 展示节点详情：PC 用右侧侧栏，触屏用底部固定浮窗 */
+    function presentNodeDetail(d, ev) {
+      if (!d) return;
+      if (isMobile) {
+        pinnedNode = d;
+        showTooltip(ev || null, d);
+        syncGraph3DMobileHighlight(d);
+        return;
+      }
+      openSidebar(d);
+    }
+
     function dismissMobilePinnedTooltip() {
       if (!isMobile || !pinnedNode) return false;
       pinnedNode = null;
@@ -4630,7 +4652,7 @@
         const flyToFocus = () => {
           if (is3DView() && graph3dView) {
             graph3dView.focusNode(focusNode);
-            openSidebar(focusNode);
+            presentNodeDetail(focusNode);
             return;
           }
           if (focusNode.x == null) return;
@@ -4641,7 +4663,7 @@
               .translate(W / 2 - scale * focusNode.x, H / 2 - scale * focusNode.y)
               .scale(scale)
           );
-          openSidebar(focusNode);
+          presentNodeDetail(focusNode);
         };
         simulation.on('end.focus', () => { flyToFocus(); simulation.on('end.focus', null); });
         setTimeout(flyToFocus, 1400);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

从详情页点击「查看全部邻居」或「在图谱中查看」会跳转到 `graph.html?focus=...`。此前该入口在触屏设备上仍会打开右侧节点侧边栏，与移动端「点击节点 → 底部固定浮窗」的交互不一致。

本次改动：
- 新增 `presentNodeDetail()`：触屏走底部 `tt-pinned` 浮窗，桌面端仍用右侧侧栏
- `?focus=` 路由改为调用 `presentNodeDetail()`，不再在移动端调用 `openSidebar()`
- 触屏 CSS 兜底：隐藏 `#graph-sidebar`，避免画布被 `sidebar-open` 挤压

## 验证

- Puppeteer 模拟 iPhone 视口访问 `graph.html?focus=wiki/concepts/sim2real.md`：
  - `sidebarOpen: false`，`sidebarDisplay: none`
  - `tooltipPinned: true`，`tooltipBottom: 20px`
- 仅改动 `docs/graph.html`，未涉及 wiki / 派生索引，无需 `make ci-preflight`

## 验证截图

![移动端 focus 入口显示底部浮窗而非侧边栏](https://cursor.com/artifacts/c/art-b0d9d5ee-3488-4b97-9e05-678d7db3b8a8)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d173c91c-ae1c-42d3-ad3d-37d733c39727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d173c91c-ae1c-42d3-ad3d-37d733c39727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

