### PR TITLE
fix(ux): 清理详情页来源链接中的角括号残留

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -3507,15 +3507,34 @@
     return '';
   }
 
+  function decodeBasicHtmlEntities(text) {
+    return String(text || '')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'");
+  }
+
+  function stripAngleBracketAutolinks(text) {
+    var cleaned = String(text || '');
+    cleaned = cleaned.replace(/<\s*https?:\/\/[^>\s]+\s*>/gi, '');
+    cleaned = cleaned.replace(/([—–\-:：])\s*<\s*(?=$|[；;])/g, '$1');
+    cleaned = cleaned.replace(/<\s*$/g, '');
+    return cleaned;
+  }
+
   function cleanReferenceLabelText(text) {
     if (!text) return '';
-    var cleaned = String(text).trim();
+    var cleaned = decodeBasicHtmlEntities(String(text).trim());
     cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
     cleaned = cleaned.replace(/\*\*/g, '');
+    cleaned = stripAngleBracketAutolinks(cleaned);
+    cleaned = cleaned.replace(/[（(]\s*[）)]/g, '');
     cleaned = cleaned.replace(/[（(]\s*\[source\][^）)]*[）)]/gi, '');
     cleaned = cleaned.replace(/[（(]\s*source\s*[）)]/gi, '');
     cleaned = cleaned.replace(/\s+/g, ' ').trim();
