### PR TITLE
fix(ux): 路线图 TOC 副标题按章节结构动态生成

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2170,8 +2170,13 @@
   function deriveRoadmapTocSubtitle(headings) {
     var h2s = (headings || []).filter(function (h) { return h.level === 2; });
     if (!h2s.length) return '章节快速导航';
-    var firstLabel = parseRoadmapTimelineNodeLabel(h2s[0].text || '');
-    var lastLabel = parseRoadmapTimelineNodeLabel(h2s[h2s.length - 1].text || '');
+    var stageH2s = h2s.filter(function (h) {
+      return !!parseRoadmapTimelineNodeLabel(h.text || '');
+    });
+    var target = stageH2s.length >= 2 ? stageH2s : h2s;
+    if (target.length < 2) return '章节快速导航';
+    var firstLabel = parseRoadmapTimelineNodeLabel(target[0].text || '');
+    var lastLabel = parseRoadmapTimelineNodeLabel(target[target.length - 1].text || '');
     if (firstLabel && lastLabel) {
       if (firstLabel.charAt(0) === 'L' && lastLabel.charAt(0) === 'L') {
         return '从 ' + firstLabel + ' 到 ' + lastLabel + ' 的全程导航';

--- a/docs/main.js
+++ b/docs/main.js
@@ -2166,6 +2166,30 @@
     return '';
   }
 
+  /** 路线侧栏 TOC 副标题：按正文 h2 层级前缀（L / Stage）推导，否则回退通用文案。 */
+  function deriveRoadmapTocSubtitle(headings) {
+    var h2s = (headings || []).filter(function (h) { return h.level === 2; });
+    if (!h2s.length) return '章节快速导航';
+    var firstLabel = parseRoadmapTimelineNodeLabel(h2s[0].text || '');
+    var lastLabel = parseRoadmapTimelineNodeLabel(h2s[h2s.length - 1].text || '');
+    if (firstLabel && lastLabel) {
+      if (firstLabel.charAt(0) === 'L' && lastLabel.charAt(0) === 'L') {
+        return '从 ' + firstLabel + ' 到 ' + lastLabel + ' 的全程导航';
+      }
+      if (firstLabel.charAt(0) === 'S' && lastLabel.charAt(0) === 'S') {
+        return '从 ' + firstLabel + ' 到 ' + lastLabel + ' 的阶段导航';
+      }
+    }
+    if (h2s.length >= 2) return '共 ' + h2s.length + ' 个章节的快速导航';
+    return '章节快速导航';
+  }
+
+  function renderRoadmapTocSubtitle(headings) {
+    var el = document.getElementById('roadmapTocSubtitle');
+    if (!el) return;
+    el.textContent = deriveRoadmapTocSubtitle(headings);
+  }
+
   function buildRoadmapStageRowHTML(stage, index, roadmapId, detailPages, options) {
     var opts = options || {};
     var related = Array.isArray(stage.related_items) ? stage.related_items.slice(0, 8) : [];
@@ -4768,6 +4792,7 @@
       renderDetailMetaSource(null, 'roadmapContentSourceLink');
       var tocRootEmpty = document.getElementById('roadmapTocList');
       if (tocRootEmpty) removeLoadingState(tocRootEmpty);
+      renderRoadmapTocSubtitle(null);
       return;
     }
 
@@ -4843,6 +4868,7 @@
         removeLoadingState(contentEl);
       }
       if (tocEl) removeLoadingState(tocEl);
+      renderRoadmapTocSubtitle(null);
       return;
     }
 
@@ -4859,6 +4885,7 @@
     if (tocEl) {
       renderDetailToc(tocEl, headings, roadmapMarkdownContext);
     }
