### PR TITLE
feat(ux): 详情页正文内链悬停浮窗并与关联知识图谱迷你图双向联动

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -53,7 +53,7 @@
 
 ### Phase 3: 体验打磨 (UX)
 - [x] 搜索结果列表优化：支持卡片式快速预览。首页搜索结果卡片摘要默认按 2 行 `-webkit-line-clamp` 收起（仅摘要长度 > 120 字符时），卡片内提供「预览全文 / 收起」就地展开开关（`.result-preview-toggle`，`aria-expanded` 同步），无需跳转详情页即可快速预览完整摘要；短摘要卡片不显示开关。验证脚本 `scripts/verify_search_preview.cjs`（`slam` → 10 张卡片 / 4 个预览开关；收起态 clientH 45 < scrollH 89、展开后全显 89）。
-- [ ] 详情页浮窗联动。
+- [x] 详情页浮窗联动：正文里指向站内知识页的内链（`detail.html?id=` / `roadmap.html?id=`）标记为 `.detail-inline-link`，悬停弹出与图谱同款 hover 卡片（类型徽标 + 标题 + 摘要 + 「打开详情页 →」）；徽标优先取 `link-graph.json` 的细类型（concept / task / paper…）与社区色，与迷你图浮窗同口径。双向联动：悬停正文内链 → 「关联知识图谱」迷你图同一节点点亮（`.mini-node-linked`）；悬停迷你图节点 → 正文中指向它的内链点亮（`.detail-inline-link-linked`）。触屏（`hover: none`）不绑定，点击仍直接跳转。验证脚本 `scripts/verify_detail_inline_link_preview.cjs`（`wiki-concepts-sim2real` → 内链 Locomotion 浮窗可见 / 迷你图点亮 1 个节点；反向悬停迷你图节点 → 正文点亮 1 条内链）。
 - [x] 图谱页移动端动态视口：Chrome 底栏显隐时 `#graph-wrap` 用 `--app-vh`（`visualViewport.height`）撑满，消除下方空白条。
 - [x] 详情页 Markdown 渲染修复：正文独立 `---` 行渲染为分隔线，并按整行分隔符剥离 YAML frontmatter。
 - [x] 首页搜索索引修复：将 `tech-map/`、roadmap 与 references 纳入 `search-index.json`，支持搜索 `tech-map`。

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -167,6 +167,8 @@
     </section>
   </main>
 
+  <div id="detail-inline-link-tooltip" class="graph-hover-tooltip hidden" role="tooltip" aria-hidden="true"></div>
+
   <button class="sidebar-toggle" id="sidebarToggle" aria-label="切换目录侧边栏">
     <svg viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
   </button>

--- a/docs/main.js
+++ b/docs/main.js
@@ -4415,6 +4415,94 @@
     ]);
   }
 
