### PR TITLE
feat(ux): 图谱筛选连接数/更新时间 Top N 默认折叠

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -93,6 +93,7 @@
   - [x] 图谱页 `graph.html`：筛选浮窗内「按社区（当前维度）/ 路线视图 / 研究机构」三区改为手风琴——同时仅展开一个，默认展开「按社区」；展开区吃满中间剩余高度，收起项靠在上方或下方；验证脚本 `scripts/verify_graph_filter_accordion.cjs`。
   - [x] 图谱页 `graph.html`：筛选浮窗在「连接数 Top N」下方新增「更新时间 Top N」滑块——左=最新子集、右=全部（默认全部）；排序口径对齐 `activity` / 更新明度；与连接数 Top N 同时生效时取交集；清除筛选一并复位；验证脚本 `scripts/verify_graph_recency_topn.cjs`。
   - [x] 图谱页 `graph.html`：筛选浮窗「连接数 Top N / 更新时间 Top N」改为与下方手风琴同款可折叠 `<details>`（默认收起；折叠标题显示当前值如「全部」/`N`；独立开关，不进三区互斥）；验证脚本 `scripts/verify_graph_topn_collapse.cjs`。
+  - [x] 图谱页 `graph.html`：筛选浮窗「当前按…着色与筛选」文案上移到标题栏正下方（模式 tab 之上）。
   - [x] 图谱页 2D 力模拟：略欠阻尼、**最多一次回弹**（验收以「刷新布局」为准，不用时序动画）——`velocityDecay=0.54`、极短 warmup 20 tick 后 `alpha=0.9` 开场、度数加权弹簧；3D 力参数保持对话前原状。
   - [x] 图谱页 2D 时序动画：退出时清零 `alpha`/`alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3）；`closeSidebar` 仅在侧栏确实打开时才 viewport sync / relayout restart，避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -92,7 +92,7 @@
   - [x] 图谱页 `graph.html`：筛选浮窗保留顶部「按类型 / 按社区 / 按健康度」按钮三选一；当前维度的勾选项改为与「路线视图 / 研究机构」一致的可折叠 `<details>`，折叠标题在有选中时显示数量（如 `3 个社区`）。
   - [x] 图谱页 `graph.html`：筛选浮窗内「按社区（当前维度）/ 路线视图 / 研究机构」三区改为手风琴——同时仅展开一个，默认展开「按社区」；展开区吃满中间剩余高度，收起项靠在上方或下方；验证脚本 `scripts/verify_graph_filter_accordion.cjs`。
   - [x] 图谱页 `graph.html`：筛选浮窗在「连接数 Top N」下方新增「更新时间 Top N」滑块——左=最新子集、右=全部（默认全部）；排序口径对齐 `activity` / 更新明度；与连接数 Top N 同时生效时取交集；清除筛选一并复位；验证脚本 `scripts/verify_graph_recency_topn.cjs`。
-  - [x] 图谱页 `graph.html`：筛选浮窗「连接数 Top N / 更新时间 Top N」改为与下方手风琴同款可折叠 `<details>`（默认收起；折叠标题显示当前值如「全部」/`N`；独立开关，不进三区互斥）；验证脚本 `scripts/verify_graph_topn_collapse.cjs`。
+  - [x] 图谱页 `graph.html`：筛选浮窗「连接数 Top N / 更新时间 Top N」改为与下方手风琴同款可折叠 `<details>`（默认收起；折叠标题显示当前值如「全部」/`N`；两区互斥二选一，可全部收起；不进三区互斥）；验证脚本 `scripts/verify_graph_topn_collapse.cjs`。
   - [x] 图谱页 `graph.html`：筛选浮窗「当前按…着色与筛选」文案上移到标题栏正下方（模式 tab 之上）。
   - [x] 图谱页 2D 力模拟：略欠阻尼、**最多一次回弹**（验收以「刷新布局」为准，不用时序动画）——`velocityDecay=0.54`、极短 warmup 20 tick 后 `alpha=0.9` 开场、度数加权弹簧；3D 力参数保持对话前原状。
   - [x] 图谱页 2D 时序动画：退出时清零 `alpha`/`alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3）；`closeSidebar` 仅在侧栏确实打开时才 viewport sync / relayout restart，避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -92,6 +92,7 @@
   - [x] 图谱页 `graph.html`：筛选浮窗保留顶部「按类型 / 按社区 / 按健康度」按钮三选一；当前维度的勾选项改为与「路线视图 / 研究机构」一致的可折叠 `<details>`，折叠标题在有选中时显示数量（如 `3 个社区`）。
   - [x] 图谱页 `graph.html`：筛选浮窗内「按社区（当前维度）/ 路线视图 / 研究机构」三区改为手风琴——同时仅展开一个，默认展开「按社区」；展开区吃满中间剩余高度，收起项靠在上方或下方；验证脚本 `scripts/verify_graph_filter_accordion.cjs`。
   - [x] 图谱页 `graph.html`：筛选浮窗在「连接数 Top N」下方新增「更新时间 Top N」滑块——左=最新子集、右=全部（默认全部）；排序口径对齐 `activity` / 更新明度；与连接数 Top N 同时生效时取交集；清除筛选一并复位；验证脚本 `scripts/verify_graph_recency_topn.cjs`。
