### PR TITLE
roadmap: 新增 WAM / VLA / 控制 / 导航等前沿方法与实体

### DIFF
--- a/roadmap/depth-bfm.md
+++ b/roadmap/depth-bfm.md
@@ -111,6 +111,7 @@ flowchart LR
 ### 推荐读什么
 - 谱系锚点：[DeepMimic](../wiki/methods/deepmimic.md)、[ASE](../wiki/methods/ase.md)、[PHC](../wiki/entities/phc.md)、[MaskedMimic](../wiki/entities/paper-bfm-17-maskedmimic.md)、[HOVER](../wiki/entities/paper-bfm-14-hover.md)（本仓库）
 - [SONIC](../wiki/methods/sonic-motion-tracking.md) 与 [BeyondMimic](../wiki/methods/beyondmimic.md)（本仓库）— 工程可用的跟踪基座
+- [Teacher-Student 多动作 BFM 学习](../wiki/methods/teacher-student-multi-skill-bfm.md)（本仓库）— BFM 三线之一：特权教师在仿真中学多参考动作跟踪，再蒸馏为单一可部署学生
 - [Whole-Body Tracking Pipeline](../wiki/concepts/whole-body-tracking-pipeline.md)（本仓库）
 - [Query：人形动作跟踪方法选型](../wiki/queries/humanoid-motion-tracking-method-selection.md)（本仓库）
 

--- a/roadmap/depth-classical-control.md
+++ b/roadmap/depth-classical-control.md
@@ -50,6 +50,7 @@ flowchart LR
 - [LQR](../wiki/formalizations/lqr.md)
 - [Modern Robotics 教材](../wiki/entities/modern-robotics-book.md) — Chapter 8（动力学）
 - [Query：Pinocchio 快速上手](../wiki/queries/pinocchio-quick-start.md)
+- [建模与求解（控制问题框架）](../wiki/concepts/modeling-and-solving-for-control.md) — 先确定状态/输入/动力学与约束，再选 QP/MPC/iLQR/RL 等求解器，是 Model-based 与 Learning-based 的共同上游
 
 ### 推荐做什么
 - 用 [Pinocchio](../wiki/entities/pinocchio.md) 加载一个人形 URDF，计算质心、惯量矩阵和重力项
@@ -73,6 +74,7 @@ flowchart LR
 - [ZMP-LIP 形式化](../wiki/formalizations/zmp-lip.md)
 - [Capture Point / DCM](../wiki/concepts/capture-point-dcm.md)
 - [Locomotion 任务地图](../wiki/tasks/locomotion.md) 与 [Footstep Planning](../wiki/concepts/footstep-planning.md)
+- [SLIP + VMC（弹簧负载倒立摆与虚拟模型控制）](../wiki/methods/slip-vmc.md) — LIP 之后、WBC 之前的中间简化层：弹簧腿近似支撑相 + 虚拟阻抗力映射到关节力矩
 - Kajita et al., *Biped Walking Pattern Generation by using Preview Control of ZMP* (2003)
 
 ### 推荐做什么
@@ -119,6 +121,8 @@ flowchart LR
 ### 推荐读什么
 - [Model Predictive Control (MPC)](../wiki/methods/model-predictive-control.md)
 - [Nonlinear MPC](../wiki/methods/nonlinear-model-predictive-control.md)
+- [SRBD + 凸 MPC + WBC](../wiki/concepts/srbd-convex-mpc-wbc.md) — 单刚体近似质心运动的凸 MPC 分层架构，人形实时行走的工程主流折中
+- [Centroidal NMPC + WBC 栈](../wiki/methods/centroidal-nmpc-wbc-stack.md) — 质心动力学 + 非线性 MPC，比凸 SRBD-MPC 更高保真的传统控制顶层
 - [LQR / iLQR](../wiki/methods/lqr-ilqr.md)
 - [MPC vs RL](../wiki/comparisons/mpc-vs-rl.md)
 - [Query：MPC 求解器选型](../wiki/queries/mpc-solver-selection.md) 与 [Query：MPC 调参指南](../wiki/queries/mpc-tuning-guide.md)

