### PR TITLE
style(test): 修复 #1517 合并后 ruff format 失败

### DIFF
--- a/tests/test_generate_link_graph_wiki_activity.py
+++ b/tests/test_generate_link_graph_wiki_activity.py
@@ -176,9 +176,7 @@ class WikiActivityFromLogTest(unittest.TestCase):
         rel = self.existing_paths[0]
         future = self.existing_paths[1]
         structural = (
-            "## [2026-05-27] structural | 扫描通配\n"
-            "- 覆盖 `wiki/concepts/*`\n"
-            f"- 显式保留 {rel}\n"
+            f"## [2026-05-27] structural | 扫描通配\n- 覆盖 `wiki/concepts/*`\n- 显式保留 {rel}\n"
         )
         self._fake_log_path.write_text(structural, encoding="utf-8")
         fake_git = {rel: "2026-05-27", future: "2026-06-01"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- #1517 合入后 `main` 上 Tests 在 **Ruff format (check)** 失败。
- 仅整理 `tests/test_generate_link_graph_wiki_activity.py` 中通配用例字符串以符合 ruff format。

## 验证
- `ruff format --check scripts tests` 本地通过（针对该文件）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45292832-920b-4cf1-8585-d15d32580693?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45292832-920b-4cf1-8585-d15d32580693&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

