### PR TITLE
Collapse homepage depth routes to latest 4 by default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,31 +45,6 @@
             <span id="heroEdgeCount">11753</span> 条连接
           </div>
         </div>
-        <div id="wiki-search" class="hero-search">
-          <div class="search-bar-wrap">
-            <input
-              id="wikiSearchInput"
-              type="search"
-              placeholder="搜索概念、方法或任务：MPC、PPO、Diffusion Policy…"
-              aria-label="搜索知识页面"
-              autocomplete="off"
-            />
-            <select id="wikiCommunityFilter" aria-label="按社区过滤">
-              <option value="">全部社区</option>
-            </select>
-          </div>
-          <!-- 热门主题：main.js 用 home-stats.json 的 top_communities 覆盖为实时 Top 社区；
-               以下静态 chips 仅为 JS/数据失败时的兜底快照 -->
-          <div id="wikiHotTopics" class="tag-cloud" aria-label="热门主题">
-            <button class="tag-chip" data-wiki-tag="移动操作">移动操作</button>
-            <button class="tag-chip" data-wiki-tag="人形论文深读笔记">人形论文深读笔记</button>
-            <button class="tag-chip" data-wiki-tag="强化学习">强化学习</button>
-            <button class="tag-chip" data-wiki-tag="全身控制">全身控制</button>
-            <button class="tag-chip" data-wiki-tag="物理引擎">物理引擎</button>
-            <button class="tag-chip" data-wiki-tag="动作重定向">动作重定向</button>
-          </div>
-          <div id="wikiSearchResults" class="card-grid" aria-live="polite"></div>
-        </div>
       </div>
     </section>
 
@@ -83,6 +58,12 @@
             <h3>建立运动控制全局认识</h3>
             <p>从机器人基础、动力学到控制与 Sim2Real，按主路线逐步学习。</p>
             <span class="home-entry-link">进入主路线 →</span>
+          </a>
+          <a class="card home-entry-card" href="#wiki-search" data-focus-search>
+            <span class="home-entry-label">项目查询</span>
+            <h3>查找框架、论文与机器人平台</h3>
+            <p>直接搜索项目名称、算法缩写或具体工程问题。</p>
+            <span class="home-entry-link">搜索知识库 →</span>
           </a>
           <div class="card home-entry-card home-entry-card-more">
             <span class="home-entry-label">更多路线</span>
@@ -111,6 +92,35 @@
             <button type="button" id="homeRouteToggle" class="home-entry-link home-route-toggle" aria-expanded="false" aria-controls="homeRouteLinks">展开全部 12 条纵深路线 ↓</button>
           </div>
         </div>
+      </div>
+    </section>
+
+    <section class="section section-alt" id="wiki-search">
+      <div class="container">
+        <h2 class="section-title">搜索知识库</h2>
+        <div class="search-bar-wrap">
+          <input
+            id="wikiSearchInput"
+            type="search"
+            placeholder="搜索概念、方法或任务：MPC、PPO、Diffusion Policy…"
+            aria-label="搜索知识页面"
+            autocomplete="off"
+          />
+          <select id="wikiCommunityFilter" aria-label="按社区过滤">
+            <option value="">全部社区</option>
+          </select>
+        </div>
+        <!-- 热门主题：main.js 用 home-stats.json 的 top_communities 覆盖为实时 Top 社区；
+             以下静态 chips 仅为 JS/数据失败时的兜底快照 -->
+        <div id="wikiHotTopics" class="tag-cloud" aria-label="热门主题">
+          <button class="tag-chip" data-wiki-tag="移动操作">移动操作</button>
+          <button class="tag-chip" data-wiki-tag="人形论文深读笔记">人形论文深读笔记</button>
+          <button class="tag-chip" data-wiki-tag="强化学习">强化学习</button>
+          <button class="tag-chip" data-wiki-tag="全身控制">全身控制</button>
+          <button class="tag-chip" data-wiki-tag="物理引擎">物理引擎</button>
+          <button class="tag-chip" data-wiki-tag="动作重定向">动作重定向</button>
+        </div>
+        <div id="wikiSearchResults" class="card-grid" aria-live="polite"></div>
       </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,6 +45,31 @@
             <span id="heroEdgeCount">11753</span> 条连接
           </div>
         </div>
