### PR TITLE
fix(ux): 详情页关联迷你图按规模优先邻居并近=重要

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -60,6 +60,7 @@
 - [x] 技术路线页 `roadmap.html`：基于导出阶段数据渲染可折叠阶段树（垂直 `<details>` 列表）；已移除折叠 Mermaid 线框总图与路线页内 Mermaid CDN。
 - [x] 技术路线页 `roadmap.html`：favicon、顶栏统一为 🚀（与首页「技术路线指南」CTA 一致）；主题切换仍为 ☀️/🌙。
 - [x] 技术路线页侧栏 TOC（桌面 ≥1632px）：卡片封顶 `min(76vh, 680px)`，列表区内滚动；移动端抽屉保持原样全高滚动。
+- [x] 详情页「关联知识图谱」迷你图：1-hop 邻居按全图度数（节点大小）优先；≤16 全显示、超出取 Top-16；弹簧距离/强度随邻居大小变化（近=重要）；完整邻居仍走 `graph.html?focus=`。
 - [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
 - [x] 详情页 Mermaid 标签裁切：`htmlLabels` 下 `foreignObject` 比 `nodeLabel` 略窄时 post-render 扩框 + CSS `overflow: visible`，修复如 world-models-15 技术地图等长标签贴边裁切。
 - [x] 纵深路线「路线一览」Mermaid：节点标签 `**Stage N**` 改为 `<b>Stage N</b>`（与已有 `<br/>`/`<em>` 对齐）；`main.js` 渲染前将残留 Markdown `**…**` 规范为 `<b>`，避免星号原样显示。

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -61,6 +61,7 @@
 - [x] 技术路线页 `roadmap.html`：favicon、顶栏统一为 🚀（与首页「技术路线指南」CTA 一致）；主题切换仍为 ☀️/🌙。
 - [x] 技术路线页侧栏 TOC（桌面 ≥1632px）：卡片封顶 `min(76vh, 680px)`，列表区内滚动；移动端抽屉保持原样全高滚动。
 - [x] 详情页「关联知识图谱」迷你图：1-hop 邻居按全图度数（节点大小）优先；≤16 全显示、超出取 Top-16；弹簧距离/强度随邻居大小变化（近=重要）；完整邻居仍走 `graph.html?focus=`。
+- [x] 首页知识图谱预览：Top-N 诱导子图剔除孤立点并按度数回填可连通候选，避免「全局度数高但邻居不在预览集」的孤儿节点漂浮。
 - [x] 详情页 Mermaid：正文 14px / 移动端 12px，增大节点 `padding` 与 `wrappingWidth`，减轻大字贴边与单行裁切；灯箱仍按 1.75× 离屏高清重绘。
 - [x] 详情页 Mermaid 标签裁切：`htmlLabels` 下 `foreignObject` 比 `nodeLabel` 略窄时 post-render 扩框 + CSS `overflow: visible`，修复如 world-models-15 技术地图等长标签贴边裁切。
 - [x] 纵深路线「路线一览」Mermaid：节点标签 `**Stage N**` 改为 `<b>Stage N</b>`（与已有 `<br/>`/`<em>` 对齐）；`main.js` 渲染前将残留 Markdown `**…**` 规范为 `<b>`，避免星号原样显示。

--- a/docs/main.js
+++ b/docs/main.js
@@ -4434,11 +4434,15 @@
       var neighborIds = Object.keys(neighborSet).filter(function (id) {
         return id !== currentPath && nodeMap[id];
       });
+      // 按全图度数（=节点大小）降序；同度数再按中文 label，保证稳定
       neighborIds.sort(function (a, b) {
+        var da = degreeMap[a] || 0;
+        var db = degreeMap[b] || 0;
+        if (db !== da) return db - da;
         return String(nodeMap[a].label || a).localeCompare(String(nodeMap[b].label || b), 'zh-CN');
       });
-      // 限制最多 12 个邻居，避免拥挤
-      var MAX_NEIGHBORS = 12;
+      // 低度数全显示；高度数取规模 Top-K，避免 180px 迷你图拥挤
+      var MAX_NEIGHBORS = 16;
       if (neighborIds.length > MAX_NEIGHBORS) neighborIds = neighborIds.slice(0, MAX_NEIGHBORS);
 
       wrap.hidden = false;
@@ -4479,6 +4483,26 @@
         return base * (scale || 1);
       }
 
