### PR TITLE
lint: 移除 arXiv 误报，更新陈旧措辞为代表性表述

### DIFF
--- a/catalog.md
+++ b/catalog.md
@@ -1434,7 +1434,7 @@
 - [VLA（Vision-Language-Action）](wiki/methods/vla.md) — VLA**：把视觉、语言和机器人动作统一到同一个模型里，让策略不只“看见状态后输出动作”，还能够显式理解任务指令和语义约束。 `📅unknown` `[method_page]`
 - [WiLoR（野外 3D 手部定位与重建）](wiki/methods/wilor.md) — WiLoR**（CVPR 2025）面向 **单目 RGB** 场景下的 **双手** 检测与 **MANO 类 3D 重建**：先用轻量全卷积结构在高分辨率特征上定位手部，再用 Transfor `📅unknown` `[method_page]`
 - [ZEST (Zero-shot Embodied Skill Transfer)](wiki/methods/zest.md) — ZEST** 是由 Boston Dynamics 团队开发的一套统一的具身技能学习与迁移框架。它通过强化学习（RL）将多样化的、异构的人类运动数据（如动捕、视频、动画）转化为机器人的高动态、多接 `📅unknown` `[method_page]`
-- [π₀ (Pi-zero) 策略模型](wiki/methods/π0-policy.md) — π₀ (Pi-zero)** 是具身智能大模型（VLA）领域的最新突破，由 Physical Intelligence 团队于 2024 年提出。它旨在打破“一个机器人一个模型”的限制，通过单一的 `📅unknown` `[method_page]`
+- [π₀ (Pi-zero) 策略模型](wiki/methods/π0-policy.md) — π₀ (Pi-zero)** 是具身智能大模型（VLA）领域的奠基性工作，由 Physical Intelligence 团队于 2024 年提出（其后继版本见 [π₀.7](./pi07-pol `📅unknown` `[method_page]`
 
 ### Wiki Tasks（任务页）
 

--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-07-21] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **2** 条信息型预警）：
+共发现 **0** 个问题（另含 **0** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -52,8 +52,8 @@
 ### 💡 频繁提及但缺少 wiki 页面的概念（0 个）
 - 无
 
-### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（1 个）
-- arXiv（被 8 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
+### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（0 个）
+- 无
 
 ### ⚠️ Frontmatter 缺少 type 字段（0 个）
 - 无
@@ -103,8 +103,8 @@
 ### 💡 dataset 实体正文缺「规模/模态/许可证/重定向就绪度」速查维度（信息型，不阻塞 CI）（0 个）
 - 无
 
-### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（1 个）
-- wiki/entities/paper-clothtransformer-unified-latent-cloth-simulation.md（含绝对化措辞「SOTA」，updated=2026-07-20；同主题更新页 wiki/entities/paper-notebook-a-hierarchical-model-based-system-for-high-perfo.md updated=2026-07-21）
+### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（0 个）
+- 无
 
 ### 💡 动力学/仿真/物理概念页缺回链「仿真物理保真度」专题枢纽（信息型，不阻塞 CI）（0 个）
 - 无

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -94,6 +94,9 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
     # clip：正文里既指 CLIP 视觉-语言模型，又指力矩「限幅」动词（torque clip），
     # 两义被小写 slug 合并，非单一可成页概念，作停用词不再误报为「缺独立页」。
     "clip",
+    # arxiv：预印本托管/出版平台（基础设施），非机器人概念/方法/形式化，
+    # 不应建独立 concepts/methods 页；与 http/https/main 同类基础设施停用词。
+    "arxiv",
 }
 
 # 高频术语但「已在 entities/ 或非同名 stem 的 methods 页有恰当归属」，

--- a/wiki/entities/paper-clothtransformer-unified-latent-cloth-simulation.md
+++ b/wiki/entities/paper-clothtransformer-unified-latent-cloth-simulation.md
@@ -107,7 +107,7 @@ flowchart LR
 
 | 轴 | 报告口径 |
 |----|----------|
-| **vs 基线** | SOTA GNN（HOOD/ContourCraft 骨干）、MAT、LayersNet；**单统一模型** 三场景 test MVE **~6.5–15 cm**，最强基线 **~31–149 cm**（约 **4–9×** 误差比） |
+| **vs 基线** | 代表性 GNN（HOOD/ContourCraft 骨干）、MAT、LayersNet；**单统一模型** 三场景 test MVE **~6.5–15 cm**，最强基线 **~31–149 cm**（约 **4–9×** 误差比） |
 | **CCD 消融** | DCD only → +CCD loss → +CCD post. 逐步消除布–物与自碰撞伪影 |
 | **Latent 压缩** | \(K=1024\) 默认：**~4.9 ms/frame** 推理，精度–效率折中最优（Human Garment 50k-step 消融） |
 | **跨分辨率** | ~3.6k 训练 → **40k 顶点测试** 仍优于基线；核心 Transformer 耗时随分辨率增长慢于 GNN/MAT |
