### PR TITLE
feat(ux): 图谱参数面板新增共享的节点名称显隐开关

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -73,7 +73,8 @@
 - [x] 修复移动端折叠态 WAM 通栏：末行居中规则改为仅 `.is-expanded` 时生效，避免 hidden 节点被 `:nth-child` 计入导致第 13 项误判孤行。
 - [x] 更新记录页 `change-log.html`：超量日先预览 10 条；提供「再展开 10 项 / 展开全部 N 项 / 收起至前 10 项」，视觉沿用箭头+文案样式（PR#1245）。
   - [x] 详情页 Mermaid 灯箱：加载态文案 + `stage-pending` 在 `fit` 完成前隐藏，消除「空面板 / 先大后缩」闪烁。
-  - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。
+  - [x] 图谱页 `graph.html`：参数面板新增「显示节点名称」开关；2D SVG 标签与 3D HTML 叠加层共享同一状态，关闭后两端同时隐藏。
+- [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/graph-3d.js
+++ b/docs/graph-3d.js
@@ -170,6 +170,23 @@
     var resolveSourceNode = opts.resolveSourceNode || function (id) {
       return sourceNodes.find(function (n) { return n.id === id; });
     };
+    var areNodeLabelsVisible = opts.areNodeLabelsVisible || function () { return true; };
+    var getNodeLabelText = opts.getNodeLabelText || function (d) {
+      return d.label || d.id;
+    };
+    var getNodeLabelFontSize = opts.getNodeLabelFontSize || function () { return 10; };
+    var getNodeLabelColor = opts.getNodeLabelColor || function () {
+      return isDark() ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.5)';
+    };
+    var getNodeLabelOpacity = opts.getNodeLabelOpacity || function () { return 0.85; };
+    var isNodeLabelHub = opts.isNodeLabelHub || function () { return false; };
+
+    var labelLayer = null;
+    var labelEls = new Map();
+    var labelTickBound = false;
+    var labelsLayoutReady = false;
+    var baselineCameraDist = null;
+    var cameraZoomInteracted = false;
 
     var nodes3d = sourceNodes.map(cloneNodeFor3D);
     var sidebarNodeId = null;
