### PR TITLE
统一详情页关联区块为首页紧凑行列表风格

### DIFF
--- a/docs/detail.html
+++ b/docs/detail.html
@@ -131,28 +131,28 @@
               </div>
               <div id="detailRelatedCommunityDistBars" class="related-community-dist-bars"></div>
             </div>
-            <div id="detailRelatedList" class="card-grid data-loading">
-              <article class="card skeleton-card"><p>正在读取关联项…</p></article>
+            <div id="detailRelatedList" class="detail-compact-mount data-loading">
+              <p class="data-meta">正在读取关联项…</p>
             </div>
           </section>
 
           <section class="section" id="detail-recent-ingest-section" style="padding: 40px 0;" hidden>
             <h2 class="section-title">最近相关 ingest</h2>
             <p class="section-subtitle">与本页相关、最近 30 天内入库的页面（按入库时间倒序，最多 6 项）。</p>
-            <div id="detailRecentIngestTimeline" class="detail-recent-ingest-timeline"></div>
+            <div id="detailRecentIngestTimeline" class="detail-compact-mount"></div>
           </section>
 
           <section class="section" id="detail-recommended" style="padding: 40px 0;">
             <h2 class="section-title">相关推荐</h2>
-            <div id="detailRecommendedList" class="card-grid data-loading">
-              <article class="card skeleton-card"><p>正在计算相关推荐…</p></article>
+            <div id="detailRecommendedList" class="detail-compact-mount data-loading">
+              <p class="data-meta">正在计算相关推荐…</p>
             </div>
           </section>
 
           <section class="section" id="detail-sources" style="padding: 40px 0;">
             <h2 class="section-title">来源链接</h2>
-            <div id="detailSourceList" class="card-grid data-loading">
-              <article class="card skeleton-card"><p>正在读取来源链接…</p></article>
+            <div id="detailSourceList" class="detail-compact-mount data-loading">
+              <p class="data-meta">正在读取来源链接…</p>
             </div>
           </section>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -316,6 +316,77 @@
     return renderUpdatesItemRepoStar(meta) + renderUpdatesItemCommunityCat(meta);
   }
 