@@ -141,7 +141,7 @@ flowchart LR
 
 | 工作 | 关系 |
 |------|------|
-| **HOOD / ContourCraft（GNN）** | 人体着装 SOTA 骨干；**单场景或统一训练均劣于** ClothTransformer latent  formulation |
+| **HOOD / ContourCraft（GNN）** | 人体着装代表性骨干；**单场景或统一训练均劣于** ClothTransformer latent  formulation |
 | **MAT / LayersNet** | Transformer 基线；mesh/UV 耦合分辨率，泛化与速度受限 |
 | **[Deform360](./paper-deform360-deformable-visuotactile-dataset.md)** | **真实** 布/绳视触觉数据 + WM；本文偏 **仿真神经求解器 + 无穿透 GT** |
 | **[Flying Knots](./paper-flying-knots.md)** | **真机绳操纵 ILC**；本文 Robotic Manip. 为 **仿真可变形体动力学** |
@@ -161,7 +161,7 @@ flowchart LR
 - [ClothTransformer 项目页](https://yucrazing.github.io/clothtransformer/)
 - [ClothTransformer 数据集（Hugging Face）](https://huggingface.co/datasets/YuCrazing1/ClothTransformer-dataset)
 - Li et al., *GIPC: GPU-Accelerated Incremental Potential Contact* — 论文 GT 仿真器
-- Bian et al., *ContourCraft* — DCD 后处理多衣穿透 SOTA 对照
+- Bian et al., *ContourCraft* — DCD 后处理多衣穿透代表性对照
 
 ## 参考来源
 

--- a/wiki/methods/π0-policy.md
+++ b/wiki/methods/π0-policy.md
@@ -2,7 +2,7 @@
 type: method
 tags: [vla, foundation-policy, deepmind, flow-matching, manipulation]
 status: complete
-updated: 2026-07-11
+updated: 2026-07-21
 related:
   - ./vla.md
   - ./pi07-policy.md
@@ -16,7 +16,7 @@ summary: "π₀ (Pi-zero) 是由 Physical Intelligence 提出的一种通用的 
 
 # π₀ (Pi-zero) 策略模型
 
-**π₀ (Pi-zero)** 是具身智能大模型（VLA）领域的最新突破，由 Physical Intelligence 团队于 2024 年提出。它旨在打破“一个机器人一个模型”的限制，通过单一的大型神经网络同时掌控不同形态（如双臂机械臂、灵巧手、移动底座）的机器人执行多样化的复杂任务。
+**π₀ (Pi-zero)** 是具身智能大模型（VLA）领域的奠基性工作，由 Physical Intelligence 团队于 2024 年提出（其后继版本见 [π₀.7](./pi07-policy.md)）。它旨在打破“一个机器人一个模型”的限制，通过单一的大型神经网络同时掌控不同形态（如双臂机械臂、灵巧手、移动底座）的机器人执行多样化的复杂任务。
 
 ## 英文缩写速查
 


### PR DESCRIPTION
## 摘要

本 PR 修复 lint 检查中的两处问题：
1. **移除 arXiv 误报**：将 `arxiv` 加入停用词表，避免将基础设施平台误报为缺独立页的高频概念
2. **更新陈旧措辞**：将 ClothTransformer 论文中的绝对化措辞「SOTA」改为「代表性」，并更新 π₀ 策略模型页面的描述为「奠基性工作」

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档

## 详细说明

### 脚本改动（`scripts/lint_wiki.py`）
- 在 `STOPWORDS_CONCEPTS` 中新增 `arxiv` 停用词，理由：arXiv 是预印本托管平台（基础设施），非机器人领域的概念/方法/形式化，与 `http/https/main` 同类基础设施停用词

### Wiki 内容改动
- **`wiki/entities/paper-clothtransformer-unified-latent-cloth-simulation.md`**：
  - 将「SOTA GNN」改为「代表性 GNN」（第 110 行）
  - 将「SOTA 骨干」改为「代表性骨干」（第 144 行）
  - 将「SOTA 对照」改为「代表性对照」（第 164 行）
  
- **`wiki/methods/π0-policy.md`**：
  - 更新 `updated` 字段为 `2026-07-21`
  - 将「最新突破」改为「奠基性工作」，并补充后继版本 π₀.7 的交叉引用

### 导出文件更新（自动生成）
- `exports/lint-report.md`：信息型预警从 2 条降至 0 条
- `catalog.md`：π₀ 策略模型摘要同步更新

## 验证

- [x] `make ci-preflight`（lint 检查通过，预警数从 2 降至 0）
- [x] 脚本逻辑验证：arXiv 停用词生效，不再误报为缺独立页

https://claude.ai/code/session_01P9u9dXQ5XXKGHo3bvyabtw