### PR TITLE
fix(ux): 修复更新记录单日收起失效

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -717,7 +717,6 @@ body.sponsor-dialog-open {
 .updates-day-meta { font-size: .78rem; font-weight: 400; color: var(--text-muted); margin-left: .55rem; }
 .updates-day-list { list-style: none; margin: 8px 0 0; padding: 0; --updates-badge-col-width: 3.25rem; }
 /* 超量日：预览 10 条；交互含再展开/展开全部/收起，视觉沿用 PR#1245 箭头+文案（非 btn-secondary） */
-.updates-item-folded { display: none; }
 .updates-day-actions {
   display: flex;
   flex-wrap: wrap;
@@ -775,6 +774,8 @@ body.sponsor-dialog-open {
   line-height: 1.6;
   padding: 2px 0;
 }
+/* 必须写在 .updates-item 之后且提高特异性：否则同权 display:grid 会盖住 display:none，单日收起失效 */
+.updates-item.updates-item-folded { display: none; }
 .updates-badge {
   font-size: .66rem;
   line-height: 1.5;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 更新记录页超量日「收起至前 10 项」点击后条目仍全部可见。
- 根因：`.updates-item-folded { display: none }` 写在 `.updates-item { display: grid }` 之前且特异性相同，后置 `display:grid` 盖住折叠隐藏。
- 修复：改为 `.updates-item.updates-item-folded { display: none }`，并置于 `.updates-item` 之后。

## 验证
- 独立 CSS 用例：折叠项 `getComputedStyle().display === 'none'`（坏版本复现为 `grid`）
- Puppeteer：展开全部 840 → 收起 → 可见条目回到 10，且折叠项全部 `display:none`

## 验证截图
默认预览（仅前 10 项 + 展开控件）：
![更新记录单日默认折叠预览](https://cursor.com/artifacts/c/art-1720e572-26e3-472e-a6dc-263743753923)

步进展开后出现「收起至前 10 项」：
![单日展开导航含收起按钮](https://cursor.com/artifacts/c/art-303da628-0c3b-4606-8d08-8c119c3b1812)

点击收起后恢复预览：
![收起后恢复前 10 项预览](https://cursor.com/artifacts/c/art-42f10e81-15e0-48f9-b987-4641cd018f3f)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f7c9c4-b5b1-47e5-8b1f-1962786b0673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f7c9c4-b5b1-47e5-8b1f-1962786b0673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