+  function renderActionBadge(action) {
+    if (action === 'added') {
+      return '<span class="updates-badge updates-badge-added">新增</span>';
+    }
+    if (action === 'maintained') {
+      return '<span class="updates-badge">维护</span>';
+    }
+    return '';
+  }
+
+  function renderActionBadgeCell(action, cellClass) {
+    var badge = renderActionBadge(action);
+    if (badge) {
+      return '<span class="' + cellClass + '">' + badge + '</span>';
+    }
+    return '<span class="' + cellClass + ' updates-badge-cell--empty" aria-hidden="true"></span>';
+  }
+
+  // 详情页关联区块复用首页「最新知识节点 / 互链枢纽」紧凑行列表
+  function renderCompactLatestRow(item, options) {
+    var opts = options || {};
+    var href = opts.href || detailHref(item.detail_id || item.id);
+    var rowType = wikiTypeLabel(item.type, opts.typeContext || 'updates');
+    return '<li class="home-latest-row">' +
+      '<span class="home-latest-row-date">' + escapeHtml(item.recency ? String(item.recency) : '') + '</span>' +
+      renderActionBadgeCell(item.action, 'home-latest-row-badge') +
+      '<span class="home-latest-row-type">' + escapeHtml(rowType) + '</span>' +
+      '<span class="home-latest-row-main"><a href="' + escapeHtml(href) + '">' +
+      escapeHtml(item.label || item.title || item.detail_id || item.id || '') + '</a>' +
+      renderUpdatesItemSuffix(item) +
+      '</span></li>';
+  }
+
+  function renderCompactHubStyleRow(item, options) {
+    var opts = options || {};
+    var id = item.detail_id || item.id || '';
+    var href = opts.href;
+    if (!href) {
+      href = item.type === 'roadmap_page' ? roadmapHref(id) : detailHref(id);
+    }
+    var typeLabel = opts.typeLabel || wikiTypeLabel(item.type, opts.typeContext || 'updates');
+    var metaHtml = opts.metaHtml || '';
+    var linkAttrs = opts.external
+      ? ' target="_blank" rel="noopener noreferrer"'
+      : '';
+    var mainHtml = href && href !== '#'
+      ? '<a href="' + escapeHtml(href) + '"' + linkAttrs + '>' +
+        escapeHtml(item.label || item.title || id) + '</a>'
+      : '<span>' + escapeHtml(item.label || item.title || id) + '</span>';
+    return '<li class="detail-compact-row">' +
+      '<span class="detail-compact-type">' + escapeHtml(typeLabel) + '</span>' +
+      '<span class="detail-compact-main">' + mainHtml +
+      renderUpdatesItemSuffix(item) +
+      '</span>' +
+      (metaHtml
+        ? '<span class="detail-compact-meta">' + metaHtml + '</span>'
+        : '<span class="detail-compact-meta detail-compact-meta--empty" aria-hidden="true"></span>') +
+      '</li>';
+  }
+
+  function renderCompactHubStyleList(container, rowsHtml, emptyText) {
+    if (!container) return;
+    if (!rowsHtml) {
+      container.innerHTML = '<p class="data-meta">' + escapeHtml(emptyText || '暂无数据') + '</p>';
+      removeLoadingState(container);
+      return;
+    }
+    container.innerHTML = '<ol class="detail-compact-list">' + rowsHtml + '</ol>';
+    removeLoadingState(container);
+  }
+
   // 首页「互链枢纽 · Top 10」：数据来自 home-stats.json 的 top_hubs / top_paper_hubs
   //（graph-stats.json 全站互链度 Top-10 的轻量投影），全站 / 论文两个 tab 共用一套紧凑行渲染
   function renderHomeHubList(mount, hubs, emptyText) {
@@ -670,24 +741,6 @@
       items = homeStats.latest_wiki_nodes;
     } else if (homeStats && homeStats.latest_wiki_node && homeStats.latest_wiki_node.detail_id) {
       items = [homeStats.latest_wiki_node];
-    }
-
-    function renderActionBadge(action) {
-      if (action === 'added') {
-        return '<span class="updates-badge updates-badge-added">新增</span>';
-      }
-      if (action === 'maintained') {
-        return '<span class="updates-badge">维护</span>';
-      }
-      return '';
-    }
-
-    function renderActionBadgeCell(action, cellClass) {
-      var badge = renderActionBadge(action);
-      if (badge) {
-        return '<span class="' + cellClass + '">' + badge + '</span>';
-      }
-      return '<span class="' + cellClass + ' updates-badge-cell--empty" aria-hidden="true"></span>';
     }
 
     // 首页紧凑模式（mount 带 data-compact）：只列最近 5 条单行记录；
@@ -3288,8 +3341,33 @@
     if (!container) return;
     const emptyText = (options && options.emptyText) || '暂无内部关联项';
     if (!Array.isArray(ids) || !ids.length) {
-      container.innerHTML = '<article class="card"><p>' + escapeHtml(emptyText) + '</p></article>';
-      removeLoadingState(container);
+      if (options && options.compact) {
+        renderCompactHubStyleList(container, '', emptyText);
+      } else {
+        container.innerHTML = '<article class="card"><p>' + escapeHtml(emptyText) + '</p></article>';
+        removeLoadingState(container);
+      }
+      return;
+    }
+
+    if (options && options.compact) {
+      var compactRows = '';
+      for (var ci = 0; ci < ids.length; ci++) {
+        var compactId = ids[ci];
+        var compactPage = detailPages[compactId] || {};
+        compactRows += renderCompactHubStyleRow({
+          id: compactId,
+          detail_id: compactId,
+          type: compactPage.type,
+          title: buildInternalLinkTitle(compactId, compactPage),
+          community_label: compactPage.community_label || '',
+          has_repo: !!compactPage.has_repo
+        }, {
+          href: compactPage.type === 'roadmap_page' ? roadmapHref(compactId) : detailHref(compactId),
+          metaHtml: options.metaExtra ? escapeHtml(options.metaExtra(compactId, compactPage) || '') : ''
+        });
+      }
+      renderCompactHubStyleList(container, compactRows, emptyText);
       return;
     }
 
