### PR TITLE
style(ux): 缩短首页「从零开始」卡描述，桌面端不再换行

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
           <a class="card home-entry-card" href="roadmap.html?id=roadmap-motion-control">
             <span class="home-entry-label">从零开始</span>
             <h3>建立运动控制全局认识</h3>
-            <p>从机器人基础、动力学到控制与 Sim2Real，按主路线逐步学习。</p>
+            <p>从基础、动力学到控制与 Sim2Real 逐步学习。</p>
             <span class="home-entry-link">进入主路线 →</span>
           </a>
           <a class="card home-entry-card" href="#wiki-search" data-focus-search>


### PR DESCRIPTION
## 摘要

首页「从零开始」入口卡的描述在桌面宽度下换行后孤出「习。」二字。缩短文案为「从基础、动力学到控制与 Sim2Real 逐步学习。」：「按主路线」与卡片下方「进入主路线 →」链接重复，删去；「机器人」由站点语境自明。学习脉络（基础 → 动力学 → 控制 → Sim2Real）保留。

## 变更类型

- [x] 前端（`docs/`）

## 验证

- [x] `make ci-preflight`（导出质量检查 12/12 通过，重生成链路对 `docs/index.html` 幂等）
- [x] 本地静态站验证：1109px（反馈截图同宽）与 1440px 下描述均为单行

## 验证截图

1109px 宽度下「从零开始」卡描述单行渲染：

``&lt;img alt="从零开始卡描述单行渲染（1109px）" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/home-entry-copy-1109.png" /&gt;``

## 相关 Issue

无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AS4GH8QuU4SSkHdTeFYn1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01AS4GH8QuU4SSkHdTeFYn1Q)_