### PR TITLE
fix(ux): 恢复图谱筛选手风琴展开区纵向滑块

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -97,39 +97,40 @@
       overflow-x: hidden;
       overflow-y: auto;
       overscroll-behavior: contain;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255,255,255,0.5) rgba(255,255,255,0.08);
+      scrollbar-width: none; /* 隐藏原生 overlay；改用 .filter-scroll-chrome 常驻滑块 */
+      padding-right: 12px;
     }
     .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar,
     .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar,
     .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar {
-      width: 8px;
+      width: 0;
+      height: 0;
     }
-    .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-track,
-    .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-track,
-    .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-track {
-      background: rgba(255,255,255,0.06);
-    }
-    .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-thumb,
-    .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-thumb,
-    .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-thumb {
-      background-color: rgba(255,255,255,0.45);
+    /* 自定义常驻滚动条（原生 overlay 在部分环境展开后看不到滑块） */
+    .filter-scroll-chrome {
+      position: absolute;
+      top: var(--filter-summary-h, 38px);
+      right: 4px;
+      bottom: 4px;
+      width: 6px;
       border-radius: 999px;
+      background: rgba(255,255,255,0.12);
+      z-index: 3;
+      pointer-events: none;
     }
-    [data-theme="light"] .filter-depth-section[open] > .filter-dimension-list,
-    [data-theme="light"] .filter-depth-section[open] > .filter-depth-chips,
-    [data-theme="light"] .filter-depth-section[open] > .filter-institution-list {
-      scrollbar-color: rgba(0,0,0,0.4) rgba(0,0,0,0.08);
+    .filter-scroll-chrome[hidden] { display: none !important; }
+    .filter-depth-section:not([open]) > .filter-scroll-chrome { display: none !important; }
+    .filter-scroll-thumb {
+      width: 100%;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.58);
+      will-change: transform;
     }
-    [data-theme="light"] .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-track,
-    [data-theme="light"] .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-track,
-    [data-theme="light"] .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-track {
-      background: rgba(0,0,0,0.06);
+    [data-theme="light"] .filter-scroll-chrome {
+      background: rgba(0,0,0,0.12);
     }
-    [data-theme="light"] .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-thumb,
-    [data-theme="light"] .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-thumb,
-    [data-theme="light"] .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-thumb {
-      background-color: rgba(0,0,0,0.35);
+    [data-theme="light"] .filter-scroll-thumb {
+      background: rgba(0,0,0,0.42);
     }
     .filter-depth-summary {
       display: flex;
@@ -2104,6 +2105,63 @@
         .filter(Boolean);
     }
 
+    function getFilterAccordionPane(section) {
+      if (!section) return null;
+      return section.querySelector(
+        ':scope > .filter-dimension-list, :scope > .filter-depth-chips, :scope > .filter-institution-list'
+      );
+    }
+
+    function ensureFilterScrollChrome(section) {
+      let chrome = section.querySelector(':scope > .filter-scroll-chrome');
+      if (chrome) return chrome;
+      chrome = document.createElement('div');
+      chrome.className = 'filter-scroll-chrome';
+      chrome.hidden = true;
+      chrome.setAttribute('aria-hidden', 'true');
+      chrome.innerHTML = '<div class="filter-scroll-thumb"></div>';
+      section.appendChild(chrome);
+      return chrome;
+    }
+
+    function syncFilterPaneScrollbar(section) {
+      if (!section) return;
+      const pane = getFilterAccordionPane(section);
+      const chrome = ensureFilterScrollChrome(section);
+      const thumb = chrome.querySelector('.filter-scroll-thumb');
+      const summary = section.querySelector(':scope > summary');
+      if (summary) {
+        section.style.setProperty('--filter-summary-h', `${Math.round(summary.offsetHeight)}px`);
+      }
+      if (!section.open || !pane || !thumb) {
+        chrome.hidden = true;
+        return;
+      }
+      const scrollH = pane.scrollHeight;
+      const clientH = pane.clientHeight;
+      if (scrollH <= clientH + 1) {
+        chrome.hidden = true;
+        return;
+      }
+      chrome.hidden = false;
+      const trackH = chrome.clientHeight || Math.max(0, section.clientHeight - (summary ? summary.offsetHeight : 0));
+      const thumbH = Math.max(28, Math.round(trackH * clientH / scrollH));
+      const maxTop = Math.max(0, trackH - thumbH);
+      const top = maxTop * pane.scrollTop / Math.max(1, scrollH - clientH);
+      thumb.style.height = `${thumbH}px`;
+      thumb.style.transform = `translateY(${Math.round(top)}px)`;
+    }
+
+    function syncOpenFilterPaneScrollbar() {
+      getFilterAccordionSections().forEach((section) => {
+        if (section.open) syncFilterPaneScrollbar(section);
+        else {
+          const chrome = section.querySelector(':scope > .filter-scroll-chrome');
+          if (chrome) chrome.hidden = true;
+        }
+      });
+    }
+
     function openFilterAccordionSection(sectionId) {
       const sections = getFilterAccordionSections();
       if (!sections.length) return;
@@ -2114,6 +2172,7 @@
       filterAccordionLock = true;
       sections.forEach((s) => { s.open = (s === target); });
       filterAccordionLock = false;
+      requestAnimationFrame(syncOpenFilterPaneScrollbar);
     }
 
     function initFilterAccordion() {
@@ -2128,19 +2187,30 @@
             if (section.open) ev.preventDefault();
           });
         }
+        const pane = getFilterAccordionPane(section);
+        if (pane) {
+          pane.addEventListener('scroll', () => syncFilterPaneScrollbar(section), { passive: true });
+        }
         section.addEventListener('toggle', () => {
           if (filterAccordionLock) return;
           if (section.open) {
             filterAccordionLock = true;
             sections.forEach((s) => { if (s !== section) s.open = false; });
             filterAccordionLock = false;
+            requestAnimationFrame(syncOpenFilterPaneScrollbar);
             return;
           }
           if (!sections.some((s) => s.open)) {
             openFilterAccordionSection(FILTER_ACCORDION_DEFAULT_ID);
+          } else {
+            requestAnimationFrame(syncOpenFilterPaneScrollbar);
           }
         });
       });
