### PR TITLE
docs(readme): 首页新增知识图谱交互演示 GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-1564节点_11754边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
 [![Sources Coverage](https://img.shields.io/badge/sources覆盖率-98%25-green)](docs/checklists/tech-stack-next-phase-checklist-v28.md)
 
+---
 
+## 在线演示
+
+[![知识图谱交互演示：1564 个知识节点按技术社区着色，悬停节点查看简介，滚轮缩放，并可切换 3D 立体视图](media/graph-demo.gif)](https://imchong.github.io/Robotics_Notebooks/graph.html)
+
+↑ [交互式知识图谱](https://imchong.github.io/Robotics_Notebooks/graph.html)：每个点是一个知识页，颜色代表所属技术社区，连线是页面间的引用关系。悬停看简介与关联边，点击进详情页，支持 2D / 3D 视图切换。
 
 ---
 


### PR DESCRIPTION
参考 withmarbleapp/os-taxonomy 的 README 演示形式，在徽章下方新增「在线演示」
小节：录制 docs/graph.html 的真实交互（力导布局、悬停节点提示、滚轮缩放、
2D/3D 视图切换与旋转），GIF 存于 media/graph-demo.gif 并链接到在线图谱页。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TDxifmx3ttUPqDwnscivtx