+        <div id="wiki-search" class="hero-search">
+          <div class="search-bar-wrap">
+            <input
+              id="wikiSearchInput"
+              type="search"
+              placeholder="搜索概念、方法或任务：MPC、PPO、Diffusion Policy…"
+              aria-label="搜索知识页面"
+              autocomplete="off"
+            />
+            <select id="wikiCommunityFilter" aria-label="按社区过滤">
+              <option value="">全部社区</option>
+            </select>
+          </div>
+          <!-- 热门主题：main.js 用 home-stats.json 的 top_communities 覆盖为实时 Top 社区；
+               以下静态 chips 仅为 JS/数据失败时的兜底快照 -->
+          <div id="wikiHotTopics" class="tag-cloud" aria-label="热门主题">
+            <button class="tag-chip" data-wiki-tag="移动操作">移动操作</button>
+            <button class="tag-chip" data-wiki-tag="人形论文深读笔记">人形论文深读笔记</button>
+            <button class="tag-chip" data-wiki-tag="强化学习">强化学习</button>
+            <button class="tag-chip" data-wiki-tag="全身控制">全身控制</button>
+            <button class="tag-chip" data-wiki-tag="物理引擎">物理引擎</button>
+            <button class="tag-chip" data-wiki-tag="动作重定向">动作重定向</button>
+          </div>
+          <div id="wikiSearchResults" class="card-grid" aria-live="polite"></div>
+        </div>
       </div>
     </section>
 
@@ -59,12 +84,6 @@
             <p>从机器人基础、动力学到控制与 Sim2Real，按主路线逐步学习。</p>
             <span class="home-entry-link">进入主路线 →</span>
           </a>
-          <a class="card home-entry-card" href="#wiki-search" data-focus-search>
-            <span class="home-entry-label">项目查询</span>
-            <h3>查找框架、论文与机器人平台</h3>
-            <p>直接搜索项目名称、算法缩写或具体工程问题。</p>
-            <span class="home-entry-link">搜索知识库 →</span>
-          </a>
           <div class="card home-entry-card home-entry-card-more">
             <span class="home-entry-label">更多路线</span>
             <h3>按研究方向进入纵深路线</h3>
@@ -72,52 +91,26 @@
                  传统控制（ZMP 1972）→ 安全控制（CLF 1983）→ 接触操作（阻抗控制 1985）
                  → 导航（概率 SLAM 1986）→ 模仿学习（行为克隆 1988）→ 强化学习（Q-learning 1989）
                  → 移动操作（移动操作臂协调 1994）→ 动作重定向（Gleicher 1998）→ BFM（DeepMimic 2018）
-                 → 感知越障（2020s）→ 动作生成（MDM 2022）→ VLA（RT-2 确立 VLA，2023） -->
-            <div class="home-entry-route-links">
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-classical-control">传统控制</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-safe-control">安全控制</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-contact-manipulation">接触操作</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-navigation">导航</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-imitation-learning">模仿学习</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-rl-locomotion">强化学习</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-mobile-manipulation">移动操作</a>
-              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-motion-retargeting">动作重定向</a>
+                 → 感知越障（2020s）→ 动作生成（MDM 2022）→ VLA（RT-2 确立 VLA，2023）
+                 默认折叠：只展示里程碑最新的 4 条，其余 8 条标记 data-route-extra + hidden，
+                 由 main.js 的展开按钮（#homeRouteToggle）控制显隐 -->
+            <div class="home-entry-route-links" id="homeRouteLinks">
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-classical-control" data-route-extra hidden>传统控制</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-safe-control" data-route-extra hidden>安全控制</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-contact-manipulation" data-route-extra hidden>接触操作</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-navigation" data-route-extra hidden>导航</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-imitation-learning" data-route-extra hidden>模仿学习</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-rl-locomotion" data-route-extra hidden>强化学习</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-mobile-manipulation" data-route-extra hidden>移动操作</a>
+              <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-motion-retargeting" data-route-extra hidden>动作重定向</a>
               <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-bfm">BFM</a>
               <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-perceptive-locomotion">感知越障</a>
               <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-motion-generation">动作生成</a>
               <a class="btn-secondary" href="roadmap.html?id=roadmap-depth-vla">VLA</a>
             </div>
