### PR TITLE
lint: 更新停用词，移除 uv 和陈旧声明误报

### DIFF
--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-07-29] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **3** 条信息型预警）：
+共发现 **0** 个问题（另含 **1** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -52,8 +52,8 @@
 ### 💡 频繁提及但缺少 wiki 页面的概念（0 个）
 - 无
 
-### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（1 个）
-- uv（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
+### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（0 个）
+- 无
 
 ### ⚠️ Frontmatter 缺少 type 字段（0 个）
 - 无
@@ -121,8 +121,8 @@
 ### 💡 dataset 实体正文缺「规模/模态/许可证/重定向就绪度」速查维度（信息型，不阻塞 CI）（0 个）
 - 无
 
-### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（1 个）
-- wiki/entities/paper-notebook-navdp-learning-sim-to-real-navigation-diffusion.md（含绝对化措辞「最新」，updated=2026-07-28；同主题更新页 wiki/entities/paper-data-pyramid-embodied-manipulation.md updated=2026-07-29）
+### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（0 个）
+- 无
 
 ### 💡 动力学/仿真/物理概念页缺回链「仿真物理保真度」专题枢纽（信息型，不阻塞 CI）（0 个）
 - 无

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -106,6 +106,10 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
     # 划分口径（如「先 train 再 eval」「train split」），非可成页的机器人概念，
     # 与 clip（限幅动词）同类语义噪声，作停用词不再误报为「缺独立页」。
     "train",
+    # uv：各页正文里的 `uv` 均为 Astral 的 Python 包管理器命令（`uv run` /
+    # `uv sync` / `uv pip install`，复现路径工具链引用），是打包/环境基础设施，
+    # 非机器人概念/方法/形式化，不应建独立页；与 arxiv/license/md 同类基础设施停用词。
+    "uv",
 }
 
 # 高频术语但「已在 entities/ 或非同名 stem 的 methods 页有恰当归属」，

--- a/wiki/entities/paper-notebook-navdp-learning-sim-to-real-navigation-diffusion.md
+++ b/wiki/entities/paper-notebook-navdp-learning-sim-to-real-navigation-diffusion.md
@@ -123,7 +123,7 @@ flowchart LR
 | benchmark | IsaacSim 4.2.0.2 + IsaacLab 1.2.0；HTTP API 将 planner 与异步 MPC follower 解耦 |
 | 评测 | `eval_nogoal_wheeled.py`、`eval_pointgoal_wheeled.py`、`eval_imagegoal_wheeled.py` |
 | 资产 | InternScene-N1 / InternData-N1 在 Hugging Face；大体积且版本依赖严格 |
-| checkpoint | README 的最新 checkpoint 需要 Google Form 获取，故“代码已开源”不等于无门槛离线复现 |
+| checkpoint | README 当前提供的 checkpoint 需要 Google Form 获取，故“代码已开源”不等于无门槛离线复现 |
 | 许可 | 仓库 API 未声明 license 文件；README 明确称 open-sourced code 为 **CC BY-NC-SA 4.0**，商用需特别核查 |
 
 ## 源码运行时序图


### PR DESCRIPTION
## 摘要

将 `uv`（Astral Python 包管理器）添加到 lint 脚本的停用词列表，避免误报为"缺独立页"；同时更新 lint 报告，移除相关的信息型预警，并修正论文页面中的绝对化措辞。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [ ] 知识入库（ingest / wiki 内容）
- [ ] 前端（`docs/`）
- [ ] 其他

## 详细说明

### 脚本改动（`scripts/lint_wiki.py`）
- 在 `STOPWORDS_INFRASTRUCTURE` 中新增 `"uv"` 条目，并附详细注释说明：`uv` 在各页正文中仅作为 Astral 的 Python 包管理器命令出现（`uv run`/`uv sync`/`uv pip install`），属于打包/环境基础设施工具链，与 `arxiv`/`license`/`md` 同类，不应建独立概念页。

### 报告更新（`exports/lint-report.md`）
- 信息型预警总数从 3 条减少到 1 条
- 移除"多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页"中的 `uv` 误报（该类别从 1 个降为 0 个）
- 移除"陈旧声明"中关于 `paper-notebook-navdp-learning-sim-to-real-navigation-diffusion.md` 的误报（该类别从 1 个降为 0 个）

### 内容改动（`wiki/entities/paper-notebook-navdp-learning-sim-to-real-navigation-diffusion.md`）
- 将 checkpoint 行的措辞从"最新 checkpoint"改为"当前提供的 checkpoint"，移除绝对化表述，更准确地反映实际情况

## 验证

- [x] `make ci-preflight`（脚本和报告改动）
- [x] 无需额外测试（停用词添加和报告更新为自动化 lint 流程的直接结果）

## 相关 Issue

无

https://claude.ai/code/session_01DUCAt7wDxZvNf2gjzPcb3s