### PR TITLE
fix(graph): 修复路线视图多 token 片段漏匹配并补齐纵深命中集

### DIFF
--- a/docs/depth-filters.js
+++ b/docs/depth-filters.js
@@ -7,6 +7,12 @@
  *   excludeSegments 命中 → 直接排除；ids 显式纳入 → 命中；
  *   communities 命中 → 命中；segments 命中任一 → 命中。
  *
+ * segments 匹配规则：
+ *   - 无分隔符的单 token：与 node id 按 [/._-] 切开后的词元集合做精确命中；
+ *   - 含 - / _ 的多 token：在把 id 分隔符归一为 '-' 后的路径串上做子串命中
+ *     （因此 loco-manip 可命中 .../loco-manipulation...，sim-to-real 可命中
+ *     ...closing_sim_to_real_gap...）。勿把过短词干放进多 token segments。
+ *
  * 每条路线的汇总锚点是对应 roadmap/*.md（DEPTH_META.wikiPath），
  * 并写入 DEPTH_FILTERS[key].ids 以保证路线视图下始终可见。
  */
@@ -159,32 +165,46 @@
     'teleoperation': {
       segments: new Set([
         'teleoperation', 'teleop', 'teleoperate', 'exoskeleton', 'mocap',
-        'visionpro', 'open-television', 'homie', 'textop', 'dexumi', 'osmo'
+        'visionpro', 'open-television', 'homie', 'textop', 'dexumi', 'osmo',
+        'data-gloves', 'vision-teleop'
       ]),
-      ids: mergeIds('teleoperation')
+      ids: mergeIds('teleoperation', [
+        'wiki/tasks/teleoperation.md',
+        'wiki/comparisons/data-gloves-vs-vision-teleop.md'
+      ])
     },
     'torque-motor-design': {
       segments: new Set([
         'torque', 'motor', 'actuator', 'foc', 'qdd', 'electromagnetic',
-        'winding', 'dynamometer', 'simplefoc', 'pyleecan', 'femm'
+        'winding', 'dynamometer', 'simplefoc', 'pyleecan', 'femm',
+        'field-oriented', 'armature', 'friction-compensation', 'roller-screw'
       ]),
       ids: mergeIds('torque-motor-design', [
         'wiki/overview/hub-actuator-drive-chain.md',
         'wiki/queries/actuator-drive-chain-selection-loop.md',
         'wiki/entities/simplefoc.md',
         'wiki/entities/kicad.md',
-        'wiki/entities/altium-designer.md'
+        'wiki/entities/altium-designer.md',
+        'wiki/concepts/field-oriented-control.md',
+        'wiki/concepts/armature-modeling.md',
+        'wiki/concepts/friction-compensation.md',
+        'wiki/concepts/planetary-roller-screw-humanoid-leg-actuation.md'
       ])
     },
     'classical-control': {
       segments: new Set([
         'wbc', 'tsid', 'hqp', 'mpc', 'zmp', 'lip', 'centroidal', 'whole',
-        'body', 'balance', 'hierarchical', 'model-predictive'
+        'body', 'balance', 'hierarchical', 'model-predictive',
+        'capture-point', 'floating-base', 'optimal-control', 'crocoddyl'
       ]),
       ids: mergeIds('classical-control', [
         'wiki/overview/hub-wbc.md',
         'wiki/concepts/whole-body-control.md',
-        'wiki/methods/model-predictive-control.md'
+        'wiki/methods/model-predictive-control.md',
+        'wiki/concepts/capture-point-dcm.md',
+        'wiki/concepts/floating-base-dynamics.md',
+        'wiki/concepts/optimal-control.md',
+        'wiki/entities/crocoddyl.md'
       ])
     },
     'humanoid-hardware-design': {
@@ -213,36 +233,53 @@
       segments: new Set([
         'grasp', 'graspnet', 'anygrasp', 'dexterous', 'manipulation',
         'tactile', 'haptic', 'impedance', 'admittance', 'wrench',
-        'force', 'compliance', 'contact', 'pick', 'place', 'bimanual'
+        'force', 'compliance', 'contact', 'pick', 'place', 'bimanual',
+        'contactmimic', 'dexverse', 'visuo-tactile'
       ]),
       excludeSegments: new Set(['reinforcement']),
       ids: mergeIds('contact-manipulation', [
         'wiki/overview/hub-grasp.md',
         'wiki/overview/hub-tactile.md',
         'wiki/overview/hub-contact-force-control.md',
-        'wiki/queries/contact-wrench-closed-loop.md'
+        'wiki/queries/contact-wrench-closed-loop.md',
+        'wiki/entities/paper-contactmimic.md',
+        'wiki/entities/paper-dexverse.md',
+        'wiki/concepts/visuo-tactile-fusion.md',
+        'wiki/concepts/impedance-control.md',
+        'wiki/tasks/manipulation.md'
       ])
     },
     'navigation': {
       segments: new Set([
-        'navigation', 'slam', 'vio', 'lio', 'nav2', 'vln', 'localize',
-        'odometry', 'mapping', 'path', 'planning'
+        'navigation', 'slam', 'vio', 'lio', 'nav2', 'navigation2', 'vln',
+        'localize', 'odometry', 'mapping', 'path', 'planning', 'cartographer',
+        'orb-slam', 'habitat', 'matterport'
       ]),
       ids: mergeIds('navigation', [
         'wiki/overview/hub-state-estimation.md',
-        'wiki/concepts/state-estimation.md'
+        'wiki/concepts/state-estimation.md',
+        'wiki/entities/navigation2.md',
+        'wiki/entities/cartographer.md',
+        'wiki/entities/orb-slam3.md',
+        'wiki/entities/habitat-sim.md',
+        'wiki/entities/matterport3d-simulator.md'
       ])
     },
     'imitation-learning': {
       segments: new Set([
         'imitation', 'behavior', 'cloning', 'dagger', 'demonstration',
-        'il', 'bc', 'act', 'diffusion-policy', 'cross-embodiment'
+        'il', 'bc', 'act', 'diffusion-policy', 'cross-embodiment',
+        'action-chunking', 'behavior-cloning'
       ]),
       ids: mergeIds('imitation-learning', [
         'wiki/overview/hub-learning.md',
         'wiki/overview/hub-cross-embodiment.md',
         'wiki/overview/hub-data-pipeline.md',
-        'wiki/methods/imitation-learning.md'
+        'wiki/methods/imitation-learning.md',
+        'wiki/methods/behavior-cloning.md',
+        'wiki/methods/dagger.md',
+        'wiki/methods/diffusion-policy.md',
+        'wiki/methods/action-chunking.md'
       ])
     },
     'rl-locomotion': {
@@ -258,80 +295,161 @@
     },
     'loco-manipulation': {
       segments: new Set([
-        'loco-manip', 'locomanip', 'loco_manip', 'mobile-manip',
-        'whole-body-manip'
+        'loco-manip', 'loco-manipulation', 'locomanip', 'loco_manip',
+        'mobile-manip', 'mobile-manipulation', 'whole-body-manip',
+        'whole-body-manipulation', 'locomanipulation', 'ultra-survey',
+        'humanoidmimicgen', 'resmimic', 'visualmimic', 'halomi', 'coordex',
+        'splitadapter'
       ]),
       ids: mergeIds('loco-manipulation', [
-        'wiki/tasks/loco-manipulation.md'
+        'wiki/tasks/loco-manipulation.md',
+        'wiki/tasks/ultra-survey.md',
+        'wiki/concepts/whole-body-coordination.md',
+        'wiki/entities/paper-resmimic.md',
+        'wiki/entities/paper-humanoidmimicgen.md',
+        'wiki/entities/paper-notebook-visualmimic.md',
+        'wiki/entities/paper-halomi-humanoid-loco-manipulation.md',
+        'wiki/entities/paper-coordex-dexterous-humanoid-loco-manipulation.md',
+        'wiki/entities/paper-splitadapter-load-aware-loco-manipulation.md',
+        'wiki/entities/paper-pilot-perceptive-loco-manipulation.md',
+        'wiki/entities/current-robotics-curr0.md',
+        'wiki/entities/flexion-reflect-v1.md'
       ])
     },
     'humanoid-soccer': {
       segments: new Set([
-        'soccer', 'football', 'robocup', 'goalkeeper', 'striker', 'ball'
+        'soccer', 'football', 'robocup', 'goalkeeper', 'striker', 'ball',
+        'soccerdiffusion', 'humanoidarena', 'robonaldo', 'socc'
       ]),
-      ids: mergeIds('humanoid-soccer')
+      ids: mergeIds('humanoid-soccer', [
+        'wiki/entities/paper-notebook-soccerdiffusion-toward-learning-end-to-end-human.md',
+        'wiki/entities/paper-humanoidarena.md',
+        'wiki/entities/paper-hrl-stack-26-learning_vision_driven_reactive_socc.md',
+        'wiki/entities/smplolympics.md'
+      ])
     },
     'motion-retargeting': {
       communities: new Set(['community-3']),
       segments: new Set([
         'retargeting', 'retarget', 'gmr', 'nmr', 'reactor', 'sonic',
-        'exoactor', 'spider', 'wilor', 'mocap', 'keyframe', 'animation'
+        'exoactor', 'spider', 'wilor', 'mocap', 'keyframe', 'animation',
+        'freemocap', 'fairmotion', 'omniretarget'
       ]),
       ids: mergeIds('motion-retargeting', [
         'wiki/overview/hub-motion-retargeting.md',
-        'wiki/overview/hub-data-pipeline.md'
+        'wiki/overview/hub-data-pipeline.md',
+        'wiki/concepts/motion-retargeting.md',
+        'wiki/concepts/motion-retargeting-pipeline.md',
+        'wiki/concepts/motion-data-quality.md',
+        'wiki/methods/motion-retargeting-gmr.md',
+        'wiki/comparisons/gmr-vs-nmr-vs-reactor.md',
+        'wiki/comparisons/humanoid-reference-motion-datasets.md',
+        'wiki/entities/amass.md',
+        'wiki/entities/freemocap.md',
+        'wiki/entities/fairmotion.md',
+        'wiki/entities/lafan1-dataset.md'
       ])
     },
     'humanoid-swarm-performance': {
       segments: new Set([
         'swarm', 'multi-robot', 'formation', 'choreography', 'performance',
-        'coordination'
+        'coordination', 'crazyswarm', 'teamplay', 'teamhoi', 'marl'
       ]),
-      ids: mergeIds('humanoid-swarm-performance')
+      ids: mergeIds('humanoid-swarm-performance', [
+        'wiki/entities/crazyswarm2.md',
+        'wiki/entities/paper-bfm-23-teamplay.md',
+        'wiki/entities/paper-amp-survey-17-teamhoi.md',
+        'wiki/concepts/humanoid-multi-robot-coordination.md',
+        'wiki/comparisons/ctde-vs-decentralized-marl.md'
+      ])
     },
     'sim2real': {
       segments: new Set([
         'sim2real', 'sim-to-real', 'domain', 'randomization', 'system-id',
-        'sysid', 'residual', 'adaptation', 'physics-fidelity'
+        'sysid', 'residual', 'adaptation', 'physics-fidelity',
+        'domain-randomization', 'privileged-training', 'curriculum-learning'
       ]),
       ids: mergeIds('sim2real', [
         'wiki/overview/hub-sim2real.md',
         'wiki/overview/hub-physics-fidelity.md',
         'wiki/concepts/sim2real.md',
-        'wiki/queries/simulation-physics-fidelity.md'
+        'wiki/queries/simulation-physics-fidelity.md',
+        'wiki/concepts/domain-randomization.md',
+        'wiki/concepts/privileged-training.md',
+        'wiki/concepts/curriculum-learning.md',
+        'wiki/concepts/system-identification.md',
+        'wiki/concepts/sim-vs-real-eval-gap.md',
+        'wiki/queries/sim2real-checklist.md'
       ])
     },
     'humanoid-boxing': {
       segments: new Set([
-        'boxing', 'combat', 'adversarial', 'sparring', 'punch'
+        'boxing', 'combat', 'adversarial', 'sparring', 'punch',
+        'robostriker', 'smplolympics', 'urkl'
       ]),
-      ids: mergeIds('humanoid-boxing')
+      ids: mergeIds('humanoid-boxing', [
+        'wiki/entities/paper-notebook-robostriker.md',
+        'wiki/entities/rek.md',
+        'wiki/entities/urkl.md',
+        'wiki/entities/smplolympics.md',
+        'wiki/entities/paper-notebook-towards-motion-turing-test.md',
+        'wiki/entities/paper-hrl-stack-41-safefall.md'
+      ])
     },
     'bfm': {
       segments: new Set([
         'bfm', 'behavior-foundation', 'ase', 'phc', 'wbt', 'motion-tracking',
-        'shadowing'
+        'shadowing', 'whole-body-tracking', 'beyondmimic', 'deepmimic'
       ]),
       ids: mergeIds('bfm', [
         'wiki/overview/hub-wbt.md',
-        'wiki/concepts/behavior-foundation-model.md'
+        'wiki/concepts/behavior-foundation-model.md',
+        'wiki/concepts/whole-body-tracking-pipeline.md',
+        'wiki/methods/deepmimic.md',
+        'wiki/methods/amp-reward.md',
+        'wiki/queries/humanoid-motion-tracking-method-selection.md'
       ])
     },
     'perceptive-locomotion': {
       segments: new Set([
         'perceptive', 'parkour', 'stair', 'terrain', 'elevation', 'obstacle',
-        'vision-locomotion'
+        'vision-locomotion', 'extreme-parkour', 'dreamwaq', 'footstep'
       ]),
       ids: mergeIds('perceptive-locomotion', [
-        'wiki/overview/hub-vision-backbone.md'
+        'wiki/overview/hub-vision-backbone.md',
+        'wiki/entities/extreme-parkour.md',
+        'wiki/entities/dreamwaq-plus.md',
+        'wiki/concepts/footstep-planning.md',
+        'wiki/concepts/hierarchical-quadruped-navigation-stack.md'
       ])
     },
     'motion-generation': {
       segments: new Set([
         'motion-generation', 'motion-diffusion', 'mdm', 'text-to-motion',
-        'generative-motion', 'human-motion'
+        'generative-motion', 'human-motion', 'humanml', 'humanml3d',
+        'motion-x', 'posescript', 'kimodo', 'physdiff', 'phygile',
+        'omnicontrol', 'hy-motion', 'genmo', 'dimos', 'motionbricks',
+        'in-betweening'
       ]),
-      ids: mergeIds('motion-generation')
+      ids: mergeIds('motion-generation', [
+        'wiki/methods/diffusion-motion-generation.md',
+        'wiki/comparisons/hy-motion-vs-genmo-vs-kimodo.md',
+        'wiki/entities/awesome-text-to-motion-zilize.md',
+        'wiki/entities/dataset-bfm-humanml3d.md',
+        'wiki/entities/dataset-bfm-kit-ml.md',
+        'wiki/entities/dataset-bfm-babel.md',
+        'wiki/entities/dataset-bfm-motion-x.md',
+        'wiki/entities/dataset-bfm-posescript.md',
+        'wiki/entities/kimodo.md',
+        'wiki/entities/ardy.md',
+        'wiki/entities/gen2humanoid.md',
+        'wiki/entities/paper-phygile.md',
+        'wiki/entities/paper-dimos-human-scene-motion-synthesis.md',
+        'wiki/entities/paper-omg-omni-modal-humanoid-control.md',
+        'wiki/entities/paper-gpc-generative-pretrained-controllers.md',
+        'wiki/entities/paper-muninn-trajectory-diffusion-acceleration.md',
+        'wiki/entities/paper-heracles-humanoid-diffusion.md'
+      ])
     },
     'vla': {
       communities: new Set(['community-5']),
@@ -349,21 +467,41 @@
     },
     'real2sim': {
       segments: new Set([
-        'real2sim', 'real-to-sim', 'gaussian', 'splatting', 'reconstruction',
-        'digital-twin', 'nerf'
+        'real2sim', 'real-to-sim', 'gaussian', 'splatting', '3dgs',
+        'reconstruction', 'digital-twin', 'nerf', 'simfoundry', 'articraft',
+        'aholo', 'gs-playground'
       ]),
-      ids: mergeIds('real2sim')
+      ids: mergeIds('real2sim', [
+        'wiki/entities/paper-agentic-real2sim.md',
+        'wiki/entities/paper-simfoundry-real2sim-scene-generation.md',
+        'wiki/entities/articraft.md',
+        'wiki/entities/aholo-viewer.md',
+        'wiki/entities/gs-playground.md',
+        'wiki/entities/spark-3dgs-renderer.md',
+        'wiki/comparisons/spark-vs-aholo-web-3dgs-renderers.md',
+        'wiki/concepts/video-as-simulation.md'
+      ])
     },
     'wam': {
       segments: new Set([
         'wam', 'world-action', 'world-model', 'worldmodel', 'video-prediction',
-        'imagination'
+        'imagination', 'cosmos', 'dreamer', 'physisforcing', 'dynawm',
+        'dreamsteer'
       ]),
       ids: mergeIds('wam', [
         'wiki/overview/hub-embodied-foundation-model.md',
         'wiki/overview/hub-embodied-eval-benchmark.md',
         'wiki/concepts/world-action-models.md',
-        'wiki/queries/embodied-eval-benchmark-selection-loop.md'
+        'wiki/queries/embodied-eval-benchmark-selection-loop.md',
+        'wiki/entities/cosmos-3.md',
+        'wiki/entities/lumo-2.md',
+        'wiki/entities/dexmal-dw05.md',
+        'wiki/entities/xiaomi-robotics-u0.md',
+        'wiki/entities/paper-dit4dit-video-action-model.md',
+        'wiki/entities/paper-dreamsteer-vla-deployment-steering.md',
+        'wiki/entities/paper-dynawm-vla-online-correction.md',
+        'wiki/entities/paper-gigaworld-1-policy-evaluation.md',
+        'wiki/entities/paper-physisforcing.md'
       ])
     }
   };
