### PR TITLE
fix(actions): 修复 Auto Export 推送竞态并放宽 Pages 超时

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -10,9 +10,10 @@ on:
       - 'scripts/**'
   workflow_dispatch:
 
+# 串行执行，避免与并发 main 推送互相 cancel / 抢写导致 git push 被拒
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: auto-export-main
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -49,6 +50,7 @@ jobs:
 
       - name: Commit updated exports
         run: |
+          set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           # 大体积站点 JSON 与 sitemap 已改为 pages.yml 部署时生成（见 .gitignore），
@@ -56,7 +58,19 @@ jobs:
           git add exports/ docs/exports/ catalog.md README.md docs/index.html
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          else
-            git commit -m "chore: auto-export + badge [skip ci]"
-            git push
+            exit 0
           fi
+          git commit -m "chore: auto-export + badge [skip ci]"
+          # 与其他 PR 合并推送竞态时 rebase 重试，避免 ! [rejected] (fetch first)
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebase onto origin/main and retry"
+            git fetch origin main
+            git rebase origin/main
+            sleep $((attempt * 2))
+          done
+          echo "Failed to push after retries" >&2
+          exit 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,6 +55,8 @@ jobs:
           path: 'docs'
 
   deploy:
+    # GitHub Pages 偶发长期停在 deployment_queued；放宽超时减少误杀
+    timeout-minutes: 30
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/weekly-lint.yml
+++ b/.github/workflows/weekly-lint.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 2 * * 1'  # 每周一 UTC 02:00
   workflow_dispatch:       # 支持手动触发
 
+concurrency:
+  group: weekly-lint-main
+  cancel-in-progress: false
+
 jobs:
   lint-report:
     runs-on: ubuntu-latest
@@ -13,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -30,8 +36,24 @@ jobs:
 
       - name: Commit report
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add exports/lint-report.md README.md
-          git diff --cached --quiet || git commit -m "chore: 自动更新每周 lint 报告 + sources badge [skip ci]"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: 自动更新每周 lint 报告 + sources badge [skip ci]"
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); rebase onto origin/main and retry"
+            git fetch origin main
+            git rebase origin/main
+            sleep $((attempt * 2))
+          done
+          echo "Failed to push after retries" >&2
+          exit 1

--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+## [2026-08-10] structural | .github/workflows/export.yml + weekly-lint.yml + pages.yml — 修复 Auto Export/Weekly Lint 与 main 并发推送的 git push 竞态（rebase 重试 + 串行 concurrency）；Pages deploy 超时放宽至 30 分钟
+
+- **触发：** 用户要求修复全部 GitHub Actions 问题。tip `main`（Harness VLA #1524）六项 workflow 已全绿；历史失败主要为 (1) 社区命名（已由 #1523 修复）(2) Auto Export `git push` 被并发 main 推送拒绝 (3) Pages `deployment_queued` 超时。
+- **改动：** [`export.yml`](.github/workflows/export.yml) / [`weekly-lint.yml`](.github/workflows/weekly-lint.yml) 改为串行 concurrency + push 失败时 `fetch`/`rebase` 最多 5 次；[`pages.yml`](.github/workflows/pages.yml) deploy `timeout-minutes: 30`。
+
 ## [2026-08-10] ingest | sources/papers/harness_vla_arxiv_2607_08448.md — 复核 Harness VLA（arXiv:2607.08448v3）+ 项目页 harnessvla.github.io；刷新 wiki/entities/paper-harness-vla.md；交叉 sources/sites/harnessvla-github-io.md、sources/repos/rpent.md、wiki/methods/vla.md、wiki/overview/vla-open-source-repro-landscape-2025.md；代码仍开源 RLinf/RPent
 
 - **触发：** 用户指定论文 <https://arxiv.org/pdf/2607.08448v3> 与项目页 <https://harnessvla.github.io/>；要求自动合并。本库 2026-07-22 已首轮入库，本轮按 v3 PDF / 项目页 / RPent README 复核深化。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- tip `main`（#1523 / #1524）六项 workflow **已全绿**；社区命名失败已由 #1523 修复。
- 历史仍反复出现的 Actions 失败：Auto Export / Weekly Lint 在并发写入 `main` 时 `git push` 被拒（`! [rejected] (fetch first)`）。
- 本 PR：串行 concurrency + push 失败时 `fetch`/`rebase` 最多 5 次；Pages deploy `timeout-minutes: 30`，降低 `deployment_queued` 误杀。

## 验证

- tip `main` Checks：Tests / Wiki Lint / Export Quality / Auto Export / Smoke / Pages 均为 success
- 本 PR 仅改 `.github/workflows/*` + `log.md`

## 验证截图

![main tip CI 全绿](https://cursor.com/artifacts/c/art-20a5a58c-59b5-42e7-b9f6-d80d2e6bcb46)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6eaeb3f-f6c0-4c77-b85b-bc87c43541fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6eaeb3f-f6c0-4c77-b85b-bc87c43541fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

