### PR TITLE
feat: 搜索结果卡片快速预览——摘要默认 2 行收起 + 就地展开

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -52,7 +52,7 @@
 - [x] 重构 Hero 区布局，引入 D3 动态背景。
 
 ### Phase 3: 体验打磨 (UX)
-- [ ] 搜索结果列表优化：支持卡片式快速预览。
+- [x] 搜索结果列表优化：支持卡片式快速预览。首页搜索结果卡片摘要默认按 2 行 `-webkit-line-clamp` 收起（仅摘要长度 > 120 字符时），卡片内提供「预览全文 / 收起」就地展开开关（`.result-preview-toggle`，`aria-expanded` 同步），无需跳转详情页即可快速预览完整摘要；短摘要卡片不显示开关。验证脚本 `scripts/verify_search_preview.cjs`（`slam` → 10 张卡片 / 4 个预览开关；收起态 clientH 45 < scrollH 89、展开后全显 89）。
 - [ ] 详情页浮窗联动。
 - [x] 图谱页移动端动态视口：Chrome 底栏显隐时 `#graph-wrap` 用 `--app-vh`（`visualViewport.height`）撑满，消除下方空白条。
 - [x] 详情页 Markdown 渲染修复：正文独立 `---` 行渲染为分隔线，并按整行分隔符剥离 YAML frontmatter。

--- a/docs/main.js
+++ b/docs/main.js
@@ -6436,10 +6436,19 @@
       var graphBtn = '<a href="' + escapeHtml(graphUrl) + '" class="js-graph-btn" '
         + 'style="font-size:.75rem;opacity:.6;margin-left:8px;text-decoration:none" '
         + 'title="查看图谱邻居" tabindex="-1">🔗图谱</a>';
+      var fullSummary = item.summary || '';
+      var needsPreview = fullSummary.length > 120;
+      var summaryHtml = fullSummary
+        ? '<p class="result-summary' + (needsPreview ? ' is-clamped' : '') + '">'
+          + escapeHtml(fullSummary) + '</p>'
+          + (needsPreview
+            ? '<button type="button" class="result-preview-toggle" aria-expanded="false">预览全文</button>'
+            : '')
+        : '';
       return '<article class="card" data-result-url="' + escapeHtml(detailUrl) + '">'
         + '<p class="card-meta" style="font-size:.75rem;margin-bottom:.25rem">' + escapeHtml(typeLabel) + explain + '</p>'
         + '<h3><a href="' + escapeHtml(detailUrl) + '">' + escapeHtml(item.title || item.id) + '</a>' + graphBtn + '</h3>'
-        + '<p>' + escapeHtml((item.summary || '').slice(0, 120)) + '</p>'
+        + summaryHtml
         + (tagLine ? '<div class="chip-list">' + tagLine + '</div>' : '')
         + '</article>';
     }
@@ -6734,6 +6743,18 @@
       var graphBtn = e.target.closest('.js-graph-btn');
       if (graphBtn) {
         e.stopPropagation();
+        return;
+      }
+      var previewToggle = e.target.closest('.result-preview-toggle');
+      if (previewToggle) {
+        e.stopPropagation();
+        var card = previewToggle.closest('.card');
+        var summary = card && card.querySelector('.result-summary');
+        if (summary) {
+          var clamped = summary.classList.toggle('is-clamped');
+          previewToggle.setAttribute('aria-expanded', clamped ? 'false' : 'true');
+          previewToggle.textContent = clamped ? '预览全文' : '收起';
+        }
         return;
       }
     });

