### PR TITLE
fix(ux): 页脚不再透出全站点阵底纹

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2321,6 +2321,8 @@ button.home-wiki-heatmap-cell.is-active {
   padding: 24px 0;
   color: var(--text-muted);
   font-size: 0.85rem;
+  /* 铺纯色底盖住 body 的点阵，页脚不带点 */
+  background: var(--bg);
 }
 .footer .container {
   display: flex;


### PR DESCRIPTION
## 摘要

`.footer` 此前没有自己的背景，`body` 上那层全站点阵底纹（`--grid-dot` 的 `radial-gradient`）直接透到页脚区域。补一层 `var(--bg)` 纯色底盖住，页脚恢复干净。

这是 #1446 配色统一的遗留问题：点阵本身在那之前就存在，上一版只换了它的颜色，没注意到它会漫到页脚。

## 变更类型

- [x] 前端（`docs/`）

## 详细变更

`docs/style.css:2319` `.footer` 规则新增一行：

```css
.footer {
  border-top: 1px solid var(--header-border);
  padding: 24px 0;
  color: var(--text-muted);
  font-size: 0.85rem;
  /* 铺纯色底盖住 body 的点阵，页脚不带点 */
  background: var(--bg);
}
```

影响范围为所有带 `class="footer"` 的页面：`index` / `detail` / `roadmap` / `module` / `hubs` / `tech-map` / `change-log`。亮色主题 `--grid-dot` 本就是 `transparent`，那边视觉零变化。

## 验证

- [x] `make ci-preflight` 通过：lint 阻塞型 0 / 信息型 0，导出质量检查 12/12
- [x] 本地静态站目视（暗色主题）：分隔线以上仍是点阵，页脚区域已是纯色

## 相关 Issue

无（承接 #1446）

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdZuUHdHceDYaQQjU3zBVm)_