+      // 近 = 重要：邻居半径归一化到 [0,1]，用于弹簧距离/强度
+      function neighborImportanceT(d) {
+        var rMin = window.RNGraphNodeSize.R_MIN;
+        var rMax = window.RNGraphNodeSize.R_MAX;
+        var r = window.RNGraphNodeSize.radiusForDegree(d._degree || 0, maxDegree);
+        var t = (r - rMin) / (rMax - rMin || 1);
+        if (t < 0) t = 0;
+        if (t > 1) t = 1;
+        return t;
+      }
+
+      // 星图边恒为 current → neighbor；兼容 forceLink 解析前后的 id / 节点对象
+      function linkNeighborNode(link) {
+        var t = link.target;
+        if (t && typeof t === 'object') return t;
+        for (var i = 0; i < nodes.length; i++) {
+          if (nodes[i].id === t) return nodes[i];
+        }
+        return { _degree: 0 };
+      }
 
       svgEl.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
       svgEl.innerHTML = '';
@@ -4500,7 +4524,15 @@
       svg.call(zoom).on('dblclick.zoom', null);
 
       var sim = window.d3.forceSimulation(nodes)
-        .force('link', window.d3.forceLink(edges).id(function (d) { return d.id; }).distance(54).strength(0.5))
+        .force('link', window.d3.forceLink(edges).id(function (d) { return d.id; })
+          .distance(function (link) {
+            // 大邻居更短弹簧（约 40–72）
+            return 72 - neighborImportanceT(linkNeighborNode(link)) * 32;
+          })
+          .strength(function (link) {
+            // 大邻居更强吸引（约 0.35–0.85）
+            return 0.35 + neighborImportanceT(linkNeighborNode(link)) * 0.5;
+          }))
         .force('charge', window.d3.forceManyBody().strength(-160).distanceMax(220))
         .force('center', window.d3.forceCenter(W / 2, H / 2).strength(0.12))
         .force('collision', window.d3.forceCollide().radius(function (d) { return detailMiniNodeRadius(d) + 8; }).strength(0.7))