--- a/roadmap/depth-contact-manipulation.md
+++ b/roadmap/depth-contact-manipulation.md
@@ -116,6 +116,8 @@ flowchart LR
 - [ContactMimic](../wiki/entities/paper-contactmimic.md) — 在 keypoint tracking 外显式跟踪 per-body 接触指令，G1 真机验证 contact controllability，无需任务专用奖励即可搬箱
 - [UHAS 统一手部动作空间](../wiki/methods/uhas-unified-hand-action-space.md) — 规范球几何形变动作表示 + 级联 IK，单一 PPO 策略跨 Allegro / LEAP / Shadow 零样本迁移
 - [FastGrasp](../wiki/entities/paper-fastgrasp-mobile-dexterous-grasping.md) — CVAE 点云抓取引导 + 全身 RL + 二值触觉反馈的移动高速灵巧抓取 sim2real
+- [TouchWorld](../wiki/entities/paper-touchworld-tactile-foundation-dexterous-manipulation.md) — 预测–反应式触觉基础模型：触觉世界模型预测接触子目标 + TRT 高频残差，人形长程六任务真机成功率 65.0%（干净）/ 53.7%（人为扰动）
+- [REGRIND](../wiki/methods/regrind-retargeting-guided-rl.md) — 单次人手–物体动捕重定向 + 残差 RL 跟踪物体关键点，零样本部署 LEAP/WUJI 完成剪刀、螺丝刀等 contact-rich 工具操作
 - Luo et al., *DEFT: Dexterous Fine-Grained Manipulation Transformer* (2024)
 
 ### 推荐做什么

--- a/roadmap/depth-motion-generation.md
+++ b/roadmap/depth-motion-generation.md
@@ -174,6 +174,7 @@ flowchart LR
 - [Learning Whole-Body Humanoid Locomotion](../wiki/entities/paper-hrl-stack-27-learning_whole_body_humanoid_locomot.md) 与 [Heracles](../wiki/entities/paper-heracles-humanoid-diffusion.md)（本仓库）— 扩散规划与恢复中间件
 - [OMG](../wiki/entities/paper-omg-omni-modal-humanoid-control.md) 与 [MotionBricks](../wiki/methods/motionbricks.md)（本仓库）— 多模态接口与实时基元
 - [GPC](../wiki/entities/paper-gpc-generative-pretrained-controllers.md)（本仓库）— token 化生成控制器
+- [Muninn](../wiki/entities/paper-muninn-trajectory-diffusion-acceleration.md)（本仓库）— training-free 轨迹扩散缓存加速：probe 稳定性 + conformal 标定偏差预算，最高约 4.6× 墙钟加速且可证轨迹偏离界，可直接叠在现有扩散规划器 / Diffusion Policy 上
 
 ### 学完输出什么
 - 能为"生成器 + 跟踪器"耦合系统设计训练与部署方案（含延迟预算）

--- a/roadmap/depth-motion-retargeting.md
+++ b/roadmap/depth-motion-retargeting.md
@@ -53,6 +53,7 @@ flowchart LR
 - [Motion Retargeting](../wiki/concepts/motion-retargeting.md)（本仓库）— 概念主入口
 - [动作重定向专题汇总](../wiki/overview/topic-motion-retargeting.md)（本仓库）
 - [Character Animation vs Robotics](../wiki/concepts/character-animation-vs-robotics.md)（本仓库）— 两界评价标准差异
+- [运动学可行与动力学可行](../wiki/concepts/kinematic-vs-dynamic-feasibility.md)（本仓库）— 「能摆出这个姿势」≠「站得住、跟得上」，与本页动画/机器人评价线差异同源
 - [Motion Retargeting Pipeline](../wiki/concepts/motion-retargeting-pipeline.md)（本仓库）— 管线定位
 
 ### 学完输出什么
@@ -110,6 +111,7 @@ flowchart LR
 - [AMASS](../wiki/entities/amass.md) 与 [LAFAN1](../wiki/entities/lafan1-dataset.md)（本仓库）— 动捕数据基座
 - [人形参考动作数据集对比](../wiki/comparisons/humanoid-reference-motion-datasets.md)（本仓库）— 选型主入口
 - [GVHMR](../wiki/entities/gvhmr.md)、[SAM 3D Body](../wiki/entities/sam-3d-body.md)、[FreeMoCap](../wiki/entities/freemocap.md)（本仓库）— 视频/低成本采集
