### PR TITLE
structural: Add source code sequence diagrams to Top-10 papers

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,5 +1,7 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-07-20] structural | wiki 链接 Top-10 论文节点新增「源码运行时序图」模块 — beyondmimic（whole_body_tracking）/ paper-hrl-stack-03-omniretarget（holosoma）/ paper-twist2（amazon-far/TWIST2）/ deepmimic（xbpeng/DeepMimic）四页各加 mermaid sequenceDiagram；其余 6 个 Top-10 论文节点（SONIC / BFM / MotionWAM / LEGS / SD-AMP / PHP）官方源码未发布，不适用
+
 ## [2026-07-20] ingest | sources/papers/actuator_constrained_rl_high_speed_quadruped_arxiv_2312_17507.md — 执行器约束 RL 高速四足 MOR；wiki/entities/paper-actuator-constrained-rl-high-speed-quadruped-locomotion.md；交叉 sim2real / locomotion / APT-RL / depth-sim2real
 
 ## [2026-07-20] ingest | sources/sites/chingmu.md — 青瞳视觉光学动捕全栈与 MotionDecode 数据计划；wiki/entities/chingmu.md；交叉更新 notable-commercial-robot-platforms

--- a/wiki/entities/paper-hrl-stack-03-omniretarget.md
+++ b/wiki/entities/paper-hrl-stack-03-omniretarget.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, rl, motion-retargeting, motion-control, interaction-mesh, loco-manipulation, data-generation, amazon-far, body-system-stack, icra-2026]
 status: complete
-updated: 2026-07-16
+updated: 2026-07-20
 arxiv: "2509.26633"
 venue: ICRA 2026
 summary: "OmniRetarget 用 interaction mesh + Sequential SOCP 硬约束生成交互保留的人形运动学参考，支持单演示增广与 holosoma 开源管线；下游 5 reward + 4 DR 无 curriculum 即可 G1 零样本实机 30 s parkour/loco-manipulation；PHP 等论文的原子技能重定向上游。"
@@ -105,6 +105,37 @@ flowchart TB
 **5 项 reward：** body tracking（DeepMimic 位姿/速度）、object tracking（适用时）、action rate、soft joint limit、self-collision（接触力 >1 N 二值惩罚）。
 
 **4 项机器人 DR：** 躯干 COM 扰动、关节默认位、随机推、观测噪声；物体侧随机化质量/COM/惯量/形状。
