### PR TITLE
fix(ux): 首页入口卡边框描边多分辨率对齐

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -87,6 +87,7 @@
   - [x] 图谱页 3D 社区漂浮标签：点「适配屏幕」飞行动画期间锁定胶囊 scale 为落稳尺寸，并提前写入目标距离基线，避免中途 `|cam−lookAt|` 偏离导致标签大小闪一下。
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。
 - [x] 首页 Hero 盘点条新增「主路线」（数字 1，位于「互链关系」与「纵深路线」之间）；四项数字可点：知识节点 / 互链关系 → `graph.html`，主路线 → 锚到「从零开始」卡并顺时针描边一圈，纵深路线 → 锚到「更多路线」卡描边一圈（不展开）后短时高亮「展开全部…」文案。
+- [x] 首页入口卡边框描边多分辨率对齐：SVG 改为按 border-box 像素定位（计入 border 宽度与亚像素 `getBoundingClientRect`），去掉 padding-box `inset`/`%` 尺寸冲突；圆角跟随 computed `border-radius`；动画期间 ResizeObserver 跟随卡片尺寸。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/main.js
+++ b/docs/main.js
@@ -5846,35 +5846,57 @@
     var prevSvg = card.querySelector('.home-border-trace-svg');
     if (prevSvg) prevSvg.remove();
 
-    // 用像素坐标画圆角矩形，避免 preserveAspectRatio=none 把圆角拉扁
+    // 绝对定位含块是 padding edge，而可见描边应对齐 border-box。
+    // 旧实现用 offsetWidth 画 viewBox、CSS 用 padding-box 的 inset/% 定尺寸，
+    // 在亚像素宽度与各分辨率下会左右/上下不对称外扩并缩放错位。
     var pad = 2;
     var stroke = 2.5;
-    var w = Math.max(card.offsetWidth + pad * 2, 1);
-    var h = Math.max(card.offsetHeight + pad * 2, 1);
-    var radius = 14; // var(--radius) 12px + 外扩
     var inset = stroke / 2;
 
     var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttribute('class', 'home-border-trace-svg');
     svg.setAttribute('aria-hidden', 'true');
-    svg.setAttribute('width', String(w));
-    svg.setAttribute('height', String(h));
-    svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
 
     var rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-    rect.setAttribute('x', String(inset));
-    rect.setAttribute('y', String(inset));
-    rect.setAttribute('width', String(Math.max(w - stroke, 0)));
-    rect.setAttribute('height', String(Math.max(h - stroke, 0)));
-    rect.setAttribute('rx', String(radius));
-    rect.setAttribute('ry', String(radius));
     rect.setAttribute('pathLength', '100');
     svg.appendChild(rect);
+
+    function layoutTraceSvg() {
+      var style = window.getComputedStyle(card);
+      var bl = parseFloat(style.borderLeftWidth) || 0;
+      var bt = parseFloat(style.borderTopWidth) || 0;
+      var box = card.getBoundingClientRect();
+      var bw = Math.max(box.width, 0);
+      var bh = Math.max(box.height, 0);
+      var w = Math.max(bw + pad * 2, 1);
+      var h = Math.max(bh + pad * 2, 1);
+      var cardRadius = parseFloat(style.borderTopLeftRadius) || 12;
+      var radius = Math.min(cardRadius + pad, w / 2, h / 2);
+
+      svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+      // 相对 padding edge 左移 border+pad，使 SVG 对称外扩于 border-box
+      svg.style.left = (-bl - pad) + 'px';
+      svg.style.top = (-bt - pad) + 'px';
+      svg.style.width = w + 'px';
+      svg.style.height = h + 'px';
+
+      rect.setAttribute('x', String(inset));
+      rect.setAttribute('y', String(inset));
+      rect.setAttribute('width', String(Math.max(w - stroke, 0)));
+      rect.setAttribute('height', String(Math.max(h - stroke, 0)));
+      rect.setAttribute('rx', String(radius));
+      rect.setAttribute('ry', String(radius));
+    }
 
     function finish() {
       if (finished) return;
       finished = true;
       card.classList.remove('is-border-tracing');
+      if (resizeObserver) {
+        try { resizeObserver.disconnect(); } catch { /* ignore */ }
+        resizeObserver = null;
+      }
       if (svg.parentNode) svg.parentNode.removeChild(svg);
       rect.removeEventListener('animationend', onAnimEnd);
       window.clearTimeout(fallbackTimer);
@@ -5884,8 +5906,16 @@
       if (event.animationName === 'home-border-trace-dash') finish();
     }
 
+    var resizeObserver = null;
     card.classList.add('is-border-tracing');