@@ -4586,7 +4618,11 @@
       var totalDeg = Object.keys(neighborSet).length;
       var shown = neighborIds.length;
       if (metaEl) {
-        metaEl.textContent = shown + ' / ' + totalDeg + ' 个 1-hop 邻居 · 悬停预览 · 拖拽平移 · 点击跳转';
+        if (shown < totalDeg) {
+          metaEl.textContent = '规模最大的 ' + shown + ' / ' + totalDeg + ' 个 1-hop 邻居（近=重要）· 悬停预览 · 拖拽平移 · 点击跳转';
+        } else {
+          metaEl.textContent = shown + ' 个 1-hop 邻居（近=重要）· 悬停预览 · 拖拽平移 · 点击跳转';
+        }
       }
       if (allNeighborsLink) {
         if (totalDeg > 0) {

--- a/docs/mini-graph.js
+++ b/docs/mini-graph.js
@@ -151,10 +151,45 @@
       return window.RNGraphNodeSize.radiusForDegree(d._degree, maxDegree);
     }
 
+    // 邻接表：预览取 Top-N 诱导子图后，可能出现「全局度数高但邻居都不在 Top-N」的孤立点
+    var adj = {};
+    (gd.edges || []).forEach(function (e) {
+      if (e.source === e.target) return;
+      if (!adj[e.source]) adj[e.source] = [];
+      if (!adj[e.target]) adj[e.target] = [];
+      adj[e.source].push(e.target);
+      adj[e.target].push(e.source);
+    });
+    function hasNeighborInSet(id, idSet) {
+      var neighbors = adj[id] || [];
+      for (var i = 0; i < neighbors.length; i++) {
+        if (idSet.has(neighbors[i])) return true;
+      }
+      return false;
+    }
+
+    var ranked = gd.nodes.slice().sort(function (a, b) {
+      return (degreeMap[b.id] || 0) - (degreeMap[a.id] || 0);
+    });
     var topIds = new Set(
-      gd.nodes.slice().sort(function(a,b){ return (degreeMap[b.id]||0)-(degreeMap[a.id]||0); })
-      .slice(0, PREVIEW_TOP_N).map(function(n){ return n.id; })
+      ranked.slice(0, PREVIEW_TOP_N).map(function (n) { return n.id; })
     );
+    // 剔除诱导子图孤立点（迭代至稳定，避免级联），再按度数序回填可连通候选
+    var dropped = true;
+    while (dropped) {
+      dropped = false;
+      Array.from(topIds).forEach(function (id) {
+        if (!hasNeighborInSet(id, topIds)) {
+          topIds.delete(id);
+          dropped = true;
+        }
+      });
+    }
+    for (var ri = 0; ri < ranked.length && topIds.size < PREVIEW_TOP_N; ri++) {
+      var cand = ranked[ri].id;
+      if (topIds.has(cand)) continue;
+      if (hasNeighborInSet(cand, topIds)) topIds.add(cand);
+    }
 
     var nodes = gd.nodes.filter(function(n){ return topIds.has(n.id); }).map(function(n){
       return {
@@ -168,7 +203,7 @@
     });
     var nodeIdSet = new Set(nodes.map(function(n){ return n.id; }));
     var edges = gd.edges.filter(function(e){
-      return nodeIdSet.has(e.source) && nodeIdSet.has(e.target);
+      return e.source !== e.target && nodeIdSet.has(e.source) && nodeIdSet.has(e.target);
     }).map(function(e){ return {source:e.source, target:e.target}; });
 
     var W = miniWrap.clientWidth || 700, H = 480;

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-08-01] fix | docs/mini-graph.js — 首页预览剔除 Top-N 诱导子图孤儿并回填
+
+- **问题：** 预览取全站度数 Top-50 后只保留诱导边；如「机器人视觉感知栈选型闭环」全局度数高但邻居都不在 Top-50，会以孤立点漂浮
+- **修复：** 剔除诱导度数为 0 的节点，再按度数序回填能连上当前集合的候选，保持约 50 且无孤儿
+- **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
+
 ## [2026-08-01] fix | docs/main.js — 详情页关联迷你图：按规模优先邻居 + 近=重要弹簧
 
 - **问题：** 1-hop 邻居按中文 label 字母序截断 12，重要大节点可能被裁掉；弹簧距离/强度对所有邻居均一，无法表达层级

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-08-01] fix | docs/main.js — 详情页关联迷你图：按规模优先邻居 + 近=重要弹簧
+
+- **问题：** 1-hop 邻居按中文 label 字母序截断 12，重要大节点可能被裁掉；弹簧距离/强度对所有邻居均一，无法表达层级
+- **修复：** 按全图度数降序取 Top-16（≤16 全显示）；`forceLink` 距离/强度随邻居半径变化（大邻居更近、吸力更强）；meta 文案标明「近=重要」；完整列表仍走 `graph.html?focus=`
+- **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
+
 ## [2026-08-01] fix | docs/main.js — 首页「项目查询 / 知识图谱」入口卡改回窗口顶端对齐
 
 - **问题：** 与 Hero 路线数字共用 `block: 'center'` 后，点击入口卡会把搜索区 / 图谱预览滚到视口中心，不再像旧锚点那样顶对齐


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 详情页「关联知识图谱」迷你图：1-hop 邻居按全图度数降序优先，≤16 全显示、超出取 Top-16；弹簧距离/强度随邻居大小变化（近=重要）。
- 首页知识图谱预览：修复 Top-50 诱导子图孤儿——剔除诱导度数为 0 的节点，并按度数回填可连通候选（例：感知栈选型闭环 Query 被剔除，回填 Foundation Policy）。

## 验证
- `node --check` + eslint：`docs/main.js` / `docs/mini-graph.js`
- `make ci-preflight`（详情页改动时已通过；本次首页预览仅为前端选择逻辑）
- 数据核验：修复后预览集合 size=50、orphans=0
- 本地静态站截图见下

## 验证截图

详情页迷你图（Sim2Real，规模最大的 16 / 334）：

![Sim2Real 关联知识图谱迷你图](https://cursor.com/artifacts/c/art-bdf82a11-ce8c-45fb-839e-29f01725173b)

详情页迷你图（SONIC，16 / 92）：

![SONIC 关联知识图谱迷你图](https://cursor.com/artifacts/c/art-2f4dadfb-0055-42e9-91df-0425a6353c2c)

首页预览（Top-50，无诱导孤立点）：

![首页知识图谱预览无孤儿](https://cursor.com/artifacts/c/art-81c92a5e-e16d-4e39-9335-59d33b865d22)

## 风险
- 详情页 hub 仍只显示 Top-16，密度高于旧版 12。
- 首页预览仍是诱导子图，个别节点可能边很少（但不再为 0）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed4c79c7-1672-443e-b90b-a40196b4e681?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed4c79c7-1672-443e-b90b-a40196b4e681&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