+- [FMPose3D](../wiki/entities/paper-fmpose3d-monocular-3d-pose-flow-matching.md)（本仓库）— 条件 Flow Matching 单目 2D→3D 姿态提升，3 步 ODE 多假设 + RPEA 聚合，可作视频→稀疏 3D 骨架的轻量上游
 - [PEAR](../wiki/entities/paper-pear-pixel-aligned-expressive-hmr.md) 与 [ViDiHand](../wiki/entities/paper-vidihand.md)（本仓库）— 表达级数据源前沿：单图 SMPL-X 身/脸/手 >100 FPS 实时恢复（SIGGRAPH 2026）与 egocentric 双手 4D 视频扩散估计
 - [Motion Data Quality](../wiki/concepts/motion-data-quality.md) 与 [LiMMT / GQS 动作数据整编](../wiki/methods/limmt-gqs-motion-curation.md)（本仓库）— 质量量化
 

--- a/roadmap/depth-navigation.md
+++ b/roadmap/depth-navigation.md
@@ -84,6 +84,7 @@ flowchart LR
 - [SLAM Toolbox](../wiki/entities/slam-toolbox.md)、[Cartographer](../wiki/entities/cartographer.md)、[FAST-LIO](../wiki/entities/fast-lio.md)、[ORB-SLAM3](../wiki/entities/orb-slam3.md)（本仓库）
 - [State Estimation](../wiki/concepts/state-estimation.md) 与 [Sensor Fusion](../wiki/concepts/sensor-fusion.md)（本仓库）
 - [Ultra-Fusion](../wiki/entities/paper-ultra-fusion-multi-sensor-slam.md)（本仓库）— 韧性多传感器融合前沿
+- [CO-Calib](../wiki/entities/paper-co-calib-multi-fisheye-calibration.md)（本仓库）— 多鱼眼标定 failure-oriented 分析：可观测性引导选帧将 Kalibr 类管线成功率 68.1%→99.3%，多相机 VIO/SLAM 外参标定的前置工具
 
 ### 学完输出什么
 - 能为给定平台（室内 AMR / 野外四足 / 手持建图）选出合理的 SLAM 配置
@@ -142,6 +143,7 @@ flowchart LR
 - [分层四足导航栈](../wiki/concepts/hierarchical-quadruped-navigation-stack.md) 与 [HiPAN](../wiki/methods/hipan.md)（本仓库）
 - [NoMaD](../wiki/entities/paper-notebook-nomad-goal-masked-diffusion-policies-for-navigat.md) 与 [NavDP](../wiki/entities/paper-notebook-navdp-learning-sim-to-real-navigation-diffusion.md)（本仓库）
 - [EgoNav](../wiki/entities/paper-notebook-egonav.md)、[LookOut](../wiki/entities/paper-notebook-lookout.md)、[FocusNav](../wiki/entities/paper-notebook-focusnav.md)（本仓库）— 人形导航深读锚点
+- [SRU](../wiki/entities/paper-sru-spatially-enhanced-recurrent-memory.md)（本仓库）— 给 RNN 补空间配准能力的循环单元，端到端 RL 无地图导航，Unitree B2W 真机零样本 50–120 m 长程目标导航
 - [Paper Notebooks · Navigation 分类](../wiki/overview/paper-notebook-category-08-navigation.md)（本仓库）— 深读论文全景入口
 
 ### 学完输出什么
@@ -199,7 +201,7 @@ flowchart LR
 
 **方向 D：导航世界模型与新载体**
 - 用 WAM 联合预测未来观测与动作；空中 VLN 等新设定
-- 关键词：[NavWAM](../wiki/entities/paper-navwam-goal-conditioned-visual-navigation-wam.md)、[WorldVLN](../wiki/entities/paper-worldvln-aerial-vln-wam.md)、[社会导航](../wiki/entities/paper-notebook-learning-social-navigation-from-positive-and-neg.md)
+- 关键词：[NavWAM](../wiki/entities/paper-navwam-goal-conditioned-visual-navigation-wam.md)、[WorldVLN](../wiki/entities/paper-worldvln-aerial-vln-wam.md)、[PanoWorld（真实世界全景可控生成）](../wiki/entities/paper-panoworld-real-world-panoramic-generation.md)、[社会导航](../wiki/entities/paper-notebook-learning-social-navigation-from-positive-and-neg.md)
 
 ---
 

