### PR TITLE
fix(ux): 修复 3D 图谱初次布局冷却后拖拽节点不回弹

### DIFF
--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -185,6 +185,8 @@
     var meshInstallScheduled = false;
     var pendingFirstShowKick = false;
     var initialFitDone = false;
+    // 拖拽手势期间是否已 reheat：见 bindGraphInstance 里 onNodeDrag 注释。
+    var nodeDragReheated = false;
     // 时序激活动画：null = 关闭（正常渲染）；Set = 「已激活」节点集合（= 进入力模拟的子集）。
     // 仿 2D：每激活一个节点就把它种在已激活邻居附近、加入力模拟子集并重排，整图随时间生长。
     var timelineRevealedIds = null;
@@ -840,6 +842,11 @@
         // alphaMin 再停（≈270 tick）。三方库默认 cooldownTicks=∞ 且 d3AlphaMin=0
         // （永不因 alpha 停，只会跑满 cooldownTime），故显式开启 alpha 收敛阈值并对齐
         // 2D 的 alphaDecay(0.025)；warmup 设 0 以便从第一帧就能看到力模拟过程。
+        //
+        // 注意：three-forcegraph 的 tickFrame 在 layout.tick() 之前就判断
+        // alpha < d3AlphaMin；引擎冷却后库内拖拽只做 d3AlphaTarget(0.3).resetCountdown()，
+        // 无法把 alpha 抬过阈值，下一帧会立刻再次停机 → 松手后节点钉在落点不回弹。
+        // 因此下方 onNodeDrag / onNodeDragEnd 需在手势期间 d3ReheatSimulation()。
         .warmupTicks(0)
         .cooldownTicks(Infinity)
         .d3AlphaDecay(0.025)
@@ -859,6 +866,19 @@
         .linkOpacity(function (l) { return linkOpacityFor(l); })
         .linkVisibility(function (l) { return linkVisibleFor(l); })
         .enableNodeDrag(true)