+  - [x] 图谱页 `graph.html`：筛选浮窗「连接数 Top N / 更新时间 Top N」改为与下方手风琴同款可折叠 `<details>`（默认收起；折叠标题显示当前值如「全部」/`N`；独立开关，不进三区互斥）；验证脚本 `scripts/verify_graph_topn_collapse.cjs`。
   - [x] 图谱页 2D 力模拟：略欠阻尼、**最多一次回弹**（验收以「刷新布局」为准，不用时序动画）——`velocityDecay=0.54`、极短 warmup 20 tick 后 `alpha=0.9` 开场、度数加权弹簧；3D 力参数保持对话前原状。
   - [x] 图谱页 2D 时序动画：退出时清零 `alpha`/`alphaTarget` 并停模拟（不再走 pause 路径把加热目标钉在 0.3）；`closeSidebar` 仅在侧栏确实打开时才 viewport sync / relayout restart，避免「退出后点空白 → 力模拟自振抖动」；验证脚本 `scripts/verify_graph_timeline_exit_settle.cjs`。
 - [x] 首页「互链枢纽 · Top 10」底部入口改为「查看完整榜单 →」，新增 `docs/hubs.html` 全量互链榜单页（数据源 `exports/hub-rankings.json`，全站 / 论文双 tab）。

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1399,7 +1399,7 @@
       font-family: inherit;
     }
     /* Top N 滑块区：与下方手风琴同款可折叠 <details>，默认收起；
-       独立开关（不进三区互斥），展开只占内容高度 */
+       两区互斥（同时仅展开一个，可全部收起），不进下方三区手风琴 */
     .filter-degree-section {
       padding: 0;
       border-bottom: 1px solid rgba(255,255,255,0.06);
@@ -2240,6 +2240,30 @@
       setTimeout(syncOpenFilterPaneScrollbar, 800);
     }
     initFilterAccordion();
+
+    /* 连接数 / 更新时间 Top N：二选一展开，允许全部收起 */
+    const FILTER_TOPN_SECTION_IDS = [
+      'filter-degree-section',
+      'filter-recency-section',
+    ];
+    let filterTopNAccordionLock = false;
+
+    function initFilterTopNAccordion() {
+      const sections = FILTER_TOPN_SECTION_IDS
+        .map((id) => document.getElementById(id))
+        .filter(Boolean);
+      if (sections.length < 2) return;
+      sections.forEach((section) => {
+        section.addEventListener('toggle', () => {
+          if (filterTopNAccordionLock) return;
+          if (!section.open) return;
+          filterTopNAccordionLock = true;
+          sections.forEach((s) => { if (s !== section) s.open = false; });
+          filterTopNAccordionLock = false;
+        });
+      });
+    }
+    initFilterTopNAccordion();
 
     function isFilterPanelMobileMode() {
       return window.matchMedia('(max-width: 768px)').matches;

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1393,7 +1393,7 @@
       flex-wrap: wrap;
     }
     .filter-subtitle {
-      padding: 10px 14px 2px;
+      padding: 8px 14px 0;
       font-size: .72rem;
       color: rgba(255,255,255,0.4);
       font-family: inherit;
@@ -1887,12 +1887,12 @@
         <span id="filter-panel-title">🔍 图谱筛选</span>
         <button id="filter-close" class="filter-close" aria-label="关闭面板">✕</button>
       </div>
+      <div class="filter-subtitle" id="filter-subtitle">当前按社区着色与筛选</div>
       <div class="filter-mode-tabs" id="filter-mode-tabs" aria-label="筛选维度">
         <button id="filter-mode-type" class="chip" type="button">按类型</button>
         <button id="filter-mode-community" class="chip active" type="button">按社区</button>
         <button id="filter-mode-health" class="chip" type="button">按健康度</button>
       </div>
-      <div class="filter-subtitle" id="filter-subtitle">当前按社区着色与筛选</div>
       <details id="filter-degree-section" class="filter-degree-section">
         <summary class="filter-depth-summary">
           <span class="filter-depth-summary-label">连接数 Top N</span>

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1398,9 +1398,18 @@
       color: rgba(255,255,255,0.4);
       font-family: inherit;
     }