@@ -3335,11 +3413,42 @@
     return '';
   }
 
-  function renderSourceCards(container, links, emptyText) {
+  function renderSourceCards(container, links, emptyText, options) {
     if (!container) return;
     if (!Array.isArray(links) || !links.length) {
-      container.innerHTML = '<article class="card"><p>' + escapeHtml(emptyText || '暂无来源链接') + '</p></article>';
-      removeLoadingState(container);
+      if (options && options.compact) {
+        renderCompactHubStyleList(container, '', emptyText || '暂无来源链接');
+      } else {
+        container.innerHTML = '<article class="card"><p>' + escapeHtml(emptyText || '暂无来源链接') + '</p></article>';
+        removeLoadingState(container);
+      }
+      return;
+    }
+
+    if (options && options.compact) {
+      var compactRows = '';
+      for (var si = 0; si < links.length; si++) {
+        var entry = links[si];
+        var item = normalizeSourceLink(entry);
+        var href = sourceLinkHref(entry);
+        var isExternal = href && /^https?:/i.test(href);
+        var typeLabel = item.detail_id ? '站内' : (isExternal ? '外链' : '来源');
+        var linkLabel = item.label || href || '参考条目';
+        var metaHtml = isExternal
+          ? '<span title="' + escapeHtml(href) + '">↗</span>'
+          : (item.detail_id ? '详情' : '');
+        compactRows += renderCompactHubStyleRow({
+          id: item.detail_id || item.url || linkLabel,
+          detail_id: item.detail_id,
+          label: linkLabel
+        }, {
+          href: href || '',
+          typeLabel: typeLabel,
+          metaHtml: metaHtml,
+          external: isExternal
+        });
+      }
+      renderCompactHubStyleList(container, compactRows, emptyText || '暂无来源链接');
       return;
     }
 
@@ -3408,7 +3517,7 @@
     var result = [];
     var limit = Math.min(scored.length, maxResults);
     for (var k = 0; k < limit; k++) {
-      result.push(scored[k].id);
+      result.push({ id: scored[k].id, score: scored[k].score, page: scored[k].page });
     }
     return result;
   }
@@ -3617,17 +3726,11 @@
 
       if (!items.length) { section.hidden = true; return; }
       section.hidden = false;
-      listEl.innerHTML = items.map(function (n) {
-        var typeLabel = wikiTypeLabel(n.type, 'node');
-        return (
-          '<a class="detail-recent-ingest-item" href="' + escapeHtml(detailHref(n.detail_id)) + '">' +
-          '<span class="detail-recent-ingest-date">' + escapeHtml(String(n.recency)) + '</span>' +
-          '<span class="detail-recent-ingest-body">' +
-          '<span class="detail-recent-ingest-type">' + escapeHtml(typeLabel) + '</span>' +
-          '<span class="detail-recent-ingest-label">' + escapeHtml(n.label || n.detail_id) + '</span>' +
-          '</span></a>'
-        );
-      }).join('');
+      var ingestRows = '';
+      for (var ii = 0; ii < items.length; ii++) {
+        ingestRows += renderCompactLatestRow(items[ii]);
+      }
+      listEl.innerHTML = '<ul class="home-latest-list">' + ingestRows + '</ul>';
     }).catch(function () {
       section.hidden = true;
     });
@@ -4100,12 +4203,11 @@
       }
       renderChipList(tagEl, [], {});
       renderRelatedCommunityDistribution(document.getElementById('detailRelatedCommunityDist'), [], detailPages);
-      renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的关联项。' });
+      renderInternalLinks(relatedEl, [], detailPages, { emptyText: '当前无可展示的关联项。', compact: true });
       if (recommendedEl) {
-        recommendedEl.innerHTML = '<article class="card"><p>当前无可展示的相关推荐。</p></article>';
-        removeLoadingState(recommendedEl);
+        renderCompactHubStyleList(recommendedEl, '', '当前无可展示的相关推荐。');
       }
-      renderSourceCards(sourceEl, [], '当前无可展示的来源链接。');
+      renderSourceCards(sourceEl, [], '当前无可展示的来源链接。', { compact: true });
       if (breadcrumb) removeLoadingState(breadcrumb);
       return;
     }
@@ -4219,40 +4321,43 @@
       }
     });
     renderRelatedCommunityDistribution(document.getElementById('detailRelatedCommunityDist'), detailPage.related, detailPages);
-    renderInternalLinks(relatedEl, detailPage.related, detailPages, { emptyText: '当前 detail page 暂无 related。' });
+    renderInternalLinks(relatedEl, detailPage.related, detailPages, {
+      emptyText: '当前 detail page 暂无 related。',
+      compact: true,
+      metaExtra: function (id, page) {
+        return page && page.updated ? String(page.updated) : '';
+      }
+    });
 
     // V17: 记录并渲染阅读足迹
     updateRecentVisits(detailPage);
 
     if (recommendedEl) {
-      var recommendedIds = findRelatedByTags(detailId, detailPage.tags, detailPages, 5);
-      if (recommendedIds.length) {
-        recommendedEl.innerHTML = recommendedIds.map(function (id) {
-          var page = detailPages[id] || {};
-          var pageTags = Array.isArray(page.tags) ? page.tags : [];
-          return [
-            '<article class="card data-card">',
-            '  <div>',
-            '    <h3><a href="' + escapeHtml(detailHref(id)) + '">' + escapeHtml(page.title || id) + '</a></h3>',
-            '    <p class="card-meta">tag 匹配推荐</p>',
-            '    <p>' + escapeHtml(page.summary || '暂无摘要') + '</p>',
-            '  </div>',
-            '  <div class="chip-list">',
-            pageTags.slice(0, 3).map(function (tag) {
-              return '<span class="data-chip">' + escapeHtml(tag) + '</span>';
-            }).join(''),
-            '    <a class="btn-secondary btn-inline" href="' + escapeHtml(detailHref(id)) + '">打开详情页</a>',
-            '  </div>',
-            '</article>'
-          ].join('');
-        }).join('');
+      var recommendedItems = findRelatedByTags(detailId, detailPage.tags, detailPages, 5);
+      if (recommendedItems.length) {
+        var recommendedRows = '';
+        for (var ri = 0; ri < recommendedItems.length; ri++) {
+          var rec = recommendedItems[ri];
+          var recPage = rec.page || detailPages[rec.id] || {};
+          recommendedRows += renderCompactHubStyleRow({
+            id: rec.id,
+            detail_id: rec.id,
+            type: recPage.type,
+            title: recPage.title || rec.id,
+            community_label: recPage.community_label || '',
+            has_repo: !!recPage.has_repo
+          }, {
+            href: detailHref(rec.id),
+            metaHtml: escapeHtml(rec.score + ' 标签')
+          });
+        }
+        renderCompactHubStyleList(recommendedEl, recommendedRows, '暂无 tag 匹配的相关推荐。');
       } else {
-        recommendedEl.innerHTML = '<article class="card"><p>暂无 tag 匹配的相关推荐。</p></article>';
+        renderCompactHubStyleList(recommendedEl, '', '暂无 tag 匹配的相关推荐。');
       }
-      removeLoadingState(recommendedEl);
     }
 
-    renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。');
+    renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。', { compact: true });
 
     renderDetailMiniMap(detailPage, detailPages);
     renderDetailRecentIngestTimeline(detailPage);

--- a/docs/main.js
+++ b/docs/main.js
@@ -3413,6 +3413,65 @@
     return '';
   }
 
+  function cleanReferenceLabelText(text) {
+    if (!text) return '';
+    var cleaned = String(text).trim();
+    cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+    cleaned = cleaned.replace(/\*\*/g, '');
+    cleaned = cleaned.replace(/[（(]\s*\[source\][^）)]*[）)]/gi, '');
+    cleaned = cleaned.replace(/[（(]\s*source\s*[）)]/gi, '');
+    cleaned = cleaned.replace(/\s+/g, ' ').trim();
+    return cleaned.replace(/^[：:，,。\s]+|[：:，,。\s]+$/g, '');
+  }
+
+  function looksLikeRepoPath(text) {
+    return /^(?:sources\/|\.\.\/|wiki\/|references\/)/i.test(text) || /\.md$/i.test(text);
+  }
+
+  function extractTitleAfterPathPrefix(label) {
+    var text = String(label || '');
+    var parts = text.split(/\s*[—–-]\s+/);
+    if (parts.length >= 2 && looksLikeRepoPath(parts[0])) {
+      return parts.slice(1).join(' — ').trim();
+    }
+    return '';
+  }
+
+  function titleFromSourceUrl(url) {
+    if (!url) return '';
+    try {
+      var parsed = new URL(url);
+      var base = parsed.pathname.split('/').pop() || '';
+      base = base.replace(/\.(md|html?)$/i, '');
+      if (!base || /^(source|sources|link|ref)$/i.test(base)) return '';
+      return base.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function isGenericSourceLabel(label) {
+    return /^(source|sources|link|ref)$/i.test(String(label || '').trim());
+  }
+
+  function formatSourceLinkDisplayLabel(item, detailPages) {
+    if (!item) return '参考条目';
+    if (item.detail_id && detailPages && detailPages[item.detail_id] && detailPages[item.detail_id].title) {
+      return detailPages[item.detail_id].title;
+    }
+    var label = cleanReferenceLabelText(item.label || '');
+    var fromPath = extractTitleAfterPathPrefix(label);
+    if (fromPath) label = fromPath;
+    if (isGenericSourceLabel(label) && item.url) {
+      var fromUrl = titleFromSourceUrl(item.url);
+      if (fromUrl) label = fromUrl;
+    }
+    if (!label && item.url) label = titleFromSourceUrl(item.url);
+    if (!label) label = item.detail_id || '参考条目';
+    if (/^https?:\/\//i.test(label)) label = titleFromSourceUrl(label) || label;
+    return label;
+  }
+
   function renderSourceCards(container, links, emptyText, options) {
     if (!container) return;
     if (!Array.isArray(links) || !links.length) {
@@ -3427,13 +3486,22 @@
 
     if (options && options.compact) {
       var compactRows = '';
+      var detailPages = (options && options.detailPages) || {};
+      var seenSourceHrefs = {};
       for (var si = 0; si < links.length; si++) {
         var entry = links[si];
         var item = normalizeSourceLink(entry);
         var href = sourceLinkHref(entry);
+        if (href) {
+          if (seenSourceHrefs[href]) continue;
+          seenSourceHrefs[href] = true;
+        }
+        if (isGenericSourceLabel(item.label) && /github\.com\/[^/]+\/[^/]+\/blob\/main\/sources\//i.test(item.url || '')) {
+          continue;
+        }
         var isExternal = href && /^https?:/i.test(href);
         var typeLabel = item.detail_id ? '站内' : (isExternal ? '外链' : '来源');
-        var linkLabel = item.label || href || '参考条目';
+        var linkLabel = formatSourceLinkDisplayLabel(item, detailPages);
         var metaHtml = isExternal
           ? '<span title="' + escapeHtml(href) + '">↗</span>'
           : (item.detail_id ? '详情' : '');
@@ -3460,17 +3528,18 @@
       const item = normalizeSourceLink(entry);
       const href = sourceLinkHref(entry);
       const isExternal = href && /^https?:/i.test(href);
+      const displayLabel = formatSourceLinkDisplayLabel(item, (options && options.detailPages) || {});
       const linkHtml = href
         ? (isExternal
-          ? '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">打开来源</a>'
-          : '<a href="' + escapeHtml(href) + '">打开详情</a>')
+          ? '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(displayLabel) + '</a>'
+          : '<a href="' + escapeHtml(href) + '">' + escapeHtml(displayLabel) + '</a>')
         : '';
       const titleHtml = linkHtml
         ? '<h3>' + linkHtml + '</h3>'
-        : '<h3>' + escapeHtml(item.label || '参考条目') + '</h3>';
+        : '<h3>' + escapeHtml(displayLabel || '参考条目') + '</h3>';
       const metaHtml = href
-        ? '<p class="data-submeta detail-source-url" title="' + escapeHtml(href) + '"><code>' + escapeHtml(item.label || href) + '</code></p>'
-        : '<p class="data-submeta">' + escapeHtml(item.label || '') + '</p>';
+        ? '<p class="data-submeta detail-source-url" title="' + escapeHtml(href) + '"><code>' + escapeHtml(href) + '</code></p>'
+        : '<p class="data-submeta">' + escapeHtml(displayLabel || '') + '</p>';
       html += '<article class="card data-card">' +
         '  <div>' +
         '    ' + titleHtml +
@@ -4357,7 +4426,10 @@
       }
     }
 
-    renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。', { compact: true });
+    renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。', {
+      compact: true,
+      detailPages: detailPages
+    });
 
     renderDetailMiniMap(detailPage, detailPages);
     renderDetailRecentIngestTimeline(detailPage);

--- a/docs/style.css
+++ b/docs/style.css
@@ -571,6 +571,62 @@ body.sponsor-dialog-open {
   justify-self: end;
 }
 .home-hub-more { margin-top: 18px; font-size: .9rem; }
+/* 详情页关联区块：复用互链枢纽紧凑行（类型 / 标题+后缀 / 尾列元信息） */
+.detail-compact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  column-gap: 12px;
+  row-gap: 10px;
+  align-items: baseline;
+}
+.detail-compact-row { display: contents; }
+.detail-compact-type {
+  color: var(--text-muted);
+  font-size: .85rem;
+  white-space: nowrap;
+}
+.detail-compact-main { min-width: 0; }
+.detail-compact-main > a {
+  overflow-wrap: anywhere;
+  padding-right: 0.55rem;
+}
+.detail-compact-main > .updates-item-opensource {
+  padding-right: 0.55rem;
+}
+.detail-compact-meta {
+  color: var(--text-muted);
+  font-size: .8rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  justify-self: end;
+}
+.detail-compact-meta--empty { visibility: hidden; }
+.detail-compact-mount { min-width: 0; }
+@media (max-width: 860px) {
+  .detail-compact-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .detail-compact-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 8px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+  }
+  .detail-compact-row:last-child { border-bottom: none; padding-bottom: 0; }
+  .detail-compact-type, .detail-compact-meta { font-size: .78rem; }
+  .detail-compact-meta--empty { display: none; }
+  .detail-compact-main {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+}
 .hubs-meta { margin: 0 0 16px; }
 .hubs-list-actions { padding-left: 0; padding-right: 0; }
 @media (max-width: 860px) {
@@ -878,34 +934,6 @@ button.home-wiki-heatmap-cell.is-active {
   word-break: keep-all;
   line-break: strict;
 }
-.detail-recent-ingest-timeline { display: grid; gap: 10px; }
-.detail-recent-ingest-item {
-  display: flex;
-  align-items: baseline;
-  gap: 14px;
-  padding: 12px 16px;
-  border: 1px solid var(--border);
-  border-left: 3px solid rgba(45,116,218,.45);
-  border-radius: 10px;
-  text-decoration: none;
-  color: var(--text);
-  transition: border-color var(--transition), background var(--transition), transform var(--transition);
-}
-.detail-recent-ingest-item:hover {
-  border-color: rgba(45,116,218,.5);
-  background: rgba(45,116,218,.06);
-  transform: translateX(2px);
-}
-.detail-recent-ingest-date {
-  flex: 0 0 auto;
-  font-size: .82rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-}
-.detail-recent-ingest-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.detail-recent-ingest-type { font-size: .76rem; color: var(--text-muted); }
-.detail-recent-ingest-label { font-weight: 650; letter-spacing: -.01em; }
 .card-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
 .card {
   padding: 20px;
@@ -1267,31 +1295,6 @@ button.home-wiki-heatmap-cell.is-active {
 /* 详情/路线主栏已由 flex 限宽，勿再叠 72ch 导致副标题提前换行 */
 .detail-content-main .section-subtitle {
   max-width: none;
-}
-/* Detail page — 来源链接：超长 URL 单行省略，悬停 title 显示完整地址 */
-#detailSourceList > article.card {
-  min-width: 0;
-}
-/* .data-card 为 grid，子 div 默认 min-width:auto 会被长 URL 撑破省略号容器 */
-#detailSourceList article.data-card > div {
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-}
-.detail-source-url {
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-}
-.detail-source-url code {
-  display: block;
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  box-sizing: border-box;
 }
 .detail-toc-panel {
   width: 320px;

--- a/scripts/screenshot_detail_anchor_viewport.cjs
+++ b/scripts/screenshot_detail_anchor_viewport.cjs
@@ -67,9 +67,52 @@ async function waitForDetailPageReady(page) {
           const root = document.getElementById('detailSourceList');
           if (!root) return false;
           return (
+            root.querySelector('.detail-compact-list') !== null ||
             root.querySelector('.detail-source-url') !== null ||
             /暂无来源|无可展示/.test(root.textContent || '')
           );
+        },
+        { timeout: 90000 }
+      );
+    }
+
+    if (anchorId === 'detail-related') {
+      await page.waitForSelector('#detailRelatedList:not(.data-loading)', { timeout: 90000 });
+      await page.waitForFunction(
+        function () {
+          const root = document.getElementById('detailRelatedList');
+          if (!root) return false;
+          return (
+            root.querySelector('.detail-compact-list') !== null ||
+            /暂无关联|无可展示/.test(root.textContent || '')
+          );
+        },
+        { timeout: 90000 }
+      );
+    }
+
+    if (anchorId === 'detail-recommended') {
+      await page.waitForSelector('#detailRecommendedList:not(.data-loading)', { timeout: 90000 });
+      await page.waitForFunction(
+        function () {
+          const root = document.getElementById('detailRecommendedList');
+          if (!root) return false;
+          return (
+            root.querySelector('.detail-compact-list') !== null ||
+            /暂无.*推荐|无可展示/.test(root.textContent || '')
+          );
+        },
+        { timeout: 90000 }
+      );
+    }
+
+    if (anchorId === 'detail-recent-ingest-section') {
+      await page.waitForSelector('#detail-recent-ingest-section:not([hidden])', { timeout: 90000 });
+      await page.waitForFunction(
+        function () {
+          const root = document.getElementById('detailRecentIngestTimeline');
+          if (!root) return false;
+          return root.querySelector('.home-latest-list') !== null;
         },
         { timeout: 90000 }
       );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

将详情页的 **关联项**、**最近相关 ingest**、**相关推荐**、**来源链接** 从 `card-grid` 卡片布局，统一为与首页「最新知识节点」「互链枢纽」一致的紧凑行列表风格，提升信息密度与视觉一致性。

## 变更类型

- [x] 前端（`docs/`）

## 主要改动

- **`docs/main.js`**：抽取 `renderCompactHubStyleRow` / `renderCompactLatestRow` 等共用渲染函数；详情页四个区块通过 `{ compact: true }` 启用新样式
- **`docs/detail.html`**：容器由 `card-grid` 改为 `detail-compact-mount`
- **`docs/style.css`**：新增 `.detail-compact-list*` 样式；移除旧 ingest 卡片样式

### 布局对照

| 区块 | 风格 | 列结构 |
|------|------|--------|
| 关联项 / 相关推荐 / 来源链接 | 互链枢纽 | 类型 · 标题+后缀 · 尾列元信息 |
| 最近相关 ingest | 最新知识节点 | 日期 · 徽标 · 类型 · 标题+后缀 |

## 验证

- [x] `node --check docs/main.js`
- [x] `eslint docs/main.js`

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5256296f-f5fd-45a7-9f8e-40e9100bf5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5256296f-f5fd-45a7-9f8e-40e9100bf5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

