### PR TITLE
feat(ux): 详情页标题为有源码节点显示⭐️

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -74,7 +74,8 @@
 - [x] 修复合并冲突冲掉的「人形群控展演」首页按钮：`docs/index.html` 补回入口，默认折叠态文案「17 → 18」。
 - [x] 修复移动端折叠态 WAM 通栏：末行居中规则改为仅 `.is-expanded` 时生效，避免 hidden 节点被 `:nth-child` 计入导致第 13 项误判孤行。
 - [x] 更新记录页 `change-log.html`：超量日先预览 10 条；提供「再展开 10 项 / 展开全部 N 项 / 收起至前 10 项」，视觉沿用箭头+文案样式（PR#1245）。
-  - [x] 详情页 Mermaid 灯箱：加载态文案 + `stage-pending` 在 `fit` 完成前隐藏，消除「空面板 / 先大后缩」闪烁。
+- [x] 详情页标题：有 `sources/repos/` 源码关联的节点在 `#detailTitle` 末尾显示 ⭐️（与首页「最新知识节点」/更新记录/互链榜同口径；`site-data` 写出 `has_repo`，前端 `detailPageHasRepo` 另有正文回退检测）。
+- [x] 详情页 Mermaid 灯箱：加载态文案 + `stage-pending` 在 `fit` 完成前隐藏，消除「空面板 / 先大后缩」闪烁。
   - [x] 图谱页 `graph.html`：参数面板新增「显示节点名称」开关（默认关闭）；2D SVG 标签与 3D HTML 叠加层共享同一状态，开启后两端同时显示。
   - [x] 图谱页 `graph.html`：参数浮窗去掉「显示节点名称」勾选项；`showNodeLabels` / `setShowNodeLabels` / 2D·3D 标签同步逻辑源码保留（默认仍关闭，无 UI 入口）。
   - [x] 图谱页 `graph.html`：参数面板新增「更新明度渐变」开关（默认关闭）；节点时间口径对齐「更新记录」页（`link-graph.json` 新增节点级 `activity` 字段，取 log.md 最近活跃日），开启后最新节点全亮、越旧越暗（下限 0.2 保持可见），无更新日期的节点按最暗显示；2D SVG 与 3D 视图共享同一开关。

--- a/docs/main.js
+++ b/docs/main.js
@@ -313,6 +313,23 @@
     return '<span class="updates-item-opensource" aria-label="含开源仓库" title="含开源仓库">⭐️</span>';
   }
 
+  // 详情页标题：有 sources/repos 关联时在标题末尾加 ⭐️（与列表行同口径）
+  function detailPageHasRepo(detailPage) {
+    if (!detailPage) return false;
+    if (detailPage.has_repo) return true;
+    return /(?:\.\.\/)*sources\/repos\/[^)\s]+\.md\b/.test(detailPage.content_markdown || '');
+  }
+
+  function renderDetailTitleWithRepoStar(titleEl, titleText, hasRepo) {
+    if (!titleEl) return;
+    var text = titleText || '';
+    if (hasRepo) {
+      titleEl.innerHTML = escapeHtml(text) + renderUpdatesItemRepoStar({ has_repo: true });
+    } else {
+      titleEl.textContent = text;
+    }
+  }
+
   function renderUpdatesItemCommunityCat(meta) {
     if (!meta || !meta.community_label) return '';
     var label = typeof shortenCommunityLabel === 'function'
@@ -4744,7 +4761,7 @@
       return /^type:\s*[\w-]+[。.]?$/i.test(String(summary || '').trim());
     }
 
-    if (titleEl) titleEl.textContent = detailPage.title || detailId;
+    renderDetailTitleWithRepoStar(titleEl, detailPage.title || detailId, detailPageHasRepo(detailPage));
     if (summaryEl) {
       const summaryText = detailPage.summary || '';
       if (summaryText && !isMetadataOnlySummary(summaryText)) {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1404,6 +1404,13 @@ button.home-wiki-heatmap-cell.is-active {
   gap: 12px;
   align-items: start;
 }
+/* 详情页标题末尾开源 ⭐️：与首页/更新记录列表行同标记 */
+.detail-hero h1 .updates-item-opensource {
+  margin-left: 0.2em;
+  padding-right: 0;
+  font-size: 0.82em;
+  vertical-align: 0.05em;
+}
 .detail-breadcrumb {
   display: flex;
   flex-wrap: wrap;

--- a/scripts/export_minimal.py
+++ b/scripts/export_minimal.py
@@ -35,6 +35,13 @@ PAPER_NOTEBOOK_MD_LINK_RE = re.compile(
     r"\((https://imchong\.github\.io/Humanoid_Robot_Learning_Paper_Notebooks/papers/[^)]+\.html)\)",
     re.IGNORECASE,
 )
+# 与 generate_link_graph.wiki_has_repo_source 同口径：关联 sources/repos/ 源码归档
+REPO_SOURCE_LINK_RE = re.compile(r"(?:\.\./)*sources/repos/[^)\s]+\.md\b")
+
+
+def page_has_repo_source(text: str) -> bool:
+    """页面正文/frontmatter 是否关联开源仓库源码归档（sources/repos/）。"""
+    return bool(REPO_SOURCE_LINK_RE.search(text or ""))
 
 
 def build_ingest_index() -> Dict[str, str]:
@@ -771,6 +778,8 @@ def build_item(path: Path) -> dict[str, Any]:
         "status": "active",
         "updated": resolve_page_updated(path, fm),
     }
+    if page_has_repo_source(text):
+        item["has_repo"] = True
 
     parts = path.relative_to(ROOT).parts
     if parts[0] == "wiki":
@@ -1020,8 +1029,9 @@ def build_site_data(items: List[Dict]) -> Dict:
         ],
     }
 