+
+## 源码运行时序图
+
+官方代码以 [holosoma](https://github.com/amazon-far/holosoma) 发布，拆为三个顶层包：`holosoma_retargeting`（OmniRetarget 重定向引擎）、`holosoma`（RL 训练）、`holosoma_inference`（sim2sim / sim2real 推理部署），共享 WandB 实验管理。`demo_scripts/demo_omomo_wb_tracking.sh` 等脚本可端到端跑通「重定向 → WBT 训练」；一次完整运行的模块交互如下（命令细节见 [sources/repos/holosoma.md](../../sources/repos/holosoma.md)）：
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as 用户
+    participant RT as holosoma_retargeting<br/>OmniRetarget 引擎
+    participant TR as holosoma<br/>train_agent.py
+    participant SIM as 仿真器<br/>IsaacGym / IsaacSim / MJWarp
+    participant WB as WandB
+    participant INF as holosoma_inference
+    U->>RT: demo_omomo_wb_tracking.sh<br/>输入 MoCap（OMOMO / LAFAN1 / 自采）
+    RT->>RT: interaction mesh + Sequential SOCP<br/>硬约束求解 + 物体/地形/embodiment 增广
+    RT-->>TR: 运动学参考轨迹
+    U->>TR: train_agent.py exp:g1-29dof-…<br/>simulator:isaacgym logger:wandb
+    TR->>SIM: 创建并行环境（G1 / T1）<br/>加载参考轨迹
+    loop RL 迭代（PPO / FastSAC）
+        TR->>SIM: 批量动作
+        SIM-->>TR: 观测 + 5 reward<br/>（4 DR · 无 curriculum）
+        TR->>WB: 曲线 / 视频 / ONNX checkpoint
+    end
+    U->>INF: 部署（sim2sim / sim2real）
+    INF->>WB: 拉取 checkpoint / ONNX
+    INF-->>U: MuJoCo 验证 → G1 真机 WBT
+```
+
+- **重定向与训练解耦**：`holosoma_retargeting` 产出的参考轨迹是纯运动学数据资产（HF 公开 4 h），可独立于 RL 复用；LAFAN1 因许可需用该包自行重定向。
+- **checkpoint 全托管 WandB**：训练自动上传 ONNX，推理端直接按运行号拉取，三包之间不靠本地文件路径耦合。
 
 ## 实验与评测
 

--- a/wiki/entities/paper-twist2.md
+++ b/wiki/entities/paper-twist2.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, rl, motion-control, body-system-stack, bfm, behavior-foundation-model, teleoperation, loco-manipulation, diffusion-policy, data-collection, unitree-g1, icra-2026]
 status: complete
-updated: 2026-07-19
+updated: 2026-07-20
 arxiv: "2511.02832"
 venue: "ICRA 2026 · arXiv"
 code: https://github.com/amazon-far/TWIST2
@@ -86,6 +86,39 @@ flowchart TB
   track --> g1
   pred --> g1
 ```
+
+## 源码运行时序图
+
+官方仓库 [amazon-far/TWIST2](https://github.com/amazon-far/TWIST2) 全栈开源：遥操作栈（XRoboToolkit 配置）、低层 RL tracking 控制器与 checkpoint、visuomotor 训练/部署脚本与颈硬件 BOM（归档见 [sources/repos/twist2.md](../../sources/repos/twist2.md)）。按「采集 → 训练 → 自主」三段运行，模块交互如下：
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor OP as 操作员
+    participant XRT as XRoboToolkit<br/>PICO 4 Ultra + Trackers
+    participant RET as 实时重定向<br/>（GMR 等）
+    participant S1 as System 1<br/>RL tracking 控制器
+    participant G1 as Unitree G1<br/>含 2-DoF 颈
+    participant DS as 示范日志 / TWIST-Data
+    participant S2 as System 2<br/>visuomotor 策略（Diffusion Policy）
+    loop 遥操作数据采集
+        OP->>XRT: 全身姿态 + 头部朝向流
+        XRT->>RET: 6-DoF 全身流
+        RET->>S1: G1 全身参考（含颈指令）
+        S1->>G1: 动态可行关节动作
+        G1-->>OP: egocentric RGB 回传（主动视角）
+        G1->>DS: 同步记录视觉 / 状态 / 动作
+    end
+    OP->>S2: 用示范数据训练<br/>模仿学习策略
+    loop 自主执行（Kick-T / WB-Dex 等）
+        G1->>S2: egocentric 观测
+        S2->>S1: 预测未来全身关节位置
+        S1->>G1: 跟踪执行
+    end
+```
+
+- **低层复用是关键**：遥操作与自主共用同一个 sim2real RL tracking 控制器（随仓库发布 checkpoint），System 2 只需输出运动学参考，无需重训低层。
+- **采集即训练数据**：示范日志与 [TWIST-Data](https://twist-data.github.io/) 社区数据集同构，跑通采集环节即可直接进入 visuomotor 训练脚本。
 
 ## 核心机制（归纳）
 

--- a/wiki/methods/beyondmimic.md
+++ b/wiki/methods/beyondmimic.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, imitation-learning, locomotion, humanoid, sampling, diffusion, paper, motion-control, body-system-stack, bfm, behavior-foundation-model, stanford, berkeley]
 status: complete
-updated: 2026-07-16
+updated: 2026-07-20
 code: https://github.com/HybridRobotics/whole_body_tracking
 venue: "2025 · arXiv"
 arxiv: "2508.08241"
@@ -123,6 +123,39 @@ flowchart TD
   P -->|动作指令| E
   P --> Pi
 ```
+
+## 源码运行时序图
+
+官方跟踪阶段实现 [whole_body_tracking](https://github.com/HybridRobotics/whole_body_tracking) 基于 Isaac Lab，参考动作用 WandB Registry 管理：先用 `scripts/csv_to_npz.py` 把重定向动作转成参考 npz 并注册，再用 `scripts/rsl_rl/train.py --task=Tracking-Flat-G1-v0` 训练，`scripts/rsl_rl/play.py` 回放与导出。一次完整运行的模块交互如下（具体张量与命令行以仓库 README 为准）：
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as 用户
+    participant PRE as scripts/csv_to_npz.py
+    participant WB as WandB Registry
+    participant TR as scripts/rsl_rl/<br/>train.py · play.py
+    participant ENV as Isaac Lab 并行环境<br/>Tracking-Flat-G1-v0
+    participant PPO as rsl_rl PPO<br/>OnPolicyRunner
+    U->>PRE: 输入重定向动作 CSV<br/>（LAFAN1 / GMR 输出等）
+    PRE->>PRE: 运动学回放补全<br/>身体位姿与速度
+    PRE->>WB: 注册参考动作 .npz
+    U->>TR: train.py --task=Tracking-Flat-G1-v0<br/>--registry_name=指定动作
+    TR->>WB: 拉取参考动作
+    TR->>ENV: 创建并行环境<br/>加载参考动作命令项
+    loop 每次 PPO 迭代
+        PPO->>ENV: 批量动作（关节目标 → PD）
+        ENV->>ENV: 物理步进 + 失败率<br/>自适应片段采样
+        ENV-->>PPO: 观测 + 统一任务空间<br/>跟踪奖励
+        PPO->>PPO: GAE + PPO 更新
+        PPO->>WB: 曲线 / 视频 / checkpoint
+    end
+    U->>TR: play.py --wandb_path=训练运行号
+    TR-->>U: 加载 checkpoint 回放<br/>并导出部署用策略
+```
+
+- **训练与部署解耦**：本仓库只覆盖「参考动作 → 跟踪策略」的训练闭环；真机部署控制器在配套 deploy 仓库，与上文「端到端数据流」中的 `策略 π` 输出衔接。
+- **动作即资产**：参考动作与 checkpoint 全走 WandB Registry，换动作只改 `--registry_name`，与「失败率驱动自适应采样」一起构成多技能批量训练的工程底座。
 
 ## 输入与输出：和实现对齐时看什么
 

--- a/wiki/methods/deepmimic.md
+++ b/wiki/methods/deepmimic.md
@@ -2,7 +2,8 @@
 type: method
 tags: [imitation-learning, tracking, rl, xbpeng, paper, humanoid, motion-control, body-system-stack, ubc, berkeley]
 status: complete
-updated: 2026-07-16
+updated: 2026-07-20
+code: https://github.com/xbpeng/DeepMimic
 venue: curated
 related:
   - ../overview/humanoid-motion-cerebellum-technology-map.md
@@ -60,6 +61,36 @@ summary: "DeepMimic 是物理角色动画的基石工作，通过精确的轨迹
 | **奖励函数** | [奖励函数设计](../concepts/reward-design.md) Multi-term Reward | 综合位置、速度、末端位姿和质心偏差 |
 | **初始化** | RSI (Reference State Initialization) | 在轨迹的任意点开始训练，增加样本多样性 |
 | **早期终止** | Early Exit | 如果跌倒或偏离过大则重置，提高训练效率 |
+
+## 源码运行时序图
+
+官方实现 [xbpeng/DeepMimic](https://github.com/xbpeng/DeepMimic)：C++ 仿真核 `DeepMimicCore`（Bullet 物理 + OpenGL 渲染，SWIG 封装给 Python）+ TensorFlow PPO Agent + MPI 多进程采样。训练入口 `DeepMimic_Optimizer.py`（headless），可视化入口 `DeepMimic.py`；场景、角色、参考动作与算法超参全部由 `args/*.txt` 参数文件指定。一次完整运行的模块交互如下：
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as 用户
+    participant TRN as DeepMimic_Optimizer.py<br/>mpiexec 多进程训练
+    participant CORE as DeepMimicCore<br/>C++ / Bullet（SWIG 封装）
+    participant AG as PPO Agent<br/>TensorFlow
+    participant VIS as DeepMimic.py<br/>OpenGL 可视化
+    U->>TRN: --arg_file args/train_humanoid3d_<br/>backflip_args.txt
+    TRN->>CORE: 加载 imitate 场景 + 角色<br/>+ 参考动作 clip
+    loop 采样迭代（MPI worker 并行）
+        CORE->>CORE: RSI 参考状态初始化
+        AG->>CORE: 30 Hz 查询动作（PD 目标）
+        CORE->>CORE: Bullet 物理步进（1.2 kHz）
+        CORE-->>AG: 状态 + 相位 + 多项跟踪奖励<br/>（位姿 / 速度 / 末端 / 质心）
+        CORE-->>AG: 跌倒或偏离过大 → Early Termination
+        AG->>AG: PPO 更新（MPI 梯度同步）<br/>+ 保存 checkpoint
+    end
+    U->>VIS: --arg_file args/run_…_args.txt<br/>--model_file 训练好的策略
+    VIS->>CORE: 加载策略执行
+    CORE-->>U: OpenGL 实时渲染模仿效果
+```
+
+- **主要技术路线的三个模块都在循环里**：RSI 对应循环开头的随机初始化，multi-term reward 对应仿真核返回的多项跟踪奖励，Early Exit 对应偏离即重置。
+- **原版栈较老（TF1 + SWIG 编译）**：现代复现建议直接用 [MimicKit](../entities/mimickit.md)（同作者，集成 DeepMimic / AMP 等算法，支持 Isaac Gym / Isaac Lab）。
 
 ## 关联页面
 - [protomotions](../entities/protomotions.md) — 提供大规模并行训练支持。


### PR DESCRIPTION
## 摘要

为 Top-10 论文节点中已开源的四篇论文（DeepMimic / BeyondMimic / OmniRetarget / TWIST2）新增「源码运行时序图」模块，用 Mermaid sequenceDiagram 展示官方实现的完整数据流与模块交互，便于读者快速理解代码架构与运行逻辑。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）

## 具体改动

1. **wiki/methods/deepmimic.md**
   - 新增「源码运行时序图」模块，展示 `DeepMimic_Optimizer.py` → `DeepMimicCore`（Bullet + SWIG）→ `PPO Agent`（TensorFlow）的训练与可视化流程
   - 补充 `code` 字段指向官方仓库 `xbpeng/DeepMimic`
   - 更新 `updated` 时间戳

2. **wiki/methods/beyondmimic.md**
   - 新增「源码运行时序图」模块，展示 `csv_to_npz.py` → `WandB Registry` → `train.py`/`play.py` → `Isaac Lab` 的参考动作管理与 PPO 训练流程
   - 更新 `updated` 时间戳

3. **wiki/entities/paper-hrl-stack-03-omniretarget.md**
   - 新增「源码运行时序图」模块，展示 `holosoma_retargeting`（OmniRetarget 引擎）→ `holosoma`（RL 训练）→ `holosoma_inference`（推理部署）的端到端流程
   - 更新 `updated` 时间戳

4. **wiki/entities/paper-twist2.md**
   - 新增「源码运行时序图」模块，展示「采集 → 训练 → 自主」三段运行中 XRoboToolkit → 实时重定向 → System 1（RL tracking）→ System 2（visuomotor 策略）的完整数据流
   - 更新 `updated` 时间戳

5. **log.md**
   - 新增 `[2026-07-20] structural` 条目，记录本次改动范围与理由（Top-10 论文中其余 6 篇官方源码未发布，不适用）

## 验证

- [x] `make ci-preflight`（wiki 链接与 schema 验证）
- [x] 四个修改页面在静态站上渲染正常，Mermaid sequenceDiagram 落稳

## 相关 Issue

无

https://claude.ai/code/session_01NctKFVTtX4VS9w6aWvR9mv