### PR TITLE
feat(ux): 路线元信息增加「路线视图」徽标

### DIFF
--- a/docs/depth-filters.js
+++ b/docs/depth-filters.js
@@ -1,7 +1,7 @@
 /*
  * 路线视图（Depth Filters）单一事实源。
  * 包含主路线 roadmap/motion-control.md + 策展的 21 条 roadmap/depth-*.md 纵深路线；
- * 由 graph.html（路线筛选）与 detail.html / main.js（详情页「所属路线」徽标）共享。
+ * 由 graph.html（路线筛选）、detail.html（「所属路线」）与 roadmap.html（「路线视图」徽标）共享。
  *
  * 命中优先级（与 graph.html nodeMatchesDepth 一致）：
  *   excludeSegments 命中 → 直接排除；ids 显式纳入 → 命中；

--- a/docs/main.js
+++ b/docs/main.js
@@ -4218,20 +4218,22 @@
     link.hidden = false;
   }
 
-  // 路线徽标：复用 graph.html 的纵深命中规则（depth-filters.js），rowId 可复用于路线页等。
-  function renderMetaDepthBadges(currentPath, rowId) {
+  // 路线徽标：复用 graph.html 的命中规则（depth-filters.js）。
+  // 详情页标签「所属路线」；路线页元信息标签「路线视图」——功能相同，均跳转 graph.html?depth=。
+  function renderMetaDepthBadges(currentPath, rowId, labelText) {
     var depthRowId = rowId || 'detailMetaDepth';
+    var rowLabel = labelText || '所属路线';
     var TF = window.RNDepthFilters;
     if (!TF || !currentPath) {
-      renderDetailMetaItemRow(depthRowId, '所属路线', '');
+      renderDetailMetaItemRow(depthRowId, rowLabel, '');
       return Promise.resolve();
     }
 
     return fetch('exports/link-graph.json').then(function (r) { return r.json(); }).then(function (gd) {
       var node = (gd.nodes || []).find(function (n) { return n.id === currentPath; });
-      if (!node) { renderDetailMetaItemRow(depthRowId, '所属路线', ''); return; }
+      if (!node) { renderDetailMetaItemRow(depthRowId, rowLabel, ''); return; }
       var topics = TF.depthsForNode({ id: node.id, community: node.community });
-      if (!topics.length) { renderDetailMetaItemRow(depthRowId, '所属路线', ''); return; }
+      if (!topics.length) { renderDetailMetaItemRow(depthRowId, rowLabel, ''); return; }
 
       // ⚡ Bolt Optimization: Replace .map().join('') with string concatenation in for loop
       // Expected impact: Eliminates closure creation and array allocation during layout generation.
@@ -4244,8 +4246,8 @@
           '<span>' + meta.emoji + '</span><span>' + escapeHtml(meta.label) + '</span></a>';
       }
 
-      renderDetailMetaItemRow(depthRowId, '所属路线', html);
-    }).catch(function () { renderDetailMetaItemRow(depthRowId, '所属路线', ''); });
+      renderDetailMetaItemRow(depthRowId, rowLabel, html);
+    }).catch(function () { renderDetailMetaItemRow(depthRowId, rowLabel, ''); });
   }
 
   function renderDetailTopicBadges(detailPage) {
@@ -4384,14 +4386,14 @@
     }
 
     renderDetailMetaItemRow('roadmapMetaCommunity', '所属社区', '');
-    renderDetailMetaItemRow('roadmapMetaDepth', '所属路线', '');
+    renderDetailMetaItemRow('roadmapMetaDepth', '路线视图', '');
     renderDetailMetaItemRow('roadmapMetaInstitution', '所属机构', '');
     if (metaEl) removeLoadingState(metaEl);
 
     var graphPath = detail.path || (roadmapPage && roadmapPage.path) || '';
     return Promise.all([
       renderMetaCommunityBadge(graphPath, 'roadmapMetaCommunity'),
-      renderMetaDepthBadges(graphPath, 'roadmapMetaDepth'),
+      renderMetaDepthBadges(graphPath, 'roadmapMetaDepth', '路线视图'),
       renderMetaInstitutionBadges(graphPath, 'roadmapMetaInstitution')
     ]);
   }

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -160,6 +160,7 @@
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script src="wiki-type-labels.js"></script>
+  <script defer src="depth-filters.js"></script>
   <script defer src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 路线页「路线元信息」增加 **路线视图：** 徽标行，点击跳转 `graph.html?depth=…`，与详情页「所属路线：」功能一致
- `roadmap.html` 补载 `depth-filters.js`（此前缺失导致徽标无法渲染）
- 详情页仍使用「所属路线：」标签，逻辑共用 `renderMetaDepthBadges`

## 验证
- 主路线页可见「路线视图：主路线-运动控制」
- Sim2Real 纵深路线页可见「路线视图：Sim2Real」

## 验证截图
![主路线元信息-路线视图](https://cursor.com/artifacts/c/art-1c89fc8d-08bd-4b65-9897-633340025291)
![Sim2Real路线元信息-路线视图](https://cursor.com/artifacts/c/art-0d74b380-59ea-4c9f-98f7-4322de11b7a1)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e1cdb53-3a29-4c1c-b117-413b860c884a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e1cdb53-3a29-4c1c-b117-413b860c884a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