+            <button type="button" id="homeRouteToggle" class="home-entry-link home-route-toggle" aria-expanded="false" aria-controls="homeRouteLinks">展开全部 12 条纵深路线 ↓</button>
           </div>
         </div>
-      </div>
-    </section>
-
-    <section class="section section-alt" id="wiki-search">
-      <div class="container">
-        <h2 class="section-title">搜索知识库</h2>
-        <div class="search-bar-wrap">
-          <input
-            id="wikiSearchInput"
-            type="search"
-            placeholder="搜索概念、方法或任务：MPC、PPO、Diffusion Policy…"
-            aria-label="搜索知识页面"
-            autocomplete="off"
-          />
-          <select id="wikiCommunityFilter" aria-label="按社区过滤">
-            <option value="">全部社区</option>
-          </select>
-        </div>
-        <!-- 热门主题：main.js 用 home-stats.json 的 top_communities 覆盖为实时 Top 社区；
-             以下静态 chips 仅为 JS/数据失败时的兜底快照 -->
-        <div id="wikiHotTopics" class="tag-cloud" aria-label="热门主题">
-          <button class="tag-chip" data-wiki-tag="移动操作">移动操作</button>
-          <button class="tag-chip" data-wiki-tag="人形论文深读笔记">人形论文深读笔记</button>
-          <button class="tag-chip" data-wiki-tag="强化学习">强化学习</button>
-          <button class="tag-chip" data-wiki-tag="全身控制">全身控制</button>
-          <button class="tag-chip" data-wiki-tag="物理引擎">物理引擎</button>
-          <button class="tag-chip" data-wiki-tag="动作重定向">动作重定向</button>
-        </div>
-        <div id="wikiSearchResults" class="card-grid" aria-live="polite"></div>
       </div>
     </section>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -5510,21 +5510,25 @@
       });
   }
 
