### PR TITLE
[2026-07-13] fix | docs/graph.html — 专题汇总导读条移至画布右下角，避免被筛选浮窗遮挡

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -126,13 +126,15 @@
       color: #e6edf3;
     }
     .filter-topic-chip span:first-child { font-size: .9rem; line-height: 1; }
-    /* 专题汇总导读条（画布左上角，选中非「全量」专题时显示） */
+    /* 专题汇总导读条（画布右下角、操作提示条上方，选中非「全量」专题时显示；
+       左上角会被筛选浮窗遮挡、左下有图例、右上有参数面板，故固定右下；
+       bottom 抬高 72px 避开操作提示条（约 61px），也天然高于移动端图例 FAB（60px） */
     .topic-intro-banner {
       position: absolute;
-      top: 12px;
-      left: 12px;
+      bottom: 72px;
+      right: 20px;
       z-index: 12;
-      max-width: min(420px, calc(100% - 24px));
+      max-width: min(420px, calc(100% - 40px));
       padding: 10px 12px 10px 11px;
       border-radius: 10px;
       border: 1px solid rgba(0, 212, 255, 0.28);


### PR DESCRIPTION
原位置（画布左上角）与筛选浮窗重叠，而选择专题必须打开筛选浮窗，导读条一出现即被遮挡。
改为固定在右下角操作提示条上方（bottom:72px），同时避开左下图例、右上参数面板与移动端图例 FAB。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DF7tNp9Z8X9noQv4Pc7tMA