@@ -216,6 +233,158 @@
 
     function backgroundColor() {
       return isDark() ? '#0d1117' : '#eef2f7';
+    }
+
+    function getCameraDistance() {
+      if (!graph || typeof graph.cameraPosition !== 'function') return null;
+      var cam = graph.cameraPosition();
+      if (!cam || !cam.lookAt) return null;
+      var dx = cam.x - cam.lookAt.x;
+      var dy = cam.y - cam.lookAt.y;
+      var dz = cam.z - cam.lookAt.z;
+      return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    function getLabelZoomFactor() {
+      var dist = getCameraDistance();
+      if (!dist || !baselineCameraDist) return 1;
+      return baselineCameraDist / dist;
+    }
+
+    function captureBaselineCameraDist() {
+      var dist = getCameraDistance();
+      if (dist && isFinite(dist)) baselineCameraDist = dist;
+    }
+
+    function ensureLabelLayer() {
+      if (labelLayer) return labelLayer;
+      labelLayer = document.createElement('div');
+      labelLayer.className = 'graph-3d-labels';
+      labelLayer.setAttribute('aria-hidden', 'true');
+      container.appendChild(labelLayer);
+      return labelLayer;
+    }
+
+    function buildLabelEls() {
+      var layer = ensureLabelLayer();
+      if (!layer) return;
+      labelEls.clear();
+      layer.innerHTML = '';
+      sourceNodes.forEach(function (src) {
+        var el = document.createElement('div');
+        el.className = 'graph-3d-label';
+        el.textContent = getNodeLabelText(src);
+        layer.appendChild(el);
+        labelEls.set(src.id, el);
+      });
+      syncLabelStyles();
+    }
+
+    function effectiveLabelOpacity(d) {
+      if (!areNodeLabelsVisible() || container.hidden || timelineActive() || nodeHiddenByFilter(d)) {
+        return 0;
+      }
+      if (!labelsLayoutReady) return 0;
+      var src = resolveSourceNode(d.id) || d;
+      var base = getNodeLabelOpacity(src, getLabelZoomFactor(), labelsLayoutReady, cameraZoomInteracted);
+      if (base <= 0) return 0;
+      return base * nodeOpacityFor(d);
+    }
+
+    function syncLabelStyles() {
+      if (!labelLayer) return;
+      var color = getNodeLabelColor();
+      labelEls.forEach(function (el, id) {
+        var d = nodeById.get(id);
+        if (!d) return;
+        var src = resolveSourceNode(id) || d;
+        el.textContent = getNodeLabelText(src);
+        el.style.color = color;
+        el.style.fontSize = getNodeLabelFontSize(src) + 'px';
+        el.classList.toggle('is-topic-hub', !!isNodeLabelHub(src));
+        var opacity = effectiveLabelOpacity(d);
+        el.style.opacity = String(opacity);
+        el.style.visibility = opacity > 0.02 ? 'visible' : 'hidden';
+      });
+    }
+
+    function syncLabelPositions() {
+      if (!graph || container.hidden || !labelLayer) return;
+      if (!areNodeLabelsVisible()) {
+        labelEls.forEach(function (el) {
+          el.style.opacity = '0';
+          el.style.visibility = 'hidden';
+        });
+        return;
+      }
+      var dist = getCameraDistance();
+      if (baselineCameraDist && dist && Math.abs(dist - baselineCameraDist) > baselineCameraDist * 0.04) {
+        cameraZoomInteracted = true;
+      }
+      var graphNodes = graph.graphData().nodes || [];
+      graphNodes.forEach(function (d) {
+        var el = labelEls.get(d.id);
+        if (!el || d.x == null || d.y == null) return;
+        var z = d.z != null ? d.z : 0;
+        var src = resolveSourceNode(d.id) || d;
+        var center = graph.graph2ScreenCoords(d.x, d.y, z);
+        if (!center || !isFinite(center.x) || !isFinite(center.y)) {
+          el.style.visibility = 'hidden';
+          return;
+        }
+        var rimY = getNodeRadius(src) + 13;
+        var bottom = graph.graph2ScreenCoords(d.x, d.y + rimY, z);
+        var topY = bottom && isFinite(bottom.y) ? bottom.y : center.y + 12;
+        el.style.left = center.x + 'px';
+        el.style.top = topY + 'px';
+        var opacity = effectiveLabelOpacity(d);
+        el.style.opacity = String(opacity);
+        el.style.visibility = opacity > 0.02 ? 'visible' : 'hidden';
+      });
+    }
+
+    function bindLabelTick() {
+      if (labelTickBound || !graph) return;
+      labelTickBound = true;
+      graph.onEngineTick(function () {
+        if (!areNodeLabelsVisible()) return;
+        maybeMarkLabelsLayoutReady();
+        syncLabelPositions();
+        syncLabelStyles();
+      });
+    }
+
+    function resetLabelsLayoutState() {
+      labelsLayoutReady = false;
+      baselineCameraDist = null;
+      cameraZoomInteracted = false;
+      syncLabelStyles();
+    }
+
+    function markLabelsLayoutReady() {
+      labelsLayoutReady = true;
+      captureBaselineCameraDist();
+      syncLabelPositions();
+      syncLabelStyles();
+    }
+
+    function maybeMarkLabelsLayoutReady() {
+      if (labelsLayoutReady || !graph) return;
+      if (typeof graph.d3Alpha === 'function' && graph.d3Alpha() > 0.02) return;
+      markLabelsLayoutReady();
+    }
+
+    function showLabelLayer() {
+      if (labelLayer) labelLayer.style.display = '';
+    }
+
+    function hideLabelLayer() {
+      if (labelLayer) labelLayer.style.display = 'none';
+    }
+
+    function syncLabels() {
+      syncLabelPositions();
+      syncLabelStyles();
     }
 
     function buildLinks() {
@@ -475,6 +644,7 @@
         .linkOpacity(function (l) { return linkOpacityFor(l); })
         .linkVisibility(function (l) { return linkVisibleFor(l); });
       updateNodeMeshes();
+      syncLabels();
     }
 
     // pop-in 期间逐帧刷新节点 mesh 缩放，让「激活」放大过程平滑（由 3d-force-graph 的渲染环负责出图）。
@@ -790,6 +960,7 @@
         // 用基于节点数据坐标的安全 fit：库自带 zoomToFit 在场景对象尚未生成时
         // （getGraphBbox 返回 null）会静默 no-op，首次切换易停在未取景的相机上。
         zoomFitToNodes(duration);
+        markLabelsLayoutReady();
       }
       if (typeof graph.onEngineStop === 'function') {
         graph.onEngineStop(function () { runFit(); });
@@ -942,8 +1113,11 @@
     return {
       show: function () {
         container.hidden = false;
+        showLabelLayer();
         syncPositionsFromSource();
         ensureGraph();
+        buildLabelEls();
+        bindLabelTick();
         syncViewport();
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
@@ -965,11 +1139,13 @@
           });
           scheduleInitialFit(650);
           firstShowKick();
+          syncLabels();
         });
       },
 
       hide: function () {
         pauseRenderLoop();
+        hideLabelLayer();
         container.hidden = true;
       },
 
