### PR TITLE
fix(ux): 修复时序动画退出后 2D 图谱力模拟自振

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -90,7 +90,7 @@
   - [x] 图谱页 3D 社区漂浮标签：点「适配屏幕」飞行动画期间锁定胶囊 scale 为落稳尺寸，并提前写入目标距离基线，避免中途 `|cam−lookAt|` 偏离导致标签大小闪一下。
   - [x] 图谱页 `graph.html`：筛选浮窗保留顶部「按类型 / 按社区 / 按健康度」按钮三选一；当前维度的勾选项改为与「路线视图 / 研究机构」一致的可折叠 `<details>`，折叠标题在有选中时显示数量（如 `3 个社区`）。
   - [x] 图谱页 2D 力模拟：略欠阻尼、**最多一次回弹**（验收以「刷新布局」为准，不用时序动画）——`velocityDecay=0.54`、极短 warmup 20 tick 后 `alpha=0.9` 开场、度数加权弹簧；3D 力参数保持对话前原状。
-  - [x] 图谱页 2D 时序动画：退出时清零 `alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3），避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。
+  - [x] 图谱页 2D 时序动画：退出时清零 `alpha`/`alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3）；`closeSidebar` 仅在侧栏确实打开时才 viewport sync / relayout restart，避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。
 - [x] 首页 Hero 盘点条新增「主路线」（数字 1，位于「互链关系」与「纵深路线」之间）；四项数字可点：知识节点 / 互链关系 → `graph.html`，主路线 → 锚到「从零开始」卡并顺时针描边一圈，纵深路线 → 锚到「更多路线」卡描边一圈（不展开）后短时高亮「展开全部…」文案。
 - [x] 首页入口卡边框描边多分辨率对齐：SVG 改为按 border-box 像素定位（计入 border 宽度与亚像素 `getBoundingClientRect`），去掉 padding-box `inset`/`%` 尺寸冲突；圆角跟随 computed `border-radius`；动画期间 ResizeObserver 跟随卡片尺寸。

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -90,6 +90,7 @@
   - [x] 图谱页 3D 社区漂浮标签：点「适配屏幕」飞行动画期间锁定胶囊 scale 为落稳尺寸，并提前写入目标距离基线，避免中途 `|cam−lookAt|` 偏离导致标签大小闪一下。
   - [x] 图谱页 `graph.html`：筛选浮窗保留顶部「按类型 / 按社区 / 按健康度」按钮三选一；当前维度的勾选项改为与「路线视图 / 研究机构」一致的可折叠 `<details>`，折叠标题在有选中时显示数量（如 `3 个社区`）。
   - [x] 图谱页 2D 力模拟：略欠阻尼、**最多一次回弹**（验收以「刷新布局」为准，不用时序动画）——`velocityDecay=0.54`、极短 warmup 20 tick 后 `alpha=0.9` 开场、度数加权弹簧；3D 力参数保持对话前原状。
