### PR TITLE
fix(ux): 优化首页「项目查询」点击卡顿

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -99,6 +99,7 @@
 - [x] 去重收敛：删除独立「学习路线」区块，纵深路线（强化学习 / 传统控制 / 模仿学习 / 安全控制 / 接触操作）统一并入目标入口区的「更多路线」卡。
 - [x] 「项目查询」入口卡点击后直接聚焦搜索输入框（`data-focus-search`），减少锚点跳转后的二次寻找。
 - [x] 「项目查询 / 知识图谱」入口卡：滚到对应模块（`#wiki-search-panel` / `#mini-graph-wrap`）中心并顺时针描边一圈；项目查询仍额外聚焦搜索框；深链 `#wiki-search` / `#mini-graph-section` 同效。
+- [x] 「项目查询」点击卡顿优化：点击后立刻 `focus`（不再等 scrollend）；滚动接近视口中心即开描边（rAF 轮询，fallback 420ms）；空查询 focus 静默预取搜索索引（不写「加载中…」）；`pointerdown`/`mouseenter`/idle 预取 `search-index.json`；描边 SVG 推迟到下一帧挂载；去掉描边 `drop-shadow` 滤镜以免动画期掉帧。
 - [x] 删除搜索区副标题（与输入框 placeholder 重复），Hero 副标题改为面向读者的引导语。
 - [x] 删除目标入口区标题「选择你的入口」与副标题「按当前目标进入最短路径…」：与 Hero「先选一个入口」重复，入口卡本身已自解释。
 - [x] 同步刷新 README `media/site-demo.gif`（`scripts/record_readme_demo.cjs`，1933 节点；首页帧已无入口区标题/副标题）。

--- a/docs/main.js
+++ b/docs/main.js
@@ -5822,7 +5822,17 @@
   var moreRoutesCard = document.getElementById('home-more-routes');
   var BORDER_TRACE_MS = 2400;
   var TOGGLE_HINT_MS = 1800;
-  var SCROLL_CENTER_FALLBACK_MS = 700;
+  // 目标接近视口中心即开启动画，避免干等 scrollend / 长 fallback 造成「点一下卡住」
+  var SCROLL_CENTER_TOLERANCE_PX = 56;
+  var SCROLL_CENTER_FALLBACK_MS = 420;
+  var prefersReducedMotion = false;
+  try {
+    prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    prefersReducedMotion = false;
+  }
+  // 搜索索引预取钩子：搜索模块初始化后替换；供入口卡 pointerdown / idle 调用
+  var prefetchWikiSearchIndex = function () {};
 
   function setHomeRoutesExpanded(expanded) {
     if (!routeToggle) return;
@@ -5843,6 +5853,9 @@
       return;
     }
     var finished = false;
+    // 取消上一轮尚未挂载的 rAF 描边，避免连点叠多个 SVG
+    var traceGen = (card._homeBorderTraceGen || 0) + 1;
+    card._homeBorderTraceGen = traceGen;
     var prevSvg = card.querySelector('.home-border-trace-svg');
     if (prevSvg) prevSvg.remove();
 
@@ -5865,8 +5878,8 @@
     rect.setAttribute('pathLength', '100');
     svg.appendChild(rect);
 
-    function layoutTraceSvg() {
-      var style = window.getComputedStyle(card);
+    function layoutTraceSvg(style) {
+      style = style || window.getComputedStyle(card);
       var bl = parseFloat(style.borderLeftWidth) || 0;
       var bt = parseFloat(style.borderTopWidth) || 0;
       var box = card.getBoundingClientRect();
@@ -5892,10 +5905,12 @@
       rect.setAttribute('ry', String(radius));
     }
 
-    function finish() {
+    function finish(fromCancel) {
       if (finished) return;
       finished = true;
-      card.classList.remove('is-border-tracing');
+      if (card._homeBorderTraceGen === traceGen) {
+        card.classList.remove('is-border-tracing');
+      }
       if (overflowWasForced) {
         if (prevOverflow) card.style.overflow = prevOverflow;
         else card.style.removeProperty('overflow');
@@ -5907,28 +5922,38 @@
       if (svg.parentNode) svg.parentNode.removeChild(svg);
       rect.removeEventListener('animationend', onAnimEnd);
       window.clearTimeout(fallbackTimer);
-      if (onDone) onDone();
+      if (onDone && !fromCancel) onDone();
     }
     function onAnimEnd(event) {
-      if (event.animationName === 'home-border-trace-dash') finish();
+      if (event.animationName === 'home-border-trace-dash') finish(false);
     }
 
     var resizeObserver = null;
+    var fallbackTimer = 0;
     card.classList.add('is-border-tracing');
-    if (window.getComputedStyle(card).overflow !== 'visible') {
-      card.style.overflow = 'visible';
-      overflowWasForced = true;
-    }
-    layoutTraceSvg();
-    card.appendChild(svg);
-    if (typeof ResizeObserver !== 'undefined') {
-      resizeObserver = new ResizeObserver(function () {
-        if (!finished) layoutTraceSvg();
-      });
-      resizeObserver.observe(card);
-    }
-    rect.addEventListener('animationend', onAnimEnd);
-    var fallbackTimer = window.setTimeout(finish, BORDER_TRACE_MS);
+
+    // 推迟到下一帧再读样式/挂载 SVG，避免与 scrollIntoView 首帧抢主线程造成点击卡顿
+    requestAnimationFrame(function () {
+      if (finished || card._homeBorderTraceGen !== traceGen) {
+        finish(true);
+        return;
+      }
+      var style = window.getComputedStyle(card);
+      if (style.overflow !== 'visible') {
+        card.style.overflow = 'visible';
+        overflowWasForced = true;
+      }
+      layoutTraceSvg(style);
+      card.appendChild(svg);
+      if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(function () {
+          if (!finished && card._homeBorderTraceGen === traceGen) layoutTraceSvg();
+        });
+        resizeObserver.observe(card);
+      }
+      rect.addEventListener('animationend', onAnimEnd);
+      fallbackTimer = window.setTimeout(function () { finish(false); }, BORDER_TRACE_MS);
+    });
   }
 
   function pulseRouteToggleHint() {
@@ -5941,7 +5966,16 @@
     }, TOGGLE_HINT_MS);
   }
 