@@ -984,16 +1160,23 @@
       resize: function () {
         if (container.hidden) return;
         syncViewport();
+        syncLabels();
       },
 
       syncFilters: function () {
         refreshAppearance();
       },
 
+      syncLabels: function () {
+        if (areNodeLabelsVisible()) maybeMarkLabelsLayoutReady();
+        syncLabels();
+      },
+
       // ── 时序激活动画（生长式，仿 2D）──
       // timelineBegin：进入时序模式，按时间顺序的 node id 列表初始化；先清空力模拟子集（0 个节点）。
       timelineBegin: function (orderedIds) {
         if (!graph) return;
+        resetLabelsLayoutState();
         timelineSnapshot = nodes3d.map(function (n) {
           return { n: n, x: n.x, y: n.y, z: n.z };
         });
@@ -1036,6 +1219,8 @@
       timelineFit: function (ms) {
         if (timelineRevealedIds === null) return;
         zoomFitToNodes(ms == null ? 500 : ms, function (n) { return timelineRevealedIds.has(n.id); });
+        captureBaselineCameraDist();
+        syncLabels();
       },
 
       // timelineEnd：退出时序模式 —— 还原进入前全图位置，恢复完整 graphData 并重排收敛。
@@ -1057,11 +1242,13 @@
         graph.graphData({ nodes: nodes3d, links: buildLinks() });
         refreshAppearance();
         reheatAfterGraphData();
+        markLabelsLayoutReady();
       },
 
       refreshColors: function () {
         graph.backgroundColor(backgroundColor());
         refreshAppearance();
+        syncLabels();
       },
 
       updateForces: function () {
@@ -1078,6 +1265,7 @@
       },
 
       restartSimulation: function () {
+        resetLabelsLayoutState();
         if (customMeshesInstalled) {
           resetNodePositionsInPlace();
           this.updateForces();
@@ -1091,11 +1279,17 @@
 
       fitToScreen: function (ms) {
         zoomFitToNodes(ms == null ? 650 : ms);
+        captureBaselineCameraDist();
+        cameraZoomInteracted = false;
+        syncLabels();
       },
 
       fitToVisible: function (ms) {
         var visible = getVisibleNodeIds();
         zoomFitToNodes(ms == null ? 650 : ms, function (n) { return visible.has(n.id); });
+        captureBaselineCameraDist();
+        cameraZoomInteracted = false;
+        syncLabels();
       },
 
       focusNode: function (node, ms) {
@@ -1108,6 +1302,10 @@
           n3,
           ms == null ? 700 : ms
         );
+        window.setTimeout(function () {
+          cameraZoomInteracted = true;
+          syncLabels();
+        }, (ms == null ? 700 : ms) + 40);
       },
 
       applySidebarHighlight: function (d, direct, secondary) {
@@ -1131,6 +1329,9 @@
         window.removeEventListener('error', reviveRenderLoopOnError);
         if (graph && graph._destructor) graph._destructor();
         graph = null;
+        labelLayer = null;
+        labelEls.clear();
+        labelTickBound = false;
         container.replaceChildren();
       },
     };

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -308,6 +308,25 @@
     }
     #graph-canvas-3d[hidden] { display: none !important; }
     #graph-canvas-3d .scene-nav-info { display: none !important; }
+    .graph-3d-labels {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      overflow: hidden;
+      z-index: 3;
+    }
+    .graph-3d-label {
+      position: absolute;
+      text-align: center;
+      white-space: nowrap;
+      transform: translate(-50%, 0);
+      user-select: none;
+      transition: opacity .15s;
+      pointer-events: none;
+    }
+    .graph-3d-label.is-topic-hub {
+      font-weight: 700;
+    }
 
     /* dot-grid overlay (CSS only) */
     #graph-wrap::before {
