### PR TITLE
fix(ux): 首页项目查询/知识图谱入口卡改回窗口顶端对齐

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -98,8 +98,8 @@
 - [x] 详情页移除“通用详情页”“正文同步内容”“消费 JSON”等面向实现的措辞，统一为读者语言。
 - [x] 去重收敛：删除独立「学习路线」区块，纵深路线（强化学习 / 传统控制 / 模仿学习 / 安全控制 / 接触操作）统一并入目标入口区的「更多路线」卡。
 - [x] 「项目查询」入口卡点击后直接聚焦搜索输入框（`data-focus-search`），减少锚点跳转后的二次寻找。
-- [x] 「项目查询 / 知识图谱」入口卡：滚到对应模块（`#wiki-search-panel` / `#mini-graph-wrap`）中心并顺时针描边一圈；项目查询仍额外聚焦搜索框；深链 `#wiki-search` / `#mini-graph-section` 同效。
-- [x] 「项目查询」点击卡顿优化：点击后立刻 `focus`（不再等 scrollend）；滚动接近视口中心即开描边（rAF 轮询，fallback 420ms）；空查询 focus 静默预取搜索索引（不写「加载中…」）；`pointerdown`/`mouseenter`/idle 预取 `search-index.json`；描边 SVG 推迟到下一帧挂载；去掉描边 `drop-shadow` 滤镜以免动画期掉帧。
+- [x] 「项目查询 / 知识图谱」入口卡：滚到对应区块（`#wiki-search` / `#mini-graph-section`）**窗口顶端**（`scrollIntoView({ block: 'start' })`，与旧锚点一致），再对模块（`#wiki-search-panel` / `#mini-graph-wrap`）顺时针描边一圈；项目查询仍额外聚焦搜索框；深链同效。Hero「主路线 / 纵深路线」仍居中。
+- [x] 「项目查询」点击卡顿优化：点击后立刻 `focus`（不再等 scrollend）；滚动接近落点即开描边（rAF 轮询，fallback 420ms）；空查询 focus 静默预取搜索索引（不写「加载中…」）；`pointerdown`/`mouseenter`/idle 预取 `search-index.json`；描边 SVG 推迟到下一帧挂载；去掉描边 `drop-shadow` 滤镜以免动画期掉帧。
 - [x] 删除搜索区副标题（与输入框 placeholder 重复），Hero 副标题改为面向读者的引导语。
 - [x] 删除目标入口区标题「选择你的入口」与副标题「按当前目标进入最短路径…」：与 Hero「先选一个入口」重复，入口卡本身已自解释。
 - [x] 同步刷新 README `media/site-demo.gif`（`scripts/record_readme_demo.cjs`，1933 节点；首页帧已无入口区标题/副标题）。

--- a/docs/main.js
+++ b/docs/main.js
@@ -5822,9 +5822,9 @@
   var moreRoutesCard = document.getElementById('home-more-routes');
   var BORDER_TRACE_MS = 2400;
   var TOGGLE_HINT_MS = 1800;
-  // 目标接近视口中心即开启动画，避免干等 scrollend / 长 fallback 造成「点一下卡住」
-  var SCROLL_CENTER_TOLERANCE_PX = 56;
-  var SCROLL_CENTER_FALLBACK_MS = 420;
+  // 目标接近落点即开启动画，避免干等 scrollend / 长 fallback 造成「点一下卡住」
+  var SCROLL_ALIGN_TOLERANCE_PX = 56;
+  var SCROLL_ALIGN_FALLBACK_MS = 420;
   var prefersReducedMotion = false;
   try {
     prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -5966,17 +5966,36 @@
     }, TOGGLE_HINT_MS);
   }
 
