### PR TITLE
fix(ux): 消除首页规模数字刷新闪跳与卡顿

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -100,7 +100,7 @@
 - [x] 首页 Hero 盘点条新增「主路线」（数字 1，位于「互链关系」与「纵深路线」之间）；四项数字可点：知识节点 / 互链关系 → `graph.html`，主路线 → 锚到「从零开始」卡并顺时针描边一圈，纵深路线 → 锚到「更多路线」卡描边一圈（不展开）后短时高亮「展开全部…」文案。
 - [x] 首页入口卡边框描边多分辨率对齐：SVG 改为按 border-box 像素定位（计入 border 宽度与亚像素 `getBoundingClientRect`），去掉 padding-box `inset`/`%` 尺寸冲突；圆角跟随 computed `border-radius`；动画期间 ResizeObserver 跟随卡片尺寸。
 - [x] 首页 Hero 顶栏下方留白收紧：桌面 `.hero` padding `68px 0 44px` → `32px 0 28px`，移动端 `38px 0 30px` → `24px 0 22px`，减少「持续更新的机器人技术栈地图」徽章上方空档，入口卡更易落在首屏。
-- [x] 首页 Hero 规模数字（知识节点 / 互链关系 / 主路线 / 纵深路线）每次进入/刷新 count-up 翻滚；`prefers-reduced-motion` 时直接显示终值。验证脚本 `scripts/verify_hero_stats_countup.cjs`。
+- [x] 首页 Hero 规模数字（知识节点 / 互链关系 / 主路线 / 纵深路线）每次进入/刷新 count-up 翻滚；内联脚本首屏前归零避免终值闪跳；立刻用 `data-fallback` 开播（不等 fetch、不重播）；去掉位移动画；重 DOM 延后以减轻卡顿；`prefers-reduced-motion` 时直接显示终值。验证脚本 `scripts/verify_hero_stats_countup.cjs`。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,24 @@
             <span class="hero-stat-label">纵深路线</span>
           </li>
         </ul>
+        <script>
+          /* 解析到数字后、首屏绘制前归零，避免「终值 → 0」闪跳；reduced-motion 保留终值 */
+          (function () {
+            try {
+              if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+            } catch (e) { /* ignore */ }
+            var ids = ['heroNodeCount', 'heroEdgeCount', 'heroMainRouteCount', 'heroDepthRouteCount'];
+            for (var i = 0; i < ids.length; i++) {
+              var el = document.getElementById(ids[i]);
+              if (!el) continue;
+              if (!el.getAttribute('data-fallback')) {
+                el.setAttribute('data-fallback', String(el.textContent || '').trim());
+              }
+              el.textContent = '0';
+              el.classList.add('is-count-pending');
+            }
+          })();
+        </script>
       </div>
     </section>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -235,9 +235,11 @@
     return out.join('\n');
   }
 
-  // 首页 Hero 规模数字：每次进入/刷新都 count-up（尊重 prefers-reduced-motion）
+  // 首页 Hero 规模数字：每次进入/刷新 count-up（尊重 prefers-reduced-motion）
+  // 内联脚本已在首屏前归零；此处立刻用 data-fallback 开播，fetch 只修正终值、不从 0 重播
   var heroStatsCountUpEnabled = null;
   var heroStatsCountUpFallbacks = null;
