### PR TITLE
fix(ux): 消除详情未找到与长正文切换时的主栏抖动

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -102,6 +102,7 @@
 - [x] 首页 Hero 顶栏下方留白收紧：桌面 `.hero` padding `68px 0 44px` → `32px 0 28px`，移动端 `38px 0 30px` → `24px 0 22px`，减少「持续更新的机器人技术栈地图」徽章上方空档，入口卡更易落在首屏。
 - [x] 首页 Hero 规模数字（知识节点 / 互链关系 / 主路线 / 纵深路线）每次进入/刷新 count-up 翻滚；内联脚本首屏前归零避免终值闪跳；立刻用 `data-fallback` 开播（不等 fetch、不重播）；翻滚中保持终值文字色（不变强调色）；去掉位移动画；重 DOM 延后以减轻卡顿；`prefers-reduced-motion` 时直接显示终值。验证脚本 `scripts/verify_hero_stats_countup.cjs`。
 - [x] 首页 Hero 徽章「持续更新…」前蓝点改为慢呼吸灯（`hero-badge-dot-breathe`，3.6s 正弦感曲线，透明度 0.68↔1 + 峰谷短暂停留 + 外环微强弱，避免闪烁）；`prefers-reduced-motion` 下保持静态圆点。
+- [x] 详情/模块/路线「未找到」与长正文切换抖动：根因是经典滚动条有无导致居中主栏横移（宽仍同为 912px），以及空态 `.section` 在 JS 隐藏前吃掉 88px 顶底留白；修复为 `html { scrollbar-gutter: stable }`、空态 section 默认 `hidden` + `padding: 0`，并把空态卡片放进与正文相同的 `detail-content-layout` / `detail-content-main`。验证脚本 `scripts/verify_detail_empty_column_stable.cjs`。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -82,15 +82,17 @@
       </div>
     </section>
 
-    <section class="section" id="detail-empty-section">
-      <div class="container">
-        <article id="detailEmptyState" class="card empty-state" hidden>
-          <h2>未找到对应内容</h2>
-          <p>链接可能无效或内容已迁移，请返回首页重新查找。</p>
-          <div class="cta-row">
-            <a class="btn-secondary" href="index.html">回到首页</a>
-          </div>
-        </article>
+    <section class="section" id="detail-empty-section" hidden>
+      <div class="container detail-content-layout">
+        <div class="detail-content-main">
+          <article id="detailEmptyState" class="card empty-state" hidden>
+            <h2>未找到对应内容</h2>
+            <p>链接可能无效或内容已迁移，请返回首页重新查找。</p>
+            <div class="cta-row">
+              <a class="btn-secondary" href="index.html">回到首页</a>
+            </div>
+          </article>
+        </div>
       </div>
     </section>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -5208,9 +5208,11 @@
     const roadmapEl = document.getElementById('moduleRoadmapList');
     const relatedModuleEl = document.getElementById('moduleRelatedModules');
     const emptyState = document.getElementById('moduleEmptyState');