+  // ── 首页「更多路线」折叠：默认只展示里程碑最新的 4 条纵深路线 ──────────────
+  var routeToggle = document.getElementById('homeRouteToggle');
+  if (routeToggle) {
+    routeToggle.addEventListener('click', function () {
+      var expanded = routeToggle.getAttribute('aria-expanded') === 'true';
+      var extras = document.querySelectorAll('#homeRouteLinks [data-route-extra]');
+      for (var rti = 0; rti < extras.length; rti++) {
+        extras[rti].hidden = expanded;
+      }
+      routeToggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      routeToggle.textContent = expanded ? '展开全部 12 条纵深路线 ↓' : '收起纵深路线 ↑';
+    });
+  }
+
   // ── Wiki 全文搜索（index.html 搜索框） ────────────────────────────────────
   var searchInput = document.getElementById('wikiSearchInput');
   var searchResults = document.getElementById('wikiSearchResults');
   var communityFilter = document.getElementById('wikiCommunityFilter');
   if (searchInput && searchResults) {
-    // 首页「项目查询」入口卡：锚点跳转到搜索区后直接聚焦输入框
-    var focusSearchTriggers = document.querySelectorAll('[data-focus-search]');
-    for (var fsti = 0; fsti < focusSearchTriggers.length; fsti++) {
-      focusSearchTriggers[fsti].addEventListener('click', function () {
-        window.setTimeout(function () {
-          searchInput.focus({ preventScroll: true });
-        }, 0);
-      });
-    }
-
     var _selectedIndex = -1;  // 键盘导航当前选中项
 
     var _searchIndex = null;

--- a/docs/main.js
+++ b/docs/main.js
@@ -5529,6 +5529,16 @@
   var searchResults = document.getElementById('wikiSearchResults');
   var communityFilter = document.getElementById('wikiCommunityFilter');
   if (searchInput && searchResults) {
+    // 首页「项目查询」入口卡：锚点跳转到搜索区后直接聚焦输入框
+    var focusSearchTriggers = document.querySelectorAll('[data-focus-search]');
+    for (var fsti = 0; fsti < focusSearchTriggers.length; fsti++) {
+      focusSearchTriggers[fsti].addEventListener('click', function () {
+        window.setTimeout(function () {
+          searchInput.focus({ preventScroll: true });
+        }, 0);
+      });
+    }
+
     var _selectedIndex = -1;  // 键盘导航当前选中项
 
     var _searchIndex = null;

--- a/docs/style.css
+++ b/docs/style.css
@@ -254,6 +254,8 @@ body.sponsor-dialog-open {
   color: var(--text);
   font-weight: 600;
 }
+/* Hero 内嵌搜索：搜索栏与统计行留白，结果卡片直接在 Hero 内展开 */
+.hero-search { margin-top: 26px; }
 .cta-row {
   display: flex;
   flex-wrap: wrap;
@@ -420,7 +422,6 @@ body.sponsor-dialog-open {
 }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
 /* 首页无副标题区块：标题与内容之间保持统一间距 */
-#wiki-search .search-bar-wrap,
 #home-latest-wiki-section .home-latest-wiki-mount,
 #mini-graph-section #mini-graph-wrap {
   margin-top: 18px;
@@ -1010,6 +1011,8 @@ button.home-wiki-heatmap-cell.is-active {
 .home-entry-grid {
   align-items: stretch;
   gap: 16px;
+  /* 搜索入口卡并入 Hero 后仅剩两张通栏卡，单列堆叠 */
+  grid-template-columns: 1fr;
 }
 .home-entry-grid > .home-entry-card {
   height: 100%;
@@ -1077,6 +1080,17 @@ button.home-wiki-heatmap-cell.is-active {
   border: 1px solid var(--border);
   text-align: center;
   white-space: nowrap;
+}
+/* 折叠态的路线按钮必须真正隐藏（btn-secondary 的 display 会覆盖 UA 的 [hidden] 样式） */
+.home-entry-route-links a[hidden] { display: none; }
+/* 展开/收起按钮：复用 home-entry-link 的文字样式，去掉 button 默认外观 */
+.home-route-toggle {
+  background: none;
+  border: none;
+  padding: 2px 0 0;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
 }
 #home-start .section-subtitle {
   margin-bottom: 20px;
@@ -2315,15 +2329,6 @@ button.home-wiki-heatmap-cell.is-active {
   background-repeat: no-repeat;
   background-position: right 10px center;
   background-size: 12px;
-}
-/* 模块背景与搜索栏反色：section-alt 底色为 --bg-alt，搜索区用 --bg、下拉用 --bg-alt（同主题内深浅，不跨昼夜配色） */
-.section-alt .search-bar-wrap {
-  background: var(--bg);
-  border: 1px solid var(--border);
-}
-.section-alt #wikiCommunityFilter {
-  background-color: var(--bg-alt);
-  border: 1px solid var(--border);
 }
 .ingest-badge {
   display: inline-block;

--- a/docs/style.css
+++ b/docs/style.css
@@ -254,8 +254,6 @@ body.sponsor-dialog-open {
   color: var(--text);
   font-weight: 600;
 }
-/* Hero 内嵌搜索：搜索栏与统计行留白，结果卡片直接在 Hero 内展开 */
-.hero-search { margin-top: 26px; }
 .cta-row {
   display: flex;
   flex-wrap: wrap;
@@ -422,6 +420,7 @@ body.sponsor-dialog-open {
 }
 .section-title { font-size: 1.72rem; font-weight: 820; margin-bottom: 10px; letter-spacing: -.02em; }
 /* 首页无副标题区块：标题与内容之间保持统一间距 */
+#wiki-search .search-bar-wrap,
 #home-latest-wiki-section .home-latest-wiki-mount,
 #mini-graph-section #mini-graph-wrap {
   margin-top: 18px;
@@ -1011,8 +1010,6 @@ button.home-wiki-heatmap-cell.is-active {
 .home-entry-grid {
   align-items: stretch;
   gap: 16px;
-  /* 搜索入口卡并入 Hero 后仅剩两张通栏卡，单列堆叠 */
-  grid-template-columns: 1fr;
 }
 .home-entry-grid > .home-entry-card {
   height: 100%;
@@ -2329,6 +2326,15 @@ button.home-wiki-heatmap-cell.is-active {
   background-repeat: no-repeat;
   background-position: right 10px center;
   background-size: 12px;
+}
+/* 模块背景与搜索栏反色：section-alt 底色为 --bg-alt，搜索区用 --bg、下拉用 --bg-alt（同主题内深浅，不跨昼夜配色） */
+.section-alt .search-bar-wrap {
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.section-alt #wikiCommunityFilter {
+  background-color: var(--bg-alt);
+  border: 1px solid var(--border);
 }
 .ingest-badge {
   display: inline-block;


### PR DESCRIPTION
## 摘要

首页「更多路线」卡片的 12 条纵深路线默认折叠，只展示里程碑最新的 4 条（BFM、感知越障、动作生成、VLA），新增展开/收起按钮，降低首页视觉密度。

> 注：本 PR 最初还包含「搜索并入 Hero」的改动，已按需求撤销（commit `2f54ffd`），现仅保留路线折叠。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 纵深路线折叠
- **标记** 前 8 条路线（传统控制～动作重定向）为 `data-route-extra hidden`，历史里程碑顺序不变
- **保留** 最新 4 条路线（BFM、感知越障、动作生成、VLA）始终可见
- **新增** 展开/收起按钮（`#homeRouteToggle`），与 `aria-expanded` 属性同步

### 样式
- 新增 `.home-entry-route-links a[hidden] { display: none; }`（`btn-secondary` 的 `display` 会覆盖 UA 的 `[hidden]` 样式，需显式隐藏）
- 新增 `.home-route-toggle` 按钮样式（复用 `home-entry-link` 文字样式，去掉 button 默认外观）

## 验证

- [x] `make ci-preflight` 通过（导出质量检查 12/12，重生成链路对 `docs/index.html` 幂等）
- [x] `npx eslint docs/main.js` 无新增问题
- [x] 本地静态站验证：
  - 默认折叠为最新 4 条，一行排布；展开显示全部 12 条（历史顺序），可再收起
  - 移动端（390px）折叠态 2×2 网格无孤行
  - 搜索区块、「项目查询」入口卡等其余首页功能与 main 一致（撤销已验证）

## 验证截图

入口区默认折叠态（4 条路线 + 展开按钮）：

``&lt;img alt="首页入口区默认折叠态" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/home-desktop-collapsed.png" /&gt;``

展开全部 12 条纵深路线（历史里程碑顺序）：

``&lt;img alt="首页更多路线展开态" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/home-desktop-expanded.png" /&gt;``

移动端折叠态（路线 2×2 无孤行）：

``&lt;img alt="首页移动端入口区折叠态" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/home-mobile-entry.png" /&gt;``

## 相关 Issue

无

https://claude.ai/code/session_01AS4GH8QuU4SSkHdTeFYn1Q