### PR TITLE
fix(ux): 修复路线页「关联知识页」嵌套列表被拍平

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -62,6 +62,7 @@
 - [x] 技术路线页侧栏 TOC（桌面 ≥1632px）：卡片封顶 `min(76vh, 680px)`，列表区内滚动；移动端抽屉保持原样全高滚动。
 - [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
 - [x] 详情页 Mermaid 标签裁切：`htmlLabels` 下 `foreignObject` 比 `nodeLabel` 略窄时 post-render 扩框 + CSS `overflow: visible`，修复如 world-models-15 技术地图等长标签贴边裁切。
+- [x] Markdown 嵌套列表：`renderMarkdownContent` 保留缩进层级，路线页「其它纵深路径 / 关联知识页」等不再被拍平为同级 bullet。
 - [x] 首页「更多路线」六按钮排版：`home-entry-route-links` 最小列宽 132px → 118px，861–940px 窗口宽度下不再出现 5+1 孤行；≤860px 移动端保持 2×3 网格。
 - [x] 首页「更多路线」按钮按方向起点里程碑的历史顺序排列：传统控制（ZMP 1972）→ 安全控制（CLF 1983）→ 接触操作（阻抗控制 1985）→ 模仿学习（行为克隆 1988）→ 强化学习（Q-learning 1989）→ 感知越障（2020s）。
 - [x] 首页「更多路线」扩为十按钮并保持历史序：新增导航（概率 SLAM 1986）、移动操作（移动操作臂协调 1994）、BFM（DeepMimic 2018）；原 VLA·BFM 合并按钮拆为独立 BFM 与 VLA（RT-2 2023）两个入口。

--- a/docs/main.js
+++ b/docs/main.js
@@ -2996,7 +2996,6 @@
     const headingQueue = Array.isArray(headings) ? headings.slice() : collectMarkdownHeadings(source);
     let paragraphLines = [];
     let listItems = [];
-    let listTag = '';
     let quoteLines = [];
     let codeLines = [];
     let codeLang = '';
@@ -3005,6 +3004,29 @@
     let htmlBlockLines = [];
     let htmlBlockOpenTag = '';
     const HTML_BLOCK_TAGS = ['div', 'details', 'summary', 'section', 'aside', 'figure', 'figcaption'];
+
+    /** Split leading whitespace indent (spaces=1, tabs=2) from list-marker content. */
+    function splitListLine(line) {
+      var i = 0;
+      var indent = 0;
+      while (i < line.length) {
+        var ch = line.charAt(i);
+        if (ch === ' ') {
+          indent += 1;
+          i += 1;
+        } else if (ch === '\t') {
+          indent += 2;
+          i += 1;
+        } else {
+          break;
+        }
+      }
+      var content = line.slice(i);
+      if (content.charAt(content.length - 1) === ' ' || content.charAt(content.length - 1) === '\t') {
+        content = content.replace(/[ \t]+$/, '');
+      }
+      return { indent: indent, content: content };
+    }
 
     /** Empty <a id="..."></a> bookmark lines (common in roadmap .md) must bypass paragraph escaping. */
     function parseStandaloneBookmarkAnchor(trimmed) {
@@ -3021,39 +3043,80 @@
 
     function flushList() {
       if (!listItems.length) return;
-      const openTag = listTag === 'ol' ? 'ol' : 'ul';
 
-      // ⚡ Bolt Optimization: Replace .some and .map with standard for loop
-      // Expected impact: Eliminates function closure allocation and invocation overhead in hot text parsing loops.
-      let hasTask = false;
-      for (let i = 0; i < listItems.length; i++) {
-        if (listItems[i] && listItems[i].task) {
-          hasTask = true;
-          break;
+      function hasTaskAtIndent(start, end, indent) {
+        for (var t = start; t < end; t++) {
+          var row = listItems[t];
+          if (row.indent < indent) break;
+          if (row.indent === indent && row.task) return true;
         }
+        return false;
       }
 
-      const listOpen = (function () {
-        if (openTag === 'ul') return hasTask ? '<ul class="contains-task-list">' : '<ul>';
-        if (openTag === 'ol') return '<ol>';
-        return '<ul>';
-      })();
-
-      let listItemsHtml = '';
-      for (let i = 0; i < listItems.length; i++) {
-        const item = listItems[i];
-        const body = renderMathBlocks(renderInlineMarkdown(item.text, context));
+      function renderListItemBody(item) {
+        var body = renderMathBlocks(renderInlineMarkdown(item.text, context));
         if (item.task) {
-          const checkedAttr = item.checked ? ' checked' : '';
-          listItemsHtml += '<li class="task-list-item"><label><input type="checkbox"' + checkedAttr + ' disabled aria-readonly="true" /> <span class="task-list-item-body">' + body + '</span></label></li>';
-        } else {
-          listItemsHtml += '<li>' + body + '</li>';
+          var checkedAttr = item.checked ? ' checked' : '';
+          return (
+            '<li class="task-list-item"><label><input type="checkbox"' +
+            checkedAttr +
+            ' disabled aria-readonly="true" /> <span class="task-list-item-body">' +
+            body +
+            '</span></label>'
+          );
         }
+        return '<li>' + body;
       }
 
-      blocks.push(listOpen + listItemsHtml + '</' + openTag + '>');
+      /** Render flat indented list items as nested <ul>/<ol> (fixes 关联知识页 / 其它纵深路径). */
+      function renderListSlice(start, end, indent) {
+        if (start >= end) return '';
+        var html = '';
+        var i = start;
+        while (i < end) {
+          var item = listItems[i];
+          if (item.indent < indent) break;
+
+          var tag = item.tag === 'ol' ? 'ol' : 'ul';
+          var groupStart = i;
+          var j = i;
+          while (j < end) {
+            var it = listItems[j];
+            if (it.indent < indent) break;
+            if (it.indent === indent && (it.tag === 'ol' ? 'ol' : 'ul') !== tag) break;
+            j += 1;
+          }
+
+          var taskClass =
+            tag === 'ul' && hasTaskAtIndent(groupStart, j, indent) ? ' class="contains-task-list"' : '';
+          html += '<' + tag + taskClass + '>';
+
+          var k = groupStart;
+          while (k < j) {
+            var cur = listItems[k];
+            if (cur.indent !== indent) {
+              k += 1;
+              continue;
+            }
+            var childStart = k + 1;
+            var childEnd = childStart;
+            while (childEnd < j && listItems[childEnd].indent > indent) childEnd += 1;
+            html += renderListItemBody(cur);
+            if (childEnd > childStart) {
+              html += renderListSlice(childStart, childEnd, listItems[childStart].indent);
+            }
+            html += '</li>';
+            k = childEnd;
+          }
+
+          html += '</' + tag + '>';
+          i = j;
+        }
+        return html;
+      }
+
+      blocks.push(renderListSlice(0, listItems.length, listItems[0].indent));
       listItems = [];
-      listTag = '';
     }
 
     function flushQuote() {
@@ -3224,37 +3287,46 @@
       continue;
       }
 
-    const taskMatch = trimmed.match(RE_TASK);
+    const listLine = splitListLine(line);
+    const taskMatch = listLine.content.match(RE_TASK);
       if (taskMatch) {
         flushParagraph();
         flushQuote();
-        if (listTag && listTag !== 'ul') flushList();
-        listTag = 'ul';
         listItems.push({
           task: true,
           checked: String(taskMatch[1] || '').trim().toLowerCase() === 'x',
-          text: String(taskMatch[2] || '').trim()
+          text: String(taskMatch[2] || '').trim(),
+          indent: listLine.indent,
+          tag: 'ul'
         });
       continue;
       }
 
-    const unorderedMatch = trimmed.match(RE_UNORDERED);
+    const unorderedMatch = listLine.content.match(RE_UNORDERED);
       if (unorderedMatch) {
         flushParagraph();
         flushQuote();
-        if (listTag && listTag !== 'ul') flushList();
-        listTag = 'ul';
-        listItems.push({ task: false, checked: false, text: unorderedMatch[1] });
+        listItems.push({
+          task: false,
+          checked: false,
+          text: unorderedMatch[1],
+          indent: listLine.indent,
+          tag: 'ul'
+        });
       continue;
       }
 
-    const orderedMatch = trimmed.match(RE_ORDERED);
+    const orderedMatch = listLine.content.match(RE_ORDERED);
       if (orderedMatch) {
         flushParagraph();
         flushQuote();
-        if (listTag && listTag !== 'ol') flushList();
-        listTag = 'ol';
-        listItems.push({ task: false, checked: false, text: orderedMatch[1] });
+        listItems.push({
+          task: false,
+          checked: false,
+          text: orderedMatch[1],
+          indent: listLine.indent,
+          tag: 'ol'
+        });
       continue;
       }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1840,6 +1840,13 @@ button.home-wiki-heatmap-cell.is-active {
 .detail-markdown-body ol {
   padding-left: 1.4em;
 }
+.detail-markdown-body ul ul,
+.detail-markdown-body ol ol,
+.detail-markdown-body ul ol,
+.detail-markdown-body ol ul {
+  margin-top: 0.35rem;
+  margin-bottom: 0.1rem;
+}
 .detail-markdown-body li + li {
   margin-top: .35em;
 }

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -44,7 +44,9 @@ class DetailContentSyncTests(unittest.TestCase):
             "function escapeMermaidForInnerHtml(text)",
             "return '<div class=\"mermaid\">' + escapeMermaidForInnerHtml(String(code || '').trim()) + '</div>';",
             "let quoteHtml = '<blockquote>';",
-            "if (openTag === 'ul') return hasTask ? '<ul class=\"contains-task-list\">' : '<ul>';",
+            "function splitListLine(line)",
+            "function renderListSlice(start, end, indent)",
+            'tag === \'ul\' && hasTaskAtIndent(groupStart, j, indent) ? \' class="contains-task-list"\' : \'\'',
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
@@ -766,6 +768,81 @@ console.log('ok');
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         self.assertIn("ok", result.stdout)
 
+    def test_render_markdown_content_preserves_nested_lists(self):
+        """Roadmap「其它纵深路径 / 关联知识页」等缩进子项不得被拍平为同级 <li>。"""
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+function stripYamlFrontmatter(markdown) {
+  return String(markdown || '').replace(/\r\n/g, '\n').trim();
+}
+function renderInlineMarkdown(text) {
+  return String(text || '').replace(/\[([^\]]+)\]\(([^)]+)\)/g, function (_, label, href) {
+    return '<a href="' + escapeHtml(href) + '">' + escapeHtml(label) + '</a>';
+  });
+}
+function renderMathBlocks(text) { return text; }
+function collectMarkdownHeadings() { return []; }
+function slugifyHeading(text) {
+  return String(text || '').toLowerCase().replace(/\s+/g, '-') || 'section';
+}
+function normalizeCodeLang(lang) { return lang || ''; }
+function renderCodeBlock(code) { return '<pre><code>' + escapeHtml(code) + '</code></pre>'; }
+function convertMermaidFencesInHtmlFragment(html) { return html; }
+function applyMathBlocksInHtmlFragment(html) { return html; }
+const start = content.indexOf('const RE_HR = ');
+const end = content.indexOf('function renderChipList', start);
+if (start < 0 || end < 0) throw new Error('cannot locate renderMarkdownContent block');
+eval(content.slice(start, end));
+const sample = [
+  '## 和其他页面的关系',
+  '',
+  '- 完整成长路线参考：[主路线](motion-control.md)',
+  '- 其它纵深路径：',
+  '  - [遥操作](depth-teleoperation.md)',
+  '  - [人形足球](depth-humanoid-soccer.md)',
+  '- 关联知识页：',
+  '  - [人形多机协调](../wiki/concepts/humanoid-multi-robot-coordination.md)',
+  '  - [MARL](../wiki/methods/marl.md)',
+].join('\n');
+const html = renderMarkdownContent(sample, [], {});
+if (!html.includes('<ul><li>完整成长路线参考')) {
+  throw new Error('missing top-level list: ' + html);
+}
+if (!html.includes('其它纵深路径：<ul><li><a href="depth-teleoperation.md">遥操作</a></li>')) {
+  throw new Error('其它纵深路径 children not nested: ' + html);
+}
+if (!html.includes('关联知识页：<ul><li><a href="../wiki/concepts/humanoid-multi-robot-coordination.md">人形多机协调</a></li>')) {
+  throw new Error('关联知识页 children not nested: ' + html);
+}
+const flatSibling = html.includes('</li><li>关联知识页：</li><li><a href="../wiki/concepts');
+if (flatSibling) throw new Error('关联知识页 was flattened to sibling bullets');
+const topLiCount = (html.match(/<ul><li>/g) || []).length;
+if (topLiCount < 1) throw new Error('expected outer ul');
+console.log('ok');
+"""
+        import subprocess
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
+
     def test_style_css_contains_heading_anchor_active_toc_and_hash_target_styles(self):
         style_content = (ROOT / "docs" / "style.css").read_text(encoding="utf-8")
         expected_snippets = [
@@ -781,6 +858,7 @@ console.log('ok');
             "padding: 2px 0",
             ".detail-hash-target",
             ".detail-markdown-body hr",
+            ".detail-markdown-body ul ul",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, style_content)

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -46,7 +46,7 @@ class DetailContentSyncTests(unittest.TestCase):
             "let quoteHtml = '<blockquote>';",
             "function splitListLine(line)",
             "function renderListSlice(start, end, indent)",
-            'tag === \'ul\' && hasTaskAtIndent(groupStart, j, indent) ? \' class="contains-task-list"\' : \'\'',
+            "tag === 'ul' && hasTaskAtIndent(groupStart, j, indent) ? ' class=\"contains-task-list\"' : ''",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 静态站自定义 Markdown 渲染对列表行做了 `trim()`，路线页「和其他页面的关系」下的「关联知识页：」「其它纵深路径：」缩进子项被拍成同级 bullet。
- `docs/main.js` 现按缩进输出嵌套 `<ul>/<ol>`；补充嵌套列表样式与单测。
- CI：`ruff format` 对 `tests/test_content_sync.py` 引号风格已对齐。

## 验证
- `pytest tests/test_content_sync.py`（含 `test_render_markdown_content_preserves_nested_lists`）通过
- `ruff format --check tests/test_content_sync.py` 通过
- 本地静态站确认 HSP 路线页「关联知识页」子链接落在父项下的嵌套 `<ul>`（5 个子项）

## 验证截图
![HSP 和其他页面的关系：关联知识页嵌套列表](https://cursor.com/artifacts/c/art-e11b26ad-4cfc-4b76-9eaa-5ea424ef885b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58c5b97e-0ab7-40a1-8d7a-0dbfdc12ebbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58c5b97e-0ab7-40a1-8d7a-0dbfdc12ebbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

