### PR TITLE
fix(ux): 「展开全部…」文案高亮改为闪两次

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -5821,7 +5821,7 @@
   var mainRouteCard = document.getElementById('home-start-main-route');
   var moreRoutesCard = document.getElementById('home-more-routes');
   var BORDER_TRACE_MS = 2400;
-  var TOGGLE_HINT_MS = 900;
+  var TOGGLE_HINT_MS = 1800;
   var SCROLL_CENTER_FALLBACK_MS = 700;
 
   function setHomeRoutesExpanded(expanded) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -525,7 +525,7 @@ a.hero-stat-num:focus-visible {
   to { stroke-dashoffset: -100; }
 }
 .home-route-toggle.is-pulse-hint {
-  animation: home-route-toggle-hint 0.85s ease;
+  animation: home-route-toggle-hint 0.85s ease 2;
 }
 @keyframes home-route-toggle-hint {
   0%, 100% {

--- a/log.md
+++ b/log.md
@@ -1,3 +1,5 @@
+## [2026-07-31] structural | docs/style.css — 纵深路线描边后「展开全部…」文案高亮改为两次
+
 ## [2026-07-31] structural | docs/main.js — Hero 路线数字描边时长×2；跳转改为 scrollIntoView 居中
 
 - **时长：** 边框顺时针描边 `1.05s → 2.1s`（`BORDER_TRACE_MS` 1200→2400）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 纵深路线数字描边结束后，「展开全部…」文案高亮由 1 次改为 **2 次**（`animation-iteration-count: 2`）
- 同步把清理定时器 `TOGGLE_HINT_MS` 调整为 `1800`，覆盖两轮动画时长

## 验证
- 改动仅 `docs/style.css` / `docs/main.js` / `log.md` 三行级更新
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c487b9a-c2e0-4db0-b41a-9f5e6a3cf1e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c487b9a-c2e0-4db0-b41a-9f5e6a3cf1e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

