### PR TITLE
feat(ux): 首页知识图谱预览扩展为 Top-50 节点

### DIFF
--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -6,7 +6,7 @@
   var tooltip  = document.getElementById('mini-graph-tooltip');
   if (!miniWrap || !miniSvg) return;
 
-  var PREVIEW_TOP_N = 40;
+  var PREVIEW_TOP_N = 50;
   var isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
   var pinnedNode = null;
 
@@ -378,7 +378,7 @@
         .height(miniWrap.clientHeight || 480)
         .backgroundColor(theme.background)
         .showNavInfo(false)
-        // 40 节点几秒即稳定；默认 cooldownTime 15s 会让 engineStop 的取景来得太晚
+        // 50 节点几秒即稳定；默认 cooldownTime 15s 会让 engineStop 的取景来得太晚
         .cooldownTime(4000)
         .nodeColor(function (d) { return nodeFill(d); })
         .nodeVal(function (d) { return Math.max(1, d._degree); })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 将首页「知识图谱预览」mini-graph 的枢纽节点采样上限从 **Top-40** 调整为 **Top-50**，与全站 hub 页维护的 top-50 规模对齐。
- 左下角统计文案同步更新为「预览：全站连接度 Top-50 枢纽节点」。

## 变更
- `docs/mini-graph.js`：`PREVIEW_TOP_N` 40 → 50；3D 预览注释同步。

## 验证
- 本地 `make export graph` 后 `python3 -m http.server 8765` 打开首页。
- `#mini-graph-stats` 文案为「预览：全站连接度 Top-50 枢纽节点」。
- SVG 中 `.mini-graph-node` 数量为 **50**。

## 验证截图
![首页知识图谱 Top-50 预览](https://cursor.com/artifacts/c/art-a5f10eba-7810-4828-87fd-0e959e2c5abb)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a71d9da-1c84-4688-9a5b-05acf9a136b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a71d9da-1c84-4688-9a5b-05acf9a136b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