+        .onNodeDrag(function () {
+          // 每个拖拽手势只 reheat 一次，避免拖动过程中反复 alpha=1 导致整图狂抖。
+          if (nodeDragReheated) return;
+          nodeDragReheated = true;
+          if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
+        })
+        .onNodeDragEnd(function () {
+          nodeDragReheated = false;
+          // 松手后再抬一次 alpha：确保回弹力模拟能跨过 alphaMin 判停门槛。
+          // （库在 onNodeDragEnd 回调之后才会 alphaTarget(0).resetCountdown()，
+          // 因此这里 reheat 后仍会以 target=0 自然收敛。）
+          if (typeof graph.d3ReheatSimulation === 'function') graph.d3ReheatSimulation();
+        })
         .onNodeClick(function (node, ev) {
           var src = resolveSourceNode(node.id) || node;
           if (onNodeClick) onNodeClick(src, ev || lastPointer);

--- a/scripts/verify_graph_3d_drag_rebound.cjs
+++ b/scripts/verify_graph_3d_drag_rebound.cjs
@@ -1,0 +1,170 @@
+// Verify 3D drag rebound AFTER initial force engine cool-down.
+// Usage: node scripts/verify_graph_3d_drag_rebound.cjs [baseUrl] [outDir]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+const baseUrl = process.argv[2] || 'http://127.0.0.1:8765/graph.html?view=3d';
+const outDir = path.resolve(process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots'));
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+(async () => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const exe = process.env.PUPPETEER_EXECUTABLE_PATH
+    || (fs.existsSync('/usr/local/bin/google-chrome') ? '/usr/local/bin/google-chrome' : 'google-chrome');
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    protocolTimeout: 180000,
+    args: [
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--window-size=1280,800',
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+    ],
+    defaultViewport: { width: 1280, height: 800 },
+  });
+
+  const report = { ok: false, steps: [], errors: [] };
+
+  try {
+    const page = await browser.newPage();
+    page.on('pageerror', (e) => report.errors.push(String(e)));
+
+    await page.evaluateOnNewDocument(() => {
+      window.__fg3dInstances = [];
+      const hook = () => {
+        if (!window.ForceGraph3D || window.__fgHooked) return;
+        window.__fgHooked = true;
+        const Orig = window.ForceGraph3D;
+        function Wrapped(cfg) {
+          const factory = Orig(cfg);
+          return function (el) {
+            const inst = factory(el);
+            window.__fg3dInstances.push(inst);
+            return inst;
+          };
+        }
+        Object.assign(Wrapped, Orig);
+        window.ForceGraph3D = Wrapped;
+      };
+      const t = setInterval(() => { hook(); if (window.__fgHooked) clearInterval(t); }, 5);
+    });
+
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-loading');
+      return !el || el.hidden || el.classList.contains('is-hidden');
+    }, { timeout: 120000 });
+
+    // Wait for initial layout to cool (positions stable).
+    await sleep(7000);
+    await page.waitForFunction(() => {
+      const g = window.__fg3dInstances && window.__fg3dInstances[window.__fg3dInstances.length - 1];
+      if (!g) return false;
+      const n = g.graphData().nodes[0];
+      if (!n) return false;
+      const key = n.x.toFixed(2) + ':' + n.y.toFixed(2) + ':' + n.z.toFixed(2);
+      if (window.__coolKey === key) window.__coolN = (window.__coolN || 0) + 1;
+      else { window.__coolKey = key; window.__coolN = 0; }
+      return window.__coolN > 20;
+    }, { timeout: 45000, polling: 100 });
+
+    const result = await page.evaluate(async () => {
+      const g = window.__fg3dInstances[window.__fg3dInstances.length - 1];
+      async function frames(n) {
+        for (let i = 0; i < n; i++) await new Promise((r) => requestAnimationFrame(r));
+      }
+      function pick() {
+        return g.graphData().nodes.reduce((a, b) => ((a.val || 0) >= (b.val || 0) ? a : b));
+      }
+
+      const hasDrag = typeof g.onNodeDrag === 'function';
+      const hasDragEnd = typeof g.onNodeDragEnd === 'function';
+      const dragCb = hasDrag ? g.onNodeDrag() : null;
+      const dragEndCb = hasDragEnd ? g.onNodeDragEnd() : null;
+
+      // Simulate library drag + our registered callbacks (as DragControls would).
+      const target = pick();
+      const before = { x: target.x, y: target.y, z: target.z, fxUndef: target.fx === undefined };
+      target.__initialFixedPos = { fx: target.fx, fy: target.fy, fz: target.fz };
+      target.__initialPos = { x: target.x, y: target.y, z: target.z };
+      target.fx = target.x = before.x + 90;
+      target.fy = target.y = before.y - 70;
+      target.fz = target.z = before.z + 50;
+      target.__dragged = true;
+
+      // Library drag frame: alphaTarget(0.3).resetCountdown() — wrapper has no
+      // d3AlphaTarget / resetCountdown; callbacks perform the needed reheat.
+      if (typeof dragCb === 'function') dragCb(target, { x: 90, y: -70, z: 50 });
+      await frames(15);
+      const mid = { x: target.x, y: target.y, z: target.z, fx: target.fx };
+
+      // Library dragend: restore fx from __initialFixedPos, then onNodeDragEnd, then alphaTarget(0)
+      const l = target.__initialFixedPos;
+      ['x', 'y', 'z'].forEach((axis) => {
+        const key = 'f' + axis;
+        if (void 0 === l[key]) delete target[key];
+      });
+      delete target.__initialFixedPos;
+      delete target.__initialPos;
+      const translate = { x: before.x - target.x, y: before.y - target.y, z: before.z - target.z };
+      delete target.__dragged;
+      if (typeof dragEndCb === 'function') dragEndCb(target, translate);
+
+      await frames(120);
+      const after = {
+        x: target.x, y: target.y, z: target.z,
+        hasOwnFx: Object.prototype.hasOwnProperty.call(target, 'fx'),
+        fx: target.fx,
+      };
+      const distFromPinned = Math.hypot(after.x - mid.x, after.y - mid.y, after.z - mid.z);
+      return {
+        before,
+        mid,
+        after,
+        distFromPinned,
+        released: !after.hasOwnFx && after.fx === undefined,
+        dragCbType: typeof dragCb,
+        dragEndCbType: typeof dragEndCb,
+        nodeCount: g.graphData().nodes.length,
+        fxNull: g.graphData().nodes.filter((n) => n.fx === null).length,
+        alphaMin: g.d3AlphaMin(),
+      };
+    });
+
+    report.steps.push(result);
+    report.metrics = {
+      distFromPinned: result.distFromPinned,
+      released: result.released,
+      callbacksWired: result.dragCbType === 'function' && result.dragEndCbType === 'function',
+    };
+    // After cool-down, released node must move away from the pinned drop point.
+    report.ok = report.metrics.callbacksWired
+      && report.metrics.released
+      && report.metrics.distFromPinned > 15
+      && result.fxNull === 0;
+
+    await page.screenshot({
+      path: path.join(outDir, 'graph-3d-drag-rebound-after-cooldown.png'),
+      type: 'png',
+    });
+    fs.writeFileSync(
+      path.join(outDir, 'graph-3d-drag-rebound-verify.json'),
+      JSON.stringify(report, null, 2)
+    );
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.ok) process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复知识图谱 3D 视图在**初次力布局冷却后**拖拽节点松手不回弹的问题。
- 根因：为对齐 2D 自然收敛设置了 `d3AlphaMin(0.001)`，而 `three-forcegraph` 的 `tickFrame` 在 `layout.tick()` **之前**就判断 `alpha < d3AlphaMin`；引擎冷却后库内拖拽只做 `d3AlphaTarget(0.3).resetCountdown()`，无法把 `alpha` 抬过阈值，下一帧立刻再次停机，松手后节点钉在落点。
- 修复：在 `onNodeDrag`（每手势一次）与 `onNodeDragEnd` 中调用 `d3ReheatSimulation()`，让回弹力模拟能跨过判停门槛。

## 验证
- 无头 Chromium 复现：冷却后不 reheat → 位移 `0`；接入回调 reheat → 松手后远离落点约 `817` 世界单位。
- `node scripts/verify_graph_3d_drag_rebound.cjs` 通过（`ok: true`）。

## 验证截图
![3D 图谱视图](https://cursor.com/artifacts/c/art-b05e4df0-eeb2-4097-942f-ba6e91415686)
![冷却后拖拽回弹验证](https://cursor.com/artifacts/c/art-eb799375-8a33-4924-b35b-3a569ee942d9)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58925824-d707-4b6e-b7aa-d2d7de819087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58925824-d707-4b6e-b7aa-d2d7de819087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