+  // 详情页「正文内链 ↔ 关联知识图谱迷你图」联动桥：
+  // 两侧渲染时机不同（正文同步、迷你图等 link-graph.json），各自注册回调，未就绪的一侧静默跳过。
+  var detailLinkBridge = {
+    highlightMiniNode: null,
+    highlightBodyLink: null,
+    graphNodeOf: null
+  };
+
+  function detailBridgeHighlightMini(path) {
+    if (detailLinkBridge.highlightMiniNode) detailLinkBridge.highlightMiniNode(path || '');
+  }
+
+  function detailBridgeHighlightBody(path) {
+    if (detailLinkBridge.highlightBodyLink) detailLinkBridge.highlightBodyLink(path || '');
+  }
+
+  function buildDetailInlineLinkTooltipHtml(pageId, page) {
+    var isRoadmap = page.type === 'roadmap_page';
+    var href = isRoadmap ? roadmapHref(pageId) : detailHref(pageId);
+    var linkHtml = '<a class="tt-link" href="' + escapeHtml(href) + '">' +
+      (isRoadmap ? '打开路线页 →' : '打开详情页 →') + '</a>';
+    // 图谱节点类型（concept / task / paper…）比 site-data 的 wiki_page 更细，
+    // 取到就用它，保证同一节点在正文浮窗与迷你图浮窗上徽标一致
+    var graphNode = detailLinkBridge.graphNodeOf ? detailLinkBridge.graphNodeOf(page.path || '') : null;
+    if (window.RNGraphTooltip && window.RNGraphTooltip.buildNodeTooltipHtml) {
+      return window.RNGraphTooltip.buildNodeTooltipHtml({
+        type: (graphNode && graphNode.type) || page.type || '',
+        title: page.title || pageId,
+        summary: formatGraphTooltipSummary(page.summary),
+        communityColor: (graphNode && graphNode.communityColor) || '',
+        linkHtml: linkHtml
+      });
+    }
+    return '';
+  }
+
+  // 正文内链悬停浮窗：复用图谱 hover 卡片，同时点亮迷你图中的同一节点
+  function setupDetailInlineLinkPreview(contentEl, detailPages) {
+    if (!contentEl) return;
+    var anchors = contentEl.querySelectorAll('a[href^="detail.html?id="], a[href^="roadmap.html?id="]');
+    var marked = [];
+    for (var i = 0; i < anchors.length; i++) {
+      var anchor = anchors[i];
+      var matched = /^(?:detail|roadmap)\.html\?id=([^&#]+)/.exec(anchor.getAttribute('href') || '');
+      if (!matched) continue;
+      var pid = decodeURIComponent(matched[1]);
+      var page = detailPages[pid];
+      if (!page || !page.path) continue;
+      anchor.classList.add('detail-inline-link');
+      anchor.dataset.wikiId = pid;
+      anchor.dataset.wikiPath = page.path;
+      marked.push(anchor);
+    }
+    if (!marked.length) return;
+
+    detailLinkBridge.highlightBodyLink = function (path) {
+      for (var k = 0; k < marked.length; k++) {
+        marked[k].classList.toggle('detail-inline-link-linked', !!path && marked[k].dataset.wikiPath === path);
+      }
+    };
+
+    var tooltipEl = document.getElementById('detail-inline-link-tooltip');
+    if (!tooltipEl) return;
+    var hoverTip = setupGraphHoverTooltip(tooltipEl);
+    if (hoverTip.isMobile) return; // 触屏无 hover，点击内链直接跳转即可
+
+    function inlineLinkOf(ev) {
+      return ev.target && ev.target.closest ? ev.target.closest('a.detail-inline-link') : null;
+    }
+
+    contentEl.addEventListener('mouseover', function (ev) {
+      var link = inlineLinkOf(ev);
+      if (!link) return;
+      hoverTip.show(ev, null, buildDetailInlineLinkTooltipHtml(link.dataset.wikiId, detailPages[link.dataset.wikiId] || {}));
+      detailBridgeHighlightMini(link.dataset.wikiPath);
+    });
+    contentEl.addEventListener('mousemove', function (ev) {
+      if (inlineLinkOf(ev)) hoverTip.move(ev);
+    });
+    contentEl.addEventListener('mouseout', function (ev) {
+      var link = inlineLinkOf(ev);
+      if (!link) return;
+      if (ev.relatedTarget && link.contains(ev.relatedTarget)) return;
+      hoverTip.hide();
+      detailBridgeHighlightMini('');
+    });
+  }
+
   function renderDetailMiniMap(detailPage, detailPages) {
     var wrap = document.getElementById('detailMiniMapWrap');
     var svgEl = document.getElementById('detailMiniMapSvg');
@@ -4437,6 +4525,16 @@
       (gd.nodes || []).forEach(function (n) { nodeMap[n.id] = n; });
       var current = nodeMap[currentPath];
       if (!current) return; // 当前节点不在图谱里
+
+      // 正文内链浮窗共用图谱节点类型与社区色，保证同一节点两处徽标一致
+      detailLinkBridge.graphNodeOf = function (path) {
+        var node = nodeMap[path];
+        if (!node) return null;
+        return {
+          type: node.type || '',
+          communityColor: (node.community && communityColor[node.community]) || ''
+        };
+      };
 
       // 节点半径继承 graph view 的标尺（graph-node-size.js），度数基准为全图
       var degreeMap = window.RNGraphNodeSize.computeDegreeMap(gd.edges);
@@ -4578,6 +4676,7 @@
           if (pid) window.location.href = pageHref(pid, detailPages);
         })
         .on('mouseenter', function (ev, d) {
+          detailBridgeHighlightBody(d.isCurrent ? '' : d.id);
           if (hoverTip.isMobile) return;
           window.d3.select(this).select('circle')
             .attr('fill-opacity', 1)
@@ -4589,12 +4688,18 @@
           if (!hoverTip.isMobile || !hoverTip.getPinned()) hoverTip.move(ev);
         })
         .on('mouseleave', function () {
+          detailBridgeHighlightBody('');
           if (hoverTip.isMobile) return;
           window.d3.select(this).select('circle')
             .attr('fill-opacity', 0.9)
             .attr('r', function (node) { return detailMiniNodeRadius(node); });
           if (!hoverTip.isMobile || !hoverTip.getPinned()) hoverTip.hide();
         });
+
+      // 正文内链悬停时点亮迷你图中的同一节点
+      detailLinkBridge.highlightMiniNode = function (path) {
+        nodeG.classed('mini-node-linked', function (d) { return !!path && d.id === path; });
+      };
 
       nodeG.append('circle')
         .attr('r', function (d) { return detailMiniNodeRadius(d); })
@@ -4836,6 +4941,7 @@
       });
       scrollToDetailHashTarget(contentEl);
       notifyTocSpyScrollSync();