-  function isEntryCardNearCenter(card) {
+  function getScrollPaddingTopPx() {
+    try {
+      var raw = window.getComputedStyle(document.documentElement).scrollPaddingTop;
+      var px = parseFloat(raw);
+      return Number.isFinite(px) ? px : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  /** block: 'center' | 'start' — 判断目标是否已接近 scrollIntoView 落点 */
+  function isEntryCardNearAlign(card, block) {
     var rect = card.getBoundingClientRect();
     var viewH = window.innerHeight || document.documentElement.clientHeight || 0;
     if (viewH <= 0) return true;
+    if (block === 'start') {
+      var expectedTop = getScrollPaddingTopPx();
+      return Math.abs(rect.top - expectedTop) <= SCROLL_ALIGN_TOLERANCE_PX;
+    }
     var cardMid = rect.top + rect.height / 2;
     var viewMid = viewH / 2;
-    return Math.abs(cardMid - viewMid) <= SCROLL_CENTER_TOLERANCE_PX;
+    return Math.abs(cardMid - viewMid) <= SCROLL_ALIGN_TOLERANCE_PX;
   }
 
-  /** 将入口卡滚到视口垂直中心，接近中心即回调（避免干等 scrollend） */
-  function scrollEntryCardToCenter(card, hash, onReady) {
+  /**
+   * 将入口卡滚入视口后回调（接近落点即触发，避免干等 scrollend）。
+   * @param {string} [block='center'] 'center'（Hero 路线数字）或 'start'（项目查询 / 知识图谱顶对齐）
+   */
+  function scrollEntryCardIntoView(card, hash, onReady, block) {
+    block = block === 'start' ? 'start' : 'center';
     if (!card) {
       if (onReady) onReady();
       return;
@@ -5997,14 +6016,14 @@
     }
     function onScrollEnd() { ready(); }
 
-    if (isEntryCardNearCenter(card)) {
+    if (isEntryCardNearAlign(card, block)) {
       rafId = window.requestAnimationFrame(function () { ready(); });
       return;
     }
 
     card.scrollIntoView({
       behavior: prefersReducedMotion ? 'auto' : 'smooth',
-      block: 'center',
+      block: block,
       inline: 'nearest'
     });
 
@@ -6014,16 +6033,21 @@
     }
 
     window.addEventListener('scrollend', onScrollEnd, { once: true });
-    function pollNearCenter() {
+    function pollNearAlign() {
       if (done) return;
-      if (isEntryCardNearCenter(card)) {
+      if (isEntryCardNearAlign(card, block)) {
         ready();
         return;
       }
-      rafId = window.requestAnimationFrame(pollNearCenter);
+      rafId = window.requestAnimationFrame(pollNearAlign);
     }
-    rafId = window.requestAnimationFrame(pollNearCenter);
-    fallbackTimer = window.setTimeout(ready, SCROLL_CENTER_FALLBACK_MS);
+    rafId = window.requestAnimationFrame(pollNearAlign);
+    fallbackTimer = window.setTimeout(ready, SCROLL_ALIGN_FALLBACK_MS);
+  }
+
+  /** Hero 主路线 / 纵深路线：滚到视口垂直中心 */
+  function scrollEntryCardToCenter(card, hash, onReady) {
+    scrollEntryCardIntoView(card, hash, onReady, 'center');
   }
 
   if (routeToggle) {
@@ -6053,7 +6077,7 @@
     });
   }
 
-  // 入口卡「项目查询 / 知识图谱」：滚到对应模块中心并顺时针描边；项目查询额外聚焦搜索框
+  // 入口卡「项目查询 / 知识图谱」：区块顶对齐（同旧锚点），模块描边特效保持；项目查询额外聚焦搜索框
   var searchInput = document.getElementById('wikiSearchInput');
   var homeTraceTriggers = document.querySelectorAll('[data-trace-target]');
   for (var htti = 0; htti < homeTraceTriggers.length; htti++) {
@@ -6062,6 +6086,9 @@
       var target = targetId ? document.getElementById(targetId) : null;
       if (!target) return;
       var hash = trigger.getAttribute('href') || '';
+      var hashId = hash.charAt(0) === '#' ? hash.slice(1) : '';
+      // 滚动锚到 href 区块（顶对齐）；描边仍画在 data-trace-target 模块上
+      var scrollTarget = (hashId && document.getElementById(hashId)) || target;
       var shouldFocusSearch = trigger.hasAttribute('data-focus-search');
       // 悬停/按下时预取搜索索引，避免 focus 时才开始拉大 JSON 造成卡顿
       if (shouldFocusSearch) {
@@ -6076,9 +6103,9 @@
           prefetchWikiSearchIndex();
           searchInput.focus({ preventScroll: true });
         }
-        scrollEntryCardToCenter(target, hash.charAt(0) === '#' ? hash : null, function () {
+        scrollEntryCardIntoView(scrollTarget, hashId ? hash : null, function () {
           playCardBorderTrace(target);
-        });
+        }, 'start');
       });
     })(homeTraceTriggers[htti]);
   }