@@ -512,6 +650,24 @@
     return segs;
   }
 
+  /* 把 id 中的 / . _ - 归一成 '-'，供多 token segment 做子串命中。 */
+  function nodePathKey(node) {
+    if (node && node._pathKey) return node._pathKey;
+    var key = ((node && node.id) || '').toLowerCase().replace(/\.md$/, '').replace(/[/._]+/g, '-');
+    if (node) node._pathKey = key;
+    return key;
+  }
+
+  /* 单 token → 精确词元；含分隔符 → 归一路径子串（兼容 loco-manip / loco-manipulation）。 */
+  function segmentHits(node, segs, segment) {
+    if (!segment) return false;
+    if (/[/._-]/.test(segment)) {
+      var needle = String(segment).toLowerCase().replace(/[/._]+/g, '-');
+      return needle.length > 0 && nodePathKey(node).indexOf(needle) !== -1;
+    }
+    return segs.has(segment);
+  }
+
   /* 判定单个节点是否命中某纵深（depthKey 为 'all' 时恒真）。 */
   function matches(node, depthKey) {
     if (depthKey === 'all') return true;
@@ -519,12 +675,16 @@
     if (!cfg) return true;
     var segs = nodeSegments(node);
     if (cfg.excludeSegments) {
-      for (var ex of cfg.excludeSegments) if (segs.has(ex)) return false;
+      for (var ex of cfg.excludeSegments) {
+        if (segmentHits(node, segs, ex)) return false;
+      }
     }
     if (cfg.ids && cfg.ids.has(node.id)) return true;
     if (cfg.communities && node.community && cfg.communities.has(node.community)) return true;
     if (cfg.segments) {
-      for (var seg of cfg.segments) if (segs.has(seg)) return true;
+      for (var seg of cfg.segments) {
+        if (segmentHits(node, segs, seg)) return true;
+      }
     }
     return false;
   }