@@ -747,6 +766,7 @@
     [data-theme="light"] .topic-intro-text { color: rgba(15, 23, 42, 0.68); }
     [data-theme="light"] .topic-intro-link { color: #1659b4; }
     [data-theme="light"] .node-topic-hub .node-label { fill: rgba(15, 23, 42, 0.88) !important; }
+    [data-theme="light"] .graph-3d-label.is-topic-hub { color: rgba(15, 23, 42, 0.88) !important; }
     [data-theme="light"] .toolbar-sep { background: rgba(0,0,0,0.1); }
     [data-theme="light"] #graph-node-count { color: rgba(0,0,0,0.38); }
     [data-theme="light"] #graph-back {
@@ -1698,6 +1718,13 @@
         </label>
       </div>
 
+      <div class="slider-row">
+        <label class="physics-toggle" for="check-node-labels">
+          <input type="checkbox" id="check-node-labels" checked />
+          <span>🏷 显示节点名称</span>
+        </label>
+      </div>
+
       <div class="slider-divider"></div>
       <div class="physics-section-title">视图模式</div>
       <div class="view-mode-toggle" role="group" aria-label="2D / 3D 视图切换">
@@ -2153,6 +2180,12 @@
     let isMagnetic2D = false;
     let isMagnetic3D = false;
     const checkMagneticEl = document.getElementById('check-magnetic');
+    // 节点名称显隐：2D / 3D 共享同一开关（与磁吸模式各自记忆不同）
+    let showNodeLabels = true;
+    let labelsSettled2D = false;
+    let userZoomed2D = false;
+    let label = null;
+    const checkNodeLabelsEl = document.getElementById('check-node-labels');
 
     function isMagneticForCurrentView() {
       return is3DView() ? isMagnetic3D : isMagnetic2D;
@@ -2160,6 +2193,10 @@
 
     function syncMagneticCheckbox() {
       if (checkMagneticEl) checkMagneticEl.checked = isMagneticForCurrentView();
+    }
+
+    function syncNodeLabelsCheckbox() {
+      if (checkNodeLabelsEl) checkNodeLabelsEl.checked = showNodeLabels;
     }
 
     const SPATIAL_VIEW_KEY = 'rn-graph-spatial-view';
@@ -2240,6 +2277,12 @@
         edgeHighlightsWithNode,
         getChargeStrength: () => chargeStrength,
         getMagneticConfig: getMagneticConfig3D,
+        areNodeLabelsVisible: () => showNodeLabels,
+        getNodeLabelText: (d) => d._info.title || d.label,
+        getNodeLabelFontSize: scaledFontSize,
+        getNodeLabelColor: labelFill,
+        getNodeLabelOpacity: computeNodeLabelOpacity,
+        isNodeLabelHub: isCurrentTopicHub,
         onNodeClick: (d, ev) => {
           if (timelinePlaying) return;
           if (isMobile) {
@@ -2341,6 +2384,7 @@
         syncGraphDomFromSimulation();
         resumeSimulation2D();
         fitToScreen();
+        sync2DNodeLabels();
       }
 
       try { localStorage.setItem(SPATIAL_VIEW_KEY, mode); } catch (_e) { /* ignore */ }
@@ -2372,6 +2416,41 @@
     }
     function labelFill() {
       return isDark() ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.5)';
+    }
+
+    function nodeLabelVisible(d) {
+      return nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
+        && nodeMatchesSearch(d) && nodeMatchesTopic(d) && nodeMatchesInstitutionFilter(d);
+    }
+
+    function computeNodeLabelOpacity(d, zoomK, labelsReady, cameraMoved) {
+      if (!showNodeLabels) return 0;
+      if (!labelsReady || timelineAnimating) return 0;
+      if (!nodeLabelVisible(d)) return 0;
+      const hub = isCurrentTopicHub(d);
+      if (searchQuery || hub) return 0.92;
+      if (!cameraMoved) return 0.85;
+      const k = zoomK != null ? zoomK : 1;
+      return k > 0.6 ? Math.min(1, (k - 0.6) * 2.5) : 0;
+    }
+
+    function sync2DNodeLabels() {
+      if (!label) return;
+      if (!showNodeLabels || timelineAnimating || !labelsSettled2D) {
+        label.style('opacity', 0);
+        return;
+      }
+      const k = d3.zoomTransform(svg.node()).k;
+      label.style('opacity', d => computeNodeLabelOpacity(d, k, true, userZoomed2D));
+    }
+
+    function setShowNodeLabels(on) {
+      showNodeLabels = !!on;
+      syncNodeLabelsCheckbox();
+      sync2DNodeLabels();
+      if (graph3dView && typeof graph3dView.syncLabels === 'function') {
+        graph3dView.syncLabels();
+      }
     }
 
     const HEALTH_COLORS = ['#f87171', '#fb923c', '#facc15', '#4ade80'];
@@ -2751,8 +2830,8 @@
       .scaleExtent([GRAPH_ZOOM_MIN, GRAPH_ZOOM_MAX])
       .on('zoom', ev => {
         gRoot.attr('transform', ev.transform);
-        const k = ev.transform.k;
-        label.style('opacity', k > 0.6 ? Math.min(1, (k - 0.6) * 2.5) : 0);
+        userZoomed2D = true;
+        sync2DNodeLabels();
       });
     svg.call(zoom);
 
@@ -2886,7 +2965,7 @@
       .attr('stroke-width', 1.5)
       .attr('stroke-opacity', 0.35);
 
-    const label = node.append('text')
+    label = node.append('text')
       .attr('class', 'node-label')
       .text(d => d._info.title || d.label)
       .attr('dy', d => scaledRadius(d) + 13)
@@ -3025,7 +3104,8 @@
     }
 
     function finishSimulationLoad() {
-      node.select('.node-label').transition().duration(400).style('opacity', 0.85);
+      labelsSettled2D = true;
+      sync2DNodeLabels();
       whenGraphViewportReady(() => fitToScreen());
     }
 