+    renderRoadmapTocSubtitle(headings);
     renderDetailMetaSource(detail, 'roadmapContentSourceLink');
     if (contentEl) {
       contentEl.innerHTML = renderMarkdownContent(contentMarkdown, headings, roadmapMarkdownContext);

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -94,7 +94,7 @@
       <div class="container detail-content-layout">
         <aside id="roadmapTocSection" class="detail-toc-panel" aria-labelledby="roadmap-toc">
           <h2 class="section-title" id="roadmap-toc">路线目录</h2>
-          <p class="section-subtitle">从 L−1 序言到 L7 出口的全程导航</p>
+          <p id="roadmapTocSubtitle" class="section-subtitle">章节快速导航</p>
           <div style="margin-bottom: 1.2rem;">
             <a id="roadmapGraphLink" href="graph.html" class="btn-secondary" style="display:flex; align-items:center; gap:6px; justify-content:center; padding:8px; border-color:rgba(0,212,255,0.3); color:var(--text);">
               <span>🕸️</span> 关联图谱节点

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -56,7 +56,9 @@ class RoadmapPageTests(unittest.TestCase):
         self.assertIn("function deriveRoadmapTocSubtitle", content)
         self.assertIn("function renderRoadmapTocSubtitle", content)
         self.assertIn("roadmapTocSubtitle", content)
-        self.assertNotIn("从 L−1 序言到 L7 出口的全程导航", ROADMAP_HTML.read_text(encoding="utf-8"))
+        self.assertNotIn(
+            "从 L−1 序言到 L7 出口的全程导航", ROADMAP_HTML.read_text(encoding="utf-8")
+        )
 
     def test_main_roadmap_knowledge_map_includes_depth_branches(self):
         content = MAIN_JS.read_text(encoding="utf-8")

--- a/tests/test_roadmap_page.py
+++ b/tests/test_roadmap_page.py
@@ -19,6 +19,7 @@ class RoadmapPageTests(unittest.TestCase):
             'id="roadmapContent"',
             'id="roadmapContentSourceLink"',
             'id="roadmapTocList"',
+            'id="roadmapTocSubtitle"',
         ]
         for marker in required_ids:
             self.assertIn(marker, content)
@@ -49,6 +50,13 @@ class RoadmapPageTests(unittest.TestCase):
         content = MAIN_JS.read_text(encoding="utf-8")
         self.assertIn("function parseRoadmapTimelineNodeLabel", content)
         self.assertIn("Stage\\s+(\\d+)", content)
+
+    def test_roadmap_toc_subtitle_is_derived_from_headings(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("function deriveRoadmapTocSubtitle", content)
+        self.assertIn("function renderRoadmapTocSubtitle", content)
+        self.assertIn("roadmapTocSubtitle", content)
+        self.assertNotIn("从 L−1 序言到 L7 出口的全程导航", ROADMAP_HTML.read_text(encoding="utf-8"))
 
     def test_main_roadmap_knowledge_map_includes_depth_branches(self):
         content = MAIN_JS.read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

路线图侧栏「路线目录」原先固定副标题为「从 L−1 序言到 L7 出口的全程导航」，这只适用于运动控制主路线；纵深路线（如 RL locomotion、导航）使用 Stage 0–5 结构，副标题与内容不符。

本次改为在 `renderRoadmapMarkdownBody` 中根据正文 h2 标题动态生成副标题：

| 路线类型 | 示例副标题 |
|----------|------------|
| L 层级主路线 | 从 L−1 到 L7 的全程导航 |
| Stage 纵深路线 | 从 S0 到 S5 的阶段导航 |
| 无 L/Stage 前缀 | 共 N 个章节的快速导航 / 章节快速导航 |

仅统计带 `L` / `Stage` 前缀的阶段章节，排除「三句话先懂」「路线一览」等导航性 h2。

## 变更文件

- `docs/roadmap.html`：副标题改为 `#roadmapTocSubtitle` 挂载点，默认「章节快速导航」
- `docs/main.js`：新增 `deriveRoadmapTocSubtitle` / `renderRoadmapTocSubtitle`
- `tests/test_roadmap_page.py`：补充挂载点与动态逻辑断言

## 验证

- `make ci-test` 通过（含 ruff format / pytest 305 项）
- 本地静态站截图（`roadmap.html?id=roadmap-motion-control` / `roadmap-depth-rl-locomotion`）

## 验证截图

![运动控制主路线 TOC：从 L−1 到 L7 的全程导航](https://cursor.com/artifacts/c/art-a2d2e88a-0776-4514-87af-32c637b00eb4)

![RL locomotion 纵深路线 TOC：从 S0 到 S5 的阶段导航](https://cursor.com/artifacts/c/art-a818ba0e-07e2-4582-9a91-07a1977c0b6a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9429f97d-5d93-457d-9e6e-743d6a3e6231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9429f97d-5d93-457d-9e6e-743d6a3e6231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