@@ -6092,19 +6119,21 @@
       playCardBorderTrace(moreRoutesCard, pulseRouteToggleHint);
     });
   } else if (window.location.hash === '#wiki-search') {
+    var searchSection = document.getElementById('wiki-search');
     var searchPanel = document.getElementById('wiki-search-panel');
-    if (searchPanel) {
+    if (searchSection || searchPanel) {
       // focus/预取放到搜索模块初始化之后，避免监听器尚未挂上
-      scrollEntryCardToCenter(searchPanel, null, function () {
-        playCardBorderTrace(searchPanel);
-      });
+      scrollEntryCardIntoView(searchSection || searchPanel, null, function () {
+        if (searchPanel) playCardBorderTrace(searchPanel);
+      }, 'start');
     }
   } else if (window.location.hash === '#mini-graph-section') {
+    var miniGraphSection = document.getElementById('mini-graph-section');
     var miniGraphPanel = document.getElementById('mini-graph-wrap');
-    if (miniGraphPanel) {
-      scrollEntryCardToCenter(miniGraphPanel, null, function () {
-        playCardBorderTrace(miniGraphPanel);
-      });
+    if (miniGraphSection || miniGraphPanel) {
+      scrollEntryCardIntoView(miniGraphSection || miniGraphPanel, null, function () {
+        if (miniGraphPanel) playCardBorderTrace(miniGraphPanel);
+      }, 'start');
     }
   }
 

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-08-01] fix | docs/main.js — 首页「项目查询 / 知识图谱」入口卡改回窗口顶端对齐
+
+- **问题：** 与 Hero 路线数字共用 `block: 'center'` 后，点击入口卡会把搜索区 / 图谱预览滚到视口中心，不再像旧锚点那样顶对齐
+- **修复：** 入口卡滚动锚到 `#wiki-search` / `#mini-graph-section`，`scrollIntoView({ block: 'start' })`；描边仍画在 `#wiki-search-panel` / `#mini-graph-wrap`；Hero「主路线 / 纵深路线」保持居中
+- **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
+
 ## [2026-08-01] ingest | sources/sites/disney-research-la.md + sources/sites/disney-research-la-holotile.md — Disney Research LA 门户与 Holotile；升格 wiki/entities/disney-research-la.md、wiki/entities/disney-holotile.md
 
 - **触发：** 用户给出 <https://la.disneyresearch.com/holotile/>、<https://la.disneyresearch.com/research/>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页「项目查询」「知识图谱」入口卡点击后，目标区块恢复为**窗口顶端对齐**（`scrollIntoView({ block: 'start' })`，与旧锚点一致）
- 顺时针描边、搜索聚焦等特效保持现状；Hero「主路线 / 纵深路线」仍居中

## 改动
- `docs/main.js`：抽取 `scrollEntryCardIntoView(..., block)`；入口卡滚动锚到 `#wiki-search` / `#mini-graph-section` 并用 `block: 'start'`；描边仍画在 `#wiki-search-panel` / `#mini-graph-wrap`
- 同步 `log.md` 与前端清单

## 验证
- 本地静态站点击两张入口卡：区块顶边相对 `scroll-padding-top` 偏差 &lt; 1px，且明显近顶而非居中
- 描边 SVG / `is-border-tracing` 仍出现

## 验证截图

项目查询 → 搜索区顶对齐：

![项目查询入口卡点击后搜索区顶对齐](https://cursor.com/artifacts/c/art-f568e671-9a47-4b19-95e7-cef42ad0e650)

知识图谱 → 图谱预览区顶对齐：

![知识图谱入口卡点击后预览区顶对齐](https://cursor.com/artifacts/c/art-8ebd481a-9b56-4e87-9331-5eb5f251b7bc)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7990c60-2430-4987-bbee-e1ff3e21d289?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7990c60-2430-4987-bbee-e1ff3e21d289&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