+      window.addEventListener('resize', () => requestAnimationFrame(syncOpenFilterPaneScrollbar));
+      // 列表异步填入后补一次滑块尺寸
+      setTimeout(syncOpenFilterPaneScrollbar, 0);
+      setTimeout(syncOpenFilterPaneScrollbar, 800);
     }
     initFilterAccordion();
 
@@ -2153,6 +2223,7 @@
       if (!filterPanel) return;
       filterPanel.hidden = !open;
       filterPanel.setAttribute('aria-hidden', open ? 'false' : 'true');
+      if (open) requestAnimationFrame(syncOpenFilterPaneScrollbar);
       if (!filterPanelScrim) return;
       if (isFilterPanelMobileMode() && open) {
         filterPanelScrim.classList.add('is-visible');
@@ -2306,6 +2377,7 @@
         });
       });
       updateInstitutionFilterSummary();
+      requestAnimationFrame(syncOpenFilterPaneScrollbar);
     }
 
     let focusedCommunityId = null;
@@ -3526,6 +3598,7 @@
           updateFilterCount();
         });
       });
+      requestAnimationFrame(syncOpenFilterPaneScrollbar);
     }
 
     function refreshNodeColors() {
@@ -4120,6 +4193,7 @@
       document.removeEventListener('mouseup', endFilterPanelResize);
       document.body.classList.remove('filter-panel-resizing');
       document.body.style.cursor = '';
+      requestAnimationFrame(syncOpenFilterPaneScrollbar);
     }
 
     (function initFilterPanelSize() {

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -71,20 +71,65 @@
       border-bottom: 1px solid rgba(255,255,255,0.06);
       min-height: 0;
     }
+    /* Chromium 对 <details> 设 flex/grid 时，非 summary 子项不会被限高，
+       列表会按内容撑开再被裁切，表现为「没有滑块」。
+       展开态用绝对定位把内容铺在 summary 下方，高度由手风琴 flex 分配。 */
     .filter-depth-section[open] {
       flex: 1 1 auto;
-      display: flex;
-      flex-direction: column;
       min-height: 0;
+      position: relative;
       overflow: hidden;
+    }
+    .filter-depth-section[open] > .filter-depth-summary {
+      position: relative;
+      z-index: 1;
     }
     .filter-depth-section[open] > .filter-dimension-list,
     .filter-depth-section[open] > .filter-depth-chips,
     .filter-depth-section[open] > .filter-institution-list {
-      flex: 1 1 auto;
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: var(--filter-summary-h, 38px);
+      bottom: 0;
       min-height: 0;
       max-height: none;
+      overflow-x: hidden;
       overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255,255,255,0.5) rgba(255,255,255,0.08);
+    }
+    .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar,
+    .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar,
+    .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar {
+      width: 8px;
+    }
+    .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-track,
+    .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-track,
+    .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-track {
+      background: rgba(255,255,255,0.06);
+    }
+    .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-thumb,
+    .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-thumb,
+    .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-thumb {
+      background-color: rgba(255,255,255,0.45);
+      border-radius: 999px;
+    }
+    [data-theme="light"] .filter-depth-section[open] > .filter-dimension-list,
+    [data-theme="light"] .filter-depth-section[open] > .filter-depth-chips,
+    [data-theme="light"] .filter-depth-section[open] > .filter-institution-list {
+      scrollbar-color: rgba(0,0,0,0.4) rgba(0,0,0,0.08);
+    }
+    [data-theme="light"] .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-track,
+    [data-theme="light"] .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-track,
+    [data-theme="light"] .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-track {
+      background: rgba(0,0,0,0.06);
+    }
+    [data-theme="light"] .filter-depth-section[open] > .filter-dimension-list::-webkit-scrollbar-thumb,
+    [data-theme="light"] .filter-depth-section[open] > .filter-depth-chips::-webkit-scrollbar-thumb,
+    [data-theme="light"] .filter-depth-section[open] > .filter-institution-list::-webkit-scrollbar-thumb {
+      background-color: rgba(0,0,0,0.35);
     }
     .filter-depth-summary {
       display: flex;
@@ -160,9 +205,6 @@
     /* PC：展开区由手风琴吃满剩余高度，chip 列表在区内滚动 */
     .filter-depth-section[open] .filter-depth-chips {
       max-height: none;
-      overflow-y: auto;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255,255,255,0.28) transparent;
     }
     /* 路线导读条（画布右下角、操作提示条上方，选中非「全量」纵深时显示；
        左上角会被筛选浮窗遮挡、左下有图例 FAB、右上有参数面板，故固定右下；
@@ -1375,23 +1417,9 @@
       display: flex;
       flex-direction: column;
       overflow: hidden;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255,255,255,0.28) transparent;
+      /* 不在此设 scrollbar-*：该属性可继承，会让子列表滑块样式被覆盖/变透明 */
     }
