### PR TITLE
feat: 搜索框与首页背景图谱联动高亮

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -22,7 +22,7 @@
     - [x] 增加搜索框的视觉权重（更大、带有毛玻璃效果、更明显的聚焦反馈）。
 - [x] **图谱深度集成 (Graph Integration)**：
     - [x] 将 `mini-graph` 移至英雄区背景或作为右侧核心视觉元素。
-    - [ ] 实现图谱节点与搜索框的联动：在搜索时，背景图谱自动高亮相关节点。
+    - [x] 实现图谱节点与搜索框的联动：在搜索时，背景图谱自动高亮相关节点。`mini-graph.js` 暴露 `window.RNMiniGraph.highlight(ids, query)/clear()`；首页 `main.js` 搜索命中后按结果 id + 标签词命中高亮相关节点、其余淡出（`.mini-node-dim`/`.mini-node-hit`），命中为空则不淡出避免整图变暗；清空/Esc 复原。验证脚本 `scripts/screenshot_home_search_graph_link.cjs`（`slam` → 命中 2 / 淡出 48 / 共 50）。
 - [x] **全局导航精简**：
     - [x] Header 仅保留：Logo、搜索图标（移动端）、图谱入口、GitHub。
     - [x] **约束**：保留当前 `site-header` 的基础视觉设计（毛玻璃效果与布局），仅精简文字。

--- a/docs/main.js
+++ b/docs/main.js
@@ -6230,6 +6230,17 @@
       return Array.from(searchResults.querySelectorAll('article.card[data-result-url]'));
     }
 
+    // 搜索联动首页背景图谱：命中节点高亮、其余淡出（图谱未就绪时暂存待应用）
+    function miniGraphHighlight(query, ids) {
+      var active = !!(query || (ids && ids.length));
+      if (window.RNMiniGraph && window.RNMiniGraph.highlight) {
+        if (active) window.RNMiniGraph.highlight(ids || [], query || '');
+        else window.RNMiniGraph.clear();
+      } else {
+        window.__miniGraphPendingQuery = active ? { query: query || '', ids: ids || [] } : null;
+      }
+    }
+
     function setSelectedIndex(idx) {
       var cards = getResultCards();
       if (!cards.length) return;
@@ -6494,7 +6505,7 @@
       var q = query.trim();
       var communityVal = communityFilter ? communityFilter.value : '';
       // 空查询：结果区留白（热门词入口是搜索框下方常驻的 tag-chip 行）
-      if (!q && !communityVal) { searchResults.innerHTML = ''; return; }
+      if (!q && !communityVal) { searchResults.innerHTML = ''; miniGraphHighlight('', []); return; }
       searchResults.innerHTML = '<p style="color:var(--text-muted);grid-column:1/-1">加载离线搜索索引中…</p>';
       Promise.all([ensureSearchIndex(), ensureCommunityByPath()])
         .then(function(results) {
@@ -6555,6 +6566,7 @@
             if (queryTokens.length && b._score !== a._score) return b._score - a._score;
             return String(a.title || '').localeCompare(String(b.title || ''));
           }).slice(0, 10);
+          miniGraphHighlight(q, matched.map(function(m){ return m.id; }));
           if (!matched.length) {
             if (communityVal && !q) {
               searchResults.innerHTML = '<div style="grid-column:1/-1;color:var(--text-muted)">'
@@ -6598,6 +6610,7 @@
         searchResults.innerHTML = '';
         _selectedIndex = -1;
         if (communityFilter) communityFilter.value = '';
+        miniGraphHighlight('', []);
       }
     });
 

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -251,6 +251,47 @@
       .attr('font-size','10px')
       .attr('pointer-events','none');
 