--- a/docs/style.css
+++ b/docs/style.css
@@ -2665,6 +2665,27 @@ button.home-wiki-heatmap-cell.is-active {
 .search-tier-heading.search-tier-exact { color:var(--accent, #1659b4); }
 .search-tier-heading .data-meta { font-weight:400; opacity:.75; margin-left:4px; }
 
+/* --- Search Result Quick Preview（卡片式快速预览：默认收起摘要，可就地展开全文） --- */
+.result-summary { margin:0; }
+.result-summary.is-clamped {
+  display:-webkit-box;
+  -webkit-box-orient:vertical;
+  -webkit-line-clamp:2;
+  overflow:hidden;
+}
+.result-preview-toggle {
+  margin-top:6px;
+  padding:0;
+  border:0;
+  background:none;
+  color:var(--accent);
+  font:inherit;
+  font-size:.75rem;
+  cursor:pointer;
+}
+.result-preview-toggle:hover { color:var(--accent-hover); text-decoration:underline; }
+.result-preview-toggle:focus-visible { outline:2px solid var(--accent); outline-offset:2px; border-radius:4px; }
+
 /* --- Roadmap page: vertical tree --- */
 .roadmap-flow-section {
   padding-bottom: 0;

--- a/scripts/verify_search_preview.cjs
+++ b/scripts/verify_search_preview.cjs
@@ -1,0 +1,97 @@
+// 验证：首页搜索结果卡片「快速预览」——长摘要默认收起（2 行 line-clamp）+ 可就地展开全文。
+//
+// 前置：仓库根目录先生成搜索索引并起静态服务
+//   python3 scripts/build_search_index.py
+//   cd docs && python3 -m http.server 8765
+//
+// 用法（仓库根目录）：
+//   node scripts/verify_search_preview.cjs [baseUrl] [outDir] [query]
+//   node scripts/verify_search_preview.cjs http://127.0.0.1:8765 .cursor-artifacts/screenshots slam
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const base = process.argv[2] || 'http://127.0.0.1:8765';
+  const outDir = process.argv[3] || path.resolve(__dirname, '..', '.cursor-artifacts', 'screenshots');
+  const query = process.argv[4] || 'slam';
+  fs.mkdirSync(outDir, { recursive: true });
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/google-chrome',
+  ].filter(Boolean);
+  const exe = candidates.find((p) => fs.existsSync(p));
+  if (!exe) throw new Error('No Chrome/Chromium found. Set CHROME_PATH.');
+
+  const browser = await puppeteer.launch({
+    executablePath: exe, headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu'],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1200, height: 1600 });
+    const errs = [];
+    page.on('pageerror', (e) => errs.push(String(e)));
+    await page.goto(base + '/index.html', { waitUntil: 'networkidle2', timeout: 30000 });
+    await page.focus('#wikiSearchInput');
+    await page.type('#wikiSearchInput', query);
+    await page.waitForFunction(
+      () => document.querySelectorAll('#wikiSearchResults article.card').length > 0,
+      { timeout: 15000 }
+    );
+    await page.waitForFunction(
+      () => document.querySelectorAll('.result-preview-toggle').length > 0,
+      { timeout: 15000 }
+    );
+
+    const collapsed = await page.evaluate(() => {
+      const btn = document.querySelector('.result-preview-toggle');
+      const sum = btn.closest('.card').querySelector('.result-summary');
+      return {
+        btnText: btn.textContent,
+        ariaExpanded: btn.getAttribute('aria-expanded'),
+        clamped: sum.classList.contains('is-clamped'),
+        clientH: sum.clientHeight,
+        scrollH: sum.scrollHeight,
+        toggles: document.querySelectorAll('.result-preview-toggle').length,
+        cards: document.querySelectorAll('#wikiSearchResults article.card').length,
+      };
+    });
+    await page.screenshot({ path: path.join(outDir, 'search-preview-collapsed.png') });
+
+    await page.click('.result-preview-toggle');
+    const expanded = await page.evaluate(() => {
+      const btn = document.querySelector('.result-preview-toggle');
+      const sum = btn.closest('.card').querySelector('.result-summary');
+      return {
+        btnText: btn.textContent,
+        ariaExpanded: btn.getAttribute('aria-expanded'),
+        clamped: sum.classList.contains('is-clamped'),
+        clientH: sum.clientHeight,
+        scrollH: sum.scrollHeight,
+      };
+    });
+    await page.screenshot({ path: path.join(outDir, 'search-preview-expanded.png') });
+
+    console.log('pageerrors:', errs.length ? errs : 'none');
+    console.log('COLLAPSED:', JSON.stringify(collapsed));
+    console.log('EXPANDED :', JSON.stringify(expanded));
+
+    const ok =
+      errs.length === 0 &&
+      collapsed.clamped === true &&
+      collapsed.btnText === '预览全文' &&
+      collapsed.ariaExpanded === 'false' &&
+      collapsed.clientH < collapsed.scrollH &&
+      expanded.clamped === false &&
+      expanded.btnText === '收起' &&
+      expanded.ariaExpanded === 'true' &&
+      expanded.clientH >= collapsed.scrollH - 2;
+    console.log(ok ? 'VERIFY: PASS' : 'VERIFY: FAIL');
+    process.exit(ok ? 0 : 1);
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => { console.error(e); process.exit(2); });


### PR DESCRIPTION
## 摘要

实现首页搜索结果卡片的快速预览功能：长摘要（>120 字符）默认按 2 行 `-webkit-line-clamp` 收起，卡片内提供「预览全文 / 收起」就地展开开关，无需跳转详情页即可快速预览完整摘要。短摘要卡片不显示开关。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他

## 变更详情

### 前端实现（`docs/main.js` + `docs/style.css`）

1. **摘要渲染逻辑**（`main.js`）：
   - 判断摘要长度：若 > 120 字符，添加 `is-clamped` 类并生成预览开关按钮
   - 短摘要直接渲染，不显示开关
   - 按钮初始状态：`aria-expanded="false"`，文本为「预览全文」

2. **展开/收起交互**（`main.js`）：
   - 监听 `.result-preview-toggle` 点击事件
   - 切换 `.result-summary` 的 `is-clamped` 类
   - 同步更新 `aria-expanded` 属性和按钮文本

3. **样式**（`docs/style.css`）：
   - `.result-summary.is-clamped`：使用 `-webkit-line-clamp: 2` 限制显示行数
   - `.result-preview-toggle`：按钮样式（无边框、继承字体、强调色、悬停下划线、焦点轮廓）

### 验证脚本（`scripts/verify_search_preview.cjs`）

新增 Puppeteer 自动化验证脚本，检验：
- 搜索结果卡片摘要默认收起（`is-clamped` 类存在）
- 按钮初始文本为「预览全文」，`aria-expanded="false"`
- 收起态下 `clientHeight < scrollHeight`（内容被截断）
- 点击后展开，`is-clamped` 移除，`aria-expanded="true"`，文本变为「收起」
- 展开后 `clientHeight ≥ scrollHeight`（完整显示）

**用法**：
```bash
# 前置：生成搜索索引并起静态服务
python3 scripts/build_search_index.py
cd docs && python3 -m http.server 8765

# 验证（仓库根目录）
node scripts/verify_search_preview.cjs http://127.0.0.1:8765 .cursor-artifacts/screenshots slam
```

### 检查清单更新

`docs/checklists/frontend-optimization-v1.md`：将「搜索结果列表优化」标记为完成，记录验证结果（`slam` 查询返回 10 张卡片、4 个预览开关）。

## 验证

- [x] 本地运行验证脚本通过：`node scripts/verify_search_preview.cjs`
  - 搜索 `slam` 返回 10 张卡片，其中 4 张摘要长度 > 120 字符
  - 收起态：`clientHeight=45 < scroll

https://claude.ai/code/session_01QVri9Hqhys2Piz3s3gEnaK