-    .filter-sections-scroll::-webkit-scrollbar { width: 8px; }
-    .filter-sections-scroll::-webkit-scrollbar-track { background: transparent; }
-    .filter-sections-scroll::-webkit-scrollbar-thumb {
-      background-color: rgba(255,255,255,0.28);
-      border-radius: 999px;
-    }
-    .filter-sections-scroll::-webkit-scrollbar-corner { background: transparent; }
-    [data-theme="light"] .filter-sections-scroll {
-      scrollbar-color: rgba(0,0,0,0.28) transparent;
-    }
-    [data-theme="light"] .filter-sections-scroll::-webkit-scrollbar-thumb {
-      background-color: rgba(0,0,0,0.28);
-    }
-    /* 维度 / 机构筛选列表：在展开的手风琴区内滚动 */
+    /* 维度 / 机构筛选列表：在展开的手风琴区内滚动（滑块样式见 [open] 规则） */
     .filter-dimension-list,
     .filter-institution-list {
       display: flex;
@@ -1399,26 +1427,7 @@
       gap: 1px;
       max-height: none;
       overflow-y: auto;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255,255,255,0.28) transparent;
       padding: 4px 0 8px;
-    }
-    .filter-dimension-list::-webkit-scrollbar,
-    .filter-institution-list::-webkit-scrollbar { width: 8px; }
-    .filter-dimension-list::-webkit-scrollbar-track,
-    .filter-institution-list::-webkit-scrollbar-track { background: transparent; }
-    .filter-dimension-list::-webkit-scrollbar-thumb,
-    .filter-institution-list::-webkit-scrollbar-thumb {
-      background-color: rgba(255,255,255,0.28);
-      border-radius: 999px;
-    }
-    [data-theme="light"] .filter-dimension-list,
-    [data-theme="light"] .filter-institution-list {
-      scrollbar-color: rgba(0,0,0,0.28) transparent;
-    }
-    [data-theme="light"] .filter-dimension-list::-webkit-scrollbar-thumb,
-    [data-theme="light"] .filter-institution-list::-webkit-scrollbar-thumb {
-      background-color: rgba(0,0,0,0.28);
     }
     [data-theme="light"] .filter-mode-tabs {
       border-bottom-color: rgba(0,0,0,0.07);

--- a/log.md
+++ b/log.md
@@ -1,7 +1,7 @@
 ## [2026-08-02] structural | docs/graph.html — 筛选浮窗三区手风琴（按社区 / 路线视图 / 研究机构）
 
 - **改动：** [`docs/graph.html`](docs/graph.html) — 「按社区（当前维度）/ 路线视图 / 研究机构」同时仅展开一个，默认展开「按社区」；展开区吃满剩余高度，收起项靠上或靠下；`?depth=` / `?community=` / `?institution=` 深链同步打开对应区
-- **跟进：** Chromium 下对 `<details>` 设 flex/grid 会导致列表不被限高、溢出被裁切且无滑块；展开态改为 absolute 铺满 summary 下方以恢复区内滚动
+- **跟进：** Chromium 下对 `<details>` 设 flex/grid 会导致列表不被限高、溢出被裁切且无滑块；展开态改为 absolute 铺满 summary 下方，并以 `.filter-scroll-chrome` 常驻滑块替代不可见的原生 overlay 滚动条
 - **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
 - **验证：** [`scripts/verify_graph_filter_accordion.cjs`](scripts/verify_graph_filter_accordion.cjs)
 

--- a/log.md
+++ b/log.md
@@ -1,6 +1,7 @@
 ## [2026-08-02] structural | docs/graph.html — 筛选浮窗三区手风琴（按社区 / 路线视图 / 研究机构）
 
 - **改动：** [`docs/graph.html`](docs/graph.html) — 「按社区（当前维度）/ 路线视图 / 研究机构」同时仅展开一个，默认展开「按社区」；展开区吃满剩余高度，收起项靠上或靠下；`?depth=` / `?community=` / `?institution=` 深链同步打开对应区
+- **跟进：** Chromium 下对 `<details>` 设 flex/grid 会导致列表不被限高、溢出被裁切且无滑块；展开态改为 absolute 铺满 summary 下方以恢复区内滚动
 - **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md)
 - **验证：** [`scripts/verify_graph_filter_accordion.cjs`](scripts/verify_graph_filter_accordion.cjs)
 

