### PR TITLE
fix(wiki): 修复 Model-Based RL 详情页格式问题

### DIFF
--- a/catalog.md
+++ b/catalog.md
@@ -1260,7 +1260,7 @@
 - [LWD（Learning while Deploying）](wiki/methods/lwd.md) — LWD（Learning while Deploying）** 是 AGIBOT Research 在 2026 年提出的**车队级（fleet-scale）offline-to-online 强 `📅unknown` `[method_page]`
 - [Multi-Agent Reinforcement Learning (MARL)](wiki/methods/marl.md) — MARL** 扩展了单智能体 RL，处理多个机器人在同一空间协作或竞争的问题（如机器人足球、多臂流水线）。 `📅unknown` `[method_page]`
 - [mimic-video（Video-Action Model, VAM）](wiki/methods/mimic-video.md) — mimic-video 是一类把互联网规模视频生成模型当作操作语义与物理动力学先验的通用操作策略：先在视频潜空间里形成与语言指令一致的视觉动力学计划，再以流匹配动作头输出机器人动作块。 `📅2026-05-17` `[method_page]`
-- [Model-Based RL（基于模型的强化学习）](wiki/methods/model-based-rl.md) —  缩写 | 英文全称 | 简要说明  `📅unknown` `[method_page]`
+- [Model-Based RL（基于模型的强化学习）](wiki/methods/model-based-rl.md) — Model-Based RL（MBRL）**：在强化学习中，智能体显式学习或利用环境的动力学模型，通过在模型中规划或生成虚拟经验来提升样本效率。 `📅unknown` `[method_page]`
 - [Model Predictive Control (MPC，模型预测控制)](wiki/methods/model-predictive-control.md) — 模型预测控制**：一种基于滚动时域优化的控制方法，在每个时刻求解一个有限时域的最优控制问题，只执行第一步，然后重复。 `📅unknown` `[method_page]`
 - [GMR: 通用动作重定向](wiki/methods/motion-retargeting-gmr.md) — GMR (General Motion Retargeting)** 是运动控制流程中的“前端”模块，负责将人类或其他来源的动作序列转换为机器人可理解的关节角度序列。 `📅unknown` `[method_page]`
 - [MotionBricks: 模块化生成式运动合成框架](wiki/methods/motionbricks.md) — MotionBricks** 是 NVIDIA Research 推出的一种用于人形机器人和数字角色的高保真运动生成框架。它代表了从「判别式运动先验」（如 [AMP](./amp-reward.m `📅unknown` `[method_page]`

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -677,7 +677,7 @@ def build_item(path: Path) -> dict[str, Any]:
         "title": title,
         "path": rel(path),
         "summary": extract_summary(body_text, fm),
-        "content_markdown": extract_body_markdown(text),
+        "content_markdown": extract_body_markdown(body_text),
         "tags": infer_tags(path, title, text),
         "related": collect_markdown_links(text, path),
         "source_links": collect_reference_sources(body_text, path),

--- a/wiki/methods/model-based-rl.md
+++ b/wiki/methods/model-based-rl.md
@@ -1,9 +1,7 @@
 ---
-
 type: method
 tags: [rl, model-based, planning, locomotion, sample-efficiency, horizon-robotics]
 status: complete
-summary: "Model-Based RL 借助环境模型提升样本效率，在机器人控制中常与规划和世界模型结合。"
 updated: 2026-07-14
 related:
   - ../entities/richard-sutton.md
@@ -12,6 +10,8 @@ related:
 sources:
   - ../../sources/blogs/sutton_one_step_trap.md
   - ../../sources/sites/incompleteideas-net-rich-sutton.md
+summary: "Model-Based RL 借助环境模型提升样本效率，在机器人控制中常与规划和世界模型结合。"
+---
 
 # Model-Based RL（基于模型的强化学习）
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

[Model-Based RL 详情页](https://imchong.github.io/Robotics_Notebooks/detail.html?id=wiki-methods-model-based-rl) 存在多处格式/元数据异常，根因是 `wiki/methods/model-based-rl.md` 的 YAML frontmatter **缺少闭合 `---`**。

由此引发的问题：
- 页面标题误显示为代码块内的 `RSSM 前向过程（简化伪代码）`
- 摘要误显示为表格头 `| 缩写 | 英文全称 | 简要说明 |`
- 前端 `stripYamlFrontmatter` 把正文第一段（含 H1 与「一句话定义」）误当作 frontmatter 剥离
- 导出层 `content_markdown` 曾带入未剥离的 YAML 元数据

## 改动

1. **`wiki/methods/model-based-rl.md`**：按仓库规范补全 frontmatter 闭合 `---`，字段顺序与同目录其他方法页对齐
2. **`scripts/export_minimal.py`**：`content_markdown` 改为基于 `body_text`（已 strip frontmatter）生成，避免元数据泄漏进正文

## 验证

- `make ci-preflight` 通过
- 导出后 `wiki-methods-model-based-rl` 标题/摘要/正文首段已恢复正确

## 验证截图

修复前（错误标题与摘要）：

![修复前 Model-Based RL 详情页](https://cursor.com/artifacts/c/art-da3fccbe-b8b7-43e1-9eea-265dfe4bf96e)

修复后：

![修复后 Model-Based RL 详情页](https://cursor.com/artifacts/c/art-a133ff00-7be4-48a9-97f5-2f3755932ba0)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c53bc27-f9fc-4aaa-a311-c57432f99bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c53bc27-f9fc-4aaa-a311-c57432f99bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

