### PR TITLE
feat(ux): 路线视图纳入主路线 motion-control

### DIFF
--- a/docs/depth-filters.js
+++ b/docs/depth-filters.js
@@ -1,20 +1,21 @@
 /*
  * 路线视图（Depth Filters）单一事实源。
- * 仅包含策展的 21 条 roadmap/depth-*.md 纵深路线；
+ * 包含主路线 roadmap/motion-control.md + 策展的 21 条 roadmap/depth-*.md 纵深路线；
  * 由 graph.html（路线筛选）与 detail.html / main.js（详情页「所属路线」徽标）共享。
  *
  * 命中优先级（与 graph.html nodeMatchesDepth 一致）：
  *   excludeSegments 命中 → 直接排除；ids 显式纳入 → 命中；
  *   communities 命中 → 命中；segments 命中任一 → 命中。
  *
- * 每个纵深的汇总锚点是对应 roadmap/depth-*.md（DEPTH_META.wikiPath），
+ * 每条路线的汇总锚点是对应 roadmap/*.md（DEPTH_META.wikiPath），
  * 并写入 DEPTH_FILTERS[key].ids 以保证路线视图下始终可见。
  */
 (function (global) {
   'use strict';
 
-  /* 与首页 / roadmap/README 一致的历史顺序（21 条）。 */
+  /* 主路线置顶，其后与首页 / roadmap/README 一致的纵深历史顺序（21 条）。 */
   var DEPTH_ORDER = [
+    'motion-control',
     'teleoperation',
     'torque-motor-design',
     'classical-control',
@@ -39,6 +40,7 @@
   ];
 
   var DEPTH_HUB_IDS = {
+    'motion-control': 'roadmap/motion-control.md',
     'teleoperation': 'roadmap/depth-teleoperation.md',
     'torque-motor-design': 'roadmap/depth-torque-motor-design.md',
     'classical-control': 'roadmap/depth-classical-control.md',
@@ -77,6 +79,83 @@
   }
 
   var DEPTH_FILTERS = {
+    /* 主路线：以 motion-control.md 正文链出的 wiki 节点为命中集（不含 depth-* 纵深页）。 */
+    'motion-control': {
+      segments: new Set(),
+      ids: mergeIds('motion-control', [
+        'wiki/comparisons/gmr-vs-nmr-vs-reactor.md',
+        'wiki/comparisons/humanoid-reference-motion-datasets.md',
+        'wiki/comparisons/mpc-vs-rl.md',
+        'wiki/comparisons/ppo-vs-sac.md',
+        'wiki/comparisons/wbc-vs-rl.md',
+        'wiki/concepts/capture-point-dcm.md',
+        'wiki/concepts/centroidal-dynamics.md',
+        'wiki/concepts/contact-dynamics.md',
+        'wiki/concepts/domain-randomization.md',
+        'wiki/concepts/embodied-rl-minimal-closed-loop.md',
+        'wiki/concepts/floating-base-dynamics.md',
+        'wiki/concepts/hqp.md',
+        'wiki/concepts/kinematic-vs-dynamic-feasibility.md',
+        'wiki/concepts/lip-zmp.md',
+        'wiki/concepts/motion-data-quality.md',
+        'wiki/concepts/motion-retargeting-pipeline.md',
+        'wiki/concepts/motion-retargeting.md',
+        'wiki/concepts/optimal-control.md',
+        'wiki/concepts/sim2real.md',
+        'wiki/concepts/state-estimation.md',
+        'wiki/concepts/system-identification.md',
+        'wiki/concepts/tsid.md',
+        'wiki/concepts/whole-body-control.md',
+        'wiki/entities/amass.md',
+        'wiki/entities/crocoddyl.md',
+        'wiki/entities/dreamwaq-plus.md',
+        'wiki/entities/extreme-parkour.md',
+        'wiki/entities/hands-on-rl-book.md',
+        'wiki/entities/humanoid-robot.md',
+        'wiki/entities/isaac-gym-isaac-lab.md',
+        'wiki/entities/lafan1-dataset.md',
+        'wiki/entities/learn-robotics-qqfly-guide.md',
+        'wiki/entities/legged-gym.md',
+        'wiki/entities/linear-algebra-curriculum.md',
+        'wiki/entities/modern-robotics-book.md',
+        'wiki/entities/numerical-optimization-curriculum.md',
+        'wiki/entities/pinocchio.md',
+        'wiki/entities/pybullet.md',
+        'wiki/formalizations/contact-wrench-cone.md',
+        'wiki/formalizations/lqr.md',
+        'wiki/formalizations/mdp.md',
+        'wiki/formalizations/motion-retargeting-objective.md',
+        'wiki/formalizations/pomdp.md',
+        'wiki/formalizations/se3-representation.md',
+        'wiki/formalizations/tsid-formulation.md',
+        'wiki/formalizations/zmp-lip.md',
+        'wiki/methods/amp-reward.md',
+        'wiki/methods/behavior-cloning.md',
+        'wiki/methods/dagger.md',
+        'wiki/methods/deepmimic.md',
+        'wiki/methods/her.md',
+        'wiki/methods/imitation-learning.md',
+        'wiki/methods/model-predictive-control.md',
+        'wiki/methods/motion-retargeting-gmr.md',
+        'wiki/methods/policy-optimization.md',
+        'wiki/methods/reinforcement-learning.md',
+        'wiki/methods/trajectory-optimization.md',
+        'wiki/methods/vla.md',
+        'wiki/overview/bfm-category-03-intrinsic-reward-pretraining.md',
+        'wiki/overview/shenlan-embodied-ai-fundamentals-series.md',
+        'wiki/queries/humanoid-motion-control-know-how.md',
+        'wiki/queries/mpc-solver-selection.md',
+        'wiki/queries/mpc-tuning-guide.md',
+        'wiki/queries/open-source-motion-control-projects.md',
+        'wiki/queries/robot-policy-debug-playbook.md',
+        'wiki/queries/sim2real-checklist.md',
+        'wiki/queries/wbc-implementation-guide.md',
+        'wiki/queries/wbc-tuning-guide.md',
+        'wiki/roadmaps/humanoid-control-roadmap.md',
+        'wiki/tasks/locomotion.md',
+        'wiki/tasks/manipulation.md'
+      ])
+    },
     'teleoperation': {
       segments: new Set([
         'teleoperation', 'teleop', 'teleoperate', 'exoskeleton', 'mocap',
@@ -289,8 +368,14 @@
     }
   };
 
-  /* 纵深展示元信息（emoji + 简称 + 路线锚点 + 导读），与 graph.html chips / 首页顺序一致。 */
+  /* 路线展示元信息（emoji + 简称 + 路线锚点 + 导读），与 graph.html chips 顺序一致。 */
   var DEPTH_META = {
+    'motion-control': {
+      emoji: '🧭',
+      label: '主路线',
+      wikiPath: DEPTH_HUB_IDS['motion-control'],
+      description: '运动控制算法工程师成长路线：L−1 全景 → L0–L7 主干与全栈出口。'
+    },
     'teleoperation': {
       emoji: '🎮',
       label: '遥操作',

--- a/docs/depth-filters.js
+++ b/docs/depth-filters.js
@@ -372,7 +372,7 @@
   var DEPTH_META = {
     'motion-control': {
       emoji: '🧭',
-      label: '主路线',
+      label: '主路线-运动控制',
       wikiPath: DEPTH_HUB_IDS['motion-control'],
       description: '运动控制算法工程师成长路线：L−1 全景 → L0–L7 主干与全栈出口。'
     },

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1862,6 +1862,7 @@
         </summary>
         <div class="filter-depth-chips" id="filter-depth-chips">
           <button class="filter-depth-chip is-active" type="button" data-depth="all" title="全量"><span>🌐</span><span>全量</span></button>
+          <button class="filter-depth-chip" type="button" data-depth="motion-control" title="主路线"><span>🧭</span><span>主路线</span></button>
           <button class="filter-depth-chip" type="button" data-depth="teleoperation" title="遥操作"><span>🎮</span><span>遥操作</span></button>
           <button class="filter-depth-chip" type="button" data-depth="torque-motor-design" title="力矩电机设计"><span>⚙️</span><span>力矩电机设计</span></button>
           <button class="filter-depth-chip" type="button" data-depth="classical-control" title="传统控制"><span>📐</span><span>传统控制</span></button>
@@ -2234,7 +2235,7 @@
       }
       if (topicIntroText) topicIntroText.textContent = meta.description || '';
       if (topicIntroLink && meta.wikiPath) {
-        topicIntroLink.href = 'detail.html?id=' + encodeURIComponent(toDetailId(meta.wikiPath));
+        topicIntroLink.href = pageUrlForPath(meta.wikiPath);
         topicIntroLink.hidden = false;
       } else if (topicIntroLink) {
         topicIntroLink.hidden = true;

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1862,7 +1862,7 @@
         </summary>
         <div class="filter-depth-chips" id="filter-depth-chips">
           <button class="filter-depth-chip is-active" type="button" data-depth="all" title="全量"><span>🌐</span><span>全量</span></button>
-          <button class="filter-depth-chip" type="button" data-depth="motion-control" title="主路线"><span>🧭</span><span>主路线</span></button>
+          <button class="filter-depth-chip" type="button" data-depth="motion-control" title="主路线-运动控制"><span>🧭</span><span>主路线-运动控制</span></button>
           <button class="filter-depth-chip" type="button" data-depth="teleoperation" title="遥操作"><span>🎮</span><span>遥操作</span></button>
           <button class="filter-depth-chip" type="button" data-depth="torque-motor-design" title="力矩电机设计"><span>⚙️</span><span>力矩电机设计</span></button>
           <button class="filter-depth-chip" type="button" data-depth="classical-control" title="传统控制"><span>📐</span><span>传统控制</span></button>

--- a/log.md
+++ b/log.md
@@ -25,12 +25,12 @@
 - **交叉：** [`wiki/entities/humanoid-motion-intelligence.md`](wiki/entities/humanoid-motion-intelligence.md)、[`wiki/queries/hmi-opensource-projects-coverage.md`](wiki/queries/hmi-opensource-projects-coverage.md)、[`scripts/utils/community_labels.py`](scripts/utils/community_labels.py)
 - **说明：** 开源项目主表 166 项此前已覆盖；本轮补齐论文侧缺口并修正两处错误挂接
 
-## [2026-07-31] structural | 图谱「路线视图」仅保留 21 条策展纵深；原专题枢纽改为 hub-* 知识链
+## [2026-07-31] structural | 图谱「路线视图」纳入主路线 + 21 条策展纵深；原专题枢纽改为 hub-* 知识链
 
-- **产品概念：** 策展学习路径仍称「纵深路线」（[`roadmap/depth-*.md`](roadmap/) 共 21 条）；图谱侧栏与详情徽标统一称「**路线视图** / **所属路线**」，取消独立「专题」概念
-- **图谱：** [`docs/depth-filters.js`](docs/depth-filters.js) 与 `graph.html` chips 仅含 21 条；锚点为 `roadmap/depth-*.md`；详情页元数据标签为「所属路线」
+- **产品概念：** 图谱侧栏与详情徽标统一称「**路线视图** / **所属路线**」；路线集 = 主路线 [`roadmap/motion-control.md`](roadmap/motion-control.md) + 21 条纵深 [`roadmap/depth-*.md`](roadmap/)；取消独立「专题」概念
+- **图谱：** [`docs/depth-filters.js`](docs/depth-filters.js) 与 `graph.html` chips：主路线置顶（命中集=主路线正文链出的 wiki 节点），其后 21 条纵深；详情页「所属路线」徽标同步
 - **原专题枢纽：** `wiki/overview/topic-*` → `wiki/overview/hub-*`（称「知识链汇总」，不再叫纵深）；旧 `topic-*` / 误改的 `overview/depth-*` 详情 ID 写入 [`schema/page-aliases.json`](schema/page-aliases.json)
-- **涉及路径：** `docs/depth-filters.js`、`docs/graph.html`、`docs/main.js`、`wiki/overview/hub-*.md`、`roadmap/depth-*.md`
+- **涉及路径：** `docs/depth-filters.js`、`docs/graph.html`、`docs/main.js`、`wiki/overview/hub-*.md`、`roadmap/depth-*.md`、`roadmap/motion-control.md`
 
 ## [2026-07-30] structural | schema/canonical-facts.json — V31 P2 事实库扩展 250 → 260 条，补 10 条感知栈选型矛盾检测规则
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 图谱「**路线视图**」chips 增加并置顶 **主路线-运动控制**（[`roadmap/motion-control.md`](roadmap/motion-control.md)）
- 命中集 = 主路线正文链出的 wiki 节点（约 71 页 + 路线锚点；不含 `depth-*` 纵深页本身）
- 详情页「**所属路线**」同步显示「主路线-运动控制」徽标
- 「打开路线页」统一走 `roadmap.html`（与节点跳转一致）

## 验证
- 本地改动已推送；标签文案为「主路线-运动控制」

## 验证截图
![路线视图主路线-运动控制](https://cursor.com/artifacts/c/art-07171f81-97ee-411c-9b17-61bc151e4803)
![详情页所属路线主路线-运动控制](https://cursor.com/artifacts/c/art-ba37fbcb-16d7-4858-b2fd-cf9b41cc3dca)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e1cdb53-3a29-4c1c-b117-413b860c884a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e1cdb53-3a29-4c1c-b117-413b860c884a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

