### PR TITLE
fix(ux): 首页规模数字翻滚保持终值白色

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -100,7 +100,7 @@
 - [x] 首页 Hero 盘点条新增「主路线」（数字 1，位于「互链关系」与「纵深路线」之间）；四项数字可点：知识节点 / 互链关系 → `graph.html`，主路线 → 锚到「从零开始」卡并顺时针描边一圈，纵深路线 → 锚到「更多路线」卡描边一圈（不展开）后短时高亮「展开全部…」文案。
 - [x] 首页入口卡边框描边多分辨率对齐：SVG 改为按 border-box 像素定位（计入 border 宽度与亚像素 `getBoundingClientRect`），去掉 padding-box `inset`/`%` 尺寸冲突；圆角跟随 computed `border-radius`；动画期间 ResizeObserver 跟随卡片尺寸。
 - [x] 首页 Hero 顶栏下方留白收紧：桌面 `.hero` padding `68px 0 44px` → `32px 0 28px`，移动端 `38px 0 30px` → `24px 0 22px`，减少「持续更新的机器人技术栈地图」徽章上方空档，入口卡更易落在首屏。
-- [x] 首页 Hero 规模数字（知识节点 / 互链关系 / 主路线 / 纵深路线）每次进入/刷新 count-up 翻滚；内联脚本首屏前归零避免终值闪跳；立刻用 `data-fallback` 开播（不等 fetch、不重播）；去掉位移动画；重 DOM 延后以减轻卡顿；`prefers-reduced-motion` 时直接显示终值。验证脚本 `scripts/verify_hero_stats_countup.cjs`。
+- [x] 首页 Hero 规模数字（知识节点 / 互链关系 / 主路线 / 纵深路线）每次进入/刷新 count-up 翻滚；内联脚本首屏前归零避免终值闪跳；立刻用 `data-fallback` 开播（不等 fetch、不重播）；翻滚中保持终值文字色（不变强调色）；去掉位移动画；重 DOM 延后以减轻卡顿；`prefers-reduced-motion` 时直接显示终值。验证脚本 `scripts/verify_hero_stats_countup.cjs`。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/style.css
+++ b/docs/style.css
@@ -309,10 +309,10 @@ body.sponsor-dialog-open {
   transition: color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
   display: inline-block;
 }
-/* count-up 期间只改色，不做位移动画，避免与数字刷新叠出「跳一下」 */
+/* count-up 期间保持终值文字色，不做变色/位移动画 */
 .hero-stat-num.is-counting,
 .hero-stat-num.is-count-pending {
-  color: var(--accent);
+  color: var(--text);
   transition: none;
 }
 a.hero-stat-num:hover,
@@ -562,10 +562,6 @@ a.hero-stat-num:focus-visible {
   #mini-graph-expand.is-pulse-hint {
     animation: none;
     color: var(--accent-hover);
-  }
-  .hero-stat-num.is-counting,
-  .hero-stat-num.is-count-pending {
-    color: var(--text);
   }
 }
 .section-alt {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- Hero 规模数字 count-up / pending 期间不再切换强调色，始终使用 `--text`（深色主题下为白色）

## 验证
- 翻滚中 `getComputedStyle` 颜色为 `rgb(245, 245, 247)`（`--text`），非 accent

## 验证截图
![翻滚中保持白色](https://cursor.com/artifacts/c/art-f00ce44d-3979-4d11-9600-89789e747c43)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b99737db-536e-41e3-b5f7-3f3972450de0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b99737db-536e-41e3-b5f7-3f3972450de0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