@@ -562,6 +722,8 @@
     DEPTH_META: DEPTH_META,
     DEPTH_HUB_IDS: DEPTH_HUB_IDS,
     nodeSegments: nodeSegments,
+    nodePathKey: nodePathKey,
+    segmentHits: segmentHits,
     matches: matches,
     depthsForNode: depthsForNode,
     depthHubPath: depthHubPath,

--- a/log.md
+++ b/log.md
@@ -1,3 +1,10 @@
+## [2026-08-02] structural | docs/depth-filters.js — 修复路线视图多 token 片段漏匹配并补齐各纵深命中集
+
+- **问题：** `nodeSegments` 按 `/._-` 切词后，`loco-manip` / `motion-generation` / `sim-to-real` 等带连字符的 segments 几乎永不命中；Loco-Manip 路线视图仅剩枢纽+任务页（约 2 节点），动作生成等路线同样偏空
+- **修复：** `segmentHits` 对多 token segment 改为归一路径子串命中（`loco-manip` 可命中 `.../loco-manipulation...`）；单 token 仍精确匹配；并补齐 boxing / soccer / motion-generation / real2sim / wam 等路线的 segments 与显式 `ids`
+- **涉及路径：** [`docs/depth-filters.js`](docs/depth-filters.js)、[`tests/test_depth_filters.py`](tests/test_depth_filters.py)
+- **验证：** `pytest tests/test_depth_filters.py`；loco-manip 命名语料 129/129 命中
+
 ## [2026-08-02] ingest | sources/papers/learning_quiet_walking_aibo_arxiv_2502_10983.md — Sony aibo QuietWalk（ICRA 2025）低噪行走
 
 - **触发：** 用户指定 *Learning Quiet Walking for a Small Home Robot*（arXiv:2502.10983；ETH / Sony / NUS 等；Watanabe / Miki / Shi / Hutter 等；ICRA 2025）

