### PR TITLE
docs: README 与全站纵深路线列表统一按历史里程碑排序并说明排序方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@
 |---------|------|
 | 可视化探索知识图谱 | [知识图谱](https://imchong.github.io/Robotics_Notebooks/graph.html) |
 | 有一条路线照着走 | [运动控制成长路线](roadmap/motion-control.md) |
-| 用强化学习做运动控制 | [RL 纵深路线](roadmap/depth-rl-locomotion.md) |
 | 学传统模型控制（MPC/WBC）| [传统控制纵深路线](roadmap/depth-classical-control.md) |
-| 学模仿学习与技能迁移 | [模仿学习纵深路线](roadmap/depth-imitation-learning.md) |
 | 学安全控制（CLF/CBF）| [安全控制纵深路线](roadmap/depth-safe-control.md) |
 | 做接触丰富的操作任务 | [接触操作纵深路线](roadmap/depth-contact-manipulation.md) |
+| 学模仿学习与技能迁移 | [模仿学习纵深路线](roadmap/depth-imitation-learning.md) |
+| 用强化学习做运动控制 | [RL 纵深路线](roadmap/depth-rl-locomotion.md) |
 | 让机器人看地形越障 | [感知越障纵深路线](roadmap/depth-perceptive-locomotion.md) |
 | 浏览所有知识页 | [完整页面目录](catalog.md) |
 | 搜索特定概念 | `python3 scripts/search_wiki.py <关键词>` |
+
+> 六条纵深路线按各方向**起点里程碑的历史顺序**排列（与首页按钮一致）：传统控制（ZMP 判据，1972）→ 安全控制（CLF，1983）→ 接触操作（阻抗控制，1985）→ 模仿学习（行为克隆，1988）→ 强化学习（Q-learning，1989）→ 感知越障（2020s 感知策略浪潮）。越靠前的方向理论积淀越深，越靠后的方向越依赖学习方法与算力。
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -11,14 +11,16 @@
 | 你的目标 | 从这里进入 |
 |---------|-----------|
 | 想有一条学习路线照着走 | [主路线：运动控制成长路线](roadmap/motion-control.md) |
-| 想用强化学习做 locomotion | [RL 纵深路线](roadmap/depth-rl-locomotion.md) |
 | 想学传统模型控制（MPC/WBC）| [传统控制纵深路线](roadmap/depth-classical-control.md) |
-| 想学模仿学习与技能迁移 | [模仿学习纵深路线](roadmap/depth-imitation-learning.md) |
 | 想学安全控制（CLF/CBF）| [安全控制纵深路线](roadmap/depth-safe-control.md) |
 | 想做接触丰富的操作任务 | [接触操作纵深路线](roadmap/depth-contact-manipulation.md) |
+| 想学模仿学习与技能迁移 | [模仿学习纵深路线](roadmap/depth-imitation-learning.md) |
+| 想用强化学习做 locomotion | [RL 纵深路线](roadmap/depth-rl-locomotion.md) |
 | 想让机器人看地形越障 | [感知越障纵深路线](roadmap/depth-perceptive-locomotion.md) |
 | 想看知识概念和方法 | [浏览完整页面目录](catalog.md) |
 | 想看模块关系和依赖 | [tech-map 总览](tech-map/overview.md) |
+
+> 纵深路线按各方向起点里程碑的历史顺序排列，排序依据见 [README](README.md) 与 [roadmap 总览](roadmap/README.md)。
 
 ---
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,7 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-07-10] structural | README.md / index.md / roadmap/README.md / roadmap/motion-control.md — 纵深路线列表统一按方向起点里程碑历史排序（与首页按钮一致），README 与 roadmap 总览向读者说明排序方法（ZMP 1972 → CLF 1983 → 阻抗控制 1985 → 行为克隆 1988 → Q-learning 1989 → 感知越障 2020s）
+
 ## [2026-07-10] structural | docs/index.html — 主页「更多路线」六按钮改按方向起点里程碑历史排序（传统控制 ZMP 1972 → 安全控制 CLF 1983 → 接触操作 阻抗控制 1985 → 模仿学习 行为克隆 1988 → 强化学习 Q-learning 1989 → 感知越障 2020s）；同步 frontend-optimization-v1 checklist
 
 ## [2026-07-10] structural | docs/style.css — 修复首页「更多路线」六按钮在 861–940px 宽度下 5+1 孤行的排版问题（auto-fit 最小列宽 132px → 118px）；同步 frontend-optimization-v1 checklist

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -15,13 +15,15 @@
 
 ## 纵深路线（按目标选其一深入）
 
