### PR TITLE
fix(ux): 修复移动端 Chrome 底栏收起后图谱下方留白

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## 在线演示
 
-[![知识图谱交互演示：1564 个知识节点按技术社区着色，悬停节点查看简介，滚轮缩放，并可切换 3D 立体视图](media/graph-demo.gif)](https://imchong.github.io/Robotics_Notebooks/graph.html)
+[![知识图谱交互演示：1776 个知识节点按技术社区着色，悬停节点查看简介，滚轮缩放，并可切换 3D 立体视图](media/graph-demo.gif)](https://imchong.github.io/Robotics_Notebooks/graph.html)
 
 ↑ [交互式知识图谱](https://imchong.github.io/Robotics_Notebooks/graph.html)：每个点是一个知识页，颜色代表所属技术社区，连线是页面间的引用关系。悬停看简介与关联边，点击进详情页，支持 2D / 3D 视图切换。
 

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -35,6 +35,7 @@
 - [x] **响应式体验优化**：
     - [x] 确保极简后的首页在手机端首屏就能看到搜索框和图谱入口。
     - [x] 图谱页 `graph.html`：「按社区着色」图例全端（PC + 移动）改为左下角 FAB，默认折叠；点击后自左侧滑出抽屉，点击空白/遮罩或 Esc 收起，避免遮挡画布。PC 端展开尺寸约为视口宽 1/4、高 1/3。
+    - [x] 图谱页 `graph.html`：移动端 Chrome 下滑隐藏底栏后，画布壳层按 `visualViewport` / `dvh` 同步高度，避免 graph view 下方留白。
 
 ---
 
@@ -51,6 +52,7 @@
 ### Phase 3: 体验打磨 (UX)
 - [ ] 搜索结果列表优化：支持卡片式快速预览。
 - [ ] 详情页浮窗联动。
+- [x] 图谱页移动端动态视口：Chrome 底栏显隐时 `#graph-wrap` 用 `--app-vh`（`visualViewport.height`）撑满，消除下方空白条。
 - [x] 详情页 Markdown 渲染修复：正文独立 `---` 行渲染为分隔线，并按整行分隔符剥离 YAML frontmatter。
 - [x] 首页搜索索引修复：将 `tech-map/`、roadmap 与 references 纳入 `search-index.json`，支持搜索 `tech-map`。
 - [x] 技术路线页 `roadmap.html`：基于导出阶段数据渲染可折叠阶段树（垂直 `<details>` 列表）；已移除折叠 Mermaid 线框总图与路线页内 Mermaid CDN。

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -36,6 +36,7 @@
     - [x] 确保极简后的首页在手机端首屏就能看到搜索框和图谱入口。
     - [x] 图谱页 `graph.html`：「按社区着色」图例全端（PC + 移动）改为左下角 FAB，默认折叠；点击后自左侧滑出抽屉，点击空白/遮罩或 Esc 收起，避免遮挡画布。PC 端展开尺寸约为视口宽 1/4、高 1/3。
     - [x] 图谱页 `graph.html`：移动端 Chrome 下滑隐藏底栏后，画布壳层按 `visualViewport` / `dvh` 同步高度，避免 graph view 下方留白。
+    - [x] 录制验证视频 `graph-mobile-viewport-fix.mp4`；同步刷新 README `media/graph-demo.gif`（1776 节点）。
 
 ---
 

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -8,13 +8,32 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕸️</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
+  <script>
+    /* 尽早写入动态视口高度，减少 Chrome 底栏态下首屏壳层高度闪一下 */
+    (function () {
+      var h = (window.visualViewport && window.visualViewport.height) || window.innerHeight;
+      if (h > 0) document.documentElement.style.setProperty('--app-vh', Math.round(h) + 'px');
+    })();
+  </script>
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── 图谱页专用样式（不影响其他页面）── */
-    body { 
-      overflow: hidden; 
+    /* --app-vh：由 JS 按 visualViewport/innerHeight 写入，跟踪移动端浏览器底栏/地址栏显隐；
+       无 JS 时回退 100dvh。画布背景与 body 对齐，避免壳层未撑满时露出浅灰底。 */
+    html {
+      height: 100%;
+      height: 100dvh;
+      height: var(--app-vh, 100dvh);
+    }
+    body {
+      overflow: hidden;
       font-family: var(--font-sans);
+      height: 100%;
+      background: #0d1117;
+    }
+    [data-theme="light"] body {
+      background: #eef2f7;
     }
 
     /* 显式声明字体以防部分浏览器组件继承失效 */
@@ -265,7 +284,12 @@
     #graph-wrap {
       position: fixed;
       top: calc(var(--header-h) + 46px);
-      left: 0; right: 0; bottom: 0;
+      left: 0; right: 0;
+      /* 不用 bottom:0：移动端 Chrome 底栏收起后 layout viewport 可能不长高，
+         会在画布下方留出一块空白。改为按动态视口高度显式计算。 */
+      bottom: auto;
+      height: calc(100dvh - var(--header-h) - 46px);
+      height: calc(var(--app-vh, 100dvh) - var(--header-h) - 46px);
       transition: right .22s cubic-bezier(.4,0,.2,1);
     }
     #graph-canvas,
@@ -2659,11 +2683,35 @@
     /* ── SVG 尺寸（移动端首屏 clientHeight 可能为 0，需延后 fit）── */
     const wrap = document.getElementById('graph-wrap');
     const svg = d3.select('#graph-canvas');
+    const GRAPH_TOOLBAR_BAND_PX = 46;
     let W = 0;
     let H = 0;
 
+    function readHeaderHeightPx() {
+      const raw = getComputedStyle(document.documentElement).getPropertyValue('--header-h').trim();
+      const n = parseFloat(raw);
+      return Number.isFinite(n) ? n : 58;
+    }
+
+    /* 将 --app-vh 同步为当前可视高度，使 #graph-wrap 在 Chrome 底栏显隐时跟着伸缩 */
+    function syncGraphShellToViewport() {
+      const vv = window.visualViewport;
+      const viewportH = Math.round((vv && vv.height) || window.innerHeight || 0);
+      if (viewportH <= 0) return false;
+      document.documentElement.style.setProperty('--app-vh', viewportH + 'px');
+      if (wrap) {
+        const shellTop = readHeaderHeightPx() + GRAPH_TOOLBAR_BAND_PX;
+        const offsetTop = (vv && Number.isFinite(vv.offsetTop)) ? Math.round(vv.offsetTop) : 0;
+        wrap.style.top = (shellTop + offsetTop) + 'px';
+        wrap.style.height = Math.max(1, viewportH - shellTop) + 'px';
+        wrap.style.bottom = 'auto';
+      }
+      return true;
+    }
+
     function measureGraphViewport() {
       if (!wrap) return false;
+      syncGraphShellToViewport();
       const nextW = wrap.clientWidth;
       const nextH = wrap.clientHeight;
       if (nextW <= 0 || nextH <= 0) return false;
@@ -4228,9 +4276,13 @@
       applyGraphFitTransform(transform);
     }
 
-    /* ── resize（移动端地址栏收起会改变可视高度）── */
+    /* ── resize（移动端地址栏/底栏显隐会改变可视高度）── */
     function onGraphViewportResize() {
+      const prevW = W;
+      const prevH = H;
       if (!updateGraphViewport()) return;
+      // 壳层未伸缩时不必重适配，避免底栏动画期间反复 fit
+      if (W === prevW && H === prevH) return;
       if (graph3dView) graph3dView.resize();
       if (is3DView()) {
         // 3D：仅同步视口尺寸（上面 resize() 已处理），不自动适配屏幕。
@@ -4250,7 +4302,11 @@
     window.addEventListener('resize', onGraphViewportResize);
     if (window.visualViewport) {
       window.visualViewport.addEventListener('resize', onGraphViewportResize);
+      // iOS 地址栏滚动时 offsetTop 会变，需同步壳层 top
+      window.visualViewport.addEventListener('scroll', onGraphViewportResize);
     }
+    // 尽早写入 --app-vh，避免首屏在 JS 测量前用错高度
+    syncGraphShellToViewport();
 
     /* ── 主题切换监听：同步更新 D3 SVG 元素颜色 ── */
     new MutationObserver(() => {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -8,23 +8,15 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🕸️</text></svg>" />
   <meta name="color-scheme" content="dark light" />
   <script src="theme-init.js"></script>
-  <script>
-    /* 尽早写入动态视口高度，减少 Chrome 底栏态下首屏壳层高度闪一下 */
-    (function () {
-      var h = (window.visualViewport && window.visualViewport.height) || window.innerHeight;
-      if (h > 0) document.documentElement.style.setProperty('--app-vh', Math.round(h) + 'px');
-    })();
-  </script>
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <style>
     /* ── 图谱页专用样式（不影响其他页面）── */
-    /* --app-vh：由 JS 按 visualViewport/innerHeight 写入，跟踪移动端浏览器底栏/地址栏显隐；
-       无 JS 时回退 100dvh。画布背景与 body 对齐，避免壳层未撑满时露出浅灰底。 */
+    /* 画布背景与 body 对齐，避免壳层未撑满时露出浅灰底。
+       高度优先 100dvh（随 Chrome 底栏显隐变化）；--app-vh 由 JS 在 resize/交互时写入作增强。 */
     html {
       height: 100%;
       height: 100dvh;
-      height: var(--app-vh, 100dvh);
     }
     body {
       overflow: hidden;
@@ -289,6 +281,7 @@
          会在画布下方留出一块空白。改为按动态视口高度显式计算。 */
       bottom: auto;
       height: calc(100dvh - var(--header-h) - 46px);
+      /* JS 写入 --app-vh 后覆盖为精确可视高度（见 syncGraphShellToViewport） */
       height: calc(var(--app-vh, 100dvh) - var(--header-h) - 46px);
       transition: right .22s cubic-bezier(.4,0,.2,1);
     }
@@ -2693,10 +2686,15 @@
       return Number.isFinite(n) ? n : 58;
     }
 
-    /* 将 --app-vh 同步为当前可视高度，使 #graph-wrap 在 Chrome 底栏显隐时跟着伸缩 */
+    /* 将 --app-vh 同步为当前可视高度，使 #graph-wrap 在 Chrome 底栏显隐时跟着伸缩。
+       注意：一旦写入 --app-vh 就会覆盖纯 dvh；因此必须在 resize / 交互时持续刷新，
+       否则底栏收起后会出现下方留白（用户点进 graph view 时最常见）。 */
     function syncGraphShellToViewport() {
       const vv = window.visualViewport;
-      const viewportH = Math.round((vv && vv.height) || window.innerHeight || 0);
+      // Chrome 底栏动画期间 visualViewport.height 可能短暂滞后于 innerHeight；
+      // 取较大值避免壳层偏矮留下底缝。
+      const vvH = (vv && Number.isFinite(vv.height)) ? vv.height : 0;
+      const viewportH = Math.round(Math.max(window.innerHeight || 0, vvH));
       if (viewportH <= 0) return false;
       document.documentElement.style.setProperty('--app-vh', viewportH + 'px');
       if (wrap) {
@@ -4277,7 +4275,8 @@
     }
 
     /* ── resize（移动端地址栏/底栏显隐会改变可视高度）── */
-    function onGraphViewportResize() {
+    let graphViewportResizeRaf = null;
+    function runGraphViewportResize() {
       const prevW = W;
       const prevH = H;
       if (!updateGraphViewport()) return;
@@ -4299,13 +4298,32 @@
       }
       simulation.alpha(0.1).restart();
     }
+    function onGraphViewportResize() {
+      // 双 rAF：等浏览器把 innerHeight / visualViewport 都更新完再量壳层
+      if (graphViewportResizeRaf != null) cancelAnimationFrame(graphViewportResizeRaf);
+      graphViewportResizeRaf = requestAnimationFrame(() => {
+        graphViewportResizeRaf = requestAnimationFrame(() => {
+          graphViewportResizeRaf = null;
+          runGraphViewportResize();
+        });
+      });
+    }
     window.addEventListener('resize', onGraphViewportResize);
+    window.addEventListener('orientationchange', onGraphViewportResize);
+    window.addEventListener('pageshow', onGraphViewportResize);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') onGraphViewportResize();
+    });
+    // 用户点到画布时再同步一次：Chrome 底栏收起后有时不立刻触发 resize，
+    // 但「点进 graph view」时 innerHeight 已变高，此时补测可消掉底缝。
+    // runGraphViewportResize 有尺寸未变早退，不会每次 tap 都 fit。
+    window.addEventListener('pointerdown', onGraphViewportResize, { passive: true });
     if (window.visualViewport) {
       window.visualViewport.addEventListener('resize', onGraphViewportResize);
       // iOS 地址栏滚动时 offsetTop 会变，需同步壳层 top
       window.visualViewport.addEventListener('scroll', onGraphViewportResize);
     }
-    // 尽早写入 --app-vh，避免首屏在 JS 测量前用错高度
+    // 尽早写入当前可视高度
     syncGraphShellToViewport();
 
     /* ── 主题切换监听：同步更新 D3 SVG 元素颜色 ── */

--- a/scripts/record_graph_viewport_and_demo.cjs
+++ b/scripts/record_graph_viewport_and_demo.cjs
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/**
+ * Record mobile Chrome toolbar-hide viewport fix verification (MP4),
+ * and regenerate README demo GIF (media/graph-demo.gif).
+ *
+ * Usage:
+ *   node scripts/record_graph_viewport_and_demo.cjs [baseUrl] [outDir]
+ */
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const baseUrl = process.argv[2] || 'http://127.0.0.1:8765/graph.html';
+const outDir = path.resolve(
+  process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots')
+);
+const mediaGif = path.resolve(__dirname, '..', 'media', 'graph-demo.gif');
+const chromePath =
+  process.env.PUPPETEER_EXECUTABLE_PATH ||
+  (fs.existsSync('/usr/local/bin/google-chrome')
+    ? '/usr/local/bin/google-chrome'
+    : 'google-chrome');
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function framesToMp4(frameDir, outMp4, fps) {
+  const pattern = path.join(frameDir, 'frame_%03d.png');
+  execSync(
+    `ffmpeg -y -framerate ${fps} -i "${pattern}" -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -c:v libx264 -pix_fmt yuv420p -movflags +faststart "${outMp4}"`,
+    { stdio: 'inherit' }
+  );
+}
+
+function framesToGif(frameDir, outGif, fps, width, height) {
+  const pattern = path.join(frameDir, 'frame_%03d.png');
+  const palette = path.join(frameDir, 'palette.png');
+  execSync(
+    `ffmpeg -y -framerate ${fps} -i "${pattern}" -vf "scale=${width}:${height}:flags=lanczos,palettegen=max_colors=128:stats_mode=diff" "${palette}"`,
+    { stdio: 'inherit' }
+  );
+  execSync(
+    `ffmpeg -y -framerate ${fps} -i "${pattern}" -i "${palette}" -lavfi "scale=${width}:${height}:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=3" -loop 0 "${outGif}"`,
+    { stdio: 'inherit' }
+  );
+}
+
+async function waitGraphReady(page) {
+  await page.waitForFunction(() => {
+    const count = document.getElementById('graph-node-count');
+    const loading = document.getElementById('graph-loading');
+    const readyCount = count && count.textContent && !/加载|失败/.test(count.textContent);
+    const loadingGone = !loading || loading.hidden || loading.classList.contains('is-hidden');
+    return readyCount && loadingGone;
+  }, { timeout: 120000 });
+}
+
+async function injectHud(page) {
+  await page.evaluate(() => {
+    let hud = document.getElementById('viewport-verify-hud');
+    if (!hud) {
+      hud = document.createElement('div');
+      hud.id = 'viewport-verify-hud';
+      hud.style.cssText = [
+        'position:fixed',
+        'left:10px',
+        'top:calc(var(--header-h) + 54px)',
+        'z-index:9999',
+        'padding:8px 10px',
+        'border-radius:8px',
+        'background:rgba(0,0,0,0.72)',
+        'color:#e6edf3',
+        'font:600 12px/1.45 -apple-system,BlinkMacSystemFont,sans-serif',
+        'pointer-events:none',
+        'backdrop-filter:blur(6px)',
+        'border:1px solid rgba(0,212,255,0.35)',
+        'max-width:78%',
+      ].join(';');
+      document.body.appendChild(hud);
+    }
+    window.__updateViewportHud = function () {
+      const wrap = document.getElementById('graph-wrap');
+      const rect = wrap ? wrap.getBoundingClientRect() : null;
+      const gap = rect ? Math.round(window.innerHeight - rect.bottom) : null;
+      const appVh = getComputedStyle(document.documentElement).getPropertyValue('--app-vh').trim();
+      hud.innerHTML =
+        '<div>视口 innerHeight = <b style="color:#7dd3fc">' + window.innerHeight + 'px</b></div>' +
+        '<div>壳层 bottom gap = <b style="color:' + (gap === 0 ? '#34d399' : '#f87171') + '">' + gap + 'px</b></div>' +
+        '<div>--app-vh = ' + (appVh || '(dvh)') + '</div>';
+      return { gap, innerHeight: window.innerHeight, wrapBottom: rect ? Math.round(rect.bottom) : null };
+    };
+    return window.__updateViewportHud();
+  });
+}
+
+async function captureSequence(page, frameDir, count, delayMs, onTick) {
+  ensureDir(frameDir);
+  for (let i = 0; i < count; i++) {
+    if (onTick) await onTick(i);
+    const file = path.join(frameDir, `frame_${String(i).padStart(3, '0')}.png`);
+    await page.screenshot({ path: file });
+    if (i + 1 < count) await sleep(delayMs);
+  }
+}
+
+async function recordMobileVerify(browser) {
+  const page = await browser.newPage();
+  const shortH = 700;
+  const tallH = 844;
+  await page.setViewport({ width: 390, height: shortH, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+  await page.goto(baseUrl + (baseUrl.includes('?') ? '&' : '?') + 'v=' + Date.now(), {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+  await waitGraphReady(page);
+  await sleep(2500);
+  await page.evaluate(() => {
+    const btn = document.getElementById('fit-to-screen');
+    if (btn) btn.click();
+  });
+  await sleep(900);
+  await injectHud(page);
+
+  const frameDir = path.join(outDir, 'viewport-verify-frames');
+  fs.rmSync(frameDir, { recursive: true, force: true });
+  ensureDir(frameDir);
+
+  // Phase A: toolbar visible (short viewport)
+  await page.evaluate(() => {
+    const el = document.getElementById('viewport-verify-hud');
+    if (el) {
+      const tag = document.createElement('div');
+      tag.id = 'viewport-verify-phase';
+      tag.style.cssText = 'margin-top:6px;color:#fbbf24';
+      tag.textContent = '阶段 A：模拟 Chrome 底栏可见';
+      el.appendChild(tag);
+    }
+    window.__updateViewportHud();
+  });
+  await captureSequence(page, frameDir, 10, 180, async () => {
+    await page.evaluate(() => window.__updateViewportHud && window.__updateViewportHud());
+  });
+
+  // Phase B: toolbar hides → taller viewport + user taps graph
+  let frameIdx = 10;
+  await page.setViewport({ width: 390, height: tallH, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+  await page.waitForFunction((h) => window.innerHeight >= h - 4, {}, tallH);
+  await page.evaluate(() => {
+    const phase = document.getElementById('viewport-verify-phase');
+    if (phase) phase.textContent = '阶段 B：底栏隐藏 → 点按画布同步壳层';
+    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 200, clientY: 420 }));
+  });
+  await page.waitForFunction(() => {
+    const wrap = document.getElementById('graph-wrap');
+    if (!wrap) return false;
+    return Math.abs(window.innerHeight - wrap.getBoundingClientRect().bottom) <= 2;
+  }, { timeout: 5000 });
+  await sleep(300);
+
+  for (let i = 0; i < 14; i++) {
+    await page.evaluate(() => window.__updateViewportHud && window.__updateViewportHud());
+    const file = path.join(frameDir, `frame_${String(frameIdx).padStart(3, '0')}.png`);
+    await page.screenshot({ path: file });
+    frameIdx += 1;
+    await sleep(160);
+  }
+
+  const metrics = await page.evaluate(() => window.__updateViewportHud());
+  const outMp4 = path.join(outDir, 'graph-mobile-viewport-fix.mp4');
+  framesToMp4(frameDir, outMp4, 8);
+  await page.close();
+  return { outMp4, metrics, frames: frameIdx };
+}
+
+async function recordReadmeDemo(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 800, height: 450, deviceScaleFactor: 1 });
+  await page.goto(baseUrl + (baseUrl.includes('?') ? '&' : '?') + 'demo=' + Date.now(), {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+  await waitGraphReady(page);
+  await sleep(2800);
+  await page.evaluate(() => {
+    const btn = document.getElementById('fit-to-screen');
+    if (btn) btn.click();
+  });
+  await sleep(1000);
+
+  const frameDir = path.join(outDir, 'readme-demo-frames');
+  fs.rmSync(frameDir, { recursive: true, force: true });
+  ensureDir(frameDir);
+
+  let idx = 0;
+  const shot = async () => {
+    const file = path.join(frameDir, `frame_${String(idx).padStart(3, '0')}.png`);
+    await page.screenshot({ path: file });
+    idx += 1;
+  };
+
+  // Settle / gentle pan of layout
+  for (let i = 0; i < 8; i++) {
+    await shot();
+    await sleep(140);
+  }
+
+  // Hover a few nodes via DOM centers
+  const hoverTargets = await page.evaluate(() => {
+    const nodes = Array.from(document.querySelectorAll('#graph-canvas .node-circle')).slice(0, 40);
+    const pts = [];
+    for (const c of nodes) {
+      const r = c.getBoundingClientRect();
+      if (r.width < 2) continue;
+      pts.push({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
+      if (pts.length >= 5) break;
+    }
+    return pts;
+  });
+
+  for (const p of hoverTargets) {
+    await page.mouse.move(p.x, p.y, { steps: 6 });
+    await sleep(220);
+    await shot();
+    await sleep(180);
+    await shot();
+  }
+
+  // Zoom in / out with wheel at center
+  await page.mouse.move(400, 240);
+  for (let i = 0; i < 6; i++) {
+    await page.mouse.wheel({ deltaY: -90 });
+    await sleep(120);
+    await shot();
+  }
+  for (let i = 0; i < 4; i++) {
+    await page.mouse.wheel({ deltaY: 110 });
+    await sleep(120);
+    await shot();
+  }
+
+  // Fit again
+  await page.evaluate(() => {
+    const btn = document.getElementById('fit-to-screen');
+    if (btn) btn.click();
+  });
+  await sleep(700);
+  for (let i = 0; i < 4; i++) {
+    await shot();
+    await sleep(150);
+  }
+
+  // Try 3D toggle if available
+  const has3d = await page.evaluate(() => {
+    const btn = document.getElementById('view-mode-3d') || document.getElementById('physics-toggle');
+    if (!btn) return false;
+    if (btn.id === 'physics-toggle') {
+      btn.click();
+      const b3 = document.getElementById('view-mode-3d');
+      if (!b3) return false;
+      b3.click();
+      return true;
+    }
+    btn.click();
+    return true;
+  });
+  if (has3d) {
+    await sleep(1800);
+    for (let i = 0; i < 10; i++) {
+      await shot();
+      await sleep(160);
+    }
+    await page.evaluate(() => {
+      const b2 = document.getElementById('view-mode-2d');
+      if (b2) b2.click();
+    });
+    await sleep(900);
+    for (let i = 0; i < 4; i++) {
+      await shot();
+      await sleep(140);
+    }
+  }
+
+  framesToGif(frameDir, mediaGif, 8, 800, 450);
+  const st = fs.statSync(mediaGif);
+  await page.close();
+  return { outGif: mediaGif, frames: idx, bytes: st.size };
+}
+
+(async () => {
+  ensureDir(outDir);
+  const browser = await puppeteer.launch({
+    executablePath: chromePath,
+    headless: 'new',
+    args: [
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--use-gl=angle',
+      '--use-angle=swiftshader',
+      '--enable-unsafe-swiftshader',
+      '--window-size=900,700',
+    ],
+  });
+
+  try {
+    console.log('Recording mobile viewport verification…');
+    const verify = await recordMobileVerify(browser);
+    console.log('verify', verify);
+
+    console.log('Recording README demo GIF…');
+    const demo = await recordReadmeDemo(browser);
+    console.log('demo', demo);
+
+    const report = { verify, demo, at: new Date().toISOString() };
+    fs.writeFileSync(path.join(outDir, 'graph-viewport-demo-record.json'), JSON.stringify(report, null, 2));
+    if (!verify.metrics || verify.metrics.gap !== 0) {
+      console.error('FAIL: verification gap is not 0', verify.metrics);
+      process.exitCode = 1;
+    } else {
+      console.log('PASS');
+    }
+  } finally {
+    await browser.close();
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/verify_graph_mobile_viewport_gap.cjs
+++ b/scripts/verify_graph_mobile_viewport_gap.cjs
@@ -1,0 +1,101 @@
+// Verify graph.html shell tracks visual viewport height (Chrome toolbar show/hide).
+// Usage: node scripts/verify_graph_mobile_viewport_gap.cjs [baseUrl] [outDir]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const baseUrl = process.argv[2] || 'http://127.0.0.1:8765/graph.html';
+  const outDir = path.resolve(process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots'));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const exe = process.env.PUPPETEER_EXECUTABLE_PATH
+    || (fs.existsSync('/usr/local/bin/google-chrome')
+      ? '/usr/local/bin/google-chrome'
+      : (fs.existsSync('/opt/pw-browsers/chromium-1194/chrome-linux/chrome')
+        ? '/opt/pw-browsers/chromium-1194/chrome-linux/chrome'
+        : 'google-chrome'));
+
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--window-size=390,844'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    // Simulate Chrome with bottom toolbar visible (shorter visual viewport)
+    await page.setViewport({ width: 390, height: 700, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.waitForFunction(() => {
+      const count = document.getElementById('graph-node-count');
+      return count && count.textContent && !count.textContent.includes('加载中');
+    }, { timeout: 90000 });
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const measure = () => page.evaluate(() => {
+      const wrap = document.getElementById('graph-wrap');
+      const rect = wrap.getBoundingClientRect();
+      const appVh = getComputedStyle(document.documentElement).getPropertyValue('--app-vh').trim();
+      const vvH = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+      const gap = Math.round(window.innerHeight - rect.bottom);
+      return {
+        wrapTop: Math.round(rect.top),
+        wrapBottom: Math.round(rect.bottom),
+        wrapHeight: Math.round(rect.height),
+        innerHeight: window.innerHeight,
+        vvHeight: Math.round(vvH),
+        appVh,
+        gapBottom: gap,
+        ok: Math.abs(gap) <= 2,
+      };
+    });
+
+    const before = await measure();
+    await page.screenshot({
+      path: path.join(outDir, 'graph-mobile-viewport-toolbar-visible.png'),
+      fullPage: false,
+    });
+
+    // Simulate Chrome bottom toolbar hiding → taller visual viewport
+    await page.setViewport({ width: 390, height: 844, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+    await page.waitForFunction(() => window.innerHeight >= 840, { timeout: 5000 });
+    // Real Chrome may fire resize; Puppeteer often does not. User scenario is「点到 graph view」—
+    // pointerdown handler re-syncs shell to the new innerHeight.
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 200, clientY: 400 }));
+    });
+    // Wait until shell catches up (dvh and/or JS --app-vh + double-rAF)
+    await page.waitForFunction(() => {
+      const wrap = document.getElementById('graph-wrap');
+      if (!wrap) return false;
+      const gap = Math.abs(window.innerHeight - wrap.getBoundingClientRect().bottom);
+      return gap <= 2;
+    }, { timeout: 5000 });
+    await new Promise((r) => setTimeout(r, 400));
+
+    const after = await measure();
+    await page.screenshot({
+      path: path.join(outDir, 'graph-mobile-viewport-toolbar-hidden.png'),
+      fullPage: false,
+    });
+
+    const grew = after.wrapHeight > before.wrapHeight;
+    const report = { before, after, grew, pass: before.ok && after.ok && grew };
+    const reportPath = path.join(outDir, 'graph-mobile-viewport-gap-report.json');
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report, null, 2));
+    if (!report.pass) {
+      console.error('FAIL: graph shell did not track viewport height');
+      process.exitCode = 1;
+    } else {
+      console.log('PASS: graph shell tracks viewport; gapBottom≈0 before/after');
+    }
+  } finally {
+    await browser.close();
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 移动端 Chrome 下滑隐藏底栏后，`graph.html` 画布壳层 `#graph-wrap` 原先用 `position: fixed; bottom: 0` 锚定 layout viewport，可视高度变高后壳层不跟着长高，下方会露出一块空白。
- 改为用 `100dvh` / `--app-vh`（`max(innerHeight, visualViewport.height)`）显式计算高度；在 `resize` / `visualViewport` / `pointerdown`（点进 graph view）等时机同步，尺寸未变则跳过自动 fit。
- 同步刷新 README `media/graph-demo.gif`（现为 1776 节点交互演示）。

## 验证
- `node scripts/verify_graph_mobile_viewport_gap.cjs`：视口 700→844 后 `gapBottom≈0`（PASS）
- `node scripts/record_graph_viewport_and_demo.cjs`：录制验证 MP4；HUD 显示 `壳层 bottom gap = 0px`
- 视频人工复核：**PASS**（底栏隐藏后点阵背景与提示条贴底，无留白）

## 验证截图 / 视频
<a href="https://cursor.com/agents/bc-2029bf5f-8a10-4380-84dc-c323820ed5ec/artifacts?path=%2Fworkspace%2F.cursor-artifacts%2Fscreenshots%2Fgraph-mobile-viewport-verify.mp4"><img src="https://cursor.com/artifacts/c/art-abc3630d-3f91-4738-8ebd-db0b80e0f6db" alt="graph-mobile-viewport-verify.mp4" /></a>

![阶段 A：底栏可见（700px，gap=0）](https://cursor.com/artifacts/c/art-4e251777-3bdd-4f36-bfdd-c480138eccf7)
![阶段 B：底栏隐藏后同步（844px，gap=0）](https://cursor.com/artifacts/c/art-400514fb-34d8-45ec-9f68-0b09c24a818a)

![更新后的 README 图谱演示 GIF 采样帧](https://cursor.com/artifacts/c/art-e0ab5dbd-cef6-4d33-b008-39cd7cbb385b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2029bf5f-8a10-4380-84dc-c323820ed5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2029bf5f-8a10-4380-84dc-c323820ed5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

