### PR TITLE
fix(ux): 短内容页将站内 footer 固定在视口底部

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -122,6 +122,7 @@
 - [x] 再次同步刷新 README `media/site-demo.gif`（`scripts/record_readme_demo.cjs`，2058 节点 / 18475 边；70 frames / 3.12 MB）。
 - [x] 再次同步刷新 README `media/site-demo.gif`：录制脚本真实点击「项目查询 / 知识图谱」入口卡并纳入顺时针描框特效（`scripts/record_readme_demo.cjs`，2060 节点 / 18500 边；88 frames / 3.48 MB）。
 - [x] 全站 footer 作者名「Chong Liu」可点击跳转个人主页 `https://imchong.github.io/index.html`（新标签打开）；`.footer a` 继承次要文字色、悬停强调色。
+- [x] 全站 sticky footer：`body:has(> .footer)` 用 flex 列布局 + `main { flex: 1 }`，短内容页把 `.footer` 推到视口最底部；无 footer 的页面（`graph.html` / `references.html`）不启用。
 
 ---
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -79,6 +79,17 @@ body {
   /* 用 clip 而非 hidden：避免 body 成为 sticky 的滚动容器导致 .site-header 不吸顶 */
   overflow-x: clip;
 }
+/* 有站内 footer 的页面：短内容时把 .footer 推到视口底部；
+   无 footer 的页面（如 graph.html / references.html）不启用，避免干扰全屏布局。 */
+body:has(> .footer) {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+body:has(> .footer) > main {
+  flex: 1 0 auto;
+}
 a { color: var(--accent); text-decoration: none; transition: all var(--transition); }
 a:hover { color: var(--accent-hover); text-decoration: none; opacity: 0.85; }
 .container { max-width: var(--content-max-width); margin: 0 auto; padding: 0 24px; }
@@ -2362,6 +2373,10 @@ button.home-wiki-heatmap-cell.is-active {
   font-size: 0.85rem;
   /* 铺纯色底盖住 body 的点阵，页脚不带点 */
   background: var(--bg);
+  /* sticky footer：短页贴底；长页仍跟在内容之后 */
+  flex-shrink: 0;
+  margin-top: auto;
+  width: 100%;
 }
 .footer a {
   color: inherit;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 对含 `.footer` 的页面启用 `body:has(> .footer)` flex 列布局，`main` 伸展后把站内 footer 推到视口最底部。
- 无 footer 的页面（`graph.html`、`references.html`）不启用，避免干扰全屏图谱布局。

## 验证
- 短内容页：`footer` 贴视口底（`gap = 0`）
- 长内容页：`footer` 仍跟在正文之后
- `graph.html`：无 `.footer`，`body` 保持原布局（`display: block`）

## 验证截图

短内容页（footer 贴底）：
![短内容页 sticky footer](https://cursor.com/artifacts/c/art-0b253493-5a37-4ae4-81b2-9f49ec647197)

互链榜单短内容态（数据未加载时 footer 仍贴底）：
![hubs 短内容 footer 贴底](https://cursor.com/artifacts/c/art-32b42881-59af-4a27-80dd-315540b5450e)

图谱页（无站内 footer，布局不受影响）：
![graph 页无站内 footer](https://cursor.com/artifacts/c/art-7ff10d06-052d-4bcd-b92a-04c9c7d90603)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d905ca5-b8e5-4d3a-94b7-f7dd6fecc282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d905ca5-b8e5-4d3a-94b7-f7dd6fecc282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