--- a/roadmap/depth-perceptive-locomotion.md
+++ b/roadmap/depth-perceptive-locomotion.md
@@ -49,6 +49,7 @@ flowchart LR
 - [Privileged Training](../wiki/concepts/privileged-training.md)
 - [Curriculum Learning](../wiki/concepts/curriculum-learning.md)
 - [ANYmal](../wiki/entities/anymal.md) — RSL 盲走与野外行走工作线
+- [DreamWaQ](../wiki/methods/dreamwaq.md) — CENet 从本体历史想象隐式地形并估计体速，无外感知单阶段 PPO 盲走基线
 
 ### 推荐做什么
 - 在 legged_gym / Isaac Lab 里用课程学习训一个能过粗糙地形的盲走策略
@@ -70,6 +71,7 @@ flowchart LR
 ### 推荐读什么
 - [Terrain Latent Representation](../wiki/concepts/terrain-latent-representation.md)
 - [AME：注意力高程图编码](../wiki/entities/paper-ame-attention-based-map-encoding.md) 与 [AME-2 深读笔记](../wiki/entities/paper-notebook-ame-2-agile-and-generalized-legged-locomotion-vi.md) — CNN + 本体条件 MHA 聚焦下一落脚可行区域，ANYmal-D 与 GR-1 上验证稀疏地形泛化与可解释注意力
+- [Attention 落足点优化](../wiki/methods/attention-foot-placement.md) — 在感知地形表示上用注意力机制选择可行走区域的方法主题页，AME 为其代表实现
 - [Sensor Fusion](../wiki/concepts/sensor-fusion.md)
 - [State Estimation](../wiki/concepts/state-estimation.md)
 - [LiDAR SLAM / LIO / VIO 选型](../wiki/comparisons/lidar-slam-lio-vio-selection.md)
@@ -98,6 +100,8 @@ flowchart LR
 - [InfiniteDiffusion / Terrain Diffusion](../wiki/entities/paper-infinite-diffusion-terrain-diffusion.md) — 学习式程序化地形的生成侧新工具（SIGGRAPH 2026，无界流式生成）
 - [Domain Randomization](../wiki/concepts/domain-randomization.md)
 - [DreamWaQ++](../wiki/entities/dreamwaq-plus.md)
+- [PIE：感知一阶段鲁棒行走](../wiki/methods/pie-perceptive-locomotion.md) — 单阶段视觉跑酷框架，深度图+本体经多头估计器输出显式高度图与隐式环境表征，与两阶段 teacher-student 路线对照
+- [Teacher-Student 与 DAgger 训练](../wiki/methods/teacher-student-dagger-training.md) — 特权教师蒸馏可部署学生的通用范式，本 Stage teacher-student 感知策略路线的方法页
 - Miki et al., *Learning Robust Perceptive Locomotion for Quadrupedal Robots in the Wild* (2022)
 
 ### 推荐做什么

--- a/roadmap/depth-rl-locomotion.md
+++ b/roadmap/depth-rl-locomotion.md
@@ -171,6 +171,8 @@ flowchart LR
 - [Domain Randomization](../wiki/concepts/domain-randomization.md)（本仓库）
 - [System Identification](../wiki/concepts/system-identification.md)（本仓库）
 - [Actuator Network](../wiki/methods/actuator-network.md) 与 [Implicit vs Explicit 执行器建模](../wiki/concepts/implicit-explicit-actuator-modeling.md)（本仓库）— 执行器 gap 是 sim2real 的第一大坑
+- [FlashSAC](../wiki/methods/flashsac.md)（本仓库）— scaling 式 off-policy SAC 改进：少更新 + 大模型 + 范数约束，G1 盲行走 sim2real 训练由小时级压到约 20 分钟
+- [PACE（足式系统化 Sim2Real）](../wiki/entities/paper-pace-sim2real-legged-robots.md)（本仓库）— chirp 悬空数据辨识紧凑关节动力学参数 + 四项物理能量 reward，无需动力学域随机化即可零样本部署
 - [Query：Sim2Real 部署检查清单](../wiki/queries/sim2real-checklist.md)
 - [Query：腿式/人形 RL 的 PD 增益设置](../wiki/queries/legged-humanoid-rl-pd-gain-setting.md)
 
