### PR TITLE
Add knowledge graph entry card to homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -56,20 +56,17 @@
           <a class="card home-entry-card" href="roadmap.html?id=roadmap-motion-control">
             <span class="home-entry-label">从零开始</span>
             <h3>建立运动控制全局认识</h3>
-            <p>从基础、动力学到控制与 Sim2Real 逐步学习。</p>
             <span class="home-entry-link">进入主路线 →</span>
           </a>
           <a class="card home-entry-card" href="#wiki-search" data-focus-search>
             <span class="home-entry-label">项目查询</span>
             <h3>查找框架、论文与机器人平台</h3>
-            <p>直接搜索项目名称、算法缩写或具体工程问题。</p>
             <span class="home-entry-link">搜索知识库 →</span>
           </a>
-          <a class="card home-entry-card" href="graph.html">
+          <a class="card home-entry-card" href="#mini-graph-section">
             <span class="home-entry-label">知识图谱</span>
             <h3>俯瞰节点与连接全貌</h3>
-            <p>在交互式图谱中探索概念、论文与项目的关联。</p>
-            <span class="home-entry-link">打开完整图谱 →</span>
+            <span class="home-entry-link">查看图谱预览 →</span>
           </a>
           <div class="card home-entry-card home-entry-card-more">
             <span class="home-entry-label">更多路线</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,12 @@
             <p>直接搜索项目名称、算法缩写或具体工程问题。</p>
             <span class="home-entry-link">搜索知识库 →</span>
           </a>
+          <a class="card home-entry-card" href="graph.html">
+            <span class="home-entry-label">知识图谱</span>
+            <h3>俯瞰节点与连接全貌</h3>
+            <p>在交互式图谱中探索概念、论文与项目的关联。</p>
+            <span class="home-entry-link">打开完整图谱 →</span>
+          </a>
           <div class="card home-entry-card home-entry-card-more">
             <span class="home-entry-label">更多路线</span>
             <h3>按研究方向进入纵深路线</h3>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1008,6 +1008,8 @@ button.home-wiki-heatmap-cell.is-active {
 .route-card-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
 .route-card { min-height: 100%; }
 .home-entry-grid {
+  /* 3 张入口卡（从零开始 / 项目查询 / 知识图谱）同排，「更多路线」卡通栏在下 */
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: stretch;
   gap: 16px;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1020,7 +1020,6 @@ button.home-wiki-heatmap-cell.is-active {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  min-height: 176px;
   color: var(--text);
 }
 .home-entry-card:hover {
@@ -1031,12 +1030,6 @@ button.home-wiki-heatmap-cell.is-active {
 .home-entry-card h3 {
   margin: 0;
   line-height: 1.35;
-}
-.home-entry-card p {
-  margin: 0;
-  flex: 1;
-  color: var(--text-muted);
-  line-height: 1.5;
 }
 .home-entry-label {
   align-self: flex-start;
@@ -2241,9 +2234,6 @@ button.home-wiki-heatmap-cell.is-active {
     padding: 30px 0;
   }
   .hero-grid, .card-grid, .preview-home-layout, .preview-split-grid, .detail-hero-top, .route-card-grid { grid-template-columns: 1fr; }
-  .home-entry-card {
-    min-height: 0;
-  }
   .home-entry-route-links {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
## 摘要

首页「选择你的入口」新增第三张「知识图谱」入口卡（跳转本页「知识图谱预览」区块），并按轻量化方案精简三张主入口卡：去掉描述行与固定最小高度，三卡并排显示。

## 变更类型

- [x] 前端（`docs/`）

## 详情

### docs/index.html
- 在「项目查询」卡后新增「知识图谱」卡片，锚点跳转本页 `#mini-graph-section`（知识图谱预览区块），链接文案「查看图谱预览 →」
- 三张主入口卡去掉一行描述文字，只保留标签、标题与操作链接

### docs/style.css
- `.home-entry-grid` 首行改为 `repeat(3, minmax(0, 1fr))`，三张入口卡同排，「更多路线」卡通栏在下
- `.home-entry-card` 移除 `min-height: 176px`，卡片高度随内容收缩
- 清理因描述行移除而失效的 `.home-entry-card p` 规则与移动端 `min-height: 0` 覆盖
- 移动端（≤860px）沿用既有 `.card-grid { 1fr }` 规则回落单列

## 验证

- [x] `make ci-preflight` 通过（12/12 项导出质量检查）
- [x] `make export graph` 后本地静态站验证：三张轻量入口卡并排显示；移动端回落单列
- [x] 锚点验证：访问 `index.html#mini-graph-section` 正确落在「知识图谱预览」区块，mini-graph 渲染正常

## 验证截图

``&lt;img alt="主页桌面端：从零开始 / 项目查询 / 知识图谱 三张轻量入口卡同排" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/homepage-graph-entry.png" /&gt;``

``&lt;img alt="主页移动端：入口卡回落单列" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/homepage-graph-entry-mobile.png" /&gt;``

``&lt;img alt="锚点跳转落点：知识图谱预览区块，mini-graph 渲染正常" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/homepage-anchor-minigraph.png" /&gt;``

https://claude.ai/code/session_01NrHdt4VHkrMS7tQGh63Swd