### PR TITLE
fix(ux): 修复浅克隆导致「只有今天有新增」

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # ci_preflight → generate_link_graph 需要完整历史以计算 git 首次加入日
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # 新增/维护徽章依赖 git 首次加入日；默认浅克隆会把几乎所有 wiki 标成 tip 日 Added
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # generate_link_graph 的新增/维护标签需要完整 git 历史
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-08-10] structural | scripts/generate_link_graph.py + pages/tests/export workflows — 新增/维护完全以 git 首次加入日为准；Pages 等 CI 改为 fetch-depth: 0（浅克隆会把全库标成 tip 日 Added，导致「只有今天有新增」）
+
+- **现象：** 线上更新记录几乎只有 2026-08-10 有「新增」，历史日 added_count 全 0
+- **根因：** `actions/checkout` 默认浅克隆下 `git log --name-status` 把几乎所有 wiki/roadmap 标成 tip 日 `A`
+- **修复：** workflows `fetch-depth: 0`；`wiki_git_added_dates` 检测浅克隆则跳过并回退日志首日；新建日仍优先 git
+
 ## [2026-08-10] structural | scripts/generate_link_graph.py — 修复更新页「新增 / 维护」误判与历史通配幽灵活动日（例：当日新建 wiki/entities/paper-ace-data-0.md 应标「新增」，且不得出现在 7/24·7/28 活动列表）
 
 - **触发：** 线上更新页将当日新建的 [`wiki/entities/paper-ace-data-0.md`](wiki/entities/paper-ace-data-0.md) 标成「维护」

--- a/scripts/generate_link_graph.py
+++ b/scripts/generate_link_graph.py
@@ -494,16 +494,40 @@ def _iter_wiki_md_paths() -> list[str]:
     return sorted(paths)
 
 
-def wiki_git_added_dates(*, force_refresh: bool = False) -> dict[str, str]:
-    """Map ``wiki/...md`` / ``roadmap/...md`` → ISO committer date of first git add
-    (fallback for action tags).
+def _git_is_shallow() -> bool:
+    """True when the repo is a shallow clone (e.g. Actions ``fetch-depth: 1``)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "--is-shallow-repository"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return result.returncode == 0 and result.stdout.strip().lower() == "true"
 
-    Single ``git log --name-status`` pass over ``wiki/`` + ``roadmap/``; rename-aware.
-    Used only when ``wiki_first_log_dates`` has no ingest/structural entry for a path
-    (e.g. nodes mentioned in ``query`` / ``lint`` blocks).
+
+def wiki_git_added_dates(*, force_refresh: bool = False) -> dict[str, str]:
+    """Map ``wiki/...md`` / ``roadmap/...md`` → ISO committer date of first git add.
+
+    新增/维护徽章的**新建日**以本表为准（完整 git 历史）。浅克隆下 tip 会把
+    几乎所有文件标成 ``A``（同一天），不可信 → 返回空 dict，调用方回退
+    ``wiki_first_log_dates``。部署侧须 ``fetch-depth: 0``。
     """
     global _WIKI_GIT_ADDED_DATES_CACHE
     if not force_refresh and _WIKI_GIT_ADDED_DATES_CACHE is not None:
+        return _WIKI_GIT_ADDED_DATES_CACHE
+
+    if _git_is_shallow():
+        print(
+            "⚠️  shallow git clone detected; skip wiki_git_added_dates "
+            "(would mark nearly all files as added on tip day). "
+            "Use actions/checkout fetch-depth: 0.",
+            flush=True,
+        )
+        _WIKI_GIT_ADDED_DATES_CACHE = {}
         return _WIKI_GIT_ADDED_DATES_CACHE
 
     current_paths = _iter_wiki_md_paths()
@@ -591,10 +615,9 @@ def _wiki_node_action(
 ) -> str | None:
     """Classify a log-day wiki touch as ``added`` or ``maintained``.
 
-    新建日与活动日（``log_date``）为同一日历日 → ``added``；跨日 → ``maintained``。
-    **新建日**优先取 git 首次加入日（文件真正落库日）；无 git 信息时回退
-    ``wiki_first_log_dates``（显式 ingest/structural）。这样「当天新建又改」
-    仍标新增，不会被更早的假日志归因打成维护。
+    新建日与活动日同一天 → ``added``，否则 ``maintained``。
+    **新建日完全以 git 首次加入日为准**（``wiki_git_added_dates``）；仅当 git
+    不可用（浅克隆被跳过 / 无记录）时回退显式 ingest/structural 首日。
     """
     git_day = git_added_dates.get(rel) if git_added_dates else None
     first_day = git_day if git_day is not None else first_log_dates.get(rel)

--- a/tests/test_wiki_first_log_dates.py
+++ b/tests/test_wiki_first_log_dates.py
@@ -156,6 +156,18 @@ class WikiFirstLogDatesTest(unittest.TestCase):
             "maintained",
         )
 
+    def test_shallow_clone_skips_git_added_dates(self) -> None:
+        """浅克隆不可信：wiki_git_added_dates 应返回空，避免全库标成 tip 日新增。"""
+        with mock.patch.object(glg, "_git_is_shallow", return_value=True):
+            glg._WIKI_GIT_ADDED_DATES_CACHE = None
+            self.assertEqual(glg.wiki_git_added_dates(force_refresh=True), {})
+        # 无 git 表时回退日志首日
+        rel = self.existing_paths[0]
+        self.assertEqual(
+            glg._wiki_node_action(rel, "2026-05-28", {rel: "2026-05-28"}, {}),
+            "added",
+        )
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- 线上更新记录几乎只有今天有「新增」、历史日 `added_count` 全 0。
- 根因：Pages 默认 **浅克隆** 下 `git log --name-status` 把几乎所有 `wiki/`/`roadmap/` 标成 tip 日 `A`，新建日全变成今天。
- 修复：
  1. `pages.yml` / `tests.yml` / `export.yml` 设 `fetch-depth: 0`
  2. `wiki_git_added_dates` 检测浅克隆则跳过（回退日志首日），避免再污染
  3. 新增/维护标签：**新建日以 git 首次加入日为准**

## 验证
- 本地复现浅克隆：`mapped=2149` 且全是 tip 日 → 与线上一致
- 加浅克隆守卫后：`days_with_added` 恢复为约 99/102
- 完整历史下：`wiki_git_added_dates` 分布正常（非单日）
- 相关单测 + `make ci-preflight` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45292832-920b-4cf1-8585-d15d32580693?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45292832-920b-4cf1-8585-d15d32580693&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