+    const emptySection = document.getElementById('module-empty-section');
     const breadcrumb = document.getElementById('moduleBreadcrumb');
 
     if (!modulePage) {
+      if (emptySection) emptySection.hidden = false;
       if (emptyState) emptyState.hidden = false;
       if (titleEl) titleEl.textContent = '未找到对应 module page';
       if (summaryEl) {
@@ -5229,6 +5231,7 @@
       return;
     }
 
+    if (emptySection) emptySection.hidden = true;
     if (emptyState) emptyState.hidden = true;
     document.title = (modulePage.title || moduleId) + ' | Robotics Notebooks';
 
@@ -5321,9 +5324,11 @@
     const summaryEl = document.getElementById('roadmapSummary');
     const metaEl = document.getElementById('roadmapMeta');
     const emptyState = document.getElementById('roadmapEmptyState');
+    const emptySection = document.getElementById('roadmap-empty-section');
     const breadcrumb = document.getElementById('roadmapBreadcrumb');
 
     if (!roadmapPage) {
+      if (emptySection) emptySection.hidden = false;
       if (emptyState) emptyState.hidden = false;
       if (titleEl) titleEl.textContent = '未找到对应 roadmap page';
       if (summaryEl) {
@@ -5351,6 +5356,7 @@
       return;
     }
 
+    if (emptySection) emptySection.hidden = true;
     if (emptyState) emptyState.hidden = true;
     document.title = (roadmapPage.title || roadmapId) + ' | Robotics Notebooks';
 

--- a/docs/module.html
+++ b/docs/module.html
@@ -64,15 +64,17 @@
       </div>
     </section>
 
-    <section class="section" id="module-empty-section">
-      <div class="container">
-        <article id="moduleEmptyState" class="card empty-state" hidden>
-          <h2>未找到对应 module page</h2>
-          <p>请在 URL 里传入合法的 <code>?id=...</code>。例如：<code>module.html?id=control</code></p>
-          <div class="cta-row">
-            <a class="btn-secondary" href="index.html">回到首页</a>
-          </div>
-        </article>
+    <section class="section" id="module-empty-section" hidden>
+      <div class="container detail-content-layout">
+        <div class="detail-content-main">
+          <article id="moduleEmptyState" class="card empty-state" hidden>
+            <h2>未找到对应 module page</h2>
+            <p>请在 URL 里传入合法的 <code>?id=...</code>。例如：<code>module.html?id=control</code></p>
+            <div class="cta-row">
+              <a class="btn-secondary" href="index.html">回到首页</a>
+            </div>
+          </article>
+        </div>
       </div>
     </section>
 

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -78,15 +78,17 @@
       </div>
     </section>
 
-    <section class="section" id="roadmap-empty-section">
-      <div class="container">
-        <article id="roadmapEmptyState" class="card empty-state" hidden>
-          <h2>未找到对应 roadmap page</h2>
-          <p>请在 URL 里传入合法的 <code>?id=...</code>。例如：<code>roadmap.html?id=roadmap-motion-control</code></p>
-          <div class="cta-row">
-            <a class="btn-secondary" href="index.html">回到首页</a>
-          </div>
-        </article>
+    <section class="section" id="roadmap-empty-section" hidden>
+      <div class="container detail-content-layout">
+        <div class="detail-content-main">
+          <article id="roadmapEmptyState" class="card empty-state" hidden>
+            <h2>未找到对应 roadmap page</h2>
+            <p>请在 URL 里传入合法的 <code>?id=...</code>。例如：<code>roadmap.html?id=roadmap-motion-control</code></p>
+            <div class="cta-row">
+              <a class="btn-secondary" href="index.html">回到首页</a>
+            </div>
+          </article>
+        </div>
       </div>
     </section>
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -61,6 +61,9 @@ html {
      （body 的 overflow-x: hidden 不阻止 documentElement.scrollWidth 增长） */
   overflow-x: hidden;
   overflow-x: clip;
+  /* 长详情有经典滚动条、短页（如未找到）没有时，居中主栏会横移约半个滚动条宽；
+     预留 gutter 让 found / not-found / 首页之间切换不再左右抖 */
+  scrollbar-gutter: stable;
 }
 body {
   font-family: var(--font-sans);
@@ -1367,6 +1370,10 @@ button.home-wiki-heatmap-cell.is-active {
   color: var(--accent);
   text-decoration: none;
 }
+/* 空态 section 默认 hidden；即便短暂可见也不要吃 .section 的 44px×2 顶底留白，
+   否则详情加载完成隐藏空态时主栏会垂直跳一下 */
+#detail-empty-section,
+#module-empty-section,
 #roadmap-empty-section {
   padding: 0;
 }

--- a/scripts/verify_detail_empty_column_stable.cjs
+++ b/scripts/verify_detail_empty_column_stable.cjs
@@ -1,0 +1,147 @@
+// 验证：详情页「未找到」与长正文切换时主栏不再因滚动条有无而左右抖动。
+//
+// 断言：
+//   1. found / not-found 主栏宽度一致（同属 detail-content-main）
+//   2. found / not-found 主栏 left 差 < 1px（scrollbar-gutter: stable 生效）
+//   3. 详情加载过程中 #detail-empty-section 不再以 88px 空 padding 占位
+//
+// 前置：仓库根目录先生成站点数据并起静态服务
+//   make export
+//   cd docs && python3 -m http.server 8765
+//
+// 用法（仓库根目录）：
+//   node scripts/verify_detail_empty_column_stable.cjs [baseUrl]
+const puppeteer = require('puppeteer-core');
+const fs = require('fs');
+
+(async () => {
+  const base = process.argv[2] || 'http://127.0.0.1:8765';
+  const candidates = [
+    process.env.CHROME_PATH,
+    '/opt/pw-browsers/chromium-1194/chrome-linux/chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/google-chrome',
+  ].filter(Boolean);
+  const exe = candidates.find((p) => fs.existsSync(p));
+  if (!exe) throw new Error('No Chrome/Chromium found. Set CHROME_PATH.');
+
+  // headed：才能稳定复现经典滚动条（headless 多为 overlay，sb 宽度常为 0）
+  const browser = await puppeteer.launch({
+    executablePath: exe,
+    headless: false,
+    args: ['--no-sandbox', '--disable-gpu', '--window-size=1400,900'],
+  });
+
+  async function measure(id) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1400, height: 900 });
+    await page.goto(base + '/detail.html?id=' + encodeURIComponent(id), {
+      waitUntil: 'networkidle0',
+      timeout: 60000,
+    });
+    await page.waitForFunction(() => {
+      const t = document.getElementById('detailTitle')?.textContent || '';
+      return t && !t.includes('正在加载');
+    }, { timeout: 30000 });
+    await new Promise((r) => setTimeout(r, 250));
+    const m = await page.evaluate(() => {
+      const empty = document.querySelector('#detailEmptyState');
+      const main = document.querySelector('#detailContentSection .detail-content-main');
+      const col = empty && !empty.hidden
+        ? document.querySelector('#detail-empty-section .detail-content-main')
+        : main;
+      const heroC = document.querySelector('.detail-hero .container');
+      return {
+        title: document.getElementById('detailTitle')?.textContent?.trim() || '',
+        sb: window.innerWidth - document.documentElement.clientWidth,
+        gutter: getComputedStyle(document.documentElement).scrollbarGutter,
+        colLeft: col ? col.getBoundingClientRect().left : null,
+        colW: col ? col.getBoundingClientRect().width : null,
+        heroLeft: heroC ? heroC.getBoundingClientRect().left : null,
+      };
+    });
+    await page.close();
+    return m;
+  }
+
+  try {
+    const found = await measure('wiki-concepts-sim2real');
+    const notfound = await measure('missing-id-xyz-jitter-check');
+
+    // 加载闪动：found 页 domcontentloaded 后立刻采样 empty section 高度
+    const flashPage = await browser.newPage();
+    await flashPage.setViewport({ width: 1400, height: 900 });
+    await flashPage.goto(base + '/detail.html?id=wiki-concepts-sim2real', {
+      waitUntil: 'domcontentloaded',
+      timeout: 60000,
+    });
+    const flash = await flashPage.evaluate(async () => {
+      const samples = [];
+      const t0 = performance.now();
+      while (performance.now() - t0 < 1500) {
+        const s = document.querySelector('#detail-empty-section');
+        samples.push({
+          t: Math.round(performance.now() - t0),
+          emptyHidden: !!s?.hidden,
+          emptyH: s && !s.hidden ? Math.round(s.getBoundingClientRect().height) : 0,
+          title: document.getElementById('detailTitle')?.textContent?.trim() || '',
+        });
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      return {
+        maxEmptyH: Math.max(...samples.map((x) => x.emptyH)),
+        anyVisible: samples.some((x) => !x.emptyHidden && x.emptyH > 0),
+      };
+    });
+    await flashPage.close();
+
+    const widthDelta = Math.abs((found.colW || 0) - (notfound.colW || 0));
+    const leftDelta = Math.abs((found.colLeft || 0) - (notfound.colLeft || 0));
+    const heroLeftDelta = Math.abs((found.heroLeft || 0) - (notfound.heroLeft || 0));
+
+    const errors = [];
+    if (!found.title || found.title.includes('未找到')) {
+      errors.push('found page did not resolve: ' + found.title);
+    }
+    if (!notfound.title.includes('未找到')) {
+      errors.push('notfound page title unexpected: ' + notfound.title);
+    }
+    if (widthDelta > 1) {
+      errors.push('main column width mismatch: found=' + found.colW + ' notfound=' + notfound.colW);
+    }
+    if (leftDelta > 1) {
+      errors.push('main column left jitter: delta=' + leftDelta.toFixed(2) + 'px (found left=' + found.colLeft + ', notfound left=' + notfound.colLeft + ', sb found/notfound=' + found.sb + '/' + notfound.sb + ')');
+    }
+    if (heroLeftDelta > 1) {
+      errors.push('hero container left jitter: delta=' + heroLeftDelta.toFixed(2) + 'px');
+    }
+    if (flash.maxEmptyH > 0 || flash.anyVisible) {
+      errors.push('empty section flashed during load: maxH=' + flash.maxEmptyH + ' anyVisible=' + flash.anyVisible);
+    }
+    if (!String(found.gutter || '').includes('stable')) {
+      errors.push('html scrollbar-gutter is not stable: ' + found.gutter);
+    }
+
+    const report = {
+      found,
+      notfound,
+      widthDelta,
+      leftDelta,
+      heroLeftDelta,
+      flash,
+      ok: errors.length === 0,
+      errors,
+    };
+    console.log(JSON.stringify(report, null, 2));
+    if (errors.length) {
+      console.error('FAIL:', errors.join('; '));
+      process.exit(1);
+    }
+    console.log('OK: detail empty/found column stable');
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 主栏**宽度本身一致**（found / not-found 均为 912px），抖动来自经典滚动条有无：长详情 `sb=15`、未找到页 `sb=0`，居中容器左右横移约 7.6px。
- 次因：`#detail-empty-section` 默认未 hidden，加载阶段空 `.section` 仍吃 88px 顶底留白，内容就绪后瞬间收起造成垂直跳一下。
- 修复：`html { scrollbar-gutter: stable }`；空态 section 默认 `hidden` + `padding: 0`；空态卡片放进与正文相同的 `detail-content-layout` / `detail-content-main`（detail / module / roadmap 对齐）。

## 验证
- `node scripts/verify_detail_empty_column_stable.cjs` 通过：`widthDelta=0`、`leftDelta=0`、`heroLeftDelta=0`，加载期 `emptyH=0`
- `npx eslint docs/main.js`：无新增 error（既有 unused `err` warning）

## 验证截图
![详情页正常正文（Sim2Real）](https://cursor.com/artifacts/c/art-01d4106a-4022-494e-920b-b079049e0571)
![未找到对应 detail page 空态](https://cursor.com/artifacts/c/art-69d03807-618f-4e26-ac98-7c3400bf0a5c)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de3de165-92db-425a-9219-42e4b48085f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de3de165-92db-425a-9219-42e4b48085f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