@@ -189,7 +191,7 @@ flowchart LR
 
 **方向 A：更复杂的 locomotion / 感知越障**
 - 跑、跳、楼梯、崎岖地形；带深度相机/LiDAR 的感知策略
-- 关键词：[Extreme Parkour](../wiki/entities/extreme-parkour.md)、[DreamWaQ++](../wiki/entities/dreamwaq-plus.md)、teacher-student
+- 关键词：[Extreme Parkour](../wiki/entities/extreme-parkour.md)、[DreamWaQ++](../wiki/entities/dreamwaq-plus.md)、[GaitSpan（从行走到跑步的技能生长）](../wiki/entities/paper-gaitspan-humanoid-locomotion-walking-running.md)、teacher-student
 - 独立路线页：[感知越障纵深路线](depth-perceptive-locomotion.md)
 
 **方向 B：模仿学习初始化 / 动作跟踪**

--- a/roadmap/depth-torque-motor-design.md
+++ b/roadmap/depth-torque-motor-design.md
@@ -171,6 +171,7 @@ flowchart LR
 - [电机驱动器底软通信协议总览](../wiki/overview/motor-drive-firmware-bus-protocols.md)
 - [Query：EtherCAT 主站优化指南](../wiki/queries/ethercat-master-optimization.md) 与 [Query：实时运控中间件配置指南](../wiki/queries/real-time-control-middleware-guide.md)
 - [Actuator Network（执行器网络）](../wiki/methods/actuator-network.md)、[Implicit/Explicit 执行器建模](../wiki/concepts/implicit-explicit-actuator-modeling.md)、[Armature Modeling（电枢惯量建模）](../wiki/concepts/armature-modeling.md) — 台架数据回馈仿真的三条路
+- [NeuralActuator](../wiki/entities/paper-neuralactuator-neural-actuation-modeling.md) — Transformer 执行器模型联合预测可微仿真 torque surrogate 与无 F/T 传感器外力估计，低成本舵机平台上力估计误差降至 0.12 N，可作台架数据回馈仿真的第四条路
 - [Query：主流人形机器人硬件对比](../wiki/queries/hardware-comparison.md) — 对照商用模组的验收指标定位自己的水平
 
 ### 推荐做什么

--- a/roadmap/depth-vla.md
+++ b/roadmap/depth-vla.md
@@ -117,6 +117,7 @@ flowchart LR
 - [π0](../wiki/methods/π0-policy.md) 与 [π0.7](../wiki/methods/pi07-policy.md)（本仓库）
 - [SayCan](../wiki/methods/saycan.md) 与 [DIAL 指令增强](../wiki/methods/dial-instruction-augmentation.md)（本仓库）
 - [InternVLA-A1.5](../wiki/entities/paper-internvla-a15-unified-vla.md)（本仓库）— 2026 主线前沿对照：统一理解 + 潜式前瞻 + flow matching 动作的单一 MoT 框架，组合泛化与长程执行显著超 π₀.₅
+- [LingBot-VLA](../wiki/entities/lingbot-vla.md)（本仓库）— Qwen2.5-VL-3B + flow 动作头，2 万小时双臂真机预训练；开源 4B 权重与 LeRobot v3.0 后训练栈，RoboTwin 仿真领先 π₀.₅
 
 ### 学完输出什么
 - 能画出典型 VLA 的三段式结构（视觉编码 → 语义 backbone → 动作专家）并说清各家差异
@@ -146,6 +147,7 @@ flowchart LR
 - [EgoScale](../wiki/methods/egoscale.md)、[HumanNet](../wiki/entities/humannet.md)、[mimic-video](../wiki/methods/mimic-video.md)（本仓库）
 - [World Action Models（WAM）](../wiki/concepts/world-action-models.md) 与 [Pelican-Unified 1.0](../wiki/methods/pelican-unified-1.md)（本仓库）
 - [DeFI](../wiki/methods/defi-decoupled-dynamics-vla.md) 与 [具身 Scaling Laws](../wiki/concepts/embodied-scaling-laws.md)（本仓库）
