### PR TITLE
style(ux): 优化移动端互链枢纽与最新知识节点的行布局

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -490,10 +490,11 @@ body.sponsor-dialog-open {
 }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
-  /* 窄屏：每条记录独立换行，不再跨行列对齐 */
+  /* 窄屏：每条记录固定三段式——元信息行（日期/标签/类型）、标题行、附注行（开源⭐️+社区标签） */
   .home-latest-list {
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 12px;
   }
   .home-latest-row {
@@ -514,6 +515,9 @@ body.sponsor-dialog-open {
     flex: 1 1 100%;
     width: 100%;
   }
+  .home-latest-row-main > a { display: block; }
+  .home-latest-row-main > .updates-item-opensource { font-size: .85em; }
+  .home-latest-row-main .updates-item-cat { white-space: normal; }
 }
 .home-latest-wiki-intro { margin-bottom: 20px; }
 /* 首页「互链枢纽 · Top 10」：全站 / 论文双 tab + 紧凑行列表（排名/类型/标题/互链度四列跨行对齐） */
@@ -630,10 +634,11 @@ body.sponsor-dialog-open {
 .hubs-meta { margin: 0 0 16px; }
 .hubs-list-actions { padding-left: 0; padding-right: 0; }
 @media (max-width: 860px) {
-  /* 窄屏：每条记录独立换行，不再跨行列对齐 */
+  /* 窄屏：每条记录固定三段式——元信息行（排名/类型 + 右端互链数）、标题行、附注行（开源⭐️+社区标签） */
   .home-hub-list {
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 12px;
   }
   .home-hub-row {
@@ -646,10 +651,17 @@ body.sponsor-dialog-open {
   }
   .home-hub-row:last-child { border-bottom: none; padding-bottom: 0; }
   .home-hub-row-rank, .home-hub-row-type, .home-hub-row-degree { font-size: .78rem; }
+  .home-hub-row-rank { order: 1; }
+  .home-hub-row-type { order: 2; }
+  .home-hub-row-degree { order: 3; margin-left: auto; }
   .home-hub-row-main {
+    order: 4;
     flex: 1 1 100%;
     width: 100%;
   }
+  .home-hub-row-main > a { display: block; }
+  .home-hub-row-main > .updates-item-opensource { font-size: .85em; }
+  .home-hub-row-main .updates-item-cat { white-space: normal; }
 }
 /* change-log 更新时间线（参考论文笔记站 updates.html：左轨道 + 日期圆点 + 条目行 + 超量折叠） */
 .updates-timeline-days { position: relative; padding-left: 18px; }


### PR DESCRIPTION
## 摘要
- 窄屏（≤860px）下「互链枢纽 · Top 10」与「最新知识节点」每条记录改为固定三段式：元信息行（排名/类型 + 右端互链数，或日期/标签/类型）、标题行、附注行（开源⭐️+社区标签）。
- 解决三个移动端显示问题：互链数孤悬左下角、⭐️星标与社区标签随机换行、短内容行整行收缩导致分隔线不通栏（补 `align-items: stretch` 覆盖桌面端 `baseline`）。
- 仅改 `docs/style.css` 两个 `max-width: 860px` 媒体查询块，桌面端网格布局不受影响；hubs.html 榜单页与详情页关联区块复用同一套行样式，移动端一并受益。

## 验证
- `make ci-preflight` 通过（12/12 导出质量检查）
- Playwright + Chromium @ 390×844 移动视口实测：互链枢纽全站 / 论文双 tab、最新知识节点渲染正常——互链数右对齐、分隔线通栏、附注行结构统一
- 桌面端 1280px 回归截图确认网格布局无变化

## 验证截图
改动前后对比截图已在 Claude 会话中发送（当前环境无法将本地截图上传重写为稳定 URL，故未内嵌）。

Claude-Session: https://claude.ai/code/session_01KnMBjfjgZY4TfT5Qs2Hs3i