+    // ── 搜索联动：首页搜索框输入时，背景图谱高亮相关节点、其余淡出 ──
+    function tokenizeMini(q) {
+      return String(q || '').toLowerCase().split(/[^a-z0-9一-鿿]+/i)
+        .filter(function(t){ return t.length >= 2; });
+    }
+    function clearHighlight() {
+      nodeG.classed('mini-node-dim', false).classed('mini-node-hit', false);
+      line.classed('mini-edge-dim', false);
+    }
+    function highlightNodes(idList, query) {
+      var idSet = {};
+      (idList || []).forEach(function(id){ idSet[id] = true; });
+      var tokens = tokenizeMini(query);
+      var hitSet = {};
+      var hitCount = 0;
+      nodes.forEach(function(n) {
+        var hit = !!idSet[n.id];
+        if (!hit && tokens.length) {
+          var lab = String(n.label || '').toLowerCase();
+          for (var i = 0; i < tokens.length; i++) {
+            if (lab.indexOf(tokens[i]) >= 0) { hit = true; break; }
+          }
+        }
+        if (hit) { hitSet[n.id] = true; hitCount++; }
+      });
+      // 预览图只含前 50 度数节点，命中可能为空；此时不淡出，避免整图变暗却无高亮的困惑
+      if (!hitCount) { clearHighlight(); return; }
+      nodeG.classed('mini-node-dim', function(d){ return !hitSet[d.id]; });
+      nodeG.classed('mini-node-hit', function(d){ return !!hitSet[d.id]; });
+      line.classed('mini-edge-dim', function(d){
+        var s = (d.source && d.source.id) || d.source;
+        var t = (d.target && d.target.id) || d.target;
+        return !(hitSet[s] && hitSet[t]);
+      });
+    }
+    window.RNMiniGraph = { highlight: highlightNodes, clear: clearHighlight };
+    var pending = window.__miniGraphPendingQuery;
+    if (pending && (pending.query || (pending.ids && pending.ids.length))) {
+      highlightNodes(pending.ids || [], pending.query || '');
+    }
+
     applyMiniGraphTheme();
 
     var observer = new MutationObserver(function() {

--- a/docs/style.css
+++ b/docs/style.css
@@ -568,6 +568,15 @@ a.hero-stat-num:focus-visible {
 #mini-graph-section #mini-graph-wrap {
   margin-top: 18px;
 }
+/* 搜索联动：输入关键词时背景图谱高亮相关节点、其余淡出 */
+.mini-graph-node { transition: opacity var(--transition, .2s) ease; }
+.mini-graph-node.mini-node-dim { opacity: .15; }
+.mini-graph-node.mini-node-hit circle {
+  stroke: var(--accent);
+  stroke-width: 2;
+  paint-order: stroke;
+}
+#mini-graph-svg line.mini-edge-dim { opacity: .08; transition: opacity var(--transition, .2s) ease; }
 /* 首页图谱预览 2D / 3D 切换（3D 画布懒加载，容器与 SVG 同位叠放） */
 #mini-graph-3d { position: absolute; inset: 0; }
 #mini-graph-3d[hidden] { display: none; }

--- a/scripts/screenshot_home_search_graph_link.cjs
+++ b/scripts/screenshot_home_search_graph_link.cjs
@@ -1,0 +1,61 @@
+// 截图验证：首页搜索框输入关键词时，背景图谱预览高亮相关节点、其余淡出
+const puppeteer = require('puppeteer-core');
+const path = require('path');
+const fs = require('fs');
+
+(async () => {
+  const [, , url, outPath, query, viewport] = process.argv;
+  const q = query || 'slam';
+  const [W, H] = (viewport || '1440x1600').split('x').map(Number);
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/google-chrome',
+  ].filter(Boolean);
+  const exe = candidates.find((p) => fs.existsSync(p));
+  if (!exe) throw new Error('No Chrome/Chromium found. Set CHROME_PATH.');
+  const d3Body = fs.readFileSync(path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js'));
+  const browser = await puppeteer.launch({
+    executablePath: exe, headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--ignore-certificate-errors'],
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: W, height: H, deviceScaleFactor: 1 });
+    await page.setRequestInterception(true);
+    page.on('request', req => {
+      if (req.url().includes('cdn.jsdelivr.net/npm/d3')) {
+        req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+      } else { req.continue(); }
+    });
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    // 等待 mini-graph 就绪（RNMiniGraph 暴露 + 节点绘制）
+    await page.waitForFunction(
+      () => window.RNMiniGraph && document.querySelectorAll('#mini-graph-svg .mini-graph-node').length > 0,
+      { timeout: 25000 }
+    ).catch(() => {});
+    await new Promise(r => setTimeout(r, 2500));
+    // 输入查询触发搜索联动
+    await page.type('#wikiSearchInput', q);
+    await new Promise(r => setTimeout(r, 900));
+    const stats = await page.evaluate(() => ({
+      hit: document.querySelectorAll('#mini-graph-svg .mini-graph-node.mini-node-hit').length,
+      dim: document.querySelectorAll('#mini-graph-svg .mini-graph-node.mini-node-dim').length,
+      total: document.querySelectorAll('#mini-graph-svg .mini-graph-node').length,
+    }));
+    console.log('highlight stats:', JSON.stringify(stats));
+    // 滚动到图谱预览区
+    await page.evaluate(() => {
+      const el = document.getElementById('mini-graph-wrap');
+      if (el) el.scrollIntoView({ block: 'center' });
+    });
+    await new Promise(r => setTimeout(r, 600));
+    fs.mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });
+    await page.screenshot({ path: path.resolve(outPath), fullPage: false });
+    console.log('Saved:', outPath);
+  } finally {
+    await browser.close();
+  }
+})().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## 摘要