+  - [x] 图谱页 2D 时序动画：退出时清零 `alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3），避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。
 - [x] 首页 Hero 盘点条新增「主路线」（数字 1，位于「互链关系」与「纵深路线」之间）；四项数字可点：知识节点 / 互链关系 → `graph.html`，主路线 → 锚到「从零开始」卡并顺时针描边一圈，纵深路线 → 锚到「更多路线」卡描边一圈（不展开）后短时高亮「展开全部…」文案。
 - [x] 首页入口卡边框描边多分辨率对齐：SVG 改为按 border-box 像素定位（计入 border 宽度与亚像素 `getBoundingClientRect`），去掉 padding-box `inset`/`%` 尺寸冲突；圆角跟随 computed `border-radius`；动画期间 ResizeObserver 跟随卡片尺寸。

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -4469,6 +4469,15 @@
       updateTimelineProgress(timelineIdx, timelineTotal);
     }
 
+    function stopTimelineTimer() {
+      if (timelineAnimTimer) {
+        clearInterval(timelineAnimTimer);
+        timelineAnimTimer = null;
+      }
+      timelinePlaying = false;
+      svg.interrupt('tlfit');
+    }
+
     function startTimelinePlayback() {
       if (!timelineAnimating || timelinePlaying) return;
       if (timelineIdx >= timelineTotal) seekTimeline(0, false); // 已到末尾再播放则从头开始
@@ -4484,21 +4493,17 @@
     }
 
     function onTimelinePlaybackComplete() {
-      if (timelineAnimTimer) { clearInterval(timelineAnimTimer); timelineAnimTimer = null; }
-      timelinePlaying = false;
+      stopTimelineTimer();
       updateTimelineControls();
       simulation.alphaTarget(0);     // 缓缓收敛（最后一批节点落位），不立即冻结
       fitToTimelineNodes();
     }
 
     function pauseTimelinePlayback() {
-      if (timelineAnimTimer) {
-        clearInterval(timelineAnimTimer);
-        timelineAnimTimer = null;
-      }
-      timelinePlaying = false;
-      svg.interrupt('tlfit');
-      simulation.alphaTarget(0.3).restart();   // 仅停计时器，力导向布局继续演化
+      stopTimelineTimer();
+      // 仅停计时器：力导向继续演化（alphaTarget>0）。退出时序绝不能走这条路径，
+      // 否则 stop() 后仍残留加热目标，空白点击 restart 会永久自振。
+      simulation.alphaTarget(0.3).restart();
       updateTimelineControls();
     }
 
@@ -4546,7 +4551,10 @@
     // 拆除时序模式：停播、恢复完整力模拟成员、复位节点显隐（供退出与「刷新布局」共用）
     function teardownTimelineMode() {
       if (timeline3D) { teardownTimelineMode3D(); return; }
-      pauseTimelinePlayback();
+      // 只停计时器，不要走 pauseTimelinePlayback（会把 alphaTarget 钉在 0.3）
+      stopTimelineTimer();
+      simulation.alphaTarget(0);
+      simulation.stop();
       timelineAnimating = false;
       timelineRevealedIds.clear();
       timelineIdx = 0;
@@ -4565,9 +4573,11 @@
 
     function exitTimelineMode() {
       teardownTimelineMode();
-      // 还原进入前布局并定格
+      // 还原进入前布局并定格；再次清零加热目标，避免后续空白点击 restart 后无法冷却
       restoreTimelinePositions();
+      simulation.alphaTarget(0);
       simulation.stop();
+      for (const n of simulation.nodes()) { n.vx = 0; n.vy = 0; }
       syncGraphDomFromSimulation();
       labelsSettled2D = true;
       sync2DNodeLabels();
@@ -5313,6 +5323,13 @@
         setTimeout(flyToFocus, 1400);
       }
     }
+
+    // 供验证脚本读取 2D 力模拟加热态（非业务 UI）
+    window.__RN_GRAPH2D_DEBUG__ = {
+      alpha: () => simulation.alpha(),
+      alphaTarget: () => simulation.alphaTarget(),
+      timelineAnimating: () => timelineAnimating,
+    };
 
   })();
   </script>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -4573,9 +4573,10 @@
 
     function exitTimelineMode() {
       teardownTimelineMode();
-      // 还原进入前布局并定格；再次清零加热目标，避免后续空白点击 restart 后无法冷却
+      // 还原进入前布局并完全冷却：alpha/alphaTarget 归零，避免后续任意 restart 残留加热
       restoreTimelinePositions();
       simulation.alphaTarget(0);
+      simulation.alpha(0);
       simulation.stop();
       for (const n of simulation.nodes()) { n.vx = 0; n.vy = 0; }
       syncGraphDomFromSimulation();
@@ -5180,11 +5181,19 @@
       scheduleSidebarViewportSync();
     }
     function closeSidebar() {
+      const wasOpen = sidebar.classList.contains('open');
       sidebar.classList.remove('open');
       wrap.classList.remove('sidebar-open');
-      scheduleSidebarViewportSync();
       if (isMobile) hideTooltip();
-      clearNodeNeighborHighlight({ relayout: true });
+      // 侧栏未开时空白点击也会走到这里：不要 scheduleSidebarViewportSync /
+      // relayout（二者都会 alpha().restart()）。曾与时序退出残留的
+      // alphaTarget=0.3 叠加，导致整图永久自振。
+      if (wasOpen) {
+        scheduleSidebarViewportSync();
+        clearNodeNeighborHighlight({ relayout: true });
+      } else {
+        clearNodeNeighborHighlight({ relayout: false });
+      }
     }
 
     sbClose.addEventListener('click', closeSidebar);

--- a/scripts/verify_graph_timeline_exit_settle.cjs
+++ b/scripts/verify_graph_timeline_exit_settle.cjs
@@ -1,0 +1,140 @@
+// Regression: 时序动画 → 退出 → 点击空白处后，2D 力模拟必须冷却，不能自振。
+// Usage: node scripts/verify_graph_timeline_exit_settle.cjs [baseUrl] [outDir]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const baseUrl = process.argv[2] || 'http://127.0.0.1:8765/graph.html';
+  const outDir = path.resolve(
+    process.argv[3] || path.join(__dirname, '..', '.cursor-artifacts', 'screenshots')
+  );
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const browser = await puppeteer.launch({
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
+      || (fs.existsSync('/usr/local/bin/google-chrome') ? '/usr/local/bin/google-chrome' : 'google-chrome'),
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--window-size=1440,900'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1440, height: 900 });
+    await page.setCacheEnabled(false);
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.waitForFunction(() => {
+      const loading = document.getElementById('graph-loading');
+      const count = document.getElementById('graph-node-count');
+      const loadingHidden = !loading || loading.hidden || loading.classList.contains('is-hidden')
+        || window.getComputedStyle(loading).display === 'none';
+      return loadingHidden && count && count.textContent && !count.textContent.includes('加载中');
+    }, { timeout: 120000 });
+
+    // Wait for initial layout settle
+    await new Promise((r) => setTimeout(r, 2500));
+
+    await page.click('#physics-toggle');
+    await page.waitForSelector('#physics-panel:not([hidden])');
+    await page.waitForSelector('#timeline-animate');
+
+    // Enter timeline animation briefly
+    await page.click('#timeline-animate');
+    await page.waitForFunction(() => {
+      const btn = document.getElementById('timeline-animate');
+      return btn && btn.classList.contains('is-timeline-active');
+    }, { timeout: 10000 });
+    await new Promise((r) => setTimeout(r, 1200));
+
+    // Exit timeline
+    await page.click('#timeline-animate');
+    await page.waitForFunction(() => {
+      const dbg = window.__RN_GRAPH2D_DEBUG__;
+      return dbg && !dbg.timelineAnimating() && dbg.alphaTarget() === 0;
+    }, { timeout: 10000 });
+
+    const afterExit = await page.evaluate(() => ({
+      alpha: window.__RN_GRAPH2D_DEBUG__.alpha(),
+      alphaTarget: window.__RN_GRAPH2D_DEBUG__.alphaTarget(),
+      timelineAnimating: window.__RN_GRAPH2D_DEBUG__.timelineAnimating(),
+    }));
+    if (afterExit.alphaTarget !== 0) {
+      throw new Error('alphaTarget must be 0 after exit, got ' + afterExit.alphaTarget);
+    }
+
+    const exitPath = path.join(outDir, 'graph-timeline-exit.png');
+    await page.screenshot({ path: exitPath, fullPage: false });
+
+    // Click blank area on SVG (triggers closeSidebar → mild reheat)
+    const canvas = await page.$('#graph-canvas');
+    const box = await canvas.boundingBox();
+    await page.mouse.click(box.x + 40, box.y + 40);
+
+    // Sample residual motion; must cool down, not stay elevated (self-oscillation)
+    const samples = await page.evaluate(async () => {
+      function stats() {
+        const gs = [...document.querySelectorAll('#graph-canvas .nodes g.node-g')];
+        let sumV = 0;
+        let n = 0;
+        gs.forEach((g) => {
+          const d = g.__data__;
+          if (!d) return;
+          sumV += Math.hypot(d.vx || 0, d.vy || 0);
+          n += 1;
+        });
+        return {
+          meanSpeed: n ? sumV / n : null,
+          alpha: window.__RN_GRAPH2D_DEBUG__.alpha(),
+          alphaTarget: window.__RN_GRAPH2D_DEBUG__.alphaTarget(),
+        };
+      }
+      const out = [];
+      const t0 = performance.now();
+      for (let i = 0; i < 30; i++) {
+        out.push({ tMs: Math.round(performance.now() - t0), ...stats() });
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return out;
+    });
+
+    const settlePath = path.join(outDir, 'graph-timeline-exit-blank-settled.png');
+    await page.screenshot({ path: settlePath, fullPage: false });
+
+    const early = samples.slice(0, 5);
+    const late = samples.slice(-8);
+    const earlyMaxAlpha = Math.max(...early.map((s) => s.alpha || 0));
+    const lateMeanSpeed = late.reduce((a, s) => a + (s.meanSpeed || 0), 0) / late.length;
+    const lateMeanAlpha = late.reduce((a, s) => a + (s.alpha || 0), 0) / late.length;
+    const anyHotTarget = samples.some((s) => (s.alphaTarget || 0) > 1e-6);
+
+    const report = {
+      afterExit,
+      earlyMaxAlpha,
+      lateMeanSpeed,
+      lateMeanAlpha,
+      anyHotTarget,
+      samplesTail: late,
+      exitPath,
+      settlePath,
+    };
+    console.log(JSON.stringify(report, null, 2));
+
+    if (anyHotTarget) {
+      throw new Error('alphaTarget stayed hot after blank click — self-oscillation risk');
+    }
+    // Mild blank-click reheat is OK, but must cool: late alpha near floor, speed tiny
+    if (lateMeanAlpha > 0.05) {
+      throw new Error('late mean alpha too high (not cooling): ' + lateMeanAlpha);
+    }
+    if (lateMeanSpeed > 0.35) {
+      throw new Error('late mean speed too high (self-oscillation): ' + lateMeanSpeed);
+    }
+
+    console.log('OK: timeline exit + blank click settles without self-oscillation');
+  } finally {
+    await browser.close();
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/verify_graph_timeline_exit_settle.cjs
+++ b/scripts/verify_graph_timeline_exit_settle.cjs
@@ -65,12 +65,18 @@ const path = require('path');
     const exitPath = path.join(outDir, 'graph-timeline-exit.png');
     await page.screenshot({ path: exitPath, fullPage: false });
 
-    // Click blank area on SVG (triggers closeSidebar → mild reheat)
+    // Close physics panel so blank click lands on the graph canvas itself
+    await page.evaluate(() => {
+      const panel = document.getElementById('physics-panel');
+      if (panel) panel.hidden = true;
+    });
+
+    // Click blank area on SVG (closeSidebar; should NOT reheat if sidebar was closed)
     const canvas = await page.$('#graph-canvas');
     const box = await canvas.boundingBox();
     await page.mouse.click(box.x + 40, box.y + 40);
 
-    // Sample residual motion; must cool down, not stay elevated (self-oscillation)
+    // After blank click with sidebar closed: sim must stay frozen (no stealth reheat)
     const samples = await page.evaluate(async () => {
       function stats() {
         const gs = [...document.querySelectorAll('#graph-canvas .nodes g.node-g')];
@@ -90,7 +96,7 @@ const path = require('path');
       }
       const out = [];
       const t0 = performance.now();
-      for (let i = 0; i < 30; i++) {
+      for (let i = 0; i < 20; i++) {
         out.push({ tMs: Math.round(performance.now() - t0), ...stats() });
         await new Promise((r) => setTimeout(r, 100));
       }
@@ -100,20 +106,17 @@ const path = require('path');
     const settlePath = path.join(outDir, 'graph-timeline-exit-blank-settled.png');
     await page.screenshot({ path: settlePath, fullPage: false });
 
-    const early = samples.slice(0, 5);
-    const late = samples.slice(-8);
-    const earlyMaxAlpha = Math.max(...early.map((s) => s.alpha || 0));
-    const lateMeanSpeed = late.reduce((a, s) => a + (s.meanSpeed || 0), 0) / late.length;
-    const lateMeanAlpha = late.reduce((a, s) => a + (s.alpha || 0), 0) / late.length;
+    const alphas = samples.map((s) => s.alpha || 0);
+    const alphaDrift = Math.max(...alphas) - Math.min(...alphas);
     const anyHotTarget = samples.some((s) => (s.alphaTarget || 0) > 1e-6);
+    const lateMeanSpeed = samples.slice(-5).reduce((a, s) => a + (s.meanSpeed || 0), 0) / 5;
 
     const report = {
       afterExit,
-      earlyMaxAlpha,
+      alphaDrift,
       lateMeanSpeed,
-      lateMeanAlpha,
       anyHotTarget,
-      samplesTail: late,
+      samplesTail: samples.slice(-5),
       exitPath,
       settlePath,
     };
@@ -122,15 +125,15 @@ const path = require('path');
     if (anyHotTarget) {
       throw new Error('alphaTarget stayed hot after blank click — self-oscillation risk');
     }
-    // Mild blank-click reheat is OK, but must cool: late alpha near floor, speed tiny
-    if (lateMeanAlpha > 0.05) {
-      throw new Error('late mean alpha too high (not cooling): ' + lateMeanAlpha);
+    // Sidebar was closed: blank click must not restart the force sim
+    if (alphaDrift > 1e-6) {
+      throw new Error('alpha drifted after blank click (unexpected reheat): ' + alphaDrift);
     }
-    if (lateMeanSpeed > 0.35) {
-      throw new Error('late mean speed too high (self-oscillation): ' + lateMeanSpeed);
+    if (lateMeanSpeed > 0.05) {
+      throw new Error('nodes still moving after exit+blank (should be frozen): ' + lateMeanSpeed);
     }
 
-    console.log('OK: timeline exit + blank click settles without self-oscillation');
+    console.log('OK: timeline exit + blank click stays settled (no self-oscillation)');
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 2D 图谱「时序动画 → 退出动画 → 点击空白处」后节点力布局永久自振抖动的问题。

## 根因
1. 退出时序时 `teardownTimelineMode()` 调用了 `pauseTimelinePlayback()`，后者把 `simulation.alphaTarget(0.3)` 钉住；随后仅 `stop()` 而未清零加热目标。
2. 空白点击走 `closeSidebar` → 即便侧栏未开也会 `scheduleSidebarViewportSync()` / `relayout` → `alpha(0.1).restart()`。
3. 两者叠加：`alphaTarget` 仍为 0.3 时 restart，力模拟无法冷却，整图持续抖动。

## 修复
- 抽出 `stopTimelineTimer()`；拆除时序只停计时器并 `alphaTarget(0)` + `stop()`，不再走 pause 加热路径。
- `exitTimelineMode` 还原布局后将 `alpha`/`alphaTarget` 归零并清零速度。
- `closeSidebar` 仅在侧栏确实打开时才做 viewport sync / relayout restart。
- 新增回归脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。

## 验证
- `node scripts/verify_graph_timeline_exit_settle.cjs` 通过：`afterExit.alpha/alphaTarget=0`，空白点击后 `alphaDrift=0`、`meanSpeed=0`
- 侧栏打开再点空白：仍会 mild reheat 且 `alphaTarget=0`（可正常冷却）

## 验证截图
时序播放中：
![时序动画播放中](https://cursor.com/artifacts/c/art-1469b766-fe47-4d7b-8dc0-417021061806)

退出动画后：
![退出时序动画后](https://cursor.com/artifacts/c/art-bbc9662d-e463-4673-a855-6beb6932a36f)

再点空白处后定格（无自振）：
![退出后点击空白定格](https://cursor.com/artifacts/c/art-e61bea89-583c-4f45-a1b6-5b50b0b27f2a)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a86a41d-0fbd-4fde-a7a3-79823ded330c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a86a41d-0fbd-4fde-a7a3-79823ded330c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

