### PR TITLE
fix: roadmap/ 路线页健康度评分规则（无 frontmatter 改正文信号）

### DIFF
--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -806,6 +806,30 @@ def compute_health_score(content: str) -> int:
     return score
 
 
+# roadmap/ 路线页站内链接达到该阈值视为「已接入交叉引用网络」
+ROADMAP_HEALTH_MIN_INTERNAL_LINKS = 5
+
+
+def compute_roadmap_health_score(content: str, internal_link_count: int) -> int:
+    """计算 roadmap/ 路线页健康度（0-3）。
+
+    路线页按仓库约定不带 frontmatter（见 lint_wiki 的豁免目录），
+    frontmatter 规则会恒判 0 分，故改用正文自身的质量信号：
+
+    +1: 首屏有 **摘要** / **首屏导读** 导读行
+    +1: 站内链接数达到阈值（已接入 wiki 交叉引用网络）
+    +1: 有阶段化结构标题（纵深页 ``## Stage N`` / 主路线 ``## L−1``…``## L7``）
+    """
+    score = 0
+    if re.search(r"^\*\*(摘要|首屏导读)\*\*", content, re.MULTILINE):
+        score += 1
+    if internal_link_count >= ROADMAP_HEALTH_MIN_INTERNAL_LINKS:
+        score += 1
+    if re.search(r"^##+\s*(?:Stage\s|L[−-]?\d)", content, re.MULTILINE):
+        score += 1
+    return score
+
+
 def parse_frontmatter_type(content: str) -> str:
     if not content.startswith("---"):
         return ""
@@ -1333,12 +1357,18 @@ def _build_graph_data() -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
         page_id = str(page.relative_to(REPO_ROOT))
         node_type = _node_type_for_page(page, content)
         node_tags = [str(t).strip().lower() for t in parse_frontmatter_list(content, "tags")]
