### PR TITLE
structural | checklist-v28 P3② 详情页「同专题相关页」验证完成

### DIFF
--- a/docs/checklists/tech-stack-next-phase-checklist-v28.md
+++ b/docs/checklists/tech-stack-next-phase-checklist-v28.md
@@ -44,8 +44,8 @@
 
 - [x] **图谱页"具身大模型"专题视图**：
     - [x] `docs/topic-filters.js` 单一事实源新增「具身大模型」专题（`embodied-foundation-model`，🧠 emoji），复用 path 片段并集机制（`vlm` / `vln` / `vlx` / `worldmodel` / `worldaction` 等干净片段——刻意剔除过宽的 `vla`（归 `topic-vla`，改用 `ids` 精选纳入），与 `vla` / `vision-backbone` 保持最小重叠）并用 `ids` 显式纳入五层闭环里未被片段命中的家族页（`embodied-fm-taxonomy-loop` / `vlm-vln-vla-vlx-world-model-taxonomy` / `behavior-foundation-model` / `unified-multimodal-tokens` / `methods/vla` / `tasks/vision-language-navigation` / `world-action-models` / `generative-world-models` / `foundation-policy` / `behavior-tree-vla-orchestration` / `3d-spatial-vqa` 等）；同步在 `docs/graph.html` `#filter-topic-chips` 增加对应 chip。专题汇总枢纽页 `wiki/overview/topic-embodied-foundation-model.md` 已建（已从 comparisons/query 家族页交叉回链），`graph-stats.json` 0 orphans。专题视图筛出 30 节点落稳后截图归档至 `.cursor-artifacts/screenshots/graph-topic-embodied-foundation-model.png`（因 `excludeSegments` 优先级高于 `ids`，`vla` 仅从 `segments` 剔除、未加入 `excludeSegments`，避免误伤含 `vla` 词元的分类对比页）。
-- [ ] **详情页"同专题相关页"提示**：
-    - [ ] 复用 `docs/topic-filters.js` 单一事实源（`renderMetaTopicBadges` → `topicsForNode` 已数据驱动），家族/新建页命中「具身大模型」专题时自动渲染对应轻量徽标 + 跳转 `graph.html?topic=embodied-foundation-model`（空态降级隐藏）。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-embodied-foundation-model.png`。
+- [x] **详情页"同专题相关页"提示**：
+    - [x] 复用 `docs/topic-filters.js` 单一事实源（`renderMetaTopicBadges` → `topicsForNode` 已数据驱动），家族/新建页命中「具身大模型」专题时自动渲染对应轻量徽标 + 跳转 `graph.html?topic=embodied-foundation-model`（空态降级隐藏）。P3① 把 `embodied-foundation-model` 写入单一事实源后，详情页「所属专题」徽标行即自动联动，无需二次实现；`wiki/methods/vla.md` 详情页端到端验证：「所属专题」行同渲「👀 视觉-语言-动作 (VLA)」+「🧠 具身大模型 (Embodied Foundation Model)」双徽标，后者跳 `graph.html?topic=embodied-foundation-model`，空态整行降级隐藏。端到端验证截图归档至 `.cursor-artifacts/screenshots/detail-topic-embodied-foundation-model.png`。
 
 ---
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,11 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-07-12] structural | checklist-v28 P3② 详情页「同专题相关页」提示 —— 具身大模型徽标端到端验证与截图归档
+
+- 详情页「所属专题」徽标行（`docs/main.js renderMetaTopicBadges`）本就以 `docs/topic-filters.js` 为单一事实源、`topicsForNode` 数据驱动：P3① 把 `embodied-foundation-model` 写入单一事实源后，详情页徽标已自动联动，无需二次实现——命中即渲染「🧠 具身大模型」徽标并跳 `graph.html?topic=embodied-foundation-model`，空态降级隐藏整行。
+- 端到端验证：`wiki/methods/vla.md` 详情页（`detail.html?id=wiki-methods-vla`）「所属专题」行同渲「👀 视觉-语言-动作 (VLA)」+「🧠 具身大模型 (Embodied Foundation Model)」双徽标；node 逐页校验 `topicsForNode` 对 methods/vla、tasks/vision-language-navigation、concepts/world-action-models、queries/embodied-fm-taxonomy-loop、methods/generative-world-models 五页均稳定命中 `embodied-foundation-model` 专题。截图归档 `.cursor-artifacts/screenshots/detail-topic-embodied-foundation-model.png`。
+- `make lint` 0 errors（另含 1 条信息型预警，不阻塞 CI）；勾选 v28 P3「详情页『同专题相关页』提示」第②项，P3 两个子项全部完成。
+
 ## [2026-07-12] ingest | sources/papers/robo_bench_arxiv_2510_17801.md — RoboBench MLLM 具身大脑五维评测；wiki/entities/robo-bench.md 及 VLA/ESI-Bench 交叉引用
 
 - wiki/entities/robo-bench.md


### PR DESCRIPTION
## 摘要

完成 checklist-v28 P3② 「详情页『同专题相关页』提示」的端到端验证与截图归档。确认「具身大模型」专题在详情页「所属专题」徽标行自动联动渲染，无需二次实现——复用 `docs/topic-filters.js` 单一事实源驱动的 `topicsForNode` 数据已覆盖此场景。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）

## 验证内容

- **单一事实源验证**：P3① 已将 `embodied-foundation-model` 写入 `docs/topic-filters.js`，详情页「所属专题」徽标行（`docs/main.js renderMetaTopicBadges` → `topicsForNode`）自动联动，无需额外代码改动。
- **端到端验证**：`wiki/methods/vla.md` 详情页（`detail.html?id=wiki-methods-vla`）「所属专题」行同时渲「👀 视觉-语言-动作 (VLA)」+「🧠 具身大模型 (Embodied Foundation Model)」双徽标，后者跳转 `graph.html?topic=embodied-foundation-model`；空态整行降级隐藏。
- **多页稳定性验证**：node 逐页校验 `topicsForNode` 对以下五页均稳定命中 `embodied-foundation-model` 专题：
  - `wiki/methods/vla.md`
  - `wiki/tasks/vision-language-navigation.md`
  - `wiki/concepts/world-action-models.md`
  - `wiki/queries/embodied-fm-taxonomy-loop.md`
  - `wiki/methods/generative-world-models.md`
- **CI 门禁**：`make lint` 0 errors（另含 1 条信息型预警，不阻塞 CI）。
- **截图归档**：验证截图已保存至 `.cursor-artifacts/screenshots/detail-topic-embodied-foundation-model.png`。

## 相关 Issue

checklist-v28 P3「详情页『同专题相关页』提示」两个子项全部完成。

https://claude.ai/code/session_01TZz74grQft3zDfuhErtGP2