+    layoutTraceSvg();
     card.appendChild(svg);
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(function () {
+        if (!finished) layoutTraceSvg();
+      });
+      resizeObserver.observe(card);
+    }
     rect.addEventListener('animationend', onAnimEnd);
     var fallbackTimer = window.setTimeout(finish, BORDER_TRACE_MS);
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -502,10 +502,13 @@ a.hero-stat-num:focus-visible {
   z-index: 1;
 }
 .home-border-trace-svg {
+  /* left/top/width/height 由 JS 按 border-box + 外扩像素写入，
+     避免 padding-box 的 inset/% 与 offsetWidth 在亚像素宽度下错位 */
   position: absolute;
-  inset: -2px;
-  width: calc(100% + 4px);
-  height: calc(100% + 4px);
+  inset: auto;
+  margin: 0;
+  padding: 0;
+  border: 0;
   pointer-events: none;
   z-index: 4;
   overflow: visible;

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-07-31] structural | docs/main.js + docs/style.css — 首页入口卡边框描边按 border-box 像素对齐，修复多分辨率错位
+
+- **问题：** 描边 SVG 用 `offsetWidth`（border-box）写 viewBox，CSS 用 padding-box 的 `inset`/`%` 定尺寸，亚像素宽度下左右/上下外扩不对称，且 viewBox 被缩放导致圆角偏离卡片边框
+- **修复：** JS 以 `getBoundingClientRect` + 边框宽度写入 `left/top/width/height`，对称外扩于 border-box；圆角取自 computed `border-radius`；动画期间 `ResizeObserver` 跟随卡片尺寸变化
+- **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
+
 ## [2026-07-31] ingest | sources/repos/wan-dancer.md + sources/papers/wan_dancer_arxiv_2607_09581.md — Wan-Dancer 分钟级 music-to-dance；升格 wiki/entities/paper-wan-dancer.md；交叉 Wan / Wan-Move / generative-world-models / hub-wbt
 
 - **触发：** 用户给出 `https://github.com/Wan-AI/Wan-Dancer-14B`（**404**）；核实为 HF/ModelScope 权重 ID，代码仓为 [`Wan-Video/Wan-Dancer`](https://github.com/Wan-Video/Wan-Dancer)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复首页 Hero「主路线 / 纵深路线」数字触发的入口卡**边框顺时针描边**在不同分辨率下外扩不对称、圆角偏离卡片边框的问题
- 根因：SVG 用 `offsetWidth`（border-box）写 viewBox，CSS 用 padding-box 的 `inset` / `%` 定尺寸，亚像素宽度下左右/上下各差约 1px，且 viewBox 被缩放

## 修复
- `docs/main.js`：`playCardBorderTrace` 以 `getBoundingClientRect` + 边框宽度写入像素级 `left/top/width/height`，对称外扩于 border-box；圆角取自 computed `border-radius`；动画期间 `ResizeObserver` 跟随卡片尺寸
- `docs/style.css`：去掉冲突的 `inset: -2px` 与 `calc(100% + 4px)`，改由 JS 负责几何

## 验证
- `make ci-preflight` 通过
- Puppeteer 覆盖 9 个视口（含 DPR 1/2/3）：SVG 相对卡片外扩均为 ±2px，viewBox 与显示尺寸差为 0
- 屏幕几何：描边中心线相对卡片边框外侧约 0.75px（设计预期：`pad=2`、`stroke=2.5`）

## 验证截图

桌面 1440：主路线卡描边

![desktop-1440 从零开始卡描边](https://cursor.com/artifacts/c/art-77de55db-b9ac-40fe-aa39-36413d0a9817)

窄屏 900：主路线卡描边

![narrow-900 从零开始卡描边](https://cursor.com/artifacts/c/art-4ee93cb6-2f18-442d-99b5-45b9dda8db68)

iPhone 390@3x：更多路线卡描边

![iphone-390 更多路线卡描边](https://cursor.com/artifacts/c/art-419ab11c-3038-4905-a104-9445d2a3ed4f)

Android 360@2x：主路线卡描边

![android-360 从零开始卡描边](https://cursor.com/artifacts/c/art-b54d65e4-3d54-4c61-9361-486214f1b8d1)

卡片局部裁切（android / desktop）确认描边贴边：

![android-360 卡片裁切](https://cursor.com/artifacts/c/art-45eeef77-2a86-4ea5-adb5-4fc3e415a275)
![desktop-1440 卡片裁切](https://cursor.com/artifacts/c/art-02ab883d-d378-427e-bb3a-e35b1df68716)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff8be00e-eea7-4b1f-9726-4ee073ff08ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff8be00e-eea7-4b1f-9726-4ee073ff08ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