+- [Xiaomi-Robotics-1](../wiki/entities/xiaomi-robotics-1.md)（本仓库）— 10 万小时 embodiment-free UMI 预训练 + 跨本体后训练，验证数据/模型规模双向可预测 scaling，预训练收益直接迁移到未见环境开箱成功率
 
 ### 学完输出什么
 - 能说清 VLA 数据金字塔（真机演示 / 仿真 / 人类视频 / 互联网视频）各层的作用与代价
@@ -175,6 +177,8 @@ flowchart LR
 - [具身模型延迟–泛化权衡](../wiki/concepts/embodied-fm-latency-generalization-tradeoff.md)（本仓库）
 - [Evo-1](../wiki/entities/paper-evo1-lightweight-vla.md)（本仓库）— 0.77B 轻量 VLA：两阶段训练保持 VLM 语义对齐，消费级 GPU 2.3 GB / 16.4 Hz，边缘侧选型的代表样本
 - [行为树 VLA 编排](../wiki/concepts/behavior-tree-vla-orchestration.md)（本仓库）
+- [EventVLA](../wiki/entities/paper-eventvla-visual-evidence-memory.md)（本仓库）— 稀疏视觉证据记忆端到端 VLA，用基础锚点 + 前瞻式关键帧预测解决长程操作的记忆瓶颈，是行为树编排之外的模型内记忆路线
+- [RoboTTT](../wiki/entities/paper-robottt-test-time-training-vla-context.md)（本仓库）— 在 VLA 层内嵌测试时训练，将 visuomotor 上下文压缩进固定大小 fast weights，扩到约 8K 步且支持部署后在线自纠偏
 - [Query：操作 VLA 架构选型](../wiki/queries/manipulation-vla-architecture-selection.md)（本仓库）
 
 ### 学完输出什么

--- a/roadmap/depth-wam.md
+++ b/roadmap/depth-wam.md
@@ -86,6 +86,7 @@ flowchart LR
 - [τ₀-World Model（τ0-WM）](../wiki/entities/tau0-world-model.md)（本仓库）— 联合预测 + 测试时修订的对照实例
 - [PhysisForcing](../wiki/entities/paper-physisforcing.md)（本仓库）— 训练期分层物理对齐（像素级轨迹 + 语义级 token 关系），推理零额外开销："视频保真 ≠ 物理可信"的正面解法
 - [PhysMani](../wiki/entities/paper-physmani-dynamic-manipulation-world-model.md)（本仓库）— 在线学习的无散度 3D Gaussian 速度场世界模型与 future-aware 策略并行耦合，面向快速动态目标操作（ECCV 2026）
+- [Xiaomi-Robotics-U0](../wiki/entities/xiaomi-robotics-u0.md)（本仓库）— 38B 统一自回归世界基础模型：T2I/X2I 与多视角具身场景生成/迁移/操纵视频共训，不内置策略头，作为下游 VLA 的合成数据引擎——「视觉逼真≠动作可推断」的直接例证
 
 ### 学完输出什么
 - 能解释"视频保真度高"为何不等于"动作可推断 / 可闭环"
@@ -113,6 +114,7 @@ flowchart LR
 ### 推荐读什么
 - [DeFI（解耦动力学 VLA）](../wiki/methods/defi-decoupled-dynamics-vla.md)（本仓库）
 - [World Action Models](../wiki/concepts/world-action-models.md) 中 Cascaded 小节（本仓库）
+- [Being-M0.7（人形潜空间 World–Action Model）](../wiki/entities/paper-being-m07-humanoid-latent-wam.md)（本仓库）— Cascaded WAM 人形实例：人中心 video-motion 先验预训练 + future-conditioned action expert，G1 真机 loco-manipulation 显著超 GR00T-N1.6
 - [动作后果技术地图](../wiki/overview/robot-world-models-action-consequence-technology-map.md)（本仓库）— 与 Joint / 部署横切对照
 
 ### 学完输出什么