-  /** 将入口卡滚到视口垂直中心，再回调（避免锚点默认顶对齐） */
+  function isEntryCardNearCenter(card) {
+    var rect = card.getBoundingClientRect();
+    var viewH = window.innerHeight || document.documentElement.clientHeight || 0;
+    if (viewH <= 0) return true;
+    var cardMid = rect.top + rect.height / 2;
+    var viewMid = viewH / 2;
+    return Math.abs(cardMid - viewMid) <= SCROLL_CENTER_TOLERANCE_PX;
+  }
+
+  /** 将入口卡滚到视口垂直中心，接近中心即回调（避免干等 scrollend） */
   function scrollEntryCardToCenter(card, hash, onReady) {
     if (!card) {
       if (onReady) onReady();
@@ -5951,17 +5985,45 @@
       window.history.replaceState(null, '', hash);
     }
     var done = false;
+    var rafId = 0;
+    var fallbackTimer = 0;
     function ready() {
       if (done) return;
       done = true;
       window.clearTimeout(fallbackTimer);
       window.removeEventListener('scrollend', onScrollEnd);
+      if (rafId) window.cancelAnimationFrame(rafId);
       if (onReady) onReady();
     }
     function onScrollEnd() { ready(); }
-    card.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+
+    if (isEntryCardNearCenter(card)) {
+      rafId = window.requestAnimationFrame(function () { ready(); });
+      return;
+    }
+
+    card.scrollIntoView({
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      block: 'center',
+      inline: 'nearest'
+    });
+
+    if (prefersReducedMotion) {
+      rafId = window.requestAnimationFrame(function () { ready(); });
+      return;
+    }
+
     window.addEventListener('scrollend', onScrollEnd, { once: true });
-    var fallbackTimer = window.setTimeout(ready, SCROLL_CENTER_FALLBACK_MS);
+    function pollNearCenter() {
+      if (done) return;
+      if (isEntryCardNearCenter(card)) {
+        ready();
+        return;
+      }
+      rafId = window.requestAnimationFrame(pollNearCenter);
+    }
+    rafId = window.requestAnimationFrame(pollNearCenter);
+    fallbackTimer = window.setTimeout(ready, SCROLL_CENTER_FALLBACK_MS);
   }
 
   if (routeToggle) {
@@ -6001,13 +6063,21 @@
       if (!target) return;
       var hash = trigger.getAttribute('href') || '';
       var shouldFocusSearch = trigger.hasAttribute('data-focus-search');
+      // 悬停/按下时预取搜索索引，避免 focus 时才开始拉大 JSON 造成卡顿
+      if (shouldFocusSearch) {
+        var prefetchOnce = function () { prefetchWikiSearchIndex(); };
+        trigger.addEventListener('pointerdown', prefetchOnce, { passive: true });
+        trigger.addEventListener('mouseenter', prefetchOnce, { passive: true });
+      }
       trigger.addEventListener('click', function (event) {
         event.preventDefault();
+        // 项目查询：立刻聚焦，不把 focus 排在滚动/描边之后（旧路径会「卡一下再跳」）
+        if (shouldFocusSearch && searchInput) {
+          prefetchWikiSearchIndex();
+          searchInput.focus({ preventScroll: true });
+        }
         scrollEntryCardToCenter(target, hash.charAt(0) === '#' ? hash : null, function () {
           playCardBorderTrace(target);
-          if (shouldFocusSearch && searchInput) {
-            searchInput.focus({ preventScroll: true });
-          }
         });
       });
     })(homeTraceTriggers[htti]);