-主路线偏"先打通主干"，下列六条纵深路线**各自独立**，从主路线某个阶段衔接出去，可单独阅读：
+主路线偏"先打通主干"，下列六条纵深路线**各自独立**，从主路线某个阶段衔接出去，可单独阅读。
 
-- [如果目标是 RL 运动控制](depth-rl-locomotion.md) —— 想用强化学习驱动人形 locomotion
-- [如果目标是传统模型控制（LIP/ZMP → MPC → WBC）](depth-classical-control.md) —— 想系统掌握 model-based 人形控制主干
-- [如果目标是模仿学习与技能迁移](depth-imitation-learning.md) —— 想从人类演示数据学习技能
-- [如果目标是安全控制（CLF / CBF / Safe RL）](depth-safe-control.md) —— 想加可证明的安全约束
-- [如果目标是接触丰富的操作任务](depth-contact-manipulation.md) —— 想做装配、插拔、双臂协同等精细接触
-- [如果目标是感知越障（Perceptive Locomotion）](depth-perceptive-locomotion.md) —— 想让机器人看着地形上楼梯、跨障碍、跑酷
+排序说明：按各方向**起点里程碑的历史顺序**排列（与首页按钮、README 一致）——越靠前的方向理论积淀越深，越靠后的方向越依赖学习方法与算力：
+
+- [如果目标是传统模型控制（LIP/ZMP → MPC → WBC）](depth-classical-control.md) —— 想系统掌握 model-based 人形控制主干（起点：ZMP 判据，1972）
+- [如果目标是安全控制（CLF / CBF / Safe RL）](depth-safe-control.md) —— 想加可证明的安全约束（起点：CLF，1983）
+- [如果目标是接触丰富的操作任务](depth-contact-manipulation.md) —— 想做装配、插拔、双臂协同等精细接触（起点：阻抗控制，1985）
+- [如果目标是模仿学习与技能迁移](depth-imitation-learning.md) —— 想从人类演示数据学习技能（起点：行为克隆，1988）
+- [如果目标是 RL 运动控制](depth-rl-locomotion.md) —— 想用强化学习驱动人形 locomotion（起点：Q-learning，1989）
+- [如果目标是感知越障（Perceptive Locomotion）](depth-perceptive-locomotion.md) —— 想让机器人看着地形上楼梯、跨障碍、跑酷（起点：2020s 感知策略浪潮）
 
 说明：感知、规划、系统、部署等更广的全栈知识在主路线的 **L−1 全景层** 和 **L7 出口层** 集中扫盲，提供进入对应子专题的入口，而不在本目录维护并列的独立路线图文件。