+  var heroStatsAnimators = null;
 
   function prefersReducedMotionQuery() {
     try {
@@ -261,93 +263,119 @@
     return 1 - Math.pow(1 - t, 3);
   }
 
-  function animateCountUp(el, target, options) {
-    options = options || {};
-    var duration = typeof options.duration === 'number' ? options.duration : 1400;
-    var delay = typeof options.delay === 'number' ? options.delay : 0;
-    var onDone = options.onDone;
-    var end = Math.max(0, Math.round(Number(target) || 0));
-    var cancelled = false;
-    var timerId = 0;
-    var rafId = 0;
-
-    function finish() {
-      if (cancelled) return;
-      el.textContent = String(end);
-      el.classList.remove('is-counting');
-      if (onDone) onDone();
-    }
-
-    function start() {
-      if (cancelled) return;
-      var startTs = null;
-      el.classList.add('is-counting');
-      el.textContent = '0';
-      function frame(now) {
-        if (cancelled) return;
-        if (startTs === null) startTs = now;
-        var t = Math.min(1, (now - startTs) / duration);
-        el.textContent = String(Math.round(end * easeOutCubic(t)));
-        if (t < 1) {
-          rafId = requestAnimationFrame(frame);
-        } else {
-          finish();
-        }
-      }
-      rafId = requestAnimationFrame(frame);
-    }
-
-    if (delay > 0) {
-      timerId = window.setTimeout(start, delay);
-    } else {
-      start();
-    }
-
-    return function cancel() {
-      cancelled = true;
-      if (timerId) window.clearTimeout(timerId);
-      if (rafId) cancelAnimationFrame(rafId);
-      el.classList.remove('is-counting');
-    };
-  }
-
-  function setHeroStatNumber(el, value, animate, delay) {
-    if (!el) return;
-    var end = Math.max(0, Math.round(Number(value) || 0));
-    if (animate) {
-      animateCountUp(el, end, { duration: 1400, delay: delay || 0 });
-    } else {
-      el.textContent = String(end);
-      el.classList.remove('is-counting');
-    }
-  }
-
   function parseHeroStatNumber(el, fallback) {
     if (!el) return fallback;
     var n = parseInt(String(el.textContent || '').replace(/[^\d]/g, ''), 10);
     return Number.isFinite(n) ? n : fallback;
   }
 
-  // 在 home-stats 到达前先清零，避免闪最终值；四个数字等数据齐后一起翻滚
+  function readHeroStatFallback(el, fallback) {
+    if (!el) return fallback;
+    var raw = el.getAttribute('data-fallback');
+    if (raw != null && String(raw).trim() !== '') {
+      var fromData = parseInt(String(raw).replace(/[^\d]/g, ''), 10);
+      if (Number.isFinite(fromData)) return fromData;
+    }
+    return parseHeroStatNumber(el, fallback);
+  }
+
+  function animateCountUp(el, target, options) {
+    options = options || {};
+    var duration = typeof options.duration === 'number' ? options.duration : 1100;
+    var end = Math.max(0, Math.round(Number(target) || 0));
+    var cancelled = false;
+    var finished = false;
+    var rafId = 0;
+    var startTs = null;
+    var lastShown = -1;
+
+    el.classList.remove('is-count-pending');
+    el.classList.add('is-counting');
+    el.style.minWidth = Math.max(String(end).length, 1) + 'ch';
+    el.textContent = '0';
+    lastShown = 0;
+
+    function finish() {
+      if (cancelled || finished) return;
+      finished = true;
+      if (lastShown !== end) {
+        el.textContent = String(end);
+        lastShown = end;
+      }
+      el.classList.remove('is-counting');
+    }
+
+    function frame(now) {
+      if (cancelled) return;
+      if (startTs === null) startTs = now;
+      var t = Math.min(1, (now - startTs) / duration);
+      var value = Math.round(end * easeOutCubic(t));
+      if (value !== lastShown) {
+        el.textContent = String(value);
+        lastShown = value;
+      }
+      if (t < 1) {
+        rafId = requestAnimationFrame(frame);
+      } else {
+        finish();
+      }
+    }
+
+    rafId = requestAnimationFrame(frame);
+
+    return {
+      setTarget: function (next) {
+        end = Math.max(0, Math.round(Number(next) || 0));
+        el.style.minWidth = Math.max(String(end).length, 1) + 'ch';
+        if (finished) {
+          el.textContent = String(end);
+          lastShown = end;
+        }
+      },
+      cancel: function () {
+        cancelled = true;
+        if (rafId) cancelAnimationFrame(rafId);
+        el.classList.remove('is-counting');
+      }
+    };
+  }
+
+  function setHeroStatStatic(el, value) {
+    if (!el) return;
+    var end = Math.max(0, Math.round(Number(value) || 0));
+    el.textContent = String(end);
+    el.classList.remove('is-counting', 'is-count-pending');
+    el.style.minWidth = '';
+  }
+
+  // 立刻用 HTML/data-fallback 开播，不等 home-stats；避免停在 0 等待网络
   function initHeroStatCountUp() {
     var nodeEl = document.getElementById('heroNodeCount');
     var edgeEl = document.getElementById('heroEdgeCount');
     var mainEl = document.getElementById('heroMainRouteCount');
     var depthEl = document.getElementById('heroDepthRouteCount');
     if (!nodeEl && !edgeEl && !mainEl && !depthEl) return;
-    if (!getHeroStatsCountUpEnabled()) return;
 
     heroStatsCountUpFallbacks = {
-      nodes: parseHeroStatNumber(nodeEl, 0),
-      edges: parseHeroStatNumber(edgeEl, 0),
-      main: parseHeroStatNumber(mainEl, 1),
-      depth: parseHeroStatNumber(depthEl, 21)
+      nodes: readHeroStatFallback(nodeEl, 0),
+      edges: readHeroStatFallback(edgeEl, 0),
+      main: readHeroStatFallback(mainEl, 1),
+      depth: readHeroStatFallback(depthEl, 21)
     };
 
-    if (nodeEl) nodeEl.textContent = '0';
-    if (edgeEl) edgeEl.textContent = '0';
-    if (mainEl) mainEl.textContent = '0';
-    if (depthEl) depthEl.textContent = '0';
+    if (!getHeroStatsCountUpEnabled()) {
+      setHeroStatStatic(nodeEl, heroStatsCountUpFallbacks.nodes);
+      setHeroStatStatic(edgeEl, heroStatsCountUpFallbacks.edges);
+      setHeroStatStatic(mainEl, heroStatsCountUpFallbacks.main);
+      setHeroStatStatic(depthEl, heroStatsCountUpFallbacks.depth);
+      return;
+    }
+
+    heroStatsAnimators = {};
+    if (nodeEl) heroStatsAnimators.nodes = animateCountUp(nodeEl, heroStatsCountUpFallbacks.nodes);
+    if (edgeEl) heroStatsAnimators.edges = animateCountUp(edgeEl, heroStatsCountUpFallbacks.edges);
+    if (mainEl) heroStatsAnimators.main = animateCountUp(mainEl, heroStatsCountUpFallbacks.main);
+    if (depthEl) heroStatsAnimators.depth = animateCountUp(depthEl, heroStatsCountUpFallbacks.depth);
   }
 
   function renderHomeStats(graphStats) {
@@ -364,27 +392,36 @@
     var edgeCount = graphStats && typeof graphStats.edge_count === 'number' ? graphStats.edge_count : null;
     var play = getHeroStatsCountUpEnabled();
     var fallbacks = heroStatsCountUpFallbacks;
+    var anim = heroStatsAnimators;
+
+    function applyStat(el, key, target) {
+      if (!el) return;
+      if (play && anim && anim[key]) {
+        anim[key].setTarget(target);
+        return;
+      }
+      setHeroStatStatic(el, target);
+    }
 
     if (heroNodeCount) {
       var nodeTarget = nodeCount !== null
         ? nodeCount
         : (fallbacks ? fallbacks.nodes : parseHeroStatNumber(heroNodeCount, 0));
-      setHeroStatNumber(heroNodeCount, nodeTarget, play, 0);
+      applyStat(heroNodeCount, 'nodes', nodeTarget);
     }
     if (heroEdgeCount) {
       var edgeTarget = edgeCount !== null
         ? edgeCount
         : (fallbacks ? fallbacks.edges : parseHeroStatNumber(heroEdgeCount, 0));
-      setHeroStatNumber(heroEdgeCount, edgeTarget, play, 0);
+      applyStat(heroEdgeCount, 'edges', edgeTarget);
     }
     if (heroMainRouteCount) {
       var mainTarget = fallbacks ? fallbacks.main : parseHeroStatNumber(heroMainRouteCount, 1);
-      // 二次进入时保持 HTML/已有终值，避免把「1」再写一遍造成闪烁
-      if (play || fallbacks) setHeroStatNumber(heroMainRouteCount, mainTarget, play, 0);
+      if (play || fallbacks) applyStat(heroMainRouteCount, 'main', mainTarget);
     }
     if (heroDepthRouteCount) {
       var depthTarget = fallbacks ? fallbacks.depth : parseHeroStatNumber(heroDepthRouteCount, 21);
-      if (play || fallbacks) setHeroStatNumber(heroDepthRouteCount, depthTarget, play, 0);
+      if (play || fallbacks) applyStat(heroDepthRouteCount, 'depth', depthTarget);
     }
     if (wikiSearchSubtitle && nodeCount !== null) {
       wikiSearchSubtitle.textContent = '在 ' + nodeCount + ' 个知识节点中快速定位概念、方法或任务。↑↓ 键导航，Enter 打开，Esc 清空。';
@@ -6075,14 +6112,18 @@
     Promise.all([homeStatsFetch, wikiActivityFetch])
       .then(function (results) {
         var stats = results[0];
+        // 轻量：只修正 count-up 终值，不重启动画
         renderHomeStats(stats);
-        renderHotTopics(stats);
-        renderHomeHubs(stats);
-        renderLatestWikiNode(stats, results[1]);
+        // 重 DOM（热门/枢纽/最新节点）延后，避免与数字翻滚抢主线程造成卡顿
+        window.setTimeout(function () {
+          renderHotTopics(stats);
+          renderHomeHubs(stats);
+          renderLatestWikiNode(stats, results[1]);
+        }, 0);
       })
       .catch(function (error) {
         console.warn('Home stats sync failed:', error);
-        // 统计失败时仍用 HTML 占位值完成翻滚，避免节点/边数停在 0
+        // 统计失败时动画已用 HTML fallback 在跑；此处无需重播
         renderHomeStats(null);
         var failedMounts = [
           document.getElementById('homeLatestWikiModule'),

--- a/docs/style.css
+++ b/docs/style.css
@@ -309,13 +309,11 @@ body.sponsor-dialog-open {
   transition: color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
   display: inline-block;
 }
-.hero-stat-num.is-counting {
+/* count-up 期间只改色，不做位移动画，避免与数字刷新叠出「跳一下」 */
+.hero-stat-num.is-counting,
+.hero-stat-num.is-count-pending {
   color: var(--accent);
-  animation: hero-stat-count-roll 0.35s ease-out;
-}
-@keyframes hero-stat-count-roll {
-  from { transform: translateY(0.28em); opacity: 0.55; }
-  to { transform: translateY(0); opacity: 1; }
+  transition: none;
 }
 a.hero-stat-num:hover,
 a.hero-stat-num:focus-visible {
@@ -565,8 +563,8 @@ a.hero-stat-num:focus-visible {
     animation: none;
     color: var(--accent-hover);
   }
-  .hero-stat-num.is-counting {
-    animation: none;
+  .hero-stat-num.is-counting,
+  .hero-stat-num.is-count-pending {
     color: var(--text);
   }
 }

--- a/scripts/verify_hero_stats_countup.cjs
+++ b/scripts/verify_hero_stats_countup.cjs
@@ -1,4 +1,4 @@
-// 验证：首页 Hero 规模数字每次加载/刷新都 count-up。
+// 验证：首页 Hero 规模数字每次加载/刷新都 count-up；无「终值→0」闪跳。
 //
 // 前置：仓库根目录生成 home-stats 并起静态服务
 //   make export graph   # 或至少有 docs/exports/home-stats.json
@@ -40,11 +40,66 @@ const path = require('path');
           ? {
               text: String(el.textContent || '').trim(),
               counting: el.classList.contains('is-counting'),
+              pending: el.classList.contains('is-count-pending'),
             }
           : null;
       }
       return out;
     });
+  }
+
+  async function installHeroTrace(page) {
+    await page.evaluateOnNewDocument(() => {
+      window.__heroTrace = [];
+      // 只从 DOMContentLoaded 起采样：此时内联归零脚本已执行，反映真实首屏，
+      // 避免解析中途读到 HTML 终值造成假阳性。
+      document.addEventListener('DOMContentLoaded', () => {
+        const push = () => {
+          const n = document.getElementById('heroNodeCount');
+          if (!n) return;
+          const text = String(n.textContent || '').trim();
+          const counting = n.classList.contains('is-counting');
+          const last = window.__heroTrace[window.__heroTrace.length - 1];
+          if (!last || last.text !== text || last.counting !== counting) {
+            window.__heroTrace.push({ t: performance.now(), text, counting });
+          }
+        };
+        push();
+        const n = document.getElementById('heroNodeCount');
+        if (n) {
+          new MutationObserver(push).observe(n, {
+            characterData: true,
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['class'],
+          });
+        }
+        let ticks = 0;
+        const id = setInterval(() => {
+          push();
+          ticks += 1;
+          if (ticks > 80) clearInterval(id);
+        }, 8);
+      });
+    });
+  }
+
+  function assertNoFinalToZeroJump(trace) {
+    // 不允许出现「已经是大终值」紧接着掉回 0 的闪跳
+    for (let i = 1; i < trace.length; i++) {
+      const prev = parseInt(trace[i - 1].text, 10);
+      const cur = parseInt(trace[i].text, 10);
+      if (Number.isFinite(prev) && Number.isFinite(cur) && prev >= 1000 && cur === 0) {
+        return false;
+      }
+    }
+    // 首个可见数字应为 0 或递增中的值，不应先闪终值再归零
+    if (trace.length) {
+      const first = parseInt(trace[0].text, 10);
+      if (Number.isFinite(first) && first >= 1000) return false;
+    }
+    return true;
   }
 
   async function waitForCountUpMid(page) {
@@ -92,10 +147,10 @@ const path = require('path');
     await page.setViewport({ width: 1280, height: 900 });
     const errs = [];
     page.on('pageerror', (e) => errs.push(String(e)));
+    await installHeroTrace(page);
 
     await page.goto(base + '/index.html', { waitUntil: 'domcontentloaded', timeout: 30000 });
 
-    // 首次加载：翻滚中
     await waitForCountUpMid(page);
     const mid = await sampleHero(page);
     await page.screenshot({
@@ -107,12 +162,13 @@ const path = require('path');
     const settledA = await sampleHero(page);
     await new Promise((r) => setTimeout(r, 200));
     const settledB = await sampleHero(page);
+    const loadTrace = await page.evaluate(() => window.__heroTrace || []);
     await page.screenshot({
       path: path.join(outDir, 'home-hero-stats-countup-done.png'),
       fullPage: false,
     });
 
-    // 刷新后应再次翻滚
+    // 刷新后应再次翻滚，且仍无终值闪跳
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 30000 });
     await waitForCountUpMid(page);
     const midReload = await sampleHero(page);
@@ -122,6 +178,7 @@ const path = require('path');
     });
     await waitForCountUpDone(page);
     const settledReload = await sampleHero(page);
+    const reloadTrace = await page.evaluate(() => window.__heroTrace || []);
     await page.screenshot({
       path: path.join(outDir, 'home-hero-stats-countup-reload-done.png'),
       fullPage: false,
@@ -144,17 +201,23 @@ const path = require('path');
       reloadMidNode < reloadDoneNode &&
       reloadMidEdge < reloadDoneEdge &&
       settledReload.heroNodeCount.text === settledB.heroNodeCount.text;
+    const okNoJumpLoad = assertNoFinalToZeroJump(loadTrace);
+    const okNoJumpReload = assertNoFinalToZeroJump(reloadTrace);
 
     console.log('pageerrors:', errs.length ? errs : 'none');
     console.log('MID   :', JSON.stringify(mid));
     console.log('DONE  :', JSON.stringify(settledB));
     console.log('RELOAD:', JSON.stringify({ midReload, settledReload }));
+    console.log('TRACE_LOAD_HEAD:', JSON.stringify(loadTrace.slice(0, 6)));
+    console.log('TRACE_RELOAD_HEAD:', JSON.stringify(reloadTrace.slice(0, 6)));
     console.log(
       'CHECKS:',
       JSON.stringify({
         okMid,
         okSettled,
         okReload,
+        okNoJumpLoad,
+        okNoJumpReload,
         midNode,
         doneNode,
         midEdge,
@@ -164,10 +227,10 @@ const path = require('path');
       })
     );
 
-    if (!okMid || !okSettled || !okReload || errs.length) {
+    if (!okMid || !okSettled || !okReload || !okNoJumpLoad || !okNoJumpReload || errs.length) {
       process.exitCode = 1;
     } else {
-      console.log('OK hero stats count-up (plays every load/refresh)');
+      console.log('OK hero stats count-up (smooth every load/refresh)');
     }
   } finally {
     await browser.close();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- **闪跳**：内联脚本在首屏绘制前归零并写入 `data-fallback`，避免「终值 → 0」
- **卡顿**：立刻用 fallback 开播（不等 `home-stats`）；fetch 只修正终值、不从 0 重播；去掉 CSS 位移动画；数字不变时不写 DOM；枢纽/最新节点等重渲染 `setTimeout(0)` 延后
- 仍每次刷新播放；`prefers-reduced-motion` 直接显示终值

## 验证
- `node --check docs/main.js` 通过
- `npx eslint docs/main.js` 无新增 error
- `scripts/verify_hero_stats_countup.cjs` 通过：首帧即为 `0` 且 counting；无终值→0；刷新再次翻滚；终值 2074 / 18750 / 1 / 21

## 验证截图
翻滚中：
![翻滚中](https://cursor.com/artifacts/c/art-3d3d3472-f0df-4ecd-bcd6-65a8069bb983)

翻滚结束：
![翻滚结束](https://cursor.com/artifacts/c/art-7afae49e-7b52-4a47-ab8f-bd9025afb462)

刷新后再次翻滚：
![刷新后再次翻滚](https://cursor.com/artifacts/c/art-8e40163c-9555-4c13-98f6-cbd0cb9c53fa)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b99737db-536e-41e3-b5f7-3f3972450de0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b99737db-536e-41e3-b5f7-3f3972450de0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

