### PR TITLE
fix: correct relative paths in roadmap documents

### DIFF
--- a/roadmap/depth-humanoid-boxing.md
+++ b/roadmap/depth-humanoid-boxing.md
@@ -248,8 +248,8 @@ flowchart LR
 
 本路线基于以下原始资料的归纳：
 
-- [RoboStriker 摘录](../../sources/papers/humanoid_pnb_robostriker.md)（arXiv:2601.22517）— 跟踪 → 潜空间 → LS-NFSP 的完整分层做法
-- [REK 官网归档](../../sources/sites/rek-com.md) — VR 遥操作全接触格斗联赛
-- [SMPLOlympics 摘录](../../sources/papers/smplolympics_arxiv_2407_00187.md)（arXiv:2407.00187）— 拳击/击剑交替自博弈基线
+- [RoboStriker 摘录](../sources/papers/humanoid_pnb_robostriker.md)（arXiv:2601.22517）— 跟踪 → 潜空间 → LS-NFSP 的完整分层做法
+- [REK 官网归档](../sources/sites/rek-com.md) — VR 遥操作全接触格斗联赛
+- [SMPLOlympics 摘录](../sources/papers/smplolympics_arxiv_2407_00187.md)（arXiv:2407.00187）— 拳击/击剑交替自博弈基线
 - Bansal et al., *Emergent Complexity via Multi-Agent Competition* (2017, arXiv:1710.03748) — MuJoCo 人形对抗自博弈起点
-- [Towards Motion Turing Test 摘录](../../sources/papers/humanoid_pnb_towards-motion-turing-test.md) — 拳击类动态行为类人度差距
+- [Towards Motion Turing Test 摘录](../sources/papers/humanoid_pnb_towards-motion-turing-test.md) — 拳击类动态行为类人度差距

--- a/roadmap/depth-humanoid-soccer.md
+++ b/roadmap/depth-humanoid-soccer.md
@@ -174,7 +174,7 @@ flowchart LR
 - [ARTEMIS 冠军系统](../wiki/entities/paper-notebook-a-hierarchical-model-based-system-for-high-perfo.md)（本仓库）— 集中式战术层，RoboCup 2024 Adult-Size 冠军
 - [Swarm Intelligence 人形足球](../wiki/entities/paper-humanoid-soccer-swarm-intelligence.md)（本仓库）— 去中心化 4v4 对照
 - [MARL](../wiki/methods/marl.md) 与 [CTDE vs 去中心化 MARL](../wiki/comparisons/ctde-vs-decentralized-marl.md)（本仓库）
-- [SPL 极低带宽协调](../../sources/papers/robocup_spl_limited_communication_coordination_arxiv_2401_15026.md)（本仓库 sources）
+- [SPL 极低带宽协调](../sources/papers/robocup_spl_limited_communication_coordination_arxiv_2401_15026.md)（本仓库 sources）
 
 ### 学完输出什么
 - 一个 2v2 仿真对抗里可运行的角色分配 + 编队方案


### PR DESCRIPTION
## 摘要

修正 `roadmap/depth-humanoid-boxing.md` 和 `roadmap/depth-humanoid-soccer.md` 中指向 `sources/` 目录的相对路径，从 `../../sources/` 改为 `../sources/`，以匹配正确的目录结构。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`（改动 wiki/导出链）
- [ ] 其他：路径修正为相对于 roadmap 文件所在目录的正确相对路径

## 相关 Issue

无

https://claude.ai/code/session_01NEjHhP2QR2uUfkqhrnti7r