### PR TITLE
style(ux): 首页搜索栏与模块背景反色

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -26,6 +26,12 @@
   --detail-toc-panel-max-height: min(76vh, 680px);
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
+  /* 首页搜索栏反色：深色模块 → 搜索区浅色、下拉深色 */
+  --search-contrast-bg: #f0f0f2;
+  --search-contrast-text: #1d1d1f;
+  --search-contrast-muted: #86868b;
+  --search-module-bg: #1c1c1e;
+  --search-module-text: #f5f5f7;
 }
 
 [data-theme="light"] {
@@ -44,6 +50,12 @@
   --quote-bg: #fef7f5;
   --header-bg: rgba(255, 255, 255, 0.8);
   --header-border: rgba(0, 0, 0, 0.1);
+  /* 首页搜索栏反色：浅色模块 → 搜索区深色、下拉浅色 */
+  --search-contrast-bg: #1c1c1e;
+  --search-contrast-text: #f5f5f7;
+  --search-contrast-muted: #9b9ba0;
+  --search-module-bg: #ffffff;
+  --search-module-text: #1d1d1f;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -2274,6 +2286,28 @@ button.home-wiki-heatmap-cell.is-active {
   background-repeat: no-repeat;
   background-position: right 10px center;
   background-size: 12px;
+}
+/* 模块背景与搜索栏反色：section-alt 内搜索区与模块底色对比，下拉与模块同调 */
+.section-alt .search-bar-wrap {
+  background: var(--search-contrast-bg);
+  border: 1px solid color-mix(in srgb, var(--search-contrast-text) 14%, transparent);
+}
+.section-alt .search-bar-wrap input[type="search"] {
+  color: var(--search-contrast-text);
+}
+.section-alt .search-bar-wrap input[type="search"]::placeholder {
+  color: var(--search-contrast-muted);
+}
+.section-alt #wikiCommunityFilter {
+  background-color: var(--search-module-bg);
+  color: var(--search-module-text);
+  border: 1px solid color-mix(in srgb, var(--search-module-text) 12%, transparent);
+}
+:root:not([data-theme="light"]) .section-alt #wikiCommunityFilter {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%23f5f5f7' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+[data-theme="light"] .section-alt #wikiCommunityFilter {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%2364748b' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 .ingest-badge {
   display: inline-block;

--- a/docs/style.css
+++ b/docs/style.css
@@ -26,12 +26,6 @@
   --detail-toc-panel-max-height: min(76vh, 680px);
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
-  /* 首页搜索栏反色：深色模块 → 搜索区浅色、下拉深色 */
-  --search-contrast-bg: #f0f0f2;
-  --search-contrast-text: #1d1d1f;
-  --search-contrast-muted: #86868b;
-  --search-module-bg: #1c1c1e;
-  --search-module-text: #f5f5f7;
 }
 
 [data-theme="light"] {
@@ -50,12 +44,6 @@
   --quote-bg: #fef7f5;
   --header-bg: rgba(255, 255, 255, 0.8);
   --header-border: rgba(0, 0, 0, 0.1);
-  /* 首页搜索栏反色：浅色模块 → 搜索区深色、下拉浅色 */
-  --search-contrast-bg: #1c1c1e;
-  --search-contrast-text: #f5f5f7;
-  --search-contrast-muted: #9b9ba0;
-  --search-module-bg: #ffffff;
-  --search-module-text: #1d1d1f;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -2287,27 +2275,14 @@ button.home-wiki-heatmap-cell.is-active {
   background-position: right 10px center;
   background-size: 12px;
 }
-/* 模块背景与搜索栏反色：section-alt 内搜索区与模块底色对比，下拉与模块同调 */
+/* 模块背景与搜索栏反色：section-alt 底色为 --bg-alt，搜索区用 --bg、下拉用 --bg-alt（同主题内深浅，不跨昼夜配色） */
 .section-alt .search-bar-wrap {
-  background: var(--search-contrast-bg);
-  border: 1px solid color-mix(in srgb, var(--search-contrast-text) 14%, transparent);
-}
-.section-alt .search-bar-wrap input[type="search"] {
-  color: var(--search-contrast-text);
-}
-.section-alt .search-bar-wrap input[type="search"]::placeholder {
-  color: var(--search-contrast-muted);
+  background: var(--bg);
+  border: 1px solid var(--border);
 }
 .section-alt #wikiCommunityFilter {
-  background-color: var(--search-module-bg);
-  color: var(--search-module-text);
-  border: 1px solid color-mix(in srgb, var(--search-module-text) 12%, transparent);
-}
-:root:not([data-theme="light"]) .section-alt #wikiCommunityFilter {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%23f5f5f7' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-}
-[data-theme="light"] .section-alt #wikiCommunityFilter {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%2364748b' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-color: var(--bg-alt);
+  border: 1px solid var(--border);
 }
 .ingest-badge {
   display: inline-block;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页 `#wiki-search`（`section-alt`）内：搜索区与模块底色反色，社区下拉与模块同调
- **修正**：反色使用**同一昼夜模式**下的 `--bg` / `--bg-alt` 层次，不再把白天配色套到黑夜、或反之

## 规则（同主题内）
| 模块底色 | 搜索栏 | 社区下拉 |
|---------|--------|---------|
| 较浅（暗色主题下 `section-alt`） | 较深 `--bg` | 较浅 `--bg-alt`（与模块同调） |
| 较深（亮色主题下 `section-alt`） | 较浅 `--bg` | 较深 `--bg-alt`（与模块同调） |

文字色沿用当前主题的 `--text` / `--text-muted`，不跨主题换色。

## 验证截图

**暗色主题**（模块 `#2c2c2e` → 搜索 `#1c1c1e`、下拉 `#2c2c2e`，文字均为浅色）

![暗色主题搜索区块](https://cursor.com/artifacts/c/art-aef798d2-e5fd-4c71-8c3d-295831b45d0a)

**亮色主题**（模块 `#f5f5f7` → 搜索 `#ffffff`、下拉 `#f5f5f7`，文字均为深色）

![亮色主题搜索区块](https://cursor.com/artifacts/c/art-578152af-86cd-4133-938a-752f38e3d2da)

**搜索栏特写**

| dark | light |
|------|-------|
| ![暗色搜索栏](https://cursor.com/artifacts/c/art-20f26cf3-d9f3-4577-b435-c5e964305e8e) | ![亮色搜索栏](https://cursor.com/artifacts/c/art-f5182330-a522-4e98-b0da-06bb655d0dcc) |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3be38e5-5c62-46f9-9a84-cc7ad15d793b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3be38e5-5c62-46f9-9a84-cc7ad15d793b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

