### PR TITLE
详情页关联项类型标签中文化（概念/实体/方法等）

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2458,6 +2458,7 @@
     ['wiki/tasks/', 'task'],
     ['wiki/comparisons/', 'comparison'],
     ['wiki/formalizations/', 'formalization'],
+    ['wiki/overview/', 'overview'],
     ['wiki/overviews/', 'overview'],
     ['wiki/queries/', 'query'],
     ['wiki/entities/', 'entity'],
@@ -3231,17 +3232,30 @@
   var _detailCommunityIndex = null;
   var _detailCommunityIndexPromise = null;
 
-  function buildHasRepoIndex(rankings) {
+  function buildHubRankingsIndex(rankings) {
     var pathToHasRepo = new Map();
     var detailIdToHasRepo = new Map();
+    var pathToNodeType = new Map();
+    var detailIdToNodeType = new Map();
     var all = rankings && Array.isArray(rankings.all) ? rankings.all : [];
     for (var hi = 0; hi < all.length; hi++) {
       var hub = all[hi];
-      if (!hub || !hub.has_repo) continue;
-      if (hub.id) pathToHasRepo.set(hub.id, true);
-      if (hub.detail_id) detailIdToHasRepo.set(hub.detail_id, true);
+      if (!hub) continue;
+      if (hub.id) {
+        if (hub.has_repo) pathToHasRepo.set(hub.id, true);
+        if (hub.type) pathToNodeType.set(hub.id, hub.type);
+      }
+      if (hub.detail_id) {
+        if (hub.has_repo) detailIdToHasRepo.set(hub.detail_id, true);
+        if (hub.type) detailIdToNodeType.set(hub.detail_id, hub.type);
+      }
     }
-    return { pathToHasRepo: pathToHasRepo, detailIdToHasRepo: detailIdToHasRepo };
+    return {
+      pathToHasRepo: pathToHasRepo,
+      detailIdToHasRepo: detailIdToHasRepo,
+      pathToNodeType: pathToNodeType,
+      detailIdToNodeType: detailIdToNodeType
+    };
   }
 
   function ensureDetailCommunityIndex() {
@@ -3273,12 +3287,14 @@
         var c = communities[ci];
         if (c && c.id) communityLabel[c.id] = c.label || c.id;
       }
-      var repoIndex = buildHasRepoIndex(rankings);
+      var hubIndex = buildHubRankingsIndex(rankings);
       _detailCommunityIndex = {
         pathToCommunity: pathToCommunity,
         communityLabel: communityLabel,
-        pathToHasRepo: repoIndex.pathToHasRepo,
-        detailIdToHasRepo: repoIndex.detailIdToHasRepo
+        pathToHasRepo: hubIndex.pathToHasRepo,
+        detailIdToHasRepo: hubIndex.detailIdToHasRepo,
+        pathToNodeType: hubIndex.pathToNodeType,
+        detailIdToNodeType: hubIndex.detailIdToNodeType
       };
       return _detailCommunityIndex;
     }).catch(function () {
@@ -3286,7 +3302,9 @@
         pathToCommunity: new Map(),
         communityLabel: {},
         pathToHasRepo: new Map(),
-        detailIdToHasRepo: new Map()
+        detailIdToHasRepo: new Map(),
+        pathToNodeType: new Map(),
+        detailIdToNodeType: new Map()
       };
       return _detailCommunityIndex;
     });
@@ -3296,6 +3314,26 @@
   function shortenCommunityLabel(label) {
     if (!label) return '未分类';
     return String(label).replace(/\s*社区\s*$/, '').trim() || '未分类';
+  }
+
+  function resolveCompactRowDisplayType(page, detailId, communityIndex) {
+    if (communityIndex && detailId && communityIndex.detailIdToNodeType) {
+      var byId = communityIndex.detailIdToNodeType.get(detailId);
+      if (byId) return byId;
+    }
+    var path = (page && page.path) || '';
+    if (communityIndex && path && communityIndex.pathToNodeType) {
+      var byPath = communityIndex.pathToNodeType.get(path);
+      if (byPath) return byPath;
+    }
+    var inferred = roadmapKmapNodeType(page, detailId);
+    if (inferred) return inferred;
+    var coarse = (page && page.type) || '';
+    if (coarse === 'entity_page') return 'entity';
+    if (coarse === 'roadmap_page') return 'roadmap_page';
+    if (coarse === 'reference_page') return 'reference';
+    if (coarse === 'wiki_page') return 'wiki_page';
+    return coarse;
   }
 
   function buildCompactPageRowMeta(page, detailId, communityIndex) {
@@ -3318,7 +3356,7 @@
     return {
       id: detailId,
       detail_id: detailId,
-      type: safePage.type,
+      type: resolveCompactRowDisplayType(safePage, detailId, communityIndex),
       title: buildInternalLinkTitle(detailId, safePage),
       community_label: communityLabel,
       has_repo: hasRepo

--- a/docs/wiki-type-labels.js
+++ b/docs/wiki-type-labels.js
@@ -16,6 +16,10 @@
     reference: '参考',
     roadmap: '路线',
     roadmap_page: '路线',
+    wiki_page: '知识页',
+    entity_page: '实体',
+    reference_page: '参考',
+    tech_map_node: '技术节点',
     detail_page: '详情页',
     '': '知识页'
   };
@@ -32,6 +36,10 @@
     reference: 'Reference',
     roadmap: 'Roadmap',
     roadmap_page: 'Roadmap',
+    wiki_page: 'Wiki',
+    entity_page: 'Entity',
+    reference_page: 'Reference',
+    tech_map_node: 'Tech Node',
     detail_page: 'Detail Page',
     '': 'Wiki'
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页 **关联项 / 相关推荐** 的类型列不再显示 `wiki_page`、`entity_page` 等粗粒度英文标识，改为与首页一致的**中文类型标签**（概念、实体、方法、总览等）。

## 变更类型

- [x] 前端（`docs/`）

## 主要改动

- **`docs/main.js`**
  - `buildHubRankingsIndex()` 同步索引 `pathToNodeType` / `detailIdToNodeType`
  - 新增 `resolveCompactRowDisplayType()`：优先 hub-rankings 细粒度 type，回退 path 推断
  - 修正 `wiki/overview/` 路径前缀映射
- **`docs/wiki-type-labels.js`**
  - 补充 `wiki_page` / `entity_page` / `reference_page` 等粗类型中文兜底

## 验证

- [x] `node --check docs/main.js`
- [x] Puppeteer：`wiki-methods-vla` 关联项类型列显示「对比 / 总览 / 概念 / 方法 / 实体 / 任务」

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5256296f-f5fd-45a7-9f8e-40e9100bf5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5256296f-f5fd-45a7-9f8e-40e9100bf5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

