### PR TITLE
feat(ux): footer 作者名跳转个人主页

### DIFF
--- a/docs/change-log.html
+++ b/docs/change-log.html
@@ -42,7 +42,7 @@
 
   <footer class="footer">
     <div class="container">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
     </div>
   </footer>
 

--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -121,6 +121,7 @@
 - [x] 再次同步刷新 README `media/site-demo.gif`（`scripts/record_readme_demo.cjs`，2031 节点 / 17987 边；70 frames / 3.21 MB）。
 - [x] 再次同步刷新 README `media/site-demo.gif`（`scripts/record_readme_demo.cjs`，2058 节点 / 18475 边；70 frames / 3.12 MB）。
 - [x] 再次同步刷新 README `media/site-demo.gif`：录制脚本真实点击「项目查询 / 知识图谱」入口卡并纳入顺时针描框特效（`scripts/record_readme_demo.cjs`，2060 节点 / 18500 边；88 frames / 3.48 MB）。
+- [x] 全站 footer 作者名「Chong Liu」可点击跳转个人主页 `https://imchong.github.io/index.html`（新标签打开）；`.footer a` 继承次要文字色、悬停强调色。
 
 ---
 

--- a/docs/detail.html
+++ b/docs/detail.html
@@ -199,7 +199,7 @@
 
   <footer class="footer">
     <div class="container footer-stack">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
     </div>
   </footer>
 

--- a/docs/hubs.html
+++ b/docs/hubs.html
@@ -51,7 +51,7 @@
 
   <footer class="footer">
     <div class="container">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
     </div>
   </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -217,7 +217,7 @@
 
   <footer class="footer">
     <div class="container">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
     </div>
   </footer>
 

--- a/docs/module.html
+++ b/docs/module.html
@@ -150,7 +150,7 @@
 
   <footer class="footer">
     <div class="container footer-stack">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
     </div>
   </footer>
 

--- a/docs/modules/imitation-learning.html
+++ b/docs/modules/imitation-learning.html
@@ -187,7 +187,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/modules/motion-control.html
+++ b/docs/modules/motion-control.html
@@ -196,7 +196,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/modules/reinforcement-learning.html
+++ b/docs/modules/reinforcement-learning.html
@@ -187,7 +187,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/relations/retargeting-pipeline.html
+++ b/docs/relations/retargeting-pipeline.html
@@ -142,7 +142,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/relations/rl-vs-il.html
+++ b/docs/relations/rl-vs-il.html
@@ -148,7 +148,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/relations/sim2real-pipeline.html
+++ b/docs/relations/sim2real-pipeline.html
@@ -139,7 +139,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/relations/wbc-vs-rl.html
+++ b/docs/relations/wbc-vs-rl.html
@@ -136,7 +136,7 @@
       </div>
     </section>
   </main>
-  <footer class="footer"><div class="container"><p>© Chong Liu 2026 · Robotics Notebooks</p></div></footer>
+  <footer class="footer"><div class="container"><p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p></div></footer>
   <script src="../main.js"></script>
 </body>
 </html>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -155,7 +155,7 @@
 
   <footer class="footer">
     <div class="container footer-stack">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
     </div>
   </footer>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>

--- a/docs/style.css
+++ b/docs/style.css
@@ -2363,6 +2363,14 @@ button.home-wiki-heatmap-cell.is-active {
   /* 铺纯色底盖住 body 的点阵，页脚不带点 */
   background: var(--bg);
 }
+.footer a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.footer a:hover {
+  color: var(--accent-hover);
+}
 .footer .container {
   display: flex;
   justify-content: center;

--- a/docs/tech-map.html
+++ b/docs/tech-map.html
@@ -160,7 +160,7 @@
 
   <footer class="footer">
     <div class="container footer-stack">
-      <p>© Chong Liu 2026 · Robotics Notebooks</p>
+      <p>© <a href="https://imchong.github.io/index.html" target="_blank" rel="noopener noreferrer">Chong Liu</a> 2026 · Robotics Notebooks</p>
       <p class="footer-note">当前页是 tech-map 的第一阶段 data-driven 版本：先验证结构化页面数据是否足够驱动真实导航页。</p>
     </div>
   </footer>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 全站页脚「Chong Liu」改为可点击链接，跳转个人主页 `https://imchong.github.io/index.html`（新标签打开）
- 补充 `.footer a` 样式：继承次要文字色，悬停强调色

## 验证
- 14 个含 footer 的 HTML 页均已更新作者名链接
- 本地静态站首页 footer 渲染正常；链接文案为「Chong Liu」，`href` 指向个人主页

## 验证截图
![首页底部 footer：Chong Liu 可点击](https://cursor.com/artifacts/c/art-5553b9e8-578b-4cfd-a78e-9e7a7ed17f0b)
![footer 特写：Chong Liu 下划线链接](https://cursor.com/artifacts/c/art-310252a2-d536-48c4-b331-b3219564a3d7)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be044fa6-27f5-4554-9769-39be47cbc474?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be044fa6-27f5-4554-9769-39be47cbc474&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

