### PR TITLE
fix(wiki): 修复 ergoCub 源码运行时序图 Mermaid Opt 关键字冲突

### DIFF
--- a/wiki/entities/paper-ergocub-shared-embodied-intelligence.md
+++ b/wiki/entities/paper-ergocub-shared-embodied-intelligence.md
@@ -104,22 +104,22 @@ flowchart TB
 sequenceDiagram
   autonumber
   actor U as 复现者
-  participant Paper as paper_sartore_…/optimal_hardware
-  participant Adam as ami-iit/adam
-  participant Opt as 硬件优化求解器
-  participant PI as paper_…/physical_intelligence
-  participant SC as shared-controllers / wholebodycontrollib
+  participant Adam as adam 动力学库
+  participant PaperHW as optimal_hardware
+  participant Solver as 硬件优化求解器
+  participant PaperPI as physical_intelligence
+  participant SC as shared-controllers
   participant Robot as ergoCub 或仿真
   U->>Adam: pip/conda 安装 adam-robotics
-  U->>Paper: 按 OptimalHardware + Docker 跑优化
-  Paper->>Adam: 参数化浮动基动力学
-  Adam-->>Opt: 质量/惯性/耦合量
-  Opt-->>U: 最优连杆长度与模型输出
-  U->>SC: conda 装 YARP/iDynTree 后 pip install
-  U->>PI: 跑 PhysicalIntelligence 脚本
-  PI->>SC: 分层 WBC / 共享控制
+  U->>PaperHW: OptimalHardware + Docker 跑优化
+  PaperHW->>Adam: 参数化浮动基动力学
+  Adam-->>Solver: 质量、惯性、耦合量
+  Solver-->>U: 最优连杆长度与模型输出
+  U->>SC: conda 装 YARP、iDynTree 后 pip install
+  U->>PaperPI: 跑 PhysicalIntelligence 脚本
+  PaperPI->>SC: 分层 WBC、共享控制
   SC->>Robot: 轨迹与关节命令
-  Robot-->>PI: F/T、状态；人体传感更新内部模型
+  Robot-->>PaperPI: F/T、状态；人体传感更新内部模型
 ```
 
 - **硬件支路：** 论文仓 + adam（可含 Docker）即可复述优化；不要求真机。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
修复 ergoCub 实体页「源码运行时序图」Mermaid 解析失败。

## 原因
`participant Opt` 被 Mermaid sequenceDiagram 当成保留字 `opt`（可选片段），报 `Syntax error ... Expecting '+', '-', 'ACTOR', got 'opt'`。

## 改动
- 将参与方 `Opt` 重命名为 `Solver`
- 去掉别名中的 `/`、省略号与引号，降低二次解析风险
- 调整参与方顺序，缩短跨生命线回箭头

## 验证
- mermaid@10 `parse` / `render` 通过
- 静态站详情页时序图 SVG 正常渲染（无 Syntax error）

## 验证截图
![ergoCub 源码运行时序图（修复后）](https://cursor.com/artifacts/c/art-04236cf5-76c2-4ae0-93a0-057e5c7fe464)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f838b-729e-76e6-9fb0-8f014e534126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f838b-729e-76e6-9fb0-8f014e534126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

