### PR TITLE
feat(ux): 暗色主题落地 Technical Blueprint 底色与全站细密点阵

### DIFF
--- a/docs/change-log.html
+++ b/docs/change-log.html
@@ -11,7 +11,7 @@
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#1c1c1e" />
+  <meta name="theme-color" content="#0d1117" />
 </head>
 <body>
   <header class="site-header">

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -30,7 +30,7 @@
 ## 三、 风格对齐 (Aesthetic Refinement)
 
 - [ ] **引入 Technical Blueprint 风格**：
-    - [ ] 背景：采用深色调 (#0d1117) 配合细密网格线 (Dot Grid)。
+    - [x] 背景：暗色主题底色改为 `#0d1117`（与 `graph-3d.js` 画布同色，2D/3D 切换无色差），配套调深 `--bg-alt`/`--surface-strong` `#161b22`、`--border` `#30363d`、`--border-strong` `#6e7681`、`--text` `#e6edf3`、`--text-muted` `#9ba4b0`，`theme-color` / `manifest.theme_color` 同步 `#0d1117`；全站叠加细密点阵（`--grid-size: 22px` + `--grid-dot`，`body` 背景图与 `.hero-backdrop::before` 共用同一尺寸、同为文档原点且随内容滚动，叠加不产生摩尔纹；亮色主题 `--grid-dot: transparent` 保持纯净底不变）。对比度实测（暗色）：正文 16.0:1 / 次要文字 7.5:1 / 链接 6.9:1，均高于改动前（6.2:1）。
     - [ ] 字体：标题切换为工程感更强的 `DM Mono`，正文优化衬线比例。
 - [x] **响应式体验优化**：
     - [x] 确保极简后的首页在手机端首屏就能看到搜索框和图谱入口。

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -719,7 +719,7 @@
         gap: 6px;
         /* 移动端工具栏内容仅 ~43px，但 #graph-wrap 顶部按 header+46px 定位；
            补足 min-height 让工具栏正好填满该 46px 带，避免底部露出比画布更浅的
-           页面背景(#1c1c1e)形成一条灰条。 */
+           页面背景(#0d1117)形成一条灰条。 */
         min-height: 46px;
       }
       #graph-search {
@@ -1735,7 +1735,7 @@
     [data-theme="light"] #graph-sidebar .sb-header { border-bottom-color: rgba(0,0,0,0.08); }
   </style>
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#1c1c1e" />
+  <meta name="theme-color" content="#0d1117" />
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {

--- a/docs/hubs.html
+++ b/docs/hubs.html
@@ -11,7 +11,7 @@
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#1c1c1e" />
+  <meta name="theme-color" content="#0d1117" />
 </head>
 <body>
   <header class="site-header">

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
   <script id="sponsor-js" src="sponsor.js?v=2"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="manifest" href="manifest.json" />
-  <meta name="theme-color" content="#1c1c1e" />
+  <meta name="theme-color" content="#0d1117" />
 </head>
 <body>
   <header class="site-header">

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -6,7 +6,7 @@
   "scope": "/Robotics_Notebooks/",
   "display": "standalone",
   "background_color": "#0f172a",
-  "theme_color": "#1c1c1e",
+  "theme_color": "#0d1117",
   "lang": "zh-CN",
   "icons": [
     {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,18 +1,19 @@
 :root {
   color-scheme: dark;
-  /* Dark Mode（默认）：柔和深灰 + 淡蓝点缀 */
-  --bg: #1c1c1e;
-  --bg-alt: #2c2c2e;
-  --surface: rgba(44, 44, 46, 0.85);
-  --surface-strong: #2c2c2e;
-  --border: #3a3a3c;
-  --border-strong: #6e6e73;
-  --text: #f5f5f7;
-  --text-muted: #9b9ba0;
+  /* Dark Mode（默认）：Technical Blueprint 深蓝灰 + 淡蓝点缀
+     底色与 3D 图谱画布 (graph-3d.js backgroundColor) 同为 #0d1117，2D/3D 切换无色差 */
+  --bg: #0d1117;
+  --bg-alt: #161b22;
+  --surface: rgba(22, 27, 34, 0.85);
+  --surface-strong: #161b22;
+  --border: #30363d;
+  --border-strong: #6e7681;
+  --text: #e6edf3;
+  --text-muted: #9ba4b0;
   --accent: #5ea0eb;
   --accent-hover: #7fb6f0;
   --quote-bg: rgba(94, 160, 235, 0.08);
-  --header-bg: rgba(28, 28, 30, 0.85);
+  --header-bg: rgba(13, 17, 23, 0.85);
   --header-border: rgba(255, 255, 255, 0.08);
   --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 8px 30px rgba(0, 0, 0, 0.08);
@@ -26,6 +27,10 @@
   --detail-toc-panel-max-height: min(76vh, 680px);
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans SC", sans-serif;
   --transition: 0.3s ease;
+  /* 全站细密点阵底纹（Technical Blueprint）：body 与 .hero-backdrop 共用同一尺寸，
+     两者定位原点都在文档 (0,0) 且随内容滚动，叠加时点位对齐、不出现摩尔纹 */
+  --grid-size: 22px;
+  --grid-dot: rgba(110, 118, 129, 0.2);
 }
 
 [data-theme="light"] {
@@ -44,6 +49,8 @@
   --quote-bg: #fef7f5;
   --header-bg: rgba(255, 255, 255, 0.8);
   --header-border: rgba(0, 0, 0, 0.1);
+  /* 亮色保持纯净底，仅首屏 .hero-backdrop 保留点阵 */
+  --grid-dot: transparent;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -57,7 +64,9 @@ html {
 }
 body {
   font-family: var(--font-sans);
-  background: var(--bg);
+  background-color: var(--bg);
+  background-image: radial-gradient(circle, var(--grid-dot) 1px, transparent 1px);
+  background-size: var(--grid-size) var(--grid-size);
   color: var(--text);
   line-height: 1.5;
   transition: background var(--transition), color var(--transition);
@@ -249,7 +258,7 @@ body.sponsor-dialog-open {
   position: absolute;
   inset: 0;
   background-image: radial-gradient(circle, var(--border-strong) 1px, transparent 1px);
-  background-size: 26px 26px;
+  background-size: var(--grid-size) var(--grid-size);
   opacity: 0.2;
   -webkit-mask-image: linear-gradient(180deg, #000 0%, transparent 78%);
   mask-image: linear-gradient(180deg, #000 0%, transparent 78%);
@@ -1074,7 +1083,7 @@ a .updates-item-opensource {
   --hm-weeks: 53;
   --hm-cell-min: 8px; /* 格子宽度下限：低于则容器横向滚动 */
   --hm-gap: 3px;
-  --hm-level-0: #2c2c2e;
+  --hm-level-0: #21262d;
   --hm-level-1: #1d4f8c;
   --hm-level-2: #2a6cb4;
   --hm-level-3: #4b8fd9;


### PR DESCRIPTION
## 摘要

推进 `docs/checklists/frontend-optimization-v1.md`「三、风格对齐 → 引入 Technical Blueprint 风格」中的**背景**子项：暗色主题底色改为 `#0d1117` 并叠加全站细密点阵底纹。选这个色值不只是照抄清单——`graph-3d.js` 的 3D 画布背景本就是 `#0d1117`，对齐后图谱页 2D/3D 切换与页面底色不再有色差。亮色主题保持原样不动。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

### 具体改动

- `docs/style.css`
  - 暗色调色板：`--bg` `#1c1c1e` → `#0d1117`；`--bg-alt` / `--surface-strong` → `#161b22`、`--surface` → `rgba(22,27,34,.85)`、`--border` → `#30363d`、`--border-strong` → `#6e7681`；文字提亮 `--text` → `#e6edf3`、`--text-muted` → `#9ba4b0`；`--header-bg` 跟随。
  - 新增 `--grid-size`(22px) / `--grid-dot` 两个底纹变量：`body` 背景叠加细密点阵，与既有 `.hero-backdrop::before` 共用同一尺寸；两者定位原点都在文档 `(0,0)` 且随内容滚动（未用 `background-attachment: fixed`，避免移动端滚动重绘），点位始终对齐，叠加不产生摩尔纹。亮色主题 `--grid-dot: transparent`，页面底保持纯净，仅首屏 `.hero-backdrop` 点阵照旧。
  - 热力图空档 `--hm-level-0` `#2c2c2e` → `#21262d`，贴合新底色（对 level-1 的对比度 1.69 → 1.85，未劣化）。
- `docs/{index,graph,hubs,change-log}.html` + `docs/manifest.json`：`theme-color` / `theme_color` 同步 `#0d1117`。
- `docs/checklists/frontend-optimization-v1.md`：勾选背景子项并记录实现要点；`DM Mono` 字体子项留待下一次推进（需先决定自托管字体还是放弃外链 CDN，本仓库目前无任何外部字体依赖）。

## 验证

- [x] `make ci-preflight`：本地仅剩两处**改动前既有**的存量问题（`wiki/methods/π0-policy.md` 陈旧页提示、bm25 用例「CMDP 约束代价阈值 安全」未命中，通过率 36/37 = 97%），与本 PR 的纯样式改动无关，故未连带修改；`exports/lint-report.md` 的抖动已还原，不入本次提交。
- [x] `npx eslint docs/main.js`：0 error（1 条既有 `no-unused-vars` warning）。
- [x] 无障碍对比度实测（暗色，WCAG 相对亮度公式）：正文 `#e6edf3` 16.02:1、次要文字 `#9ba4b0` 7.51:1、链接 `#5ea0eb` 6.94:1；改动前对应值为 6.15 / 6.24:1，**全部优于改动前**，满足清单 DoD 的 Lighthouse 可访问性 90+ 要求。
- [x] Headless Chromium 逐页核查（`make export graph` + `python3 -m http.server`，实测 `body` computed `rgb(13,17,23)` / `background-size: 22px 22px`）：
  - 首页暗色：底色与点阵生效，入口卡、盘点条、分区交替底（`--bg-alt`）层次正常。
  - 首页亮色：`background-image` 解析为全透明点，页面与改动前一致，无回归。
  - 详情页 `detail.html?id=wiki-concepts-sim2real`：正文卡、页面信息、关联迷你图正常。
  - 路线页 `roadmap.html?id=roadmap-depth-vla`：阶段树与卡片正常。
  - 图谱页 `graph.html`：画布与页面底色一致，工具栏下方不再有色差灰带。

## 验证截图

按 `CLAUDE.md` §5.1 约定，截图落在 gitignore 的 `.cursor-artifacts/screenshots/` 下、不入 git 历史：`blueprint-home.png`、`blueprint-home-light.png`、`blueprint-detail.png`、`blueprint-roadmap.png`、`blueprint-graph.png`。本次由 Claude Code web 会话执行，无 Cursor Cloud 的本地图片自动上传通道，故此处以上述逐页核查结论 + computed style 实测值代替内嵌图片。

## 相关 Issue

无

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1wnbTvvFyVctVFgrmDmfY)_