@@ -6024,9 +6094,9 @@
   } else if (window.location.hash === '#wiki-search') {
     var searchPanel = document.getElementById('wiki-search-panel');
     if (searchPanel) {
+      // focus/预取放到搜索模块初始化之后，避免监听器尚未挂上
       scrollEntryCardToCenter(searchPanel, null, function () {
         playCardBorderTrace(searchPanel);
-        if (searchInput) searchInput.focus({ preventScroll: true });
       });
     }
   } else if (window.location.hash === '#mini-graph-section') {
@@ -6123,6 +6193,21 @@
           throw error;
         });
       return _searchIndexPromise;
+    }
+
+    // 供入口卡 pointerdown / 首页 idle 预取；失败静默，不影响后续正式搜索
+    prefetchWikiSearchIndex = function () {
+      ensureSearchIndex().catch(function () {});
+    };
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(function () { prefetchWikiSearchIndex(); }, { timeout: 2500 });
+    } else {
+      window.setTimeout(function () { prefetchWikiSearchIndex(); }, 1200);
+    }
+    // 深链 #wiki-search：搜索模块就绪后再聚焦并预取
+    if (window.location.hash === '#wiki-search') {
+      prefetchWikiSearchIndex();
+      searchInput.focus({ preventScroll: true });
     }
 
     function tokenizeQuery(text) {
@@ -6518,15 +6603,19 @@
 
     searchInput.addEventListener('focus', function() {
       if (_searchIndex || _searchIndexFailed || _searchIndexPromise) return;
-      searchResults.innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1">加载中…</p>';
+      // 空查询静默预取，不写「加载中…」以免与入口卡滚动/描边同帧抢布局
+      var hadQuery = !!searchInput.value.trim();
+      if (hadQuery) {
+        searchResults.innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1">加载中…</p>';
+      }
       ensureSearchIndex().then(function() {
         if (searchInput.value.trim()) {
           triggerSearch();
-        } else {
+        } else if (hadQuery) {
           searchResults.innerHTML = '';
         }
       }).catch(function() {
-        searchResults.innerHTML = '';
+        if (hadQuery) searchResults.innerHTML = '';
       });
     });
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -519,7 +519,7 @@ a.hero-stat-num:focus-visible {
   stroke-width: 2.5;
   stroke-linecap: round;
   vector-effect: non-scaling-stroke;
-  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--accent) 70%, transparent));
+  /* 避免对动画中的 dashoffset 每帧做 drop-shadow（主线程/合成开销大，点击后易卡） */
   stroke-dasharray: 14 86;
   stroke-dashoffset: 0;
   animation: home-border-trace-dash 2.1s linear forwards;

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-07-31] fix | docs/main.js + docs/style.css — 首页「项目查询」点击卡顿：立刻聚焦、近中心即描边、静默预取搜索索引
+
+- **问题：** 点击「项目查询」后需等 `scrollend`（或 700ms fallback）才聚焦/播描边；同时 focus 同步写「加载中…」并拉取解析大体积 `search-index.json`，主线程卡一下再跳
+- **修复：** 点击立刻 `focus({preventScroll})`；rAF 检测接近视口中心即 `playCardBorderTrace`；空查询静默预取；`pointerdown`/`mouseenter`/idle 预取索引；描边布局推迟到下一帧；去掉描边 `drop-shadow`
+- **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
+
 ## [2026-07-31] fix | docs/graph-3d.js — 3D 社区漂浮标签按画布分辨率连续缩放，避免过小/过大
 
 - **问题：** 旧逻辑在移动端/粗指针上字号×0.55 且相机 zoom 再×0.55，手机/平板有效字号可落到 ~3–5px；桌面端字号固定 8–16px，900–2560 宽度几乎不变，大屏相对过小


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页点击「项目查询」后会出现一小段卡顿，再跳到搜索框并开始描边动画
- 根因：focus/描边被排在 `scrollend`（或 700ms fallback）之后；同时空查询 focus 会同步写「加载中…」并拉取解析约 41MB 的 `search-index.json`
- 修复：点击立刻聚焦；滚动接近视口中心即开描边；静默/预取搜索索引；描边布局推迟到下一帧；去掉描边 `drop-shadow`

## 验证
- `make ci-preflight` 通过
- Headless 实测：`click → focus` ≈ **0.4ms**（原先需等 scrollend / 最长 700ms）；`click → 描边 SVG` ≈ **323ms**；空查询不再出现「加载中…」

## 验证截图
![首页项目查询点击后搜索框描边](https://cursor.com/artifacts/c/art-5a0ffb2c-5dad-44a7-9ad8-c341bc18d13e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88fcbdab-8e20-487b-9188-d4400235e8e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88fcbdab-8e20-487b-9188-d4400235e8e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

