### PR TITLE
详情页关联项与相关推荐显示社区短标签

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -3272,6 +3272,26 @@
     return String(label).replace(/\s*社区\s*$/, '').trim() || '未分类';
   }
 
+  function buildCompactPageRowMeta(page, detailId, communityIndex) {
+    var safePage = page || {};
+    var communityLabel = safePage.community_label || '';
+    var path = safePage.path || '';
+    if (communityIndex && path) {
+      var cid = communityIndex.pathToCommunity.get(path);
+      if (cid && communityIndex.communityLabel[cid]) {
+        communityLabel = communityIndex.communityLabel[cid];
+      }
+    }
+    return {
+      id: detailId,
+      detail_id: detailId,
+      type: safePage.type,
+      title: buildInternalLinkTitle(detailId, safePage),
+      community_label: communityLabel,
+      has_repo: !!safePage.has_repo
+    };
+  }
+
   function renderRelatedCommunityDistribution(wrapperEl, ids, detailPages) {
     if (!wrapperEl) return;
     var barsEl = document.getElementById('detailRelatedCommunityDistBars');
@@ -3351,23 +3371,26 @@
     }
 
     if (options && options.compact) {
-      var compactRows = '';
-      for (var ci = 0; ci < ids.length; ci++) {
-        var compactId = ids[ci];
-        var compactPage = detailPages[compactId] || {};
-        compactRows += renderCompactHubStyleRow({
-          id: compactId,
-          detail_id: compactId,
-          type: compactPage.type,
-          title: buildInternalLinkTitle(compactId, compactPage),
-          community_label: compactPage.community_label || '',
-          has_repo: !!compactPage.has_repo
-        }, {
-          href: compactPage.type === 'roadmap_page' ? roadmapHref(compactId) : detailHref(compactId),
-          metaHtml: options.metaExtra ? escapeHtml(options.metaExtra(compactId, compactPage) || '') : ''
-        });
+      function renderCompactRows(communityIndex) {
+        var compactRows = '';
+        for (var ci = 0; ci < ids.length; ci++) {
+          var compactId = ids[ci];
+          var compactPage = detailPages[compactId] || {};
+          var rowMeta = buildCompactPageRowMeta(compactPage, compactId, communityIndex);
+          compactRows += renderCompactHubStyleRow(rowMeta, {
+            href: compactPage.type === 'roadmap_page' ? roadmapHref(compactId) : detailHref(compactId),
+            metaHtml: options.metaExtra ? escapeHtml(options.metaExtra(compactId, compactPage) || '') : ''
+          });
+        }
+        renderCompactHubStyleList(container, compactRows, emptyText);
       }
-      renderCompactHubStyleList(container, compactRows, emptyText);
+      if (options.enrichCommunity !== false) {
+        ensureDetailCommunityIndex()
+          .then(renderCompactRows)
+          .catch(function () { renderCompactRows(null); });
+        return;
+      }
+      renderCompactRows(null);
       return;
     }
 
@@ -4403,27 +4426,26 @@
 
     if (recommendedEl) {
       var recommendedItems = findRelatedByTags(detailId, detailPage.tags, detailPages, 5);
-      if (recommendedItems.length) {
+      function renderRecommendedRows(communityIndex) {
+        if (!recommendedItems.length) {
+          renderCompactHubStyleList(recommendedEl, '', '暂无 tag 匹配的相关推荐。');
+          return;
+        }
         var recommendedRows = '';
         for (var ri = 0; ri < recommendedItems.length; ri++) {
           var rec = recommendedItems[ri];
           var recPage = rec.page || detailPages[rec.id] || {};
-          recommendedRows += renderCompactHubStyleRow({
-            id: rec.id,
-            detail_id: rec.id,
-            type: recPage.type,
-            title: recPage.title || rec.id,
-            community_label: recPage.community_label || '',
-            has_repo: !!recPage.has_repo
-          }, {
+          var rowMeta = buildCompactPageRowMeta(recPage, rec.id, communityIndex);
+          recommendedRows += renderCompactHubStyleRow(rowMeta, {
             href: detailHref(rec.id),
             metaHtml: escapeHtml(rec.score + ' 标签')
           });
         }
         renderCompactHubStyleList(recommendedEl, recommendedRows, '暂无 tag 匹配的相关推荐。');
-      } else {
-        renderCompactHubStyleList(recommendedEl, '', '暂无 tag 匹配的相关推荐。');
       }
+      ensureDetailCommunityIndex()
+        .then(renderRecommendedRows)
+        .catch(function () { renderRecommendedRows(null); });
     }
 
     renderSourceCards(sourceEl, detailPage.source_links, '当前 detail page 暂无来源链接。', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

在详情页 **关联项** 与 **相关推荐** 的紧凑行列表中，补全与首页「最新知识节点 / 互链枢纽」一致的社区短标签（`.updates-item-cat`），数据来自 `link-graph.json` 的社区划分。

> 前置 PR #991 已合并：详情页四区块紧凑行列表 + 来源链接标题优化。

## 变更类型

- [x] 前端（`docs/`）

## 主要改动

- **`docs/main.js`**
  - 新增 `buildCompactPageRowMeta()`：按页面 `path` 从 `ensureDetailCommunityIndex()` 解析 `community_label`
  - **关联项**：`renderInternalLinks` 紧凑模式默认异步补全社区标签
  - **相关推荐**：渲染前同样拉取社区索引并补全

## 验证

- [x] `node --check docs/main.js`
- [x] Puppeteer 截图：`wiki-methods-vla` 关联项 / 相关推荐均显示社区短标签（如 `视觉-语言-动作`、`模仿学习`）

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5256296f-f5fd-45a7-9f8e-40e9100bf5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5256296f-f5fd-45a7-9f8e-40e9100bf5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