--- a/tests/test_depth_filters.py
+++ b/tests/test_depth_filters.py
@@ -1,0 +1,186 @@
+"""Regression tests for docs/depth-filters.js route-view matching."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPTH_FILTERS_JS = ROOT / "docs" / "depth-filters.js"
+
+
+def _run_depth_filters_node(script: str) -> str:
+    """Load depth-filters.js in Node and run a small script; return stdout."""
+    prologue = f"""
+const fs = require('fs');
+const vm = require('vm');
+const sandbox = {{ window: {{}} }};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync({json.dumps(str(DEPTH_FILTERS_JS))}, 'utf8'), sandbox);
+const DF = sandbox.RNDepthFilters;
+"""
+    proc = subprocess.run(
+        ["node", "-e", prologue + script],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node failed ({proc.returncode}):\n{proc.stderr}\n{proc.stdout}"
+        )
+    return proc.stdout
+
+
+class DepthFiltersTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.assertTrue(DEPTH_FILTERS_JS.exists(), "docs/depth-filters.js should exist")
+
+    def test_module_exports_expected_api(self):
+        out = _run_depth_filters_node(
+            """
+const keys = ['DEPTH_ORDER','DEPTH_FILTERS','DEPTH_META','matches','segmentHits','nodePathKey','depthsForNode'];
+for (const k of keys) {
+  if (DF[k] == null) { console.error('missing', k); process.exit(2); }
+}
+console.log(JSON.stringify({
+  orderLen: DF.DEPTH_ORDER.length,
+  hasLoco: DF.DEPTH_ORDER.includes('loco-manipulation'),
+  hasMotionGen: DF.DEPTH_ORDER.includes('motion-generation'),
+}));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertEqual(data["orderLen"], 22)
+        self.assertTrue(data["hasLoco"])
+        self.assertTrue(data["hasMotionGen"])
+
+    def test_hyphenated_segments_match_normalized_path_substring(self):
+        """Multi-token segments must survive [/._-] splitting (the historic bug)."""
+        out = _run_depth_filters_node(
+            """
+const cases = [
+  // loco-manip stem must hit full loco-manipulation filenames
+  ['loco-manipulation', 'wiki/entities/paper-halomi-humanoid-loco-manipulation.md', true],
+  ['loco-manipulation', 'wiki/entities/paper-abot-m05-mobile-manipulation-wam.md', true],
+  ['loco-manipulation', 'wiki/entities/paper-deep-whole-body-control-loco-manip.md', true],
+  ['loco-manipulation', 'wiki/tasks/loco-manipulation.md', true],
+  // underscore form of sim-to-real
+  ['sim2real', 'wiki/entities/paper-hrl-stack-39-closing_sim_to_real_gap_for_heavy_lo.md', true],
+  // diffusion-policy / motion-generation compounds
+  ['imitation-learning', 'wiki/methods/diffusion-policy.md', true],
+  ['motion-generation', 'wiki/methods/diffusion-motion-generation.md', true],
+  ['motion-generation', 'wiki/entities/awesome-text-to-motion-zilize.md', true],
+  // cross-route negative: plain WBC is not loco-manip by path
+  ['loco-manipulation', 'wiki/concepts/whole-body-control.md', false],
+];
+const failed = [];
+for (const [depth, id, expect] of cases) {
+  const got = DF.matches({ id }, depth);
+  if (got !== expect) failed.push({ depth, id, expect, got });
+}
+console.log(JSON.stringify({ failed }));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertEqual(data["failed"], [], msg=json.dumps(data["failed"], indent=2))
+
+    def test_route_anchor_pages_always_match(self):
+        out = _run_depth_filters_node(
+            """
+const failed = [];
+for (const key of DF.DEPTH_ORDER) {
+  const hub = DF.DEPTH_HUB_IDS[key];
+  if (!hub) { failed.push({ key, reason: 'no hub' }); continue; }
+  if (!DF.matches({ id: hub }, key)) failed.push({ key, hub, reason: 'hub miss' });
+  if (!DF.isDepthHub({ id: hub }, key)) failed.push({ key, hub, reason: 'isDepthHub' });
+}
+console.log(JSON.stringify({ failed }));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertEqual(data["failed"], [])
+
+    def test_explicit_anchor_ids_for_sparse_routes(self):
+        """Routes whose core papers lack path keywords still need explicit ids."""
+        out = _run_depth_filters_node(
+            """
+const cases = [
+  ['humanoid-boxing', 'wiki/entities/paper-notebook-robostriker.md'],
+  ['humanoid-boxing', 'wiki/entities/rek.md'],
+  ['humanoid-boxing', 'wiki/entities/urkl.md'],
+  ['humanoid-soccer', 'wiki/entities/paper-notebook-soccerdiffusion-toward-learning-end-to-end-human.md'],
+  ['motion-generation', 'wiki/entities/kimodo.md'],
+  ['motion-generation', 'wiki/comparisons/hy-motion-vs-genmo-vs-kimodo.md'],
+  ['real2sim', 'wiki/entities/articraft.md'],
+  ['wam', 'wiki/entities/cosmos-3.md'],
+  ['loco-manipulation', 'wiki/entities/paper-resmimic.md'],
+];
+const failed = [];
+for (const [depth, id] of cases) {
+  if (!DF.matches({ id }, depth)) failed.push({ depth, id });
+}
+console.log(JSON.stringify({ failed }));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertEqual(data["failed"], [])
+
+    def test_loco_manipulation_route_recovers_corpus(self):
+        """After the hyphen bugfix, loco-manip route must surface the named corpus."""
+        wiki_root = ROOT / "wiki"
+        candidates = sorted(
+            str(p.relative_to(ROOT)).replace("\\", "/")
+            for p in wiki_root.rglob("*.md")
+            if "loco-manip" in p.name or "mobile-manip" in p.name
+        )
+        self.assertGreaterEqual(len(candidates), 20, "fixture corpus unexpectedly small")
+        payload = json.dumps(candidates)
+        out = _run_depth_filters_node(
+            f"""
+const ids = {payload};
+const missed = ids.filter(id => !DF.matches({{ id }}, 'loco-manipulation'));
+console.log(JSON.stringify({{ total: ids.length, missed }}));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertEqual(
+            data["missed"],
+            [],
+            msg=f"missed {len(data['missed'])}/{data['total']}: {data['missed'][:10]}",
+        )
+
+    def test_single_token_segments_remain_exact(self):
+        """Single-token rules must not become raw substring matches."""
+        out = _run_depth_filters_node(
+            """
+// 'ball' is a soccer single-token segment; must not match inside 'football' token only via substring —
+// football tokenizes to ['football'], so 'ball' exact-token miss is expected unless path has 'ball'.
+const football = DF.matches({ id: 'wiki/entities/paper-humanoid-football-demo.md' }, 'humanoid-soccer');
+const ball = DF.matches({ id: 'wiki/entities/paper-learning-to-ball.md' }, 'humanoid-soccer');
+// segmentHits API: multi vs single
+const multi = DF.segmentHits(
+  { id: 'wiki/entities/paper-halomi-humanoid-loco-manipulation.md' },
+  DF.nodeSegments({ id: 'wiki/entities/paper-halomi-humanoid-loco-manipulation.md' }),
+  'loco-manip'
+);
+const singleExact = DF.segmentHits(
+  { id: 'wiki/tasks/locomotion.md' },
+  DF.nodeSegments({ id: 'wiki/tasks/locomotion.md' }),
+  'locomotion'
+);
+console.log(JSON.stringify({ football, ball, multi, singleExact }));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertTrue(data["multi"])
+        self.assertTrue(data["singleExact"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_depth_filters.py
+++ b/tests/test_depth_filters.py
@@ -30,9 +30,7 @@ const DF = sandbox.RNDepthFilters;
         check=False,
     )
     if proc.returncode != 0:
-        raise AssertionError(
-            f"node failed ({proc.returncode}):\n{proc.stderr}\n{proc.stdout}"
-        )
+        raise AssertionError(f"node failed ({proc.returncode}):\n{proc.stderr}\n{proc.stdout}")
     return proc.stdout
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复图谱「路线视图」中带连字符的 path segments（如 `loco-manip`、`motion-generation`、`sim-to-real`）因按 `/._-` 切词后几乎永不命中的问题。
- 多 token segment 改为归一路径子串匹配（单 token 仍精确命中）；并补齐 boxing / soccer / motion-generation / real2sim / wam / loco-manipulation 等路线的 segments 与显式 `ids`。
- 新增 `tests/test_depth_filters.py` 回归锁定该行为。

## 验证
- `node --check docs/depth-filters.js` 通过
- `pytest tests/test_depth_filters.py`：6 passed（loco-manip 命名语料 129/129 命中）
- 本地静态站 `graph.html?depth=…` 节点计数：
  - Loco-Manip：**137 / 2070**
  - 动作生成：**33 / 2070**
  - 人形拳击：**11 / 2070**

## 验证截图

Loco-Manip 路线视图（修复前约 2 节点）：

![Loco-Manip 路线视图](https://cursor.com/artifacts/c/art-7360119a-f7e5-4372-ae3c-53ac41bbe503)

动作生成路线视图（修复前约 1 节点）：

![动作生成路线视图](https://cursor.com/artifacts/c/art-32804ca2-d7a5-4417-84bc-2036312fcfcc)

人形拳击路线视图（含 RoboStriker / REK 等锚点）：

![人形拳击路线视图](https://cursor.com/artifacts/c/art-0a393487-6486-4675-8462-365ac5935848)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27dec385-d889-4a4f-a59a-f0e4d3416fcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27dec385-d889-4a4f-a59a-f0e4d3416fcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