+    /* Top N 滑块区：与下方手风琴同款可折叠 <details>，默认收起；
+       独立开关（不进三区互斥），展开只占内容高度 */
     .filter-degree-section {
-      padding: 0 0 4px;
+      padding: 0;
       border-bottom: 1px solid rgba(255,255,255,0.06);
+      flex-shrink: 0;
+    }
+    .filter-degree-section > .filter-depth-summary {
+      padding: 8px 14px;
+    }
+    .filter-degree-section[open] > .filter-depth-summary {
+      padding-bottom: 4px;
     }
     .filter-degree-section .slider-row {
       padding: 4px 14px 12px;
@@ -1884,8 +1893,11 @@
         <button id="filter-mode-health" class="chip" type="button">按健康度</button>
       </div>
       <div class="filter-subtitle" id="filter-subtitle">当前按社区着色与筛选</div>
-      <div id="filter-degree-section" class="filter-degree-section">
-        <div class="filter-section-title">连接数 Top N</div>
+      <details id="filter-degree-section" class="filter-degree-section">
+        <summary class="filter-depth-summary">
+          <span class="filter-depth-summary-label">连接数 Top N</span>
+          <span class="filter-depth-summary-current" id="filter-degree-current">全部</span>
+        </summary>
         <p class="filter-degree-hint">按节点连接数（度）保留前 N 个；滑到最右为全部节点。</p>
         <div class="slider-row">
           <div class="slider-label">
@@ -1895,9 +1907,12 @@
           <input type="range" id="sl-degree-top" min="10" max="10" value="10" step="1"
                  aria-label="按连接数显示前 N 个节点" />
         </div>
-      </div>
-      <div id="filter-recency-section" class="filter-degree-section">
-        <div class="filter-section-title">更新时间 Top N</div>
+      </details>
+      <details id="filter-recency-section" class="filter-degree-section">
+        <summary class="filter-depth-summary">
+          <span class="filter-depth-summary-label">更新时间 Top N</span>
+          <span class="filter-depth-summary-current" id="filter-recency-current">全部</span>
+        </summary>
         <p class="filter-degree-hint">按最近活跃日保留最新 N 个；滑到最左偏最新，滑到最右为全部节点。可与连接数 Top N 同时生效（取交集）。</p>
         <div class="slider-row">
           <div class="slider-label">
@@ -1907,7 +1922,7 @@
           <input type="range" id="sl-recency-top" min="10" max="10" value="10" step="1"
                  aria-label="按更新时间显示最新 N 个节点" />
         </div>
-      </div>
+      </details>
       <div class="filter-sections-scroll" id="filter-dimension-sections">
         <details class="filter-depth-section" id="filter-dimension-section" open>
           <summary class="filter-depth-summary">
@@ -3065,9 +3080,11 @@
     }
 
     function updateDegreeTopLabel() {
+      const text = topDegreeLimit >= totalNodeCount ? '全部' : String(topDegreeLimit);
       const valEl = document.getElementById('val-degree-top');
-      if (!valEl) return;
-      valEl.textContent = topDegreeLimit >= totalNodeCount ? '全部' : String(topDegreeLimit);
+      if (valEl) valEl.textContent = text;
+      const summaryEl = document.getElementById('filter-degree-current');
+      if (summaryEl) summaryEl.textContent = text;
     }
 
     function initDegreeTopSlider() {
@@ -3128,9 +3145,11 @@
     }
 
     function updateRecencyTopLabel() {
+      const text = topRecencyLimit >= totalNodeCount ? '全部' : String(topRecencyLimit);
       const valEl = document.getElementById('val-recency-top');
-      if (!valEl) return;
-      valEl.textContent = topRecencyLimit >= totalNodeCount ? '全部' : String(topRecencyLimit);
+      if (valEl) valEl.textContent = text;
+      const summaryEl = document.getElementById('filter-recency-current');
+      if (summaryEl) summaryEl.textContent = text;
     }
 
     function initRecencyTopSlider() {

--- a/scripts/verify_graph_topn_collapse.cjs
+++ b/scripts/verify_graph_topn_collapse.cjs
@@ -1,5 +1,6 @@
 // Verify graph filter Top N sections are collapsible <details>, default closed,
-// and summary shows current value (全部 / N). Independent of the 三区 accordion.
+// summary shows current value (全部 / N), and the two are mutually exclusive
+// (only one open at a time; both may be closed). Independent of the 三区 accordion.
 const puppeteer = require('puppeteer-core');
 const path = require('path');
 const fs = require('fs');
@@ -135,12 +136,23 @@ async function readTopN(page) {
     copyToArtifacts(degOpenOut, 'graph-filter-topn-degree-open.png');
     console.log('Saved:', degOpenOut);
 
-    // Expand 更新时间 Top N (independent — both may be open)
+    // Expand 更新时间 Top N → 连接数应收起（二选一）
     await page.click('#filter-recency-section > summary');
     await new Promise((r) => setTimeout(r, 250));
     state = await readTopN(page);
-    assert(state.degOpen && state.recOpen, 'both Top N can be open independently');
+    assert(!state.degOpen && state.recOpen, 'Top N should be exclusive: only recency open');
     assert(state.dimOpen, 'accordion still open');
+
+    const recOpenOut = path.join(OUT_DIR, 'graph-filter-topn-recency-open.png');
+    await page.screenshot({ path: recOpenOut, fullPage: false });
+    copyToArtifacts(recOpenOut, 'graph-filter-topn-recency-open.png');
+    console.log('Saved:', recOpenOut);
+
+    // Switch back to degree → recency closes
+    await page.click('#filter-degree-section > summary');
+    await new Promise((r) => setTimeout(r, 250));
+    state = await readTopN(page);
+    assert(state.degOpen && !state.recOpen, 'switching to degree should close recency');
 
     // Change slider → summary updates while open
     await page.$eval('#sl-degree-top', (el) => {
@@ -153,19 +165,19 @@ async function readTopN(page) {
     assert(state.degSummary === minLabel, `degree summary should be ${minLabel}, got ${state.degSummary}`);
     assert(state.degVal === minLabel, `degree slider label should be ${minLabel}`);
 
-    const bothOut = path.join(OUT_DIR, 'graph-filter-topn-both-open.png');
-    await page.screenshot({ path: bothOut, fullPage: false });
-    copyToArtifacts(bothOut, 'graph-filter-topn-both-open.png');
-    console.log('Saved:', bothOut);
+    const exclusiveOut = path.join(OUT_DIR, 'graph-filter-topn-exclusive.png');
+    await page.screenshot({ path: exclusiveOut, fullPage: false });
+    copyToArtifacts(exclusiveOut, 'graph-filter-topn-exclusive.png');
+    console.log('Saved:', exclusiveOut);
 
-    // Collapse degree again — summary still shows active N
+    // Collapse degree — both may be closed
     await page.click('#filter-degree-section > summary');
     await new Promise((r) => setTimeout(r, 200));
     state = await readTopN(page);
-    assert(!state.degOpen && state.recOpen, 'degree collapsed, recency still open');
+    assert(!state.degOpen && !state.recOpen, 'both Top N may collapse');
     assert(state.degSummary === minLabel, 'collapsed summary keeps active value');
 
-    console.log('OK: Top N collapse default + independent toggle verified');
+    console.log('OK: Top N collapse default + exclusive toggle verified');
   } finally {
     await browser.close();
   }

--- a/scripts/verify_graph_topn_collapse.cjs
+++ b/scripts/verify_graph_topn_collapse.cjs
@@ -1,0 +1,175 @@
+// Verify graph filter Top N sections are collapsible <details>, default closed,
+// and summary shows current value (全部 / N). Independent of the 三区 accordion.
+const puppeteer = require('puppeteer-core');
+const path = require('path');
+const fs = require('fs');
+
+const OUT_DIR = path.resolve(__dirname, '..', '.cursor-artifacts', 'screenshots');
+const ART_DIR = '/opt/cursor/artifacts/screenshots';
+const CHROME_CANDIDATES = [
+  process.env.CHROME_PATH,
+  '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+  '/usr/local/bin/google-chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+].filter(Boolean);
+const exe = CHROME_CANDIDATES.find((p) => fs.existsSync(p));
+if (!exe) {
+  console.error('No Chrome/Chromium found. Set CHROME_PATH.');
+  process.exit(1);
+}
+const d3Candidates = [
+  path.resolve(__dirname, '..', 'node_modules', 'd3', 'dist', 'd3.min.js'),
+  path.resolve(__dirname, '..', 'docs', 'vendor', 'd3.min.js'),
+];
+const d3Path = d3Candidates.find((p) => fs.existsSync(p));
+if (!d3Path) {
+  console.error('No d3.min.js found.');
+  process.exit(1);
+}
+const d3Body = fs.readFileSync(d3Path);
+
+function copyToArtifacts(src, name) {
+  try {
+    fs.mkdirSync(ART_DIR, { recursive: true });
+    const dest = path.join(ART_DIR, name);
+    fs.copyFileSync(src, dest);
+    return dest;
+  } catch (_) {
+    return null;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+async function readTopN(page) {
+  return page.evaluate(() => {
+    const deg = document.getElementById('filter-degree-section');
+    const rec = document.getElementById('filter-recency-section');
+    const dim = document.getElementById('filter-dimension-section');
+    return {
+      degIsDetails: deg && deg.tagName === 'DETAILS',
+      recIsDetails: rec && rec.tagName === 'DETAILS',
+      degOpen: !!(deg && deg.open),
+      recOpen: !!(rec && rec.open),
+      degSummary: document.getElementById('filter-degree-current')?.textContent.trim() || '',
+      recSummary: document.getElementById('filter-recency-current')?.textContent.trim() || '',
+      degVal: document.getElementById('val-degree-top')?.textContent.trim() || '',
+      recVal: document.getElementById('val-recency-top')?.textContent.trim() || '',
+      degHeight: deg ? deg.getBoundingClientRect().height : 0,
+      recHeight: rec ? rec.getBoundingClientRect().height : 0,
+      degSummaryH: deg?.querySelector('summary')?.getBoundingClientRect().height || 0,
+      recSummaryH: rec?.querySelector('summary')?.getBoundingClientRect().height || 0,
+      dimOpen: !!(dim && dim.open),
+    };
+  });
+}
+
+(async () => {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-gpu', '--ignore-certificate-errors'],
+    ignoreHTTPSErrors: true,
+  });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      if (req.url().includes('cdn.jsdelivr.net/npm/d3')) {
+        req.respond({ status: 200, contentType: 'application/javascript', body: d3Body });
+      } else {
+        req.continue();
+      }
+    });
+    const base = process.env.GRAPH_BASE_URL || 'http://127.0.0.1:8765/graph.html';
+    await page.goto(base, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => {
+      const el = document.getElementById('graph-node-count');
+      return el && el.textContent && !el.textContent.includes('加载中');
+    }, { timeout: 60000 });
+    await page.waitForFunction(() => {
+      const slider = document.getElementById('sl-degree-top');
+      return slider && Number(slider.max) > Number(slider.min);
+    }, { timeout: 30000 });
+    await page.evaluate(() => {
+      const ld = document.getElementById('graph-loading');
+      if (ld) ld.style.display = 'none';
+    });
+
+    await page.click('#filter-toggle');
+    await page.waitForFunction(() => {
+      const panel = document.getElementById('filter-panel');
+      return panel && !panel.hidden;
+    }, { timeout: 5000 });
+    await new Promise((r) => setTimeout(r, 400));
+
+    let state = await readTopN(page);
+    console.log('default', state);
+    assert(state.degIsDetails && state.recIsDetails, 'Top N sections should be <details>');
+    assert(!state.degOpen && !state.recOpen, 'Top N should default collapsed');
+    assert(state.degSummary === '全部' && state.recSummary === '全部', 'summary should show 全部');
+    assert(state.degHeight <= state.degSummaryH + 8, `degree collapsed too tall: ${state.degHeight}`);
+    assert(state.recHeight <= state.recSummaryH + 8, `recency collapsed too tall: ${state.recHeight}`);
+    assert(state.dimOpen, 'dimension accordion default open should be preserved');
+
+    const collapsedOut = path.join(OUT_DIR, 'graph-filter-topn-collapsed.png');
+    await page.screenshot({ path: collapsedOut, fullPage: false });
+    copyToArtifacts(collapsedOut, 'graph-filter-topn-collapsed.png');
+    console.log('Saved:', collapsedOut);
+
+    // Expand 连接数 Top N
+    await page.click('#filter-degree-section > summary');
+    await new Promise((r) => setTimeout(r, 250));
+    state = await readTopN(page);
+    assert(state.degOpen && !state.recOpen, 'only degree should open');
+    assert(state.degHeight > state.degSummaryH + 20, 'degree open should show slider');
+    assert(state.dimOpen, 'opening Top N must not close dimension accordion');
+
+    const degOpenOut = path.join(OUT_DIR, 'graph-filter-topn-degree-open.png');
+    await page.screenshot({ path: degOpenOut, fullPage: false });
+    copyToArtifacts(degOpenOut, 'graph-filter-topn-degree-open.png');
+    console.log('Saved:', degOpenOut);
+
+    // Expand 更新时间 Top N (independent — both may be open)
+    await page.click('#filter-recency-section > summary');
+    await new Promise((r) => setTimeout(r, 250));
+    state = await readTopN(page);
+    assert(state.degOpen && state.recOpen, 'both Top N can be open independently');
+    assert(state.dimOpen, 'accordion still open');
+
+    // Change slider → summary updates while open
+    await page.$eval('#sl-degree-top', (el) => {
+      el.value = el.min;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    state = await readTopN(page);
+    const minLabel = await page.$eval('#sl-degree-top', (el) => String(el.min));
+    assert(state.degSummary === minLabel, `degree summary should be ${minLabel}, got ${state.degSummary}`);
+    assert(state.degVal === minLabel, `degree slider label should be ${minLabel}`);
+
+    const bothOut = path.join(OUT_DIR, 'graph-filter-topn-both-open.png');
+    await page.screenshot({ path: bothOut, fullPage: false });
+    copyToArtifacts(bothOut, 'graph-filter-topn-both-open.png');
+    console.log('Saved:', bothOut);
+
+    // Collapse degree again — summary still shows active N
+    await page.click('#filter-degree-section > summary');
+    await new Promise((r) => setTimeout(r, 200));
+    state = await readTopN(page);
+    assert(!state.degOpen && state.recOpen, 'degree collapsed, recency still open');
+    assert(state.degSummary === minLabel, 'collapsed summary keeps active value');
+
+    console.log('OK: Top N collapse default + independent toggle verified');
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 筛选浮窗内「连接数 Top N」「更新时间 Top N」改为可折叠 `<details>`，默认收起
- 两区展开互斥（二选一），可全部收起；不进入下方三区手风琴
- 折叠标题同步显示当前值（`全部` / `N`）
- 「当前按…着色与筛选」文案上移到标题栏正下方、模式 tab 之上

## 验证
- `scripts/verify_graph_topn_collapse.cjs` 通过（默认收起 / 互斥展开 / 摘要同步）
- `scripts/verify_graph_recency_topn.cjs` 通过（滑块逻辑未回归）
- `scripts/verify_graph_filter_accordion.cjs` 通过（三区手风琴未回归）

## 验证截图
副标题置顶 + Top N 默认折叠：

![副标题置顶与 Top N 折叠](https://cursor.com/artifacts/c/art-3b333ce7-63f0-4f5f-aa44-cbb7dea0ec68)

展开「连接数 Top N」：

![连接数 Top N 展开](https://cursor.com/artifacts/c/art-129f1750-55a3-4176-8999-f6d4849b3e71)

切换展开「更新时间 Top N」（连接数自动收起）：

![更新时间 Top N 展开](https://cursor.com/artifacts/c/art-a4eb14e1-0f2b-453c-a3fe-503983684cd3)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88ae81a9-ebf2-43e1-813d-3adb0653d695?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88ae81a9-ebf2-43e1-813d-3adb0653d695&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