@@ -142,6 +144,8 @@ flowchart LR
 - [DiT4DiT（双 DiT 联合 VAM）](../wiki/entities/paper-dit4dit-video-action-model.md)（本仓库）
 - [MotionWAM（人形 loco-manip · 实时 WAM）](../wiki/entities/paper-motionwam-humanoid-loco-manipulation-wam.md)（本仓库）
 - [ABot-M0.5（移动操作 · latent action + Dream Forcing）](../wiki/entities/paper-abot-m05-mobile-manipulation-wam.md)（本仓库）
+- [Dexmal DW05（OpenDW）](../wiki/entities/dexmal-dw05.md)（本仓库）— Wan 骨干 + MoT 三专家头联合视频/动作/价值的开源 Joint WAM，含训练/推理全栈与 RoboTwin 2.0 微调评测包
+- [Lumo-2（Latent World-Action Model）](../wiki/entities/lumo-2.md)（本仓库）— Qwen3.5-4B 潜空间世界–动作模型，三阶段渐进模态预对齐 + BAR 块解码，真机 22 项挑战全面超 π₀.₅/Fast-WAM
 - [Pelican-Unified 1.0](../wiki/methods/pelican-unified-1.md)、[Kairos](../wiki/entities/paper-kairos-native-world-model-stack.md)（本仓库）
 - [Cosmos 3](../wiki/entities/cosmos-3.md)（本仓库）— 平台级 Joint / 多任务 I/O 对照
 
@@ -187,7 +191,7 @@ flowchart LR
 
 **方向 A：人–机数据与世界监督目标**
 - 野外 egocentric 人数据如何与机器人遥操作共训；世界预测目标（Pixel / DINO / 3D flow）如何改变具身差距下的增益
-- 关键词：[EgoWAM](../wiki/entities/paper-egowam-egocentric-human-wam-co-training.md)、[模仿学习纵深](depth-imitation-learning.md)
+- 关键词：[EgoWAM](../wiki/entities/paper-egowam-egocentric-human-wam-co-training.md)、[WAM-TTT（人视频测试时训练 steering）](../wiki/entities/paper-wam-ttt-human-video-test-time-steering.md)、[模仿学习纵深](depth-imitation-learning.md)
 
 **方向 B：导航与空间决策中的 WAM**
 - image-goal / 空中 VLN 上的 Joint 或自回归 WAM；与经典 VLN / 导航 VLA 的接口


### PR DESCRIPTION
## 摘要

跨多条纵深路线补充 2025–2026 前沿研究与工程实体，涵盖：
- **WAM 路线**：Xiaomi-Robotics-U0（统一自回归世界基础模型）、Being-M0.7（人形潜空间 WAM）、Dexmal DW05 / Lumo-2（Joint WAM 开源实现）
- **VLA 路线**：LingBot-VLA（开源 4B 权重）、Xiaomi-Robotics-1（embodiment-free 预训练验证 scaling）、EventVLA / RoboTTT（记忆与测试时训练）
- **控制路线**：SRBD+凸MPC+WBC、Centroidal NMPC+WBC 栈、SLIP+VMC 中间简化层
- **导航路线**：CO-Calib（多鱼眼标定）、SRU（循环单元空间配准）、PanoWorld（全景可控生成）
- **感知越障**：DreamWaQ、PIE、Teacher-Student 与 DAgger、GaitSpan（行走到跑步技能生长）
- **灵巧操作**：TouchWorld（触觉基础模型）、REGRIND（重定向+残差RL）
- **其他**：FlashSAC（快速 Sim2Real）、PACE（系统化 Sim2Real）、Muninn（轨迹扩散缓存加速）、NeuralActuator（神经执行器建模）、FMPose3D（Flow Matching 姿态提升）

## 变更类型

- [x] 知识入库（ingest / wiki 内容）

## 验证

- [x] `make ci-preflight`（所有 roadmap 链接有效，无格式错误）
- [x] 本地验证 markdown 渲染无误

## 相关 Issue

无

## 说明

本次更新主要为 roadmap 各纵深路线补充最新的研究论文、开源实现与工程方案，确保学习路径与 2025–2026 前沿对齐。所有新增条目均指向已存在或待入库的 wiki 页面，不涉及代码逻辑改动。

https://claude.ai/code/session_01Nmzdt9MzoqkDV7RjitFNSc