### PR TITLE
feat(ux): 知识图谱预览描边后高亮「打开完整图谱」

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,7 +76,7 @@
             <h3>查找框架、论文与机器人平台</h3>
             <span class="home-entry-link">搜索知识库 →</span>
           </a>
-          <a class="card home-entry-card" href="#mini-graph-section" data-trace-target="mini-graph-wrap">
+          <a class="card home-entry-card" href="#mini-graph-section" data-trace-target="mini-graph-wrap" data-pulse-hint="mini-graph-expand">
             <span class="home-entry-label">知识图谱</span>
             <h3>俯瞰节点与连接全貌</h3>
             <span class="home-entry-link">查看图谱预览 →</span>

--- a/docs/main.js
+++ b/docs/main.js
@@ -5992,14 +5992,23 @@
     });
   }
 
-  function pulseRouteToggleHint() {
-    if (!routeToggle) return;
-    routeToggle.classList.remove('is-pulse-hint');
-    void routeToggle.offsetWidth;
-    routeToggle.classList.add('is-pulse-hint');
+  /** 描边结束后对 CTA 文案闪两下（纵深「展开…」/ 图谱「打开完整图谱」共用） */
+  function pulseHintElement(el) {
+    if (!el) return;
+    el.classList.remove('is-pulse-hint');
+    void el.offsetWidth;
+    el.classList.add('is-pulse-hint');
     window.setTimeout(function () {
-      routeToggle.classList.remove('is-pulse-hint');
+      el.classList.remove('is-pulse-hint');
     }, TOGGLE_HINT_MS);
+  }
+
+  function pulseRouteToggleHint() {
+    pulseHintElement(routeToggle);
+  }
+
+  function pulseMiniGraphExpandHint() {
+    pulseHintElement(document.getElementById('mini-graph-expand'));
   }
 
   function getScrollPaddingTopPx() {
@@ -6126,6 +6135,7 @@
       // 滚动锚到 href 区块（顶对齐）；描边仍画在 data-trace-target 模块上
       var scrollTarget = (hashId && document.getElementById(hashId)) || target;
       var shouldFocusSearch = trigger.hasAttribute('data-focus-search');
+      var pulseHintId = trigger.getAttribute('data-pulse-hint');
       // 悬停/按下时预取搜索索引，避免 focus 时才开始拉大 JSON 造成卡顿
       if (shouldFocusSearch) {
         var prefetchOnce = function () { prefetchWikiSearchIndex(); };
@@ -6140,7 +6150,12 @@
           searchInput.focus({ preventScroll: true });
         }
         scrollEntryCardIntoView(scrollTarget, hashId ? hash : null, function () {
-          playCardBorderTrace(target);
+          var onTraceDone = null;
+          if (pulseHintId) {
+            var hintEl = document.getElementById(pulseHintId);
+            if (hintEl) onTraceDone = function () { pulseHintElement(hintEl); };
+          }
+          playCardBorderTrace(target, onTraceDone);
         }, 'start');
       });
     })(homeTraceTriggers[htti]);
@@ -6168,7 +6183,7 @@
     var miniGraphPanel = document.getElementById('mini-graph-wrap');
     if (miniGraphSection || miniGraphPanel) {
       scrollEntryCardIntoView(miniGraphSection || miniGraphPanel, null, function () {
-        if (miniGraphPanel) playCardBorderTrace(miniGraphPanel);
+        if (miniGraphPanel) playCardBorderTrace(miniGraphPanel, pulseMiniGraphExpandHint);
       }, 'start');
     }
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -527,7 +527,8 @@ a.hero-stat-num:focus-visible {
 @keyframes home-border-trace-dash {
   to { stroke-dashoffset: -100; }
 }
-.home-route-toggle.is-pulse-hint {
+.home-route-toggle.is-pulse-hint,
+#mini-graph-expand.is-pulse-hint {
   animation: home-route-toggle-hint 0.85s ease 2;
 }
 @keyframes home-route-toggle-hint {
@@ -548,7 +549,8 @@ a.hero-stat-num:focus-visible {
     stroke-dasharray: none;
     opacity: 0.95;
   }
-  .home-route-toggle.is-pulse-hint {
+  .home-route-toggle.is-pulse-hint,
+  #mini-graph-expand.is-pulse-hint {
     animation: none;
     color: var(--accent-hover);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页点击「知识图谱」入口卡（或 `#mini-graph-section`）描边结束后，对「打开完整图谱 →」做与纵深路线「展开全部…」相同的两次高亮提示。

## 改动
- `docs/main.js`：抽出共用 `pulseHintElement`；图谱入口支持 `data-pulse-hint`；hash 直达同样回调
- `docs/index.html`：知识图谱入口卡增加 `data-pulse-hint="mini-graph-expand"`
- `docs/style.css`：`#mini-graph-expand.is-pulse-hint` 复用纵深展开按钮的两次 pulse 动画

## 验证
- Puppeteer：点击入口卡后 `#mini-graph-expand` 出现 `is-pulse-hint`，`animation-iteration-count: 2`，约 1.8s 后清除
- 有头 Chrome 端到端录屏：描边 → CTA 闪两下（无 DevTools 注入）

## 验证截图
描边进行中：
![知识图谱预览描边](https://cursor.com/artifacts/c/art-6b6f1ce1-e930-4115-802f-9b5998dc894b)

描边后 CTA（区块全景）：
![打开完整图谱高亮](https://cursor.com/artifacts/c/art-825f6692-c259-4974-a885-340c115d117f)

## 验证录屏
<a href="https://cursor.com/agents/bc-a9f318f3-5fcf-4b71-988b-8aabbf3311ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmini-graph-expand-pulse-e2e.mp4"><img src="https://cursor.com/artifacts/c/art-2c9fd4ba-996d-406f-bfcf-79b562ee151f" alt="mini-graph-expand-pulse-e2e.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9f318f3-5fcf-4b71-988b-8aabbf3311ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9f318f3-5fcf-4b71-988b-8aabbf3311ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