@@ -3035,7 +3115,9 @@
         graph3dView.fitToScreen(350);
         return;
       }
-      node.select('.node-label').style('opacity', 0);
+      labelsSettled2D = false;
+      userZoomed2D = false;
+      label.style('opacity', 0);
       updateGraphViewport();
       randomizeNodePositions();
       syncGraphDomFromSimulation();
@@ -3701,9 +3783,9 @@
           .attr('stroke-opacity', ok ? (hub ? 0.85 : 0.35) : 0.05)
           .attr('stroke-width', hub ? 2.5 : 1.5);
         d3.select(this).select('.node-label')
-          .style('opacity', ok && (searchQuery || hub) ? 0.92 : null)
           .style('font-weight', hub ? 700 : null);
       });
+      sync2DNodeLabels();
 
       link
         .style('opacity', null) // V21 修复：清除 openSidebar 的内联 style 干扰
@@ -4052,7 +4134,8 @@
       restoreTimelinePositions();
       simulation.stop();
       syncGraphDomFromSimulation();
-      node.select('.node-label').transition().duration(350).style('opacity', 0.85);
+      labelsSettled2D = true;
+      sync2DNodeLabels();
       fitToScreen();
     }
 
@@ -4368,6 +4451,14 @@
         if (is3DView()) isMagnetic3D = ev.target.checked;
         else isMagnetic2D = ev.target.checked;
         updateForces();
+      });
+    }
+
+    /* 显示节点名称（2D / 3D 共享同一开关） */
+    if (checkNodeLabelsEl) {
+      checkNodeLabelsEl.checked = showNodeLabels;
+      checkNodeLabelsEl.addEventListener('change', ev => {
+        setShowNodeLabels(ev.target.checked);
       });
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 在图谱页「参数」面板增加 **「显示节点名称」** 复选框（默认开启）
- **2D / 3D 共享同一状态**：关闭后 SVG 节点标签与 3D HTML 叠加层同时隐藏；切换视图后开关状态保持
- 3D 关闭名称时跳过逐帧定位计算，避免无谓开销

## 验证
- 本地 `docs/graph.html`：打开参数面板可见开关
- 关闭后 2D 标签 opacity=0；切到 3D 仍为关闭且无可见标签；开启后 3D 出现名称叠加层
- 再切回 2D，复选框仍为开启（共享状态）

## 验证截图

**参数面板（新增开关）**
![图谱参数面板：显示节点名称](https://cursor.com/artifacts/c/art-39911f4d-b42f-4559-a0aa-5f0e00b84c52)

**2D：开启名称**
![2D 开启节点名称](https://cursor.com/artifacts/c/art-bd2e7806-98c0-46aa-aa54-0a93b4f9e8e8)

**2D：关闭名称**
![2D 关闭节点名称](https://cursor.com/artifacts/c/art-1a2d8a75-74ce-4c78-a4ce-9ca341f01b96)

**3D：关闭名称（从 2D 关闭态切入，状态共享）**
![3D 关闭节点名称](https://cursor.com/artifacts/c/art-0f8e6169-7858-4ba1-a139-3ca7a65519da)

**3D：开启名称**
![3D 开启节点名称](https://cursor.com/artifacts/c/art-af70d342-8fa4-4b32-95a2-de32c6d892c7)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0de9bc73-58de-42da-bb4e-dfce63a5a959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0de9bc73-58de-42da-bb4e-dfce63a5a959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

