### PR TITLE
fix(docs): 修复 README 在线演示「知识图谱」粗体链接星号外露

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [![站点使用演示：首页按目标选入口、全库即时搜索、图谱预览，进入知识图谱后悬停节点看简介、滚轮缩放、点击节点打开详情侧栏，并可切换 3D 立体视图](media/site-demo.gif)](https://imchong.github.io/Robotics_Notebooks/)
 
-↑ [在线站点](https://imchong.github.io/Robotics_Notebooks/)使用方式：**首页**按目标选入口（路线 / 搜索 / 图谱），搜索框输入关键词即时命中知识页；**[知识图谱](https://imchong.github.io/Robotics_Notebooks/graph.html)**中每个点是一个知识页，颜色代表技术社区，连线是页面互链——悬停看简介，滚轮缩放、拖拽平移，点击节点打开详情侧栏并一键进知识页，支持 2D / 3D 视图切换。
+↑ [在线站点](https://imchong.github.io/Robotics_Notebooks/)使用方式：**首页**按目标选入口（路线 / 搜索 / 图谱），搜索框输入关键词即时命中知识页；[**知识图谱**](https://imchong.github.io/Robotics_Notebooks/graph.html)中每个点是一个知识页，颜色代表技术社区，连线是页面互链——悬停看简介，滚轮缩放、拖拽平移，点击节点打开详情侧栏并一键进知识页，支持 2D / 3D 视图切换。
 
 ---
 
@@ -98,7 +98,7 @@
 
 ## 如何贡献
 
-详见 **[CONTRIBUTING.md](CONTRIBUTING.md)**（流程与本地/CI 命令）。简述：
+详见 [**CONTRIBUTING.md**](CONTRIBUTING.md)（流程与本地/CI 命令）。简述：
 
 1.  **Ingest 模式**：如果你发现好的论文或 Repo，按照 `schema/ingest-workflow.md` 加入 `sources/`。
 2.  **Wiki 完善**：将 `sources/` 提炼为 `wiki/` 页面，并建立 [Link](schema/linking.md)。

--- a/log.md
+++ b/log.md
@@ -1,5 +1,10 @@
 > 核心规范：所有日常动作（ingest / query / lint / structural）必须追加记录到此文件。
 
+## [2026-07-24] fix(docs) | README 在线演示「知识图谱」粗体链接 `**` 原样显示
+
+- **现象：** `**[知识图谱](url)**`（粗体包住整段链接）在 GitHub Markdown 下星号可原样露出；同模式亦见于「如何贡献」的 `**[CONTRIBUTING.md](...)**`。
+- **修复：** 改为链接内粗体 `[**知识图谱**](url)` / `[**CONTRIBUTING.md**](CONTRIBUTING.md)`。
+
 ## [2026-07-24] fix(ux) | 纵深路线「路线一览」Mermaid 节点 `**Stage**` 原样显示 — 改为 `<b>` 并渲染前规范化
 
 - **现象：** 二十条 `roadmap/depth-*.md`「路线一览」flowchart 节点写 `**Stage N**`，与已有 `<br/>` / `<em>` 混用；站点 `htmlLabels` 不解析 Markdown 粗体，星号原样出现在图上。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- README「在线演示」说明里写了 `**[知识图谱](url)**`（粗体包住整段链接），GitHub Markdown 常把 `**` 原样露在「知识图谱」两侧。
- 改为链接内粗体 `[**知识图谱**](url)`；顺手修同模式的 `**[CONTRIBUTING.md](...)**`。

## 验证
- README 中已无 `\*\*[...](...)**` 模式
- 本地渲染对照：修复前星号外露 / 修复后正常粗体链接

## 验证截图
![README 知识图谱粗体链接修复对照](https://cursor.com/artifacts/c/art-ed960426-75f2-4637-a530-e633d97f7c06)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f067633-4cc6-4347-b3ff-5ba9ee9d439f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f067633-4cc6-4347-b3ff-5ba9ee9d439f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

