### PR TITLE
style(ux): 移动端首页与互链榜单将⭐️置于链接末尾、社区标签独占换行

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -407,8 +407,9 @@
         '<span class="home-hub-row-rank">' + rank + '</span>' +
         '<span class="home-hub-row-type">' + escapeHtml(wikiTypeLabel(hub.type, 'updates')) + '</span>' +
         '<span class="home-hub-row-main"><a href="' + escapeHtml(href) + '">' +
-        escapeHtml(hub.label || hub.detail_id) + '</a>' +
-        renderUpdatesItemSuffix(hub) +
+        escapeHtml(hub.label || hub.detail_id) +
+        renderUpdatesItemRepoStar(hub) + '</a>' +
+        renderUpdatesItemCommunityCat(hub) +
         '</span>' +
         '<span class="home-hub-row-degree" title="无向边总数（入链+出链）">互链 ' +
         escapeHtml(String(hub.degree != null ? hub.degree : 0)) + '</span>' +
@@ -766,8 +767,8 @@
           escapeHtml(detailHref(rowMeta.detail_id)) +
           '">' +
           escapeHtml(rowMeta.label || rowMeta.detail_id) +
-          '</a>' +
-          renderUpdatesItemSuffix(rowMeta) +
+          renderUpdatesItemRepoStar(rowMeta) + '</a>' +
+          renderUpdatesItemCommunityCat(rowMeta) +
           '</span></li>';
       }
       mount.innerHTML =

--- a/docs/style.css
+++ b/docs/style.css
@@ -490,7 +490,7 @@ body.sponsor-dialog-open {
 }
 .home-latest-more { margin-top: 18px; font-size: .9rem; }
 @media (max-width: 860px) {
-  /* 窄屏：每条记录固定三段式——元信息行（日期/标签/类型）、标题行、附注行（开源⭐️+社区标签） */
+  /* 窄屏：每条记录固定三段式——元信息行（日期/标签/类型）、标题行（链接末尾⭐️）、附注行（仅社区标签） */
   .home-latest-list {
     display: flex;
     flex-direction: column;
@@ -512,12 +512,24 @@ body.sponsor-dialog-open {
   .home-latest-row-badge.updates-badge-cell--empty,
   .updates-badge-cell--empty { display: none; }
   .home-latest-row-main {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
     flex: 1 1 100%;
     width: 100%;
   }
-  .home-latest-row-main > a { display: block; }
-  .home-latest-row-main > .updates-item-opensource { font-size: .85em; }
-  .home-latest-row-main .updates-item-cat { white-space: normal; }
+  .home-latest-row-main > a {
+    display: inline;
+    min-width: 0;
+    padding-right: 0;
+  }
+  .home-latest-row-main > a .updates-item-opensource { font-size: .85em; }
+  .home-latest-row-main > .updates-item-cat {
+    flex: 0 0 100%;
+    white-space: normal;
+    padding-left: 0;
+    margin-left: 0;
+  }
 }
 .home-latest-wiki-intro { margin-bottom: 20px; }
 /* 首页「互链枢纽 · Top 10」：全站 / 论文双 tab + 紧凑行列表（排名/类型/标题/互链度四列跨行对齐） */
@@ -635,7 +647,7 @@ body.sponsor-dialog-open {
 .hubs-meta { margin: 0 0 16px; }
 .hubs-list-actions { padding-left: 0; padding-right: 0; }
 @media (max-width: 860px) {
-  /* 窄屏：每条记录固定三段式——元信息行（排名/类型 + 右端互链数）、标题行、附注行（开源⭐️+社区标签） */
+  /* 窄屏：每条记录固定三段式——元信息行（排名/类型 + 右端互链数）、标题行（链接末尾⭐️）、附注行（仅社区标签） */
   .home-hub-list {
     display: flex;
     flex-direction: column;
@@ -657,12 +669,24 @@ body.sponsor-dialog-open {
   .home-hub-row-degree { order: 3; margin-left: auto; }
   .home-hub-row-main {
     order: 4;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
     flex: 1 1 100%;
     width: 100%;
   }
-  .home-hub-row-main > a { display: block; }
-  .home-hub-row-main > .updates-item-opensource { font-size: .85em; }
-  .home-hub-row-main .updates-item-cat { white-space: normal; }
+  .home-hub-row-main > a {
+    display: inline;
+    min-width: 0;
+    padding-right: 0;
+  }
+  .home-hub-row-main > a .updates-item-opensource { font-size: .85em; }
+  .home-hub-row-main > .updates-item-cat {
+    flex: 0 0 100%;
+    white-space: normal;
+    padding-left: 0;
+    margin-left: 0;
+  }
 }
 /* change-log 更新时间线（参考论文笔记站 updates.html：左轨道 + 日期圆点 + 条目行 + 超量折叠） */
 .updates-timeline-days { position: relative; padding-left: 18px; }
@@ -737,6 +761,10 @@ body.sponsor-dialog-open {
 .updates-item-opensource {
   line-height: 1;
   padding-right: 0.55rem;
+}
+a .updates-item-opensource {
+  padding-right: 0;
+  padding-left: 0.15em;
 }
 .updates-item-cat {
   font-size: .72rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 移动端（≤860px）`index.html` 的「最新知识节点」与 `hubs.html` 互链榜单行：将开源 ⭐️ 移入节点链接末尾，社区短标签单独占一行换行。
- 窄屏下 `.home-latest-row-main` / `.home-hub-row-main` 使用 flex 布局：`flex: 0 0 100%` 强制社区标签换行，并去除行首缩进/空隙。

## 验证
- `make lint-js` 通过（仅既有 `no-unused-vars` 警告）
- 本地 `make export graph` + `http.server` 后，375px 视口截图确认 ⭐️ 紧跟链接、社区标签独占下一行且无行首空格

## 验证截图
![移动端首页最新知识节点](https://cursor.com/artifacts/c/art-4cb9352a-abee-4a86-8a56-e1cf53085593)
![移动端互链枢纽完整榜单](https://cursor.com/artifacts/c/art-cc32779e-9ecd-428e-80bc-6720aba8d2b7)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f032211-4b9e-454e-b638-76b1c1bc8a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f032211-4b9e-454e-b638-76b1c1bc8a02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