--- a/scripts/verify_graph_filter_accordion.cjs
+++ b/scripts/verify_graph_filter_accordion.cjs
@@ -57,6 +57,12 @@ async function sectionLayout(page) {
         bodyScrollH: body ? body.scrollHeight : 0,
         bodyCanScroll: !!(body && body.scrollHeight > body.clientHeight + 1),
         bodyOverflowY: body ? getComputedStyle(body).overflowY : '',
+        chromeVisible: (() => {
+          const chrome = el.querySelector(':scope > .filter-scroll-chrome');
+          if (!chrome || chrome.hidden) return false;
+          const thumb = chrome.querySelector('.filter-scroll-thumb');
+          return !!(thumb && thumb.getBoundingClientRect().height >= 20);
+        })(),
       };
     });
     return {
@@ -99,6 +105,13 @@ function assertExclusive(layout, expectedOpenId) {
     throw new Error(
       `Open pane not clamped: bodyClient=${open.bodyClientH} section=${open.height} summary=${open.summaryH}`
     );
+  }
+  if (
+    (expectedOpenId === 'filter-dimension-section' ||
+      expectedOpenId === 'filter-institution-section') &&
+    !open.chromeVisible
+  ) {
+    throw new Error(`Open ${expectedOpenId} should show custom scroll thumb`);
   }
   const openIdx = layout.items.findIndex((i) => i.id === expectedOpenId);
   layout.items.forEach((item, idx) => {

--- a/scripts/verify_graph_filter_accordion.cjs
+++ b/scripts/verify_graph_filter_accordion.cjs
@@ -43,6 +43,9 @@ async function sectionLayout(page) {
     const items = ids.map((id) => {
       const el = document.getElementById(id);
       const r = el.getBoundingClientRect();
+      const body = el.querySelector(
+        ':scope > .filter-dimension-list, :scope > .filter-depth-chips, :scope > .filter-institution-list'
+      );
       return {
         id,
         open: !!el.open,
@@ -50,6 +53,10 @@ async function sectionLayout(page) {
         bottom: r.bottom,
         height: r.height,
         summaryH: el.querySelector('summary')?.getBoundingClientRect().height || 0,
+        bodyClientH: body ? body.clientHeight : 0,
+        bodyScrollH: body ? body.scrollHeight : 0,
+        bodyCanScroll: !!(body && body.scrollHeight > body.clientHeight + 1),
+        bodyOverflowY: body ? getComputedStyle(body).overflowY : '',
       };
     });
     return {
@@ -73,6 +80,25 @@ function assertExclusive(layout, expectedOpenId) {
   // Expanded pane should meaningfully fill remaining space (taller than a summary row)
   if (open.height < 120) {
     throw new Error(`Open section too short to fill accordion: ${open.height}`);
+  }
+  // Long lists (community / institution) must be height-clamped so the scrollbar appears
+  if (
+    (expectedOpenId === 'filter-dimension-section' ||
+      expectedOpenId === 'filter-institution-section') &&
+    !open.bodyCanScroll
+  ) {
+    throw new Error(
+      `Open ${expectedOpenId} should scroll (client=${open.bodyClientH}, scroll=${open.bodyScrollH})`
+    );
+  }
+  if (open.bodyOverflowY !== 'auto' && open.bodyOverflowY !== 'scroll') {
+    throw new Error(`Open pane overflow-y should allow scroll, got ${open.bodyOverflowY}`);
+  }
+  // Body must be height-clamped inside the open section (not content-sized then clipped)
+  if (open.bodyClientH > open.height - open.summaryH + 2) {
+    throw new Error(
+      `Open pane not clamped: bodyClient=${open.bodyClientH} section=${open.height} summary=${open.summaryH}`
+    );
   }
   const openIdx = layout.items.findIndex((i) => i.id === expectedOpenId);
   layout.items.forEach((item, idx) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 修复 #1426 合并后「展开后上下滑动的滑块没了」：Chromium 下对 `<details>` 使用 flex/grid 时列表不被限高，内容被裁切且无法滚动
- 展开态改为 absolute 铺满 summary 下方，恢复区内滚动
- 增加 `.filter-scroll-chrome` 常驻滑块（原生 overlay 滚动条在部分环境不可见）

## 验证
- `node scripts/verify_graph_filter_accordion.cjs` 通过（含自定义滑块可见断言）

## 验证截图

展开「按社区」后右侧可见滑块：

![筛选手风琴按社区展开与滑块](https://cursor.com/artifacts/c/art-20612283-4af3-49f1-9047-7dc30650cf88)

滑块特写：

![筛选展开区滚动滑块特写](https://cursor.com/artifacts/c/art-0a1d8c22-016b-4039-a5c8-a8a8fd54ac0c)

展开「研究机构」：

![筛选手风琴展开研究机构](https://cursor.com/artifacts/c/art-6dba2f09-daba-4b11-91dc-1a767e140a56)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70871ca9-9288-428d-95e4-39c66cfa3c41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70871ca9-9288-428d-95e4-39c66cfa3c41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

