### PR TITLE
fix(ux): 移除卡片 backdrop-filter，修复向上滚动时入口卡偶发空白

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -280,7 +280,8 @@ body.sponsor-dialog-open {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(10px);
+  /* 不加 backdrop-filter：这些是文档流内面板，背后只有纯色区块背景，blur 无视觉作用，
+     反而触发 Chromium 合成层滚动重绘 bug（向上滚动时卡片偶发整块空白） */
 }
 .hero-panel { padding: 20px 20px 18px; }
 .hero-panel h3 { font-size: 1rem; margin-bottom: 12px; }


### PR DESCRIPTION
## 摘要

修复 #1092 合并后发现的现象：从页面下方往上滚动时（例如从「知识图谱预览」锚点返回顶部），入口卡片偶发整块空白，hover 或下次重绘后才恢复。根因是卡片的半透明背景 + `backdrop-filter: blur(10px)` 组合触发 Chromium 合成层滚动不重绘 bug；而 `.hero-panel / .simple-card / .card / .toc-card` 均为文档流内面板，背后只有纯色区块背景，blur 本无视觉作用。删除该行即可，视觉零变化。

## 变更类型

- [x] 前端（`docs/`）

## 详情

### docs/style.css
- 从 `.hero-panel, .simple-card, .card, .toc-card` 共享规则中移除 `backdrop-filter: blur(10px)`，并留注释说明原因，防止回归
- 吸顶导航等 overlay 元素的 backdrop-filter（blur 20px / 4px / 2px）不受影响——那些位置的 blur 才有实际作用对象

## 验证

- [x] `make ci-preflight`：N/A（仅 CSS 单行改动，不涉及 wiki/导出链）
- [x] 本地静态站截图对比：卡片外观与修复前完全一致（半透明渐变背景保留，仅去掉无作用的 blur 层）

## 验证截图

``&lt;img alt="修复后主页：入口卡外观与修复前一致" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/homepage-no-backdrop-filter.png" /&gt;``

## 相关 Issue

无（跟进 #1092 合并后的现象反馈）

https://claude.ai/code/session_01NrHdt4VHkrMS7tQGh63Swd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrHdt4VHkrMS7tQGh63Swd)_