### PR TITLE
style(ux): 窄屏下 change-log 时间线与详情页关联区块的社区标签允许断行

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2619,6 +2619,11 @@ button.home-wiki-heatmap-cell.is-active {
   .roadmap-kmap-leaf-type {
     display: none;
   }
+  /* 窄屏：叶子标签允许换行，避免省略号截断（悬停 title 在触屏上不可用） */
+  .roadmap-kmap-leaf-label {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }
 
 /* 嵌入正文各 L 章节下的单阶段「速览」块（与顶部整块二选一） */
@@ -2941,10 +2946,17 @@ button.home-wiki-heatmap-cell.is-active {
   font-variant-numeric: tabular-nums;
 }
 @media (max-width: 540px) {
+  /* 窄屏：标签独占首行并允许换行，进度条 + 计数移至次行，避免固定窄列截断长标签 */
   .related-community-bar-row {
-    grid-template-columns: 110px 1fr 46px;
-    gap: 8px;
+    grid-template-columns: 1fr 46px;
+    gap: 2px 8px;
     font-size: .78rem;
+  }
+  .related-community-bar-label {
+    grid-column: 1 / -1;
+    text-align: left;
+    white-space: normal;
+    overflow: visible;
   }
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -630,6 +630,7 @@ body.sponsor-dialog-open {
     flex: 1 1 100%;
     width: 100%;
   }
+  .detail-compact-main .updates-item-cat { white-space: normal; }
 }
 .hubs-meta { margin: 0 0 16px; }
 .hubs-list-actions { padding-left: 0; padding-right: 0; }
@@ -761,6 +762,7 @@ body.sponsor-dialog-open {
     flex: 1 1 100%;
     width: 100%;
   }
+  .updates-item-main .updates-item-cat { white-space: normal; }
 }
 .updates-day.is-folded .updates-item-folded { display: none; }
 .updates-day-more {


### PR DESCRIPTION
## 摘要

移动端窄屏「不断行 / 截断」问题的系统性修复，共两个 commit：

1. **社区标签断行**（`bfb6f00`）：`.updates-item-cat` 全局 `white-space: nowrap`，移动端过窄时长标签截断溢出。首页两个区块已在 #1002 修复；本次补齐复用该标签的另外两处 `≤860px` 媒体查询：`.updates-item`（change-log 更新时间线）与 `.detail-compact-row`（详情页关联区块）。
2. **320px 全站审计后的截断修复**（`005ef98`）：用 Playwright 对 11 类页面（index / change-log / hubs / graph / tech-map / references / module / roadmap / 3 个代表性详情页含全站最长标题）做 320px 视口溢出与裁剪扫描，发现并修复两处省略号截断丢信息（触屏无法悬停查看 title）：
   - 详情页「关联项」社区分布条标签固定 110px 列、长标签丢失约 2/3 → 标签独占首行允许换行，进度条+计数移至次行（`≤540px`）；
   - roadmap / references 知识地图叶子标签 nowrap 截断 → 允许换行（`≤640px`）。

审计中其余检出项（站名省略号、页内 subnav / 表格 / 热力图横向滚动容器）均为有意设计，不改动。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`（12/12 导出质量检查通过；本 PR 仅改 CSS，不影响导出链）
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`（未跑，纯 CSS 改动，交由 CI 执行）
- [x] 其他：Playwright + Chromium @ 320×700 视口全站扫描——修复后 11 类页面页面级水平溢出均为 0；详情页与 roadmap 页 `.related-community-bar-label` / `.roadmap-kmap-leaf-label` 残余截断为 0；知识地图换行后树形连接线对齐正常；桌面端规则未触及（改动全部在媒体查询内）

## 验证截图

改动后 320px 视口截图（互链枢纽长标签断行、change-log 时间线断行、社区分布条两行布局、知识地图叶子换行）已在 Claude 会话中发送；当前环境无法将本地截图上传重写为稳定 URL，故未内嵌。

## 相关 Issue

无（跟进 #1002 的移动端显示优化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnMBjfjgZY4TfT5Qs2Hs3i