+      setupDetailInlineLinkPreview(contentEl, detailPages);
       removeLoadingState(contentEl);
     }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -1565,6 +1565,16 @@ button.home-wiki-heatmap-cell.is-active {
   stroke: var(--accent);
   stroke-width: 2.4px;
 }
+/* 正文内链 ↔ 迷你图联动高亮：悬停一侧，另一侧同一节点点亮 */
+.detail-mini-map-svg .mini-node-linked circle {
+  stroke: var(--accent);
+  stroke-width: 2.4px;
+  fill-opacity: 1;
+}
+.detail-mini-map-svg .mini-node-linked text {
+  fill: var(--text);
+  font-weight: 700;
+}
 .detail-content-sync {
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -2080,6 +2090,11 @@ button.home-wiki-heatmap-cell.is-active {
 }
 .detail-markdown-body a {
   color: var(--accent);
+}
+.detail-markdown-body a.detail-inline-link-linked {
+  background: rgba(0, 212, 255, 0.14);
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px rgba(0, 212, 255, 0.14);
 }
 .detail-markdown-body code {
   padding: .12em .38em;

--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## [2026-08-02] structural | docs/main.js — 详情页正文内链悬停浮窗，并与关联知识图谱迷你图双向联动
+
+- **改动：** [`docs/main.js`](docs/main.js) — 正文中指向站内知识页的内链标记为 `.detail-inline-link`，悬停弹出与图谱同款 hover 卡片（类型徽标 + 标题 + 摘要 + 「打开详情页 →」）；类型与社区色优先取 `link-graph.json` 的细类型（concept / task / paper…），与迷你图浮窗同口径
+- **联动：** 悬停正文内链 → 迷你图同一节点点亮（`.mini-node-linked`）；悬停迷你图节点 → 正文中指向它的内链点亮（`.detail-inline-link-linked`）；触屏（`hover: none`）不绑定，点击内链仍直接跳转
+- **涉及路径：** [`docs/detail.html`](docs/detail.html)（新增 `#detail-inline-link-tooltip`）、[`docs/style.css`](docs/style.css)
+- **清单：** [`docs/checklists/frontend-optimization-v1.md`](docs/checklists/frontend-optimization-v1.md) Phase 3「详情页浮窗联动」
+- **验证：** [`scripts/verify_detail_inline_link_preview.cjs`](scripts/verify_detail_inline_link_preview.cjs)（`wiki-concepts-sim2real` → 浮窗可见 / 迷你图点亮 1 节点；反向 → 正文点亮 1 条内链）；`make ci-preflight` 通过
+
 ## [2026-08-02] structural | docs/graph.html — 筛选浮窗三区手风琴（按社区 / 路线视图 / 研究机构）
 
 - **改动：** [`docs/graph.html`](docs/graph.html) — 「按社区（当前维度）/ 路线视图 / 研究机构」同时仅展开一个，默认展开「按社区」；展开区吃满剩余高度，收起项靠上或靠下；`?depth=` / `?community=` / `?institution=` 深链同步打开对应区

--- a/scripts/verify_detail_inline_link_preview.cjs
+++ b/scripts/verify_detail_inline_link_preview.cjs
@@ -1,0 +1,123 @@
+// 验证：详情页「正文内链 ↔ 关联知识图谱迷你图」浮窗联动。
+//
+// 断言两个方向：
+//   1. 悬停正文内链 → 弹出图谱同款浮窗（标题/摘要/打开详情页），迷你图同一节点点亮（.mini-node-linked）
+//   2. 悬停迷你图节点 → 正文中指向该节点的内链点亮（.detail-inline-link-linked）
+//
+// 前置：仓库根目录先生成站点数据并起静态服务
+//   make export graph
+//   cd docs && python3 -m http.server 8765
+//
+// 用法（仓库根目录）：
+//   node scripts/verify_detail_inline_link_preview.cjs [baseUrl] [outDir] [pageId]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  const base = process.argv[2] || 'http://127.0.0.1:8765';
+  const outDir = process.argv[3] || path.resolve(__dirname, '..', '.cursor-artifacts', 'screenshots');
+  const pageId = process.argv[4] || 'wiki-concepts-sim2real';
+  fs.mkdirSync(outDir, { recursive: true });
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/google-chrome',
+  ].filter(Boolean);
+  const exe = candidates.find((p) => fs.existsSync(p));
+  if (!exe) throw new Error('No Chrome/Chromium found. Set CHROME_PATH.');
+
+  const browser = await puppeteer.launch({
+    executablePath: exe, headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu'],
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1400, height: 1000 });
+    const errs = [];
+    page.on('pageerror', (e) => errs.push(String(e)));
+    await page.goto(base + '/detail.html?id=' + encodeURIComponent(pageId), {
+      waitUntil: 'networkidle2', timeout: 60000,
+    });
+    await page.waitForFunction(
+      () => document.querySelectorAll('#detailContent a.detail-inline-link').length > 0,
+      { timeout: 30000 }
+    );
+    await page.waitForFunction(
+      () => document.querySelectorAll('#detailMiniMapSvg g.mini-node').length > 0,
+      { timeout: 30000 }
+    );
+    // 等力模拟落稳 + 适配动画结束，节点坐标才可用于鼠标命中
+    await new Promise((r) => setTimeout(r, 2500));
+
+    await page.addStyleTag({ content: 'html { scroll-behavior: auto !important; }' });
+
+    // 挑一个「正文内链 + 迷你图节点」都存在的 path，才能验证双向联动
+    const target = await page.evaluate(() => {
+      const miniIds = new Set(
+        [...document.querySelectorAll('#detailMiniMapSvg g.mini-node')].map((g) => g.__data__ && g.__data__.id)
+      );
+      const link = [...document.querySelectorAll('#detailContent a.detail-inline-link')]
+        .find((a) => miniIds.has(a.dataset.wikiPath) && a.getClientRects().length);
+      if (!link) return null;
+      link.id = 'rn-verify-inline-link';
+      // 迷你图在 hero 区，滚动到内链上方留白，保证两者同屏可见
+      window.scrollTo(0, link.getBoundingClientRect().top + window.scrollY - 620);
+      return { wikiPath: link.dataset.wikiPath, wikiId: link.dataset.wikiId, text: link.textContent.trim() };
+    });
+    if (!target) throw new Error('未找到同时出现在正文内链与迷你图中的节点');
+    await new Promise((r) => setTimeout(r, 400));
+
+    // 跨行内链的 boundingRect 会并成整块，取首个行盒中心才落在文字上
+    const linkPoint = await page.evaluate(() => {
+      const r = document.getElementById('rn-verify-inline-link').getClientRects()[0];
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    });
+    await page.mouse.move(linkPoint.x, linkPoint.y);
+    await new Promise((r) => setTimeout(r, 300));
+    const bodyHover = await page.evaluate(() => {
+      const tip = document.getElementById('detail-inline-link-tooltip');
+      return {
+        tooltipVisible: !tip.classList.contains('hidden'),
+        tooltipTitle: (tip.querySelector('.tt-title') || {}).textContent || '',
+        tooltipHasSummary: !!tip.querySelector('.tt-summary'),
+        tooltipHasLink: !!tip.querySelector('.tt-link'),
+        miniLinked: document.querySelectorAll('#detailMiniMapSvg g.mini-node-linked').length,
+      };
+    });
+    await page.screenshot({ path: path.join(outDir, 'detail-inline-link-hover.png') });
+
+    // 反向：鼠标移出正文，滚回 hero 区（迷你图所在）后悬停同一节点
+    await page.mouse.move(5, 5);
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await new Promise((r) => setTimeout(r, 400));
+    const nodeBox = await page.evaluate((wikiPath) => {
+      const g = [...document.querySelectorAll('#detailMiniMapSvg g.mini-node')]
+        .find((el) => el.__data__ && el.__data__.id === wikiPath);
+      if (!g) return null;
+      const c = g.querySelector('circle').getBoundingClientRect();
+      return { x: c.x + c.width / 2, y: c.y + c.height / 2 };
+    }, target.wikiPath);
+    if (!nodeBox) throw new Error('迷你图中找不到目标节点');
+    await page.mouse.move(nodeBox.x, nodeBox.y);
+    await new Promise((r) => setTimeout(r, 300));
+    const miniHover = await page.evaluate(() => ({
+      bodyLinked: document.querySelectorAll('#detailContent a.detail-inline-link-linked').length,
+      miniTooltipVisible: !document.getElementById('detail-mini-map-tooltip').classList.contains('hidden'),
+    }));
+    await page.screenshot({ path: path.join(outDir, 'detail-inline-link-mini-hover.png') });
+
+    console.log('pageerrors :', errs.length ? errs : 'none');
+    console.log('target     :', JSON.stringify(target));
+    console.log('BODY→MINI  :', JSON.stringify(bodyHover));
+    console.log('MINI→BODY  :', JSON.stringify(miniHover));
+
+    const ok = bodyHover.tooltipVisible && bodyHover.tooltipTitle && bodyHover.tooltipHasLink
+      && bodyHover.miniLinked === 1 && miniHover.bodyLinked >= 1 && !errs.length;
+    console.log(ok ? 'PASS' : 'FAIL');
+    process.exitCode = ok ? 0 : 1;
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
## 摘要

推进 `docs/checklists/frontend-optimization-v1.md` Phase 3 剩余项「详情页浮窗联动」：详情页正文里指向站内知识页的内链，悬停即弹出与图谱同款的 hover 卡片，并与页面顶部「关联知识图谱」迷你图**双向**点亮，读者不必跳转就能判断一条内链值不值得点。

- 正文内链（`detail.html?id=` / `roadmap.html?id=`）渲染后标记为 `.detail-inline-link`，悬停弹出浮窗：类型徽标 + 标题 + 摘要 + 「打开详情页 →」
- 徽标类型与社区色优先取 `link-graph.json` 的细类型（concept / task / paper…）而非 site-data 的 `wiki_page`，与迷你图浮窗**同口径**（同一节点两处徽标一致）
- 双向联动：悬停正文内链 → 迷你图同一节点点亮（`.mini-node-linked`）；悬停迷你图节点 → 正文中指向它的内链点亮（`.detail-inline-link-linked`）
- 触屏（`hover: none and pointer: coarse`）不绑定悬停，点击内链仍直接跳转，行为不变

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight` 通过（12/12 导出质量检查、wiki lint 全绿）
- [x] `PYTHONPATH=scripts python3 -m pytest` 全部通过（377 项，覆盖率 62.44% ≥ 阈值 52%）
- [x] `npm run lint:js` 无新增告警（仅存量 `main.js:3842 'err' is defined but never used`）
- [x] `node scripts/verify_detail_inline_link_preview.cjs` → **PASS**

```
pageerrors : none
target     : {"wikiPath":"wiki/tasks/locomotion.md","wikiId":"wiki-tasks-locomotion","text":"Locomotion"}
BODY→MINI  : {"tooltipVisible":true,"tooltipTitle":"Locomotion","tooltipHasSummary":true,"tooltipHasLink":true,"miniLinked":1}
MINI→BODY  : {"bodyLinked":1,"miniTooltipVisible":true}
PASS
```

## 验证截图

正文内链 `Locomotion` 悬停 → 浮窗显示「任务 (TASK)」徽标 + 标题 + 摘要 + 「打开详情页 →」：

``&lt;img alt="详情页正文内链悬停浮窗" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-inline-link-hover.png" /&gt;``

反向：悬停迷你图上的同一节点 → 图谱浮窗弹出，正文中指向它的内链同步点亮（脚本断言 `bodyLinked: 1`）：

``&lt;img alt="迷你图节点悬停联动正文内链" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/detail-inline-link-mini-hover.png" /&gt;``

## 相关 Issue

无


---
_Generated by [Claude Code](https://claude.ai/code/session_019YNN6ysosD2fY7bSN5GPcq)_