### PR TITLE
style(ux): PC 端 Mermaid 灯箱扩大至窗口边缘留小间隙

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1820,6 +1820,17 @@ button.home-wiki-heatmap-cell.is-active {
   width: auto !important;
   height: auto !important;
 }
+@media (min-width: 900px) {
+  .mermaid-lightbox {
+    padding: 0.5rem;
+  }
+  .mermaid-lightbox-panel {
+    width: min(98vw, calc(100vw - 1rem));
+    height: min(96vh, calc(100dvh - 1rem));
+    max-width: calc(100vw - 1rem);
+    max-height: calc(100dvh - 1rem);
+  }
+}
 .detail-markdown-body hr {
   margin: 1.5rem 0;
   border: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- PC 端（≥900px）Mermaid 流程图灯箱面板由 `min(92vw, 1200px) × 88vh` 调整为 `min(98vw, calc(100vw - 1rem)) × min(96vh, calc(100dvh - 1rem))`，去掉 1200px 宽度上限。
- 外层容器 padding 从 `1.25rem` 缩至 `0.5rem`，窗口边缘仅留小间隙；移动端样式不变。

## 验证
- 1440×900 视口本地预览：灯箱面板约 1411×864 px（约 98%×96% 视口）。
- 仅 CSS 改动，未改 JS / wiki。

## 验证截图
![PC 端 Mermaid 灯箱放大预览](https://cursor.com/artifacts/c/art-33857a02-b15d-48b5-9a8b-839a6264a44f)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84a8f161-b934-4b4a-8b7b-e673b685b35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84a8f161-b934-4b4a-8b7b-e673b685b35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