+        internal_links = extract_internal_links(content, page)
+        # roadmap/ 路线页无 frontmatter，健康度走正文信号规则
+        if page.relative_to(REPO_ROOT).parts[0] == "roadmap":
+            health_score = compute_roadmap_health_score(content, len(internal_links))
+        else:
+            health_score = compute_health_score(content)
         node: dict[str, Any] = {
             "id": page_id,
             "detail_id": path_to_id(page, REPO_ROOT),
             "label": extract_title(content) or page.stem,
             "type": node_type,
-            "health_score": compute_health_score(content),
+            "health_score": health_score,
             "summary": extract_summary(content),
             "_recency": wiki_recency_date(content, page).isoformat(),
             # 论文节点：type=entity 且 frontmatter tags 含 paper（私有标记，写出前剔除）
@@ -1351,7 +1381,7 @@ def _build_graph_data() -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
             node["institutions"] = institutions
         nodes.append(node)
 
-        for target in extract_internal_links(content, page):
+        for target in internal_links:
             target_id = str(target.relative_to(REPO_ROOT))
             if page_id == target_id:
                 continue

--- a/tests/test_generate_link_graph_health.py
+++ b/tests/test_generate_link_graph_health.py
@@ -1,0 +1,47 @@
+"""健康度评分：frontmatter 规则与 roadmap/ 正文信号规则。
+
+回归背景：roadmap/ 路线页按约定不带 frontmatter，旧逻辑统一走
+``compute_health_score`` 导致 14 个路线节点健康度恒为 0。
+"""
+
+from __future__ import annotations
+
+import generate_link_graph as glg
+
+
+def test_compute_health_score_requires_frontmatter() -> None:
+    """无 frontmatter 页面在 wiki 规则下仍为 0（既有行为不变）。"""
+    assert glg.compute_health_score("# 标题\n\n正文。\n") == 0
+
+
+def test_roadmap_full_signals_score_three() -> None:
+    content = "# 路线（纵深）：示例\n\n**摘要**：一句话摘要。\n\n## Stage 0 全景\n\n正文。\n"
+    assert glg.compute_roadmap_health_score(content, internal_link_count=10) == 3
+
+
+def test_roadmap_main_route_headings_count_as_stage_structure() -> None:
+    """主路线的 ``## L−1``…``## L7`` 分层标题同样算阶段化结构。"""
+    content = "# 主路线\n\n**首屏导读**：\n\n## L−1 序言\n\n## L0 数学\n"
+    assert glg.compute_roadmap_health_score(content, internal_link_count=0) == 2
+
+
+def test_roadmap_missing_all_signals_scores_zero() -> None:
+    assert glg.compute_roadmap_health_score("# 标题\n\n正文。\n", internal_link_count=0) == 0
+
+
+def test_roadmap_link_threshold_boundary() -> None:
+    content = "# 标题\n\n正文。\n"
+    threshold = glg.ROADMAP_HEALTH_MIN_INTERNAL_LINKS
+    assert glg.compute_roadmap_health_score(content, internal_link_count=threshold - 1) == 0
+    assert glg.compute_roadmap_health_score(content, internal_link_count=threshold) == 1
+
+
+def test_all_repo_roadmap_pages_score_full() -> None:
+    """仓库现有路线页应全部拿满 3 分（曾全部为 0 的回归防线）。"""
+    pages = [p for p in sorted(glg.ROADMAP_DIR.glob("*.md")) if p.name != "README.md"]
+    assert pages, "roadmap/ 下应存在路线页"
+    for page in pages:
+        content = page.read_text(encoding="utf-8")
+        links = glg.extract_internal_links(content, page)
+        score = glg.compute_roadmap_health_score(content, len(links))
+        assert score == 3, f"{page.name} 健康度 {score} != 3"


### PR DESCRIPTION
## 摘要

修复 roadmap/ 路线节点健康度恒为 0 的问题。路线页按仓库约定不带 frontmatter,旧逻辑统一走 `compute_health_score`,该函数要求内容以 `---` frontmatter 开头,否则开头即短路返回 0。新增 `compute_roadmap_health_score`,改用正文自身的质量信号(摘要/导读行、站内链接、阶段化结构)评分,并在构图时按目录分派。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [ ] 知识入库(ingest / wiki 内容)
- [ ] 前端(`docs/`)
- [ ] 其他

## 详细说明

### 问题背景
- `roadmap/` 下 14 个路线页(`motion-control.md` 与 13 个 `depth-*.md`)按仓库约定不含 frontmatter(参见 `lint_wiki.py` 的 frontmatter 豁免目录)
- 原 `compute_health_score` 的三项评分信号(summary / sources / updated)全部读取 frontmatter,内容不以 `---` 开头时直接返回 0
- 导致链接图「按健康度」着色时 14 个路线节点全为最差档;全图 1599 个节点中健康度 0 分的恰好就是这 14 个
- 对照佐证:`wiki/roadmaps/humanoid-control-roadmap.md` 同为 roadmap_page 类型但带 frontmatter,健康度 3 分

### 解决方案
1. **新增 `compute_roadmap_health_score(content, internal_link_count)`**(0–3 分):
   - +1 分:首屏有 `**摘要**` 或 `**首屏导读**` 导读行
   - +1 分:站内链接数达到阈值(≥5,已接入 wiki 交叉引用网络,复用 `extract_internal_links` 的结果)
   - +1 分:有阶段化结构标题(纵深页 `## Stage N` / 主路线 `## L−1`…`## L7`)
2. **`_build_graph_data` 按目录分派**:`roadmap/` 下的页面走新规则;wiki 页(含带 frontmatter 的 `wiki/roadmaps/`)沿用原规则不变。站内链接提取收敛为一次调用,健康度与边构建共用结果
3. **新增测试** `tests/test_generate_link_graph_health.py`:覆盖 frontmatter 规则既有行为、新规则满分/零分/链接阈值边界、主路线 L 层标题识别,以及「仓库现有 14 个路线页必须全部拿满 3 分」的回归防线

## 验证

- [x] `PYTHONPATH=scripts python3 -m pytest` 全量通过(覆盖率 62.73%,高于 52% 门槛)
- [x] `make ci-preflight` 通过(导出质量检查 12/12)
- [x] `ruff check` / `ruff format --check` 通过
- [x] 重新生成图谱:健康度分布由 `{3: 1585, 0: 14}` 变为 `{3: 1599}`,仅 14 个 roadmap 节点分数变化,其余节点不受影响
- [x] 静态站人工验证:`make export graph` 后起 `docs/` 静态服务,`graph.html` 切「按健康度」着色并聚焦 `roadmap/motion-control.md`,路线节点已进入 3 分(绿色)档(截图见 PR 评论区/会话附件;当前环境不支持正文内嵌本地图片)

## 验证截图

本改动属于「仅改维护工具 / 脚本」类,按 CLAUDE.md §5 证据分级以门禁输出为准:

```text
$ make ci-preflight
...
✅ docs/exports/link-graph.json 同步:src=2098828B dst=2098828B
✅ graph 节点数与 wiki 页面数合理:nodes=1599 wiki_pages=1585 ratio=1.01
✅ graph-stats.json 无孤儿节点:0 个孤儿节点
通过:12/12
✅ 所有导出质量检查通过。
Preflight complete.
```

图谱渲染截图(`graph.html` 按健康度着色 + 聚焦路线节点)已生成于 `.cursor-artifacts/screenshots/graph-health-roadmap.png`,由会话附件送达。

## 相关 Issue

无

https://claude.ai/code/session_01K47C3PzquE1NStA2TDfSuf