-    detail_pages = {
-        item["id"]: {
+    detail_pages = {}
+    for item in items:
+        entry: dict[str, Any] = {
             "id": item["id"],
             "title": item["title"],
             "type": item.get("type"),
@@ -1034,8 +1044,9 @@ def build_site_data(items: List[Dict]) -> Dict:
             "status": item.get("status", "active"),
             "updated": item.get("updated"),
         }
-        for item in items
-    }
+        if item.get("has_repo"):
+            entry["has_repo"] = True
+        detail_pages[item["id"]] = entry
 
     home_page = {
         "hero": {

--- a/tests/test_detail_page.py
+++ b/tests/test_detail_page.py
@@ -36,6 +36,13 @@ class DetailPageScaffoldTests(unittest.TestCase):
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
 
+    def test_detail_title_renders_repo_star_for_opensource_pages(self):
+        content = MAIN_JS.read_text(encoding="utf-8")
+        self.assertIn("function detailPageHasRepo", content)
+        self.assertIn("function renderDetailTitleWithRepoStar", content)
+        self.assertIn("renderDetailTitleWithRepoStar(titleEl", content)
+        self.assertIn(r"sources\/repos\/", content)
+
     def test_detail_page_redirects_roadmap_pages_to_roadmap_html(self):
         content = MAIN_JS.read_text(encoding="utf-8")
         self.assertIn("detailPage.type === 'roadmap_page'", content)

--- a/tests/test_export_has_repo.py
+++ b/tests/test_export_has_repo.py
@@ -1,0 +1,37 @@
+"""export_minimal：关联 sources/repos/ 的页面应写出 has_repo。"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from export_minimal import build_item, page_has_repo_source
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ExportHasRepoTests(unittest.TestCase):
+    def test_page_has_repo_source_detects_relative_repo_link(self) -> None:
+        self.assertTrue(
+            page_has_repo_source("见 [PBHC](../../sources/repos/pbhc.md) 仓库")
+        )
+        self.assertFalse(page_has_repo_source("仅有 [wiki](../concepts/sim2real.md)"))
+
+    def test_build_item_sets_has_repo_for_sim2real(self) -> None:
+        item = build_item(ROOT / "wiki" / "concepts" / "sim2real.md")
+        self.assertTrue(item.get("has_repo"))
+
+    def test_build_item_omits_has_repo_when_no_repo_source(self) -> None:
+        # 任选一个不链 sources/repos 的短页；若不存在则跳过
+        candidates = sorted((ROOT / "wiki" / "concepts").glob("*.md"))
+        for path in candidates:
+            text = path.read_text(encoding="utf-8")
+            if not page_has_repo_source(text):
+                item = build_item(path)
+                self.assertNotIn("has_repo", item)
+                return
+        self.skipTest("no wiki/concepts page without sources/repos link")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_export_has_repo.py
+++ b/tests/test_export_has_repo.py
@@ -12,9 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 class ExportHasRepoTests(unittest.TestCase):
     def test_page_has_repo_source_detects_relative_repo_link(self) -> None:
-        self.assertTrue(
-            page_has_repo_source("见 [PBHC](../../sources/repos/pbhc.md) 仓库")
-        )
+        self.assertTrue(page_has_repo_source("见 [PBHC](../../sources/repos/pbhc.md) 仓库"))
         self.assertFalse(page_has_repo_source("仅有 [wiki](../concepts/sim2real.md)"))
 
     def test_build_item_sets_has_repo_for_sim2real(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 有 `sources/repos/` 源码关联的知识节点，在详情页标题 `#detailTitle` 末尾显示 ⭐️
- 与首页「最新知识节点」、更新记录、互链榜同口径；`export_minimal` 在 `site-data` 写出 `has_repo`，前端另有正文回退检测

## 验证
- `pytest tests/test_export_has_repo.py tests/test_detail_page.py --no-cov` 通过
- Puppeteer：`wiki-concepts-sim2real` 标题含 `.updates-item-opensource`；无源码对照页 `wiki-concepts-armature-modeling` 不含

## 验证截图
![Sim2Real 详情页标题带开源⭐️](https://cursor.com/artifacts/c/art-342e940b-a917-4339-aa68-e6eebad0c412)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b63b6837-1465-42f9-aa3d-897ed2f214ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b63b6837-1465-42f9-aa3d-897ed2f214ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

