### PR TITLE
fix(ux): 路线数字描边时长加倍并将目标卡滚至视口中心

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -5818,8 +5818,9 @@
   var depthRouteCount = document.getElementById('heroDepthRouteCount');
   var mainRouteCard = document.getElementById('home-start-main-route');
   var moreRoutesCard = document.getElementById('home-more-routes');
-  var BORDER_TRACE_MS = 1200;
+  var BORDER_TRACE_MS = 2400;
   var TOGGLE_HINT_MS = 900;
+  var SCROLL_CENTER_FALLBACK_MS = 700;
 
   function setHomeRoutesExpanded(expanded) {
     if (!routeToggle) return;
@@ -5897,6 +5898,29 @@
     }, TOGGLE_HINT_MS);
   }
 
+  /** 将入口卡滚到视口垂直中心，再回调（避免锚点默认顶对齐） */
+  function scrollEntryCardToCenter(card, hash, onReady) {
+    if (!card) {
+      if (onReady) onReady();
+      return;
+    }
+    if (hash && window.history && typeof window.history.replaceState === 'function') {
+      window.history.replaceState(null, '', hash);
+    }
+    var done = false;
+    function ready() {
+      if (done) return;
+      done = true;
+      window.clearTimeout(fallbackTimer);
+      window.removeEventListener('scrollend', onScrollEnd);
+      if (onReady) onReady();
+    }
+    function onScrollEnd() { ready(); }
+    card.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+    window.addEventListener('scrollend', onScrollEnd, { once: true });
+    var fallbackTimer = window.setTimeout(ready, SCROLL_CENTER_FALLBACK_MS);
+  }
+
   if (routeToggle) {
     routeToggle.addEventListener('click', function () {
       var expanded = routeToggle.getAttribute('aria-expanded') === 'true';
@@ -5904,27 +5928,33 @@
     });
   }
 
-  // Hero「主路线」数字：定位到「从零开始」卡并顺时针描边一圈
+  // Hero「主路线」数字：滚到「从零开始」卡中心并顺时针描边一圈
   if (mainRouteCount && mainRouteCard) {
-    mainRouteCount.addEventListener('click', function () {
-      window.setTimeout(function () {
+    mainRouteCount.addEventListener('click', function (event) {
+      event.preventDefault();
+      scrollEntryCardToCenter(mainRouteCard, '#home-start-main-route', function () {
         playCardBorderTrace(mainRouteCard);
-      }, 0);
+      });
     });
   }
 
-  // Hero「纵深路线」数字：定位到「更多路线」卡描边一圈（不展开），随后高亮展开按钮文案
+  // Hero「纵深路线」数字：滚到「更多路线」卡中心描边一圈（不展开），随后高亮展开按钮文案
   if (depthRouteCount && moreRoutesCard) {
-    depthRouteCount.addEventListener('click', function () {
-      window.setTimeout(function () {
+    depthRouteCount.addEventListener('click', function (event) {
+      event.preventDefault();
+      scrollEntryCardToCenter(moreRoutesCard, '#home-more-routes', function () {
         playCardBorderTrace(moreRoutesCard, pulseRouteToggleHint);
-      }, 0);
+      });
     });
   }
   if (window.location.hash === '#home-start-main-route' && mainRouteCard) {
-    playCardBorderTrace(mainRouteCard);
+    scrollEntryCardToCenter(mainRouteCard, null, function () {
+      playCardBorderTrace(mainRouteCard);
+    });
   } else if (window.location.hash === '#home-more-routes' && moreRoutesCard) {
-    playCardBorderTrace(moreRoutesCard, pulseRouteToggleHint);
+    scrollEntryCardToCenter(moreRoutesCard, null, function () {
+      playCardBorderTrace(moreRoutesCard, pulseRouteToggleHint);
+    });
   }
 
   // ── Wiki 全文搜索（index.html 搜索框） ────────────────────────────────────

--- a/docs/style.css
+++ b/docs/style.css
@@ -494,8 +494,7 @@ a.hero-stat-num:focus-visible {
 .section { padding: 44px 0; }
 /* 首页入口区与 Hero 同底色、语义相连：去掉自身顶距，只保留 Hero 底部留白 */
 #home-start.section { padding-top: 0; }
-#home-start-main-route,
-#home-more-routes { scroll-margin-top: calc(var(--header-h) + 12px); }
+/* 路线数字用 JS scrollIntoView(block:center)，不再用 scroll-margin 顶对齐 */
 
 /* Hero 盘点数字定位入口卡：SVG 短弧沿边框顺时针扫一圈 */
 .home-entry-card.is-border-tracing {
@@ -520,7 +519,7 @@ a.hero-stat-num:focus-visible {
   filter: drop-shadow(0 0 4px color-mix(in srgb, var(--accent) 70%, transparent));
   stroke-dasharray: 14 86;
   stroke-dashoffset: 0;
-  animation: home-border-trace-dash 1.05s linear forwards;
+  animation: home-border-trace-dash 2.1s linear forwards;
 }
 @keyframes home-border-trace-dash {
   to { stroke-dashoffset: -100; }

--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+## [2026-07-31] structural | docs/main.js — Hero 路线数字描边时长×2；跳转改为 scrollIntoView 居中
+
+- **时长：** 边框顺时针描边 `1.05s → 2.1s`（`BORDER_TRACE_MS` 1200→2400）
+- **滚动：** 主路线/纵深路线数字 `preventDefault` 后 `scrollIntoView({ block: 'center' })`，卡片落在视口垂直中心再播特效
+
 ## [2026-07-31] structural | docs/index.html — Hero 主路线/纵深路线改为锚到入口卡+顺时针描边；纵深不再自动展开，描边后高亮展开按钮
 
 - **主路线数字：** `#home-start-main-route`（从零开始卡）+ 边框顺时针高亮一圈后移除


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页 Hero「主路线 / 纵深路线」描边特效时长加倍：`1.05s → 2.1s`
- 点击后将对应入口卡滚到**视口垂直中心**（`scrollIntoView({ block: 'center' })`），不再锚点顶对齐；滚动完成后再播描边

## 验证
- Puppeteer：CSS `animationDuration=2.1s`；主路线卡片中心接近视口中线；约 2s 时描边仍在进行
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c487b9a-c2e0-4db0-b41a-9f5e6a3cf1e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c487b9a-c2e0-4db0-b41a-9f5e6a3cf1e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

