### PR TITLE
fix(ux): 收紧首页 Hero 顶栏下方留白

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -92,6 +92,7 @@
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。
 - [x] 首页 Hero 盘点条新增「主路线」（数字 1，位于「互链关系」与「纵深路线」之间）；四项数字可点：知识节点 / 互链关系 → `graph.html`，主路线 → 锚到「从零开始」卡并顺时针描边一圈，纵深路线 → 锚到「更多路线」卡描边一圈（不展开）后短时高亮「展开全部…」文案。
 - [x] 首页入口卡边框描边多分辨率对齐：SVG 改为按 border-box 像素定位（计入 border 宽度与亚像素 `getBoundingClientRect`），去掉 padding-box `inset`/`%` 尺寸冲突；圆角跟随 computed `border-radius`；动画期间 ResizeObserver 跟随卡片尺寸。
+- [x] 首页 Hero 顶栏下方留白收紧：桌面 `.hero` padding `68px 0 44px` → `32px 0 28px`，移动端 `38px 0 30px` → `24px 0 22px`，减少「持续更新的机器人技术栈地图」徽章上方空档，入口卡更易落在首屏。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/style.css
+++ b/docs/style.css
@@ -224,10 +224,11 @@ body.sponsor-dialog-open {
 
 /* ── 首页 Landing 首屏 ─────────────────────────────────────────────
    .hero 只用于 index.html（其余页面用 .page-hero），可独立调整。
-   与 #home-start 的 padding-top:0 配合，Hero + 入口卡片读作同一屏。 */
+   与 #home-start 的 padding-top:0 配合，Hero + 入口卡片读作同一屏。
+   顶距刻意压到 ~32px：避免顶栏下方大块留白把入口卡挤出首屏。 */
 .hero {
   position: relative;
-  padding: 68px 0 44px;
+  padding: 32px 0 28px;
   isolation: isolate;
 }
 /* 氛围层：左上角柔光 + 向下渐隐的点阵，给首屏一点「地图 / 图纸」质感 */
@@ -2414,7 +2415,7 @@ button.home-wiki-heatmap-cell.is-active {
     line-height: 1;
   }
   .hero {
-    padding: 38px 0 30px;
+    padding: 24px 0 22px;
   }
   .hero-badge { margin-bottom: 16px; }
   .hero .hero-subtitle { margin-bottom: 24px; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 首页「持续更新的机器人技术栈地图」徽章上方留白偏多（桌面 `.hero` 顶距 68px，加上 58px 顶栏后视觉空档约 ~78px）
- 收紧为桌面 `32px 0 28px`、移动端 `24px 0 22px`，让 Hero 与入口卡更贴首屏

## 验证
- 本地静态站截图对比：徽章相对顶栏下方间距约 78px → 42px
- CSS-only，未改 wiki / 导出链路；N/A `make ci-preflight`

## 验证截图
### Before（桌面 1280）
![首页 Hero 顶距收紧前](https://cursor.com/artifacts/c/art-84de4cc0-5b11-424d-a4d7-5d00d8979dcf)

### After（桌面 1280）
![首页 Hero 顶距收紧后](https://cursor.com/artifacts/c/art-3149bb7e-a0a9-471b-9388-b292e343d49a)

### After（移动端 390）
![首页 Hero 顶距收紧后（移动端）](https://cursor.com/artifacts/c/art-eb4c0d89-81c0-4b16-a26c-141d8758d9de)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2b8e564-d13b-4712-9800-9d5b4be43ae9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2b8e564-d13b-4712-9800-9d5b4be43ae9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