-    return cleaned.replace(/^[：:，,。\s]+|[：:，,。\s]+$/g, '');
+    return cleaned.replace(/^[：:，,。;；—–\-\s]+|[：:，,。;；—–\-\s]+$/g, '');
   }
 
   function looksLikeRepoPath(text) {

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -387,12 +387,33 @@ def collect_external_links(text: str) -> List[str]:
 GITHUB_BLOB_BASE = "https://github.com/ImChong/Robotics_Notebooks/blob/main/"
 
 
+def decode_basic_html_entities(text: str) -> str:
+    return (
+        text.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+        .replace("&quot;", '"')
+        .replace("&#39;", "'")
+    )
+
+
+def strip_angle_bracket_autolinks(text: str) -> str:
+    """Remove <https://...> autolinks and orphan '<' left after URL extraction."""
+    text = re.sub(r"<\s*https?://[^>\s]+\s*>", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"([—–\-:：])\s*<\s*(?=$|[；;])", r"\1", text)
+    text = re.sub(r"<\s*$", "", text)
+    return text
+
+
 def clean_reference_label(text: str) -> str:
-    text = text.strip()
+    text = decode_basic_html_entities(text.strip())
     text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
     text = text.replace("**", "")
+    text = strip_angle_bracket_autolinks(text)
+    text = re.sub(r"[（(]\s*[）)]", "", text)
     text = re.sub(r"\s+", " ", text)
-    return text.strip(" ：:，,。")
+    text = text.strip(" ：:，,。;；—–-")
+    return text
 
 
 def extract_section_body(text: str, heading_labels: List[str]) -> str:
@@ -453,6 +474,7 @@ def parse_reference_line(line: str, current_path: Path) -> List[Dict[str, str]]:
                 tail = tail.lstrip("—-").strip()
                 if tail:
                     label = f"{label} — {tail}"
+            label = clean_reference_label(label)
             entry: Dict[str, str] = {"label": label}
             entry.update(resolve_reference_target(target, current_path))
             entries.append(entry)
@@ -461,8 +483,8 @@ def parse_reference_line(line: str, current_path: Path) -> List[Dict[str, str]]:
     urls = re.findall(r"https?://[^)\s>]+", stripped)
     if urls:
         url = urls[0].rstrip(".,")
-        label = clean_reference_label(re.sub(r"https?://\S+", "", stripped))
-        if not label:
+        label = clean_reference_label(stripped)
+        if not label or label in {"<", ">"}:
             label = url
         return [{"label": label, "url": url}]
 

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -573,6 +573,8 @@ def _clean_paper_notebook_label(label: str, url: str, fallback_title: str = "") 
     text = re.sub(r"^机器人论文阅读笔记[:：]\s*", "", text)
     text = re.sub(r"^[深读笔记论]+[:：<\s]+", "", text)
     text = text.strip("<> ").strip()
+    if re.fullmatch(r"(?:机器人)?(?:深读)?(?:论文)?(?:阅读)?笔记", text):
+        text = ""
     if not text or len(text) < 3:
         stem = url.rsplit("/", 1)[-1].removesuffix(".html")
         text = stem.replace("__", ": ").replace("_", " ").strip()

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -490,9 +490,44 @@ console.log('ok');
             "stripLinkedReferenceSourceLines(",
             "function stripDetailContentSections(markdown, sectionLabels)",
             "stripDetailContentSections(detailPage.content_markdown || '', DETAIL_CONTENT_SKIP_SECTIONS)",
+            "function decodeBasicHtmlEntities(text)",
+            "function stripAngleBracketAutolinks(text)",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
+
+    def test_main_js_clean_reference_label_strips_angle_bracket_autolinks(self):
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('function decodeBasicHtmlEntities');
+const end = content.indexOf('function looksLikeRepoPath', start);
+eval(content.slice(start, end));
+const samples = [
+  ['FastStair 论文 HTML：<', 'FastStair 论文 HTML'],
+  ['wechat.md — <https://mp.weixin.qq.com/s/example>', 'wechat.md'],
+  ['BOM &lt;$400', 'BOM <$400'],
+];
+for (const [input, expected] of samples) {
+  const got = cleanReferenceLabelText(input);
+  if (got !== expected) throw new Error('expected ' + JSON.stringify(expected) + ' got ' + JSON.stringify(got));
+}
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
 
     def test_strip_detail_content_sections_removes_related_heading_block(self):
         node = r"""

--- a/tests/test_reference_sources_export.py
+++ b/tests/test_reference_sources_export.py
@@ -46,6 +46,34 @@ class ReferenceSourcesExportTests(unittest.TestCase):
         labels = [entry["label"] for entry in sources]
         self.assertFalse(any("Tobin" in label for label in labels))
 
+    def test_clean_reference_label_strips_angle_bracket_autolinks(self) -> None:
+        from export_minimal import clean_reference_label, parse_reference_line
+
+        path = ROOT / "wiki" / "concepts" / "sample.md"
+        samples = [
+            (
+                "- FastStair 论文 HTML：<https://arxiv.org/html/2601.10365v1>",
+                "FastStair 论文 HTML",
+            ),
+            (
+                "- [wechat.md](../../sources/blogs/wechat.md) — <https://mp.weixin.qq.com/s/example>",
+                "wechat.md",
+            ),
+            (
+                "- 论文 PDF：<https://arxiv.org/pdf/2602.08602>",
+                "论文 PDF",
+            ),
+            (
+                "- sources/papers/barkour.md — Barkour：>1m/s 敏捷动作",
+                "sources/papers/barkour.md — Barkour：>1m/s 敏捷动作",
+            ),
+        ]
+        for line, expected in samples:
+            entries = parse_reference_line(line, path)
+            self.assertEqual(entries[0]["label"], expected, msg=line)
+            self.assertNotIn("<", entries[0]["label"])
+        self.assertEqual(clean_reference_label("BOM &lt;$400"), "BOM <$400")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「来源链接」区块在解析 wiki `参考来源` 时，会把 `<https://...>` 角括号自动链接的残留 `<` 字符带进展示标签（全库约 539 处）。
- 在导出脚本 `export_minimal.py` 与前端 `main.js` 中统一清理角括号自动链接、孤立 `<`，并解码 `&lt;` 等 HTML 实体，使来源标题只保留可读文本。
- **CI 修复**：标签清理后 `深读笔记：<` 变为 `深读笔记`，`_clean_paper_notebook_label` 需将独立通用标签视为空并回退到论文 URL stem（如 `ZeroWBC`），修复 `test_collect_paper_notebook_links_prefers_notebook_html` 失败。

## 根因
参考来源行常见两种写法：
1. `论文 PDF：<https://arxiv.org/pdf/...>`（纯角括号链接）
2. `[source.md](../../sources/...) — <https://...>`（Markdown 链接 + 补充外链）

旧逻辑在剥离 URL 后未清理 `<`，导出 JSON 的 `label` 会残留 `论文 PDF：<` 等片段；前端 `escapeHtml` 后页面上即显示为不需要的 `<` 字符。

## 验证
- `make ci-test` 通过（301 passed）
- 新增 Python / Node 单测覆盖角括号剥离与 `&lt;` 解码
- 全库重新扫描后，来源 `label` 中不再含孤立 `<`

## 验证截图
![AMASS 详情页来源链接区块（无多余 &lt; 字符）](https://cursor.com/artifacts/c/art-b0f92bb0-d9d1-450d-a6a7-6a802cb7422b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa0e69e0-c8bf-41ba-bc92-178843f202ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa0e69e0-c8bf-41ba-bc92-178843f202ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

