### PR TITLE
fix(ux): 刷新布局恢复真随机重铺节点位置

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -3231,8 +3231,19 @@
       }
     }
 
+    /** 「刷新布局」：真随机重铺（与 3D resetNodePositionsInPlace 同尺度）。
+     *  首屏仍用叶序；若这里也走确定性叶序，每次刷新会收敛到几乎同一布局。 */
     function randomizeNodePositions() {
-      seedNodePositionsPhyllotaxis(nodes);
+      const cx = W / 2;
+      const cy = H / 2;
+      for (const n of nodes) {
+        n.fx = null;
+        n.fy = null;
+        n.vx = 0;
+        n.vy = 0;
+        n.x = cx + (Math.random() - 0.5) * 80;
+        n.y = cy + (Math.random() - 0.5) * 80;
+      }
     }
 
     function linkStrengthFor(link) {
@@ -3654,10 +3665,11 @@
       whenGraphViewportReady(() => fitToScreen());
     }
 
-    /** 叶序种子 + 极短 warmup 后开场：可见一次扩张/回弹，再靠摩擦与冷却落稳。 */
+    /** 极短 warmup 后开场：可见一次扩张/回弹，再靠摩擦与冷却落稳。
+     *  reseed=true（刷新布局）走真随机；首屏不传 reseed，沿用已铺好的叶序种子。 */
     function runStabilizedLayout2D(options) {
       const opts = options || {};
-      if (opts.reseed) seedNodePositionsPhyllotaxis(nodes);
+      if (opts.reseed) randomizeNodePositions();
       simulation.stop();
       simulation.alphaTarget(0);
       for (const n of simulation.nodes()) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 「刷新布局」此前 reseeds 到确定性黄金角叶序，每次收敛到几乎同一布局，观感上「没有随机」。
- 首屏仍用叶序铺开（防中心小团爆炸）；交互刷新改回中心附近 `Math.random` 散布，与 3D `resetNodePositionsInPlace` 对齐。

## 验证
- 本地 `docs/graph.html`：连续两次点击「刷新布局」，采样 120 个节点的平均位移约 **793px**（脚本 PASS）。
- 仅前端 `docs/graph.html` 改动；wiki 派生文件门禁 N/A。

## 验证截图
初始布局：
![图谱初始布局](https://cursor.com/artifacts/c/art-3c2047e9-8cbc-4c88-8bbb-a70b9571d733)

第一次刷新布局：
![第一次刷新布局](https://cursor.com/artifacts/c/art-3069ac16-7907-4352-8c7e-0e4bcc4b92b8)

第二次刷新布局（应与上图明显不同）：
![第二次刷新布局](https://cursor.com/artifacts/c/art-5db71ee2-8fa7-49ea-afe9-b995e75bc4c4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-045d0cd4-1e3b-41de-ac0d-d5cdebb63fbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-045d0cd4-1e3b-41de-ac0d-d5cdebb63fbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