实现首页搜索框与背景 mini-graph 的联动：输入关键词时，图谱自动高亮相关节点、其余淡出；清空搜索或按 Esc 时复原。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他

## 详细说明

### 核心实现

1. **`docs/mini-graph.js`**：
   - 新增 `window.RNMiniGraph` 对象，暴露 `highlight(ids, query)` 和 `clear()` 方法
   - `highlight()` 支持两种匹配模式：
     - 按结果 ID 精确匹配（搜索命中的文章 ID）
     - 按标签词模糊匹配（query 分词后与节点标签对比）
   - 预览图仅含前 50 度数节点，命中为空时不淡出（避免整图变暗却无高亮的困惑）
   - 应用 CSS 类 `.mini-node-dim`（淡出）、`.mini-node-hit`（高亮）、`.mini-edge-dim`（边淡出）

2. **`docs/main.js`**：
   - 新增 `miniGraphHighlight(query, ids)` 函数，在搜索结果更新时调用
   - 搜索命中后传入结果 ID 列表和查询词
   - 清空搜索或按 Esc 时调用 `clear()`
   - 图谱未就绪时暂存待应用（`window.__miniGraphPendingQuery`）

3. **`docs/style.css`**：
   - `.mini-node-dim`：不透明度 0.15，平滑过渡
   - `.mini-node-hit`：圆形节点加描边（accent 色，宽度 2px）
   - `.mini-edge-dim`：边不透明度 0.08，平滑过渡

### 验证脚本

新增 `scripts/screenshot_home_search_graph_link.cjs`：
- 使用 Puppeteer 自动化验证搜索联动效果
- 输入 `slam` 后统计高亮节点数、淡出节点数、总节点数
- 预期结果：命中 2 / 淡出 48 / 共 50
- 支持自定义 URL、输出路径、查询词、视口尺寸

## 验证

- [x] `make ci-preflight`（无 wiki 改动，N/A）
- [x] 本地静态站验证：
  - 搜索框输入关键词 → 背景图谱相关节点高亮、其余淡出
  - 清空搜索或按 Esc → 图谱复原
  - 图谱未就绪时搜索 → 待图谱加载后自动应用高亮
- [x] 验证脚本 `scripts/screenshot_home_search_graph_link.cjs slam` 通过

## 相关 Issue

无

https://claude.ai/code/session_01U6fL77KJ84rtyR5zr7zyBL