### PR TITLE
feat(ux): 首页互链枢纽置于最新知识节点之前

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -98,16 +98,7 @@
       </div>
     </section>
 
-    <section class="section" id="home-latest-wiki-section" aria-labelledby="home-latest-wiki-heading">
-      <div class="container">
-        <h2 class="section-title" id="home-latest-wiki-heading">最新知识节点</h2>
-        <div id="homeLatestWikiModule" class="home-latest-wiki-mount data-loading" data-compact aria-live="polite">
-          <p class="data-meta">加载中…</p>
-        </div>
-      </div>
-    </section>
-
-    <section class="section section-alt" id="home-hub-section" aria-labelledby="home-hub-heading">
+    <section class="section" id="home-hub-section" aria-labelledby="home-hub-heading">
       <div class="container">
         <div class="home-hub-head">
           <h2 class="section-title" id="home-hub-heading">互链枢纽 · Top 10</h2>
@@ -122,6 +113,15 @@
         </div>
         <div id="homeHubPanelPaper" class="home-hub-panel" aria-live="polite" hidden></div>
         <p class="home-hub-more"><a href="hubs.html">查看完整榜单 →</a></p>
+      </div>
+    </section>
+
+    <section class="section section-alt" id="home-latest-wiki-section" aria-labelledby="home-latest-wiki-heading">
+      <div class="container">
+        <h2 class="section-title" id="home-latest-wiki-heading">最新知识节点</h2>
+        <div id="homeLatestWikiModule" class="home-latest-wiki-mount data-loading" data-compact aria-live="polite">
+          <p class="data-meta">加载中…</p>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 调整 `docs/index.html` 首页区块顺序：**互链枢纽 · Top 10** 上移至图谱预览之后，**最新知识节点** 置于其下。
- 同步修正 `section` / `section-alt` 交替样式，保持视觉条纹一致。

## 动机

图谱预览之后优先展示按互链度排序的结构枢纽，便于新访客从核心页进入；时效性更强的最新节点作为补充信息放在其后（完整维护历史仍见 `change-log.html`）。

## 验证

- 仅改动 `docs/index.html` 结构顺序，无脚本 / wiki / 派生数据变更；本地静态站渲染正常。
- 未跑全量 `make ci-preflight`（本次不涉及 wiki 或派生索引同步）。

## 验证截图

![首页互链枢纽在最新知识节点之前](https://cursor.com/artifacts/c/art-64be48a8-5c7e-4a5f-a6ed-450273bc6c33)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a96131-7461-4e8d-b9c2-2f3641816362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a96131-7461-4e8d-b9c2-2f3641816362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