--- a/roadmap/motion-control.md
+++ b/roadmap/motion-control.md
@@ -29,12 +29,12 @@
 - 想 **30 秒先理解整个机器人技术栈**：跳到 [L−1 序言](#l1-序言机器人技术栈全景--怎么读这条路线)。
 - 想 **最短可执行路径**：跳到 [最小可执行学习路径（90 天版本）](#最小可执行学习路径90-天版本)。
 - 想 **完整路线**：按 L−1 → L0 → … → L7 依次阅读。
-- 想 **走纵深**（各自独立路线页）：
-  - [如果目标是 RL 运动控制](depth-rl-locomotion.md)
+- 想 **走纵深**（各自独立路线页，按方向起点里程碑的历史排序）：
   - [如果目标是传统模型控制（LIP/ZMP → MPC → WBC）](depth-classical-control.md)
-  - [如果目标是模仿学习与技能迁移](depth-imitation-learning.md)
   - [如果目标是安全控制](depth-safe-control.md)
   - [如果目标是接触丰富的操作任务](depth-contact-manipulation.md)
+  - [如果目标是模仿学习与技能迁移](depth-imitation-learning.md)
+  - [如果目标是 RL 运动控制](depth-rl-locomotion.md)
   - [如果目标是感知越障](depth-perceptive-locomotion.md)
 
 ---
@@ -1364,15 +1364,15 @@ flowchart TD
 
 ## 可选纵深（独立路线页）
 
-主路线偏向"先稳住一条主干"，但实际研究方向往往要继续深入某一个子专题。下面六条纵深路径**各自是独立的 roadmap 页面**，从主路线的某个阶段衔接出去：
+主路线偏向"先稳住一条主干"，但实际研究方向往往要继续深入某一个子专题。下面六条纵深路径**各自是独立的 roadmap 页面**，从主路线的某个阶段衔接出去（按各方向起点里程碑的历史顺序排列，与首页、README 一致）：
 
 | 纵深路径 | 适合谁 | 主线衔接点 |
 |---------|------|-----------|
-| [如果目标是 RL 运动控制](depth-rl-locomotion.md) | 想用 RL 让人形走起来、不愿从头啃控制理论 | L3 → L5.2 |
 | [如果目标是传统模型控制（LIP/ZMP → MPC → WBC）](depth-classical-control.md) | 想把 model-based 主干写成可运行的控制器 | L2 → L4 |
-| [如果目标是模仿学习与技能迁移](depth-imitation-learning.md) | 想从人类演示数据驱动机器人技能 | L5.3 之后 |
 | [如果目标是安全控制（CLF / CBF / Safe RL）](depth-safe-control.md) | 想给 WBC / MPC / RL 加可证明的安全约束 | L4.4 / L5 任意 |
 | [如果目标是接触丰富的操作任务](depth-contact-manipulation.md) | 想做装配、插拔、双臂协同等精细接触 | L4.4 / L5.3 之后 |
+| [如果目标是模仿学习与技能迁移](depth-imitation-learning.md) | 想从人类演示数据驱动机器人技能 | L5.3 之后 |
+| [如果目标是 RL 运动控制](depth-rl-locomotion.md) | 想用 RL 让人形走起来、不愿从头啃控制理论 | L3 → L5.2 |
 | [如果目标是感知越障（Perceptive Locomotion）](depth-perceptive-locomotion.md) | 想让机器人看着地形上楼梯、跨障碍、跑酷 | L5 之后 |
 
 每条纵深页都有自己的 Stage 0–N 划分，可以独立阅读；遇到理论卡点再回主路线对应章节补。
@@ -1403,11 +1403,11 @@ flowchart TD
 - 传统机器人学主教材：[Modern Robotics](../wiki/entities/modern-robotics-book.md)
 - 更详细的阶段参考：[Humanoid Control Roadmap](../wiki/roadmaps/humanoid-control-roadmap.md)
 - 实战经验补充：[Query：人形机器人运动控制 Know-How](../wiki/queries/humanoid-motion-control-know-how.md)
-- 可选纵深路线页：
-  - [如果目标是 RL 运动控制](depth-rl-locomotion.md)
+- 可选纵深路线页（按方向起点里程碑的历史排序）：
   - [如果目标是传统模型控制](depth-classical-control.md)
-  - [如果目标是模仿学习与技能迁移](depth-imitation-learning.md)
   - [如果目标是安全控制](depth-safe-control.md)
   - [如果目标是接触丰富的操作任务](depth-contact-manipulation.md)
+  - [如果目标是模仿学习与技能迁移](depth-imitation-learning.md)
+  - [如果目标是 RL 运动控制](depth-rl-locomotion.md)
   - [如果目标是感知越障](depth-perceptive-locomotion.md)
 - 技术栈地图参考：[tech-map/dependency-graph.md](../tech-map/dependency-graph.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 跟进 PR #1022（主页按钮历史排序）：`README.md`「从哪里开始」表中六条纵深路线行改为同一历史顺序，并在表后向读者说明排序方法——按各方向**起点里程碑的历史顺序**：传统控制（ZMP 判据，1972）→ 安全控制（CLF，1983）→ 接触操作（阻抗控制，1985）→ 模仿学习（行为克隆，1988）→ 强化学习（Q-learning，1989）→ 感知越障（2020s 感知策略浪潮）；并注明"越靠前理论积淀越深，越靠后越依赖学习方法与算力"。
- 同步对齐其余三处纵深路线列表，避免各入口顺序不一致：`index.md` 快速入口表（附指向 README/roadmap 总览的排序说明）、`roadmap/README.md`（每条路线标注起点里程碑）、`roadmap/motion-control.md`（导航列表、可选纵深表、关系区三处）。
- 追加 `log.md` structural 记录。

## 验证
- `make ci-preflight` 通过（lint 0 errors、断链 0，导出质量检查 12/12）
- 纯 Markdown 文档排序与文字说明改动，无渲染层变更（首页按钮排序已在 PR #1022 合并）

## 排序后的 README 表（节选）
| 你的目标 | 入口 |
|---------|------|
| 学传统模型控制（MPC/WBC）| 传统控制纵深路线 |
| 学安全控制（CLF/CBF）| 安全控制纵深路线 |
| 做接触丰富的操作任务 | 接触操作纵深路线 |
| 学模仿学习与技能迁移 | 模仿学习纵深路线 |
| 用强化学习做运动控制 | RL 纵深路线 |
| 让机器人看地形越障 | 感知越障纵深路线 |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-677ca7eb-ed5f-43d0-b683-33a3f8abb26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677ca7eb-ed5f-43d0-b683-33a3f8abb26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

