### PR TITLE
feat(ux): 图谱筛选增加「更新时间 Top N」滑块

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -91,6 +91,7 @@
   - [x] 图谱页 3D 社区漂浮标签：点「适配屏幕」飞行动画期间锁定胶囊 scale 为落稳尺寸，并提前写入目标距离基线，避免中途 `|cam−lookAt|` 偏离导致标签大小闪一下。
   - [x] 图谱页 `graph.html`：筛选浮窗保留顶部「按类型 / 按社区 / 按健康度」按钮三选一；当前维度的勾选项改为与「路线视图 / 研究机构」一致的可折叠 `<details>`，折叠标题在有选中时显示数量（如 `3 个社区`）。
   - [x] 图谱页 `graph.html`：筛选浮窗内「按社区（当前维度）/ 路线视图 / 研究机构」三区改为手风琴——同时仅展开一个，默认展开「按社区」；展开区吃满中间剩余高度，收起项靠在上方或下方；验证脚本 `scripts/verify_graph_filter_accordion.cjs`。
+  - [x] 图谱页 `graph.html`：筛选浮窗在「连接数 Top N」下方新增「更新时间 Top N」滑块——左=最新子集、右=全部（默认全部）；排序口径对齐 `activity` / 更新明度；与连接数 Top N 同时生效时取交集；清除筛选一并复位；验证脚本 `scripts/verify_graph_recency_topn.cjs`。
   - [x] 图谱页 2D 力模拟：略欠阻尼、**最多一次回弹**（验收以「刷新布局」为准，不用时序动画）——`velocityDecay=0.54`、极短 warmup 20 tick 后 `alpha=0.9` 开场、度数加权弹簧；3D 力参数保持对话前原状。
   - [x] 图谱页 2D 时序动画：退出时清零 `alpha`/`alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3）；`closeSidebar` 仅在侧栏确实打开时才 viewport sync / relayout restart，避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1896,6 +1896,18 @@
                  aria-label="按连接数显示前 N 个节点" />
         </div>
       </div>
+      <div id="filter-recency-section" class="filter-degree-section">
+        <div class="filter-section-title">更新时间 Top N</div>
+        <p class="filter-degree-hint">按最近活跃日保留最新 N 个；滑到最左偏最新，滑到最右为全部节点。可与连接数 Top N 同时生效（取交集）。</p>
+        <div class="slider-row">
+          <div class="slider-label">
+            <span>最新节点数</span>
+            <span class="slider-val" id="val-recency-top">全部</span>
+          </div>
+          <input type="range" id="sl-recency-top" min="10" max="10" value="10" step="1"
+                 aria-label="按更新时间显示最新 N 个节点" />
+        </div>
+      </div>
       <div class="filter-sections-scroll" id="filter-dimension-sections">
         <details class="filter-depth-section" id="filter-dimension-section" open>
           <summary class="filter-depth-summary">
@@ -2735,7 +2747,7 @@
     }
 
     function nodeLabelVisible(d) {
-      return nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
+      return nodeMatchesDegreeTop(d) && nodeMatchesRecencyTop(d) && nodeMatchesCurrentFilter(d)
         && nodeMatchesSearch(d) && nodeMatchesDepth(d) && nodeMatchesInstitutionFilter(d);
     }
 
@@ -3086,6 +3098,69 @@
       });
       slDegreeTop.addEventListener('change', () => {
         if (topDegreeIds) fitToScreen();
+      });
+    }
+
+    /* ── 更新时间 Top N 筛选（滑动条）：左=最新子集，右=全部；
+       排序口径与「更新明度渐变」一致（log.md 最近活跃日 activity / _recencyTs）；
+       无 activity 的节点视为最旧。与连接数 Top N 同时生效时取交集 ── */
+    const recencyTopMin = Math.min(10, totalNodeCount);
+    let topRecencyLimit = totalNodeCount;
+    let topRecencyIds = null;
+
+    function computeTopRecencyIds(limit) {
+      if (limit >= totalNodeCount) return null;
+      return new Set(
+        nodes.slice()
+          .sort((a, b) => {
+            const ta = a._recencyTs != null ? a._recencyTs : -Infinity;
+            const tb = b._recencyTs != null ? b._recencyTs : -Infinity;
+            if (tb !== ta) return tb - ta;
+            return a.id < b.id ? -1 : (a.id > b.id ? 1 : 0);
+          })
+          .slice(0, limit)
+          .map(n => n.id)
+      );
+    }
+
+    function nodeMatchesRecencyTop(d) {
+      return !topRecencyIds || topRecencyIds.has(d.id);
+    }
+
+    function updateRecencyTopLabel() {
+      const valEl = document.getElementById('val-recency-top');
+      if (!valEl) return;
+      valEl.textContent = topRecencyLimit >= totalNodeCount ? '全部' : String(topRecencyLimit);
+    }
+
+    function initRecencyTopSlider() {
+      const slider = document.getElementById('sl-recency-top');
+      if (!slider) return;
+      slider.min = String(recencyTopMin);
+      slider.max = String(totalNodeCount);
+      slider.value = String(topRecencyLimit);
+      updateRecencyTopLabel();
+    }
+
+    function setTopRecencyLimit(limit) {
+      topRecencyLimit = Math.max(recencyTopMin, Math.min(totalNodeCount, Number(limit)));
+      topRecencyIds = computeTopRecencyIds(topRecencyLimit);
+      const slider = document.getElementById('sl-recency-top');
+      if (slider) slider.value = String(topRecencyLimit);
+      updateRecencyTopLabel();
+      applyFilters();
+      updateFilterCount();
+    }
+
+    initRecencyTopSlider();
+    const slRecencyTop = document.getElementById('sl-recency-top');
+    if (slRecencyTop) {
+      slRecencyTop.addEventListener('input', ev => {
+        if (areFiltersLocked()) return;
+        setTopRecencyLimit(ev.target.value);
+      });
+      slRecencyTop.addEventListener('change', () => {
+        if (topRecencyIds) fitToScreen();
       });
     }
 
@@ -3938,7 +4013,8 @@
     }
 
     function hasActiveGraphFilter() {
-      return topDegreeIds !== null || activeFilters.size > 0 || searchQuery.length > 0
+      return topDegreeIds !== null || topRecencyIds !== null
+        || activeFilters.size > 0 || searchQuery.length > 0
         || focusedCommunityId || focusedType || focusedHealth !== null
         || activeInstitutions.size > 0 || currentDepth !== 'all';
     }
@@ -4269,6 +4345,9 @@
       topDegreeLimit = totalNodeCount;
       topDegreeIds = null;
       initDegreeTopSlider();
+      topRecencyLimit = totalNodeCount;
+      topRecencyIds = null;
+      initRecencyTopSlider();
       renderFilterPanel();
       renderInstitutionFilterSection();
       setActiveTopic('all');
@@ -4279,6 +4358,7 @@
     function updateFilterCount() {
       const count = activeFilters.size + activeInstitutions.size
         + (topDegreeIds ? 1 : 0)
+        + (topRecencyIds ? 1 : 0)
         + (currentDepth && currentDepth !== 'all' ? 1 : 0);
       const countEl = document.getElementById('filter-count');
       if (count > 0) {
@@ -4368,7 +4448,8 @@
       let visible = 0;
 
       node.each(function(d) {
-        const ok = nodeMatchesDegreeTop(d) && nodeMatchesCurrentFilter(d)
+        const ok = nodeMatchesDegreeTop(d) && nodeMatchesRecencyTop(d)
+          && nodeMatchesCurrentFilter(d)
           && nodeMatchesSearch(d) && nodeMatchesDepth(d) && nodeMatchesInstitutionFilter(d);
         if (ok) { visible++; visibleNodeIds.add(d.id); }
 
@@ -4403,6 +4484,7 @@
           const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
           if (!s || !t) return 0.2;
           return (nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
+                  && nodeMatchesRecencyTop(s) && nodeMatchesRecencyTop(t)
                   && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesDepth(s) && nodeMatchesInstitutionFilter(s)
                   && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesDepth(t) && nodeMatchesInstitutionFilter(t)) ? 1 : 0.2;
         })
@@ -4412,6 +4494,7 @@
           const t = typeof e.target === 'object' ? e.target : nodes.find(n => n.id === e.target);
           if (!s || !t) return linkWidthBase * 0.5;
           const edgeOk = nodeMatchesDegreeTop(s) && nodeMatchesDegreeTop(t)
+            && nodeMatchesRecencyTop(s) && nodeMatchesRecencyTop(t)
             && edgeMatchesCurrentFilter(s) && nodeMatchesSearch(s) && nodeMatchesDepth(s) && nodeMatchesInstitutionFilter(s)
             && edgeMatchesCurrentFilter(t) && nodeMatchesSearch(t) && nodeMatchesDepth(t) && nodeMatchesInstitutionFilter(t);
           return edgeOk ? linkWidthBase : linkWidthBase * 0.5;

--- a/scripts/verify_graph_recency_topn.cjs
+++ b/scripts/verify_graph_recency_topn.cjs
@@ -1,0 +1,243 @@
+// Verify graph.html「更新时间 Top N」slider: default=all, left=latest subset,
+// AND with degree Top N, clear resets both. Screenshots filter panel states.
+const puppeteer = require('puppeteer-core');
+const path = require('path');
+const fs = require('fs');
+
+const OUT_DIR = path.resolve(__dirname, '..', '.cursor-artifacts', 'screenshots');
+const ART_DIR = '/opt/cursor/artifacts/screenshots';
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  '/usr/local/bin/google-chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+].filter(Boolean);
+const exe = CHROME_CANDIDATES.find((p) => fs.existsSync(p));
+if (!exe) {
+  console.error('No Chrome/Chromium found. Set CHROME_PATH.');
+  process.exit(1);
+}
+const d3Candidates = [
+  path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js'),
+  path.resolve(__dirname, '..', 'docs', 'vendor', 'd3.min.js'),
+];
+const d3Path = d3Candidates.find((p) => fs.existsSync(p));
+if (!d3Path) {
+  console.error('No d3.min.js found in node_modules or docs/vendor.');
+  process.exit(1);
+}
+const d3Body = fs.readFileSync(d3Path);
+
+function copyToArtifacts(src, name) {
+  try {
+    fs.mkdirSync(ART_DIR, { recursive: true });
+    const dest = path.join(ART_DIR, name);
+    fs.copyFileSync(src, dest);
+    return dest;
+  } catch (_) {
+    return null;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+async function preparePage(browser) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+  await page.setRequestInterception(true);
+  page.on('request', (req) => {
+    if (req.url().includes('cdn.jsdelivr.net/npm/d3')) {
+      req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+    } else {
+      req.continue();
+    }
+  });
+  const base = process.env.GRAPH_BASE_URL || 'http://127.0.0.1:8765/graph.html';
+  await page.goto(base, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => {
+    const el = document.getElementById('graph-node-count');
+    return el && el.textContent && !el.textContent.includes('加载中');
+  }, { timeout: 60000 });
+  await page.waitForFunction(() => {
+    const slider = document.getElementById('sl-recency-top');
+    return slider && Number(slider.max) > Number(slider.min);
+  }, { timeout: 30000 });
+  await page.evaluate(() => {
+    const ld = document.getElementById('graph-loading');
+    if (ld) ld.style.display = 'none';
+  });
+  return page;
+}
+
+async function openFilter(page) {
+  await page.click('#filter-toggle');
+  await page.waitForFunction(() => {
+    const panel = document.getElementById('filter-panel');
+    return panel && !panel.hidden && getComputedStyle(panel).display !== 'none';
+  }, { timeout: 5000 });
+}
+
+async function readState(page) {
+  return page.evaluate(() => {
+    const slider = document.getElementById('sl-recency-top');
+    const label = document.getElementById('val-recency-top');
+    const countEl = document.getElementById('graph-node-count');
+    const badge = document.getElementById('filter-count');
+    const degSlider = document.getElementById('sl-degree-top');
+    const visible = [];
+    document.querySelectorAll('#graph-canvas .nodes g').forEach((g) => {
+      const op = getComputedStyle(g).opacity;
+      const pe = getComputedStyle(g).pointerEvents;
+      if (Number(op) > 0.5 && pe !== 'none') {
+        const title = g.querySelector('title');
+        // fallback: data from __data__ via d3 not available; use circle presence
+        visible.push(g.getAttribute('data-id') || g.id || 'node');
+      }
+    });
+    // Prefer the toolbar count text which applyFilters updates
+    return {
+      min: Number(slider.min),
+      max: Number(slider.max),
+      value: Number(slider.value),
+      label: label ? label.textContent.trim() : '',
+      countText: countEl ? countEl.textContent.trim() : '',
+      badgeText: badge && badge.style.display !== 'none' ? badge.textContent.trim() : '',
+      badgeVisible: !!(badge && badge.style.display !== 'none'),
+      degValue: degSlider ? Number(degSlider.value) : null,
+      degMax: degSlider ? Number(degSlider.max) : null,
+      sectionExists: !!document.getElementById('filter-recency-section'),
+    };
+  });
+}
+
+async function setRecency(page, value) {
+  await page.$eval('#sl-recency-top', (el, v) => {
+    el.value = String(v);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+async function setDegree(page, value) {
+  await page.$eval('#sl-degree-top', (el, v) => {
+    el.value = String(v);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+function parseVisibleCount(countText) {
+  // e.g. "128 / 2072 节点" or "2072 节点"
+  const m = countText.match(/(\d+)\s*\/\s*(\d+)/);
+  if (m) return { visible: Number(m[1]), total: Number(m[2]) };
+  const m2 = countText.match(/(\d+)/);
+  if (m2) return { visible: Number(m2[1]), total: Number(m2[1]) };
+  return { visible: NaN, total: NaN };
+}
+
+(async () => {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--ignore-certificate-errors'],
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const page = await preparePage(browser);
+    await openFilter(page);
+
+    const initial = await readState(page);
+    console.log('initial', initial);
+    assert(initial.sectionExists, 'filter-recency-section missing');
+    assert(initial.value === initial.max, `default should be max/all, got value=${initial.value} max=${initial.max}`);
+    assert(initial.label === '全部', `default label should be 全部, got ${initial.label}`);
+    assert(!initial.badgeVisible, 'filter badge should be hidden at default');
+
+    const shotAll = path.join(OUT_DIR, 'graph-recency-topn-all.png');
+    await page.screenshot({ path: shotAll, fullPage: false });
+    copyToArtifacts(shotAll, 'graph-recency-topn-all.png');
+    console.log('Saved:', shotAll);
+
+    // Slide to minimum (latest subset)
+    await setRecency(page, initial.min);
+    const latest = await readState(page);
+    console.log('latest', latest);
+    assert(latest.value === latest.min, `min value expected ${latest.min}, got ${latest.value}`);
+    assert(latest.label === String(latest.min), `label should be ${latest.min}, got ${latest.label}`);
+    assert(latest.badgeVisible, 'filter badge should show when recency Top N active');
+    const latestCounts = parseVisibleCount(latest.countText);
+    assert(latestCounts.visible === latest.min, `visible count should be ${latest.min}, got ${latest.countText}`);
+    assert(latestCounts.total === latest.max, `total should be ${latest.max}, got ${latest.countText}`);
+
+    const shotLatest = path.join(OUT_DIR, 'graph-recency-topn-latest.png');
+    await page.screenshot({ path: shotLatest, fullPage: false });
+    copyToArtifacts(shotLatest, 'graph-recency-topn-latest.png');
+    console.log('Saved:', shotLatest);
+
+    // Mid value
+    const mid = Math.max(latest.min, Math.round(latest.max * 0.25));
+    await setRecency(page, mid);
+    const midState = await readState(page);
+    const midCounts = parseVisibleCount(midState.countText);
+    assert(midCounts.visible === mid, `mid visible should be ${mid}, got ${midState.countText}`);
+
+    // AND with degree Top N — expected size from page-side sets
+    const degN = Math.max(initial.min, 20);
+    await setDegree(page, degN);
+    const expectedAnd = await page.evaluate((recN, degLimit) => {
+      // Recompute from node circles' __data__ if present; else trust toolbar only.
+      const nodes = [];
+      const sel = d3.selectAll('#graph-canvas .node-g');
+      if (!sel.empty()) {
+        sel.each(function (d) { if (d && d.id) nodes.push(d); });
+      }
+      if (!nodes.length) return null;
+      const byDegree = nodes.slice().sort((a, b) => (b._degree || 0) - (a._degree || 0)).slice(0, degLimit).map((n) => n.id);
+      const byRecency = nodes.slice().sort((a, b) => {
+        const ta = a._recencyTs != null ? a._recencyTs : -Infinity;
+        const tb = b._recencyTs != null ? b._recencyTs : -Infinity;
+        if (tb !== ta) return tb - ta;
+        return a.id < b.id ? -1 : (a.id > b.id ? 1 : 0);
+      }).slice(0, recN).map((n) => n.id);
+      const degSet = new Set(byDegree);
+      return byRecency.filter((id) => degSet.has(id)).length;
+    }, mid, degN);
+    const andState = await readState(page);
+    const andCounts = parseVisibleCount(andState.countText);
+    console.log('and', andState, andCounts, 'expected', expectedAnd);
+    assert(andCounts.visible <= Math.min(mid, degN),
+      `AND visible ${andCounts.visible} should be <= min(${mid},${degN})`);
+    if (expectedAnd != null) {
+      assert(andCounts.visible === expectedAnd,
+        `AND visible ${andCounts.visible} should equal expected ${expectedAnd}`);
+    }
+
+    const shotAnd = path.join(OUT_DIR, 'graph-recency-topn-and-degree.png');
+    await page.screenshot({ path: shotAnd, fullPage: false });
+    copyToArtifacts(shotAnd, 'graph-recency-topn-and-degree.png');
+    console.log('Saved:', shotAnd);
+
+    // Clear resets both
+    await page.click('#filter-clear');
+    await new Promise((r) => setTimeout(r, 300));
+    const cleared = await readState(page);
+    console.log('cleared', cleared);
+    assert(cleared.value === cleared.max, 'clear should reset recency to max');
+    assert(cleared.label === '全部', 'clear label should be 全部');
+    assert(cleared.degValue === cleared.degMax, 'clear should reset degree to max');
+    assert(!cleared.badgeVisible, 'badge hidden after clear');
+
+    console.log('OK verify_graph_recency_topn');
+  } finally {
+    await browser.close();
+  }
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 在图谱筛选浮窗「连接数 Top N」下方新增「更新时间 Top N」滑块：滑到最左显示最新节点，滑到最右显示全部节点（默认全部）。
- 排序口径对齐现有 `activity` / 更新明度渐变；与连接数 Top N 同时生效时取交集；「清除全部」一并复位。

## 验证
- `make ci-preflight` 通过
- `node scripts/verify_graph_recency_topn.cjs` 通过（默认全部 → 最新 10 → 与度数 Top 20 交集 → 清除复位）

## 验证截图
默认（全部）：
![更新时间 Top N 默认全部](https://cursor.com/artifacts/c/art-7101c93e-3028-4358-89be-0a4f148c8d2b)

滑到最左（最新 10）：
![更新时间 Top N 最新 10 节点](https://cursor.com/artifacts/c/art-a2209665-23fb-4179-bdce-731e9fa69ad7)

与连接数 Top N 取交集：
![更新时间与连接数 Top N 交集](https://cursor.com/artifacts/c/art-a30b82f9-1556-4921-89fc-e36b3711f298)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ace29710-b1ae-4147-95d3-9aa2e12074ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ace29710-b1ae-4147-95d3-9aa2e12074ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

