### PR TITLE
fix(ux): 桌面端 TOC 浮窗封顶 min(76vh, 680px)，移动端不变

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -55,7 +55,7 @@
 - [x] 首页搜索索引修复：将 `tech-map/`、roadmap 与 references 纳入 `search-index.json`，支持搜索 `tech-map`。
 - [x] 技术路线页 `roadmap.html`：基于导出阶段数据渲染可折叠阶段树（垂直 `<details>` 列表）；已移除折叠 Mermaid 线框总图与路线页内 Mermaid CDN。
 - [x] 技术路线页 `roadmap.html`：favicon、顶栏统一为 🚀（与首页「技术路线指南」CTA 一致）；主题切换仍为 ☀️/🌙。
-- [x] 技术路线页侧栏 TOC：浮窗/抽屉卡片封顶 `min(76vh, 680px)`，目录列表区内滚动。
+- [x] 技术路线页侧栏 TOC（桌面 ≥1632px）：卡片封顶 `min(76vh, 680px)`，列表区内滚动；移动端抽屉保持原样全高滚动。
 - [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
 - [x] 详情页 Mermaid 标签裁切：`htmlLabels` 下 `foreignObject` 比 `nodeLabel` 略窄时 post-render 扩框 + CSS `overflow: visible`，修复如 world-models-15 技术地图等长标签贴边裁切。
   - [x] 详情页 Mermaid 灯箱：加载态文案 + `stage-pending` 在 `fit` 完成前隐藏，消除「空面板 / 先大后缩」闪烁。

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -55,7 +55,7 @@
 - [x] 首页搜索索引修复：将 `tech-map/`、roadmap 与 references 纳入 `search-index.json`，支持搜索 `tech-map`。
 - [x] 技术路线页 `roadmap.html`：基于导出阶段数据渲染可折叠阶段树（垂直 `<details>` 列表）；已移除折叠 Mermaid 线框总图与路线页内 Mermaid CDN。
 - [x] 技术路线页 `roadmap.html`：favicon、顶栏统一为 🚀（与首页「技术路线指南」CTA 一致）；主题切换仍为 ☀️/🌙。
-- [x] 技术路线页侧栏 TOC：浮窗/抽屉卡片封顶 `min(60vh, 460px)`，目录列表区内滚动，避免几乎铺满视口。
+- [x] 技术路线页侧栏 TOC：浮窗/抽屉卡片封顶 `min(76vh, 680px)`，目录列表区内滚动。
 - [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
 - [x] 详情页 Mermaid 标签裁切：`htmlLabels` 下 `foreignObject` 比 `nodeLabel` 略窄时 post-render 扩框 + CSS `overflow: visible`，修复如 world-models-15 技术地图等长标签贴边裁切。
   - [x] 详情页 Mermaid 灯箱：加载态文案 + `stage-pending` 在 `fit` 完成前隐藏，消除「空面板 / 先大后缩」闪烁。

--- a/docs/style.css
+++ b/docs/style.css
@@ -23,7 +23,7 @@
   /* 负边距 TOC 完整露出： (vw - content-max) / 2 + container-padding - (toc宽+gap) ≥ 0 → vw ≥ 1632 */
   --detail-toc-desktop-min: 1632px;
   /* 侧栏 / 抽屉 TOC 卡片封顶高度（列表区内部滚动，避免浮窗几乎铺满视口） */
-  --detail-toc-panel-max-height: min(60vh, 460px);
+  --detail-toc-panel-max-height: min(76vh, 680px);
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1303,36 +1303,36 @@ button.home-wiki-heatmap-cell.is-active {
   border: 1px solid var(--border);
   background: var(--surface);
   box-shadow: var(--shadow-sm);
-  display: flex;
-  flex-direction: column;
-  max-height: var(--detail-toc-panel-max-height);
-  box-sizing: border-box;
-  overflow: hidden;
-}
-.detail-toc-panel .detail-toc-list {
-  flex: 1 1 auto;
-  min-height: 0;
-  min-width: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--text-muted) 48%, transparent) transparent;
-}
-.detail-toc-panel .detail-toc-list::-webkit-scrollbar {
-  width: 10px;
-}
-.detail-toc-panel .detail-toc-list::-webkit-scrollbar-track {
-  background: transparent;
-}
-.detail-toc-panel .detail-toc-list::-webkit-scrollbar-thumb {
-  background-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
-  border-radius: 999px;
 }
 @media (min-width: 1632px) {
   .detail-toc-panel {
     /* width(320) + .detail-content-layout gap(40) — 与主栏对齐且不占横向滚动 */
     margin-left: -360px;
+    display: flex;
+    flex-direction: column;
+    max-height: var(--detail-toc-panel-max-height);
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+  .detail-toc-panel .detail-toc-list {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 48%, transparent) transparent;
+  }
+  .detail-toc-panel .detail-toc-list::-webkit-scrollbar {
+    width: 10px;
+  }
+  .detail-toc-panel .detail-toc-list::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .detail-toc-panel .detail-toc-list::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
+    border-radius: 999px;
   }
 }
 .detail-toc-panel[hidden] {
@@ -1986,32 +1986,44 @@ button.home-wiki-heatmap-cell.is-active {
 @media (max-width: 1631px) {
   .detail-toc-panel {
     position: fixed;
-    top: 72px;
-    bottom: auto;
+    top: 16px;
+    bottom: 96px; /* Avoid overlapping sidebar-toggle button */
     left: -300px;
     width: 300px;
     height: auto;
-    max-height: var(--detail-toc-panel-max-height);
     margin: 0;
     padding: 20px;
     background: var(--bg);
     box-shadow: 2px 0 12px rgba(0,0,0,0.15);
     border-radius: 0 16px 16px 0;
     z-index: 1000;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--text-muted) 48%, transparent) transparent;
     transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    display: flex;
-    flex-direction: column;
+    display: block;
+    max-height: none;
+  }
+  .detail-toc-panel::-webkit-scrollbar {
+    width: 10px;
+  }
+  .detail-toc-panel::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .detail-toc-panel::-webkit-scrollbar-thumb {
+    background-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
+    border-radius: 999px;
+  }
+  .detail-toc-panel .detail-toc-list {
+    overflow-y: visible;
+    min-height: 0;
   }
   .detail-toc-panel[hidden] {
     display: none;
   }
   .detail-toc-panel.open {
     left: 0;
-  }
-  .detail-toc-panel .detail-toc-list {
-    overflow-y: auto;
-    min-height: 0;
   }
   .sidebar-toggle {
     display: flex;

--- a/log.md
+++ b/log.md
@@ -1,6 +1,6 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
-## [2026-07-09] fix(ux) | docs/style.css — 路线/详情页 TOC 浮窗封顶 min(60vh, 460px)，列表区内滚动
+## [2026-07-09] fix(ux) | docs/style.css — TOC 浮窗封顶调高为 min(76vh, 680px)
 
 ## [2026-07-08] ingest | sources/papers/discrete_terrain_minimal_proximity_sensing_arxiv_2606_31912.md — ETH RSL 四足足底 ToF 最小感知离散地形；wiki/entities/paper-discrete-terrain-minimal-proximity-sensing.md；交叉更新 quadruped-robot / terrain-adaptation / stair-obstacle-perceptive-locomotion
 

--- a/log.md
+++ b/log.md
@@ -1,6 +1,6 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
-## [2026-07-09] fix(ux) | docs/style.css — TOC 浮窗封顶调高为 min(76vh, 680px)
+## [2026-07-09] fix(ux) | docs/style.css — TOC 浮窗封顶仅桌面端 min(76vh, 680px)，移动端抽屉恢复原样
 
 ## [2026-07-08] ingest | sources/papers/discrete_terrain_minimal_proximity_sensing_arxiv_2606_31912.md — ETH RSL 四足足底 ToF 最小感知离散地形；wiki/entities/paper-discrete-terrain-minimal-proximity-sensing.md；交叉更新 quadruped-robot / terrain-adaptation / stair-obstacle-perceptive-locomotion
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

路线/详情页 TOC 浮窗原先在桌面端几乎铺满视口。本 PR **仅调整桌面端（≥1632px）**：

- `--detail-toc-panel-max-height: min(76vh, 680px)`
- 卡片 flex 列布局：标题 + 图谱按钮固定，`.detail-toc-list` 内部滚动

**移动端（≤1631px）保持最初行为**：抽屉 `top: 16px` / `bottom: 96px` 全高滚动，整面板 `overflow-y: auto`。

## 验证

- 桌面 1680×900：TOC 卡片 **680px**，列表区内滚动
- 移动 390×844：抽屉高度 **732px**（16px–748px），`max-height: none`，与改前一致

## 验证截图

### 桌面侧栏（1680×900）

![桌面 TOC 封顶 680px](https://cursor.com/artifacts/c/art-e6315090-5d5e-4971-87b2-609970d0f6ea)

### 移动端抽屉（390×844，已恢复原样）

![移动端 TOC 抽屉全高滚动](https://cursor.com/artifacts/c/art-6cd7af93-ee10-4fc8-93df-084ffa4c7f71)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-131c5244-2405-4b71-bacf-3b937c43dff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-131c5244-2405-4b71-bacf-3b937c43dff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

