### PR TITLE
fix(wiki): 修复 DeepSeek Harness 时序图 Mermaid 解析失败

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,10 @@
+## [2026-08-13] structural | wiki/entities/deepseek-harness.md — 修复源码运行时序图 Mermaid：参与者名 Loop 被解析为保留字
+
+- **触发：** 用户反馈 DeepSeek Harness 详情页 Mermaid 时序图格式问题；要求自动合并
+- **根因：** `participant Loop` / `CLI->>Loop` 中的 `Loop` 被 Mermaid sequenceDiagram 当成保留字 `loop`，报 `Expecting ACTOR, got 'loop'`
+- **修复：** 参与者改为 `Driver`（对齐官方 agent-lifecycle 的 driver）；去掉消息里的 `/`、`*`、`→`；流程图 `subgraph loop` 改名为 `agentRing`，链式边拆开
+- **页面：** [`wiki/entities/deepseek-harness.md`](wiki/entities/deepseek-harness.md)
+
 ## [2026-08-13] ingest | sources/repos/deepseek-harness.md — 接入 DeepSeek Harness（dsh）官方插件化 agent 运行时
 
 - **触发：** 用户指定 <https://github.com/deepseek-ai/deepseek-harness>；要求自动合并

--- a/wiki/entities/deepseek-harness.md
+++ b/wiki/entities/deepseek-harness.md
@@ -103,7 +103,7 @@ flowchart TB
     BASE["bundle dsh-base"]
     PATCH["cordis.patch.yml"]
   end
-  subgraph loop [agent 环]
+  subgraph agentRing [agent 环]
     IN["inbox / claim"]
     PRE["agent/pre-step"]
     PR["systemPrompt + tool schemas"]
@@ -121,8 +121,13 @@ flowchart TB
   HD --> PROF
   PY --> PROF
   ACP --> PROF
-  PROF --> BASE --> PATCH --> loop
-  IN --> PRE --> PR --> LLM --> TOOL
+  PROF --> BASE
+  BASE --> PATCH
+  PATCH --> agentRing
+  IN --> PRE
+  PRE --> PR
+  PR --> LLM
+  LLM --> TOOL
   TOOL --> LOG
   LOG --> PR
   TOOL --> seams
@@ -136,38 +141,38 @@ flowchart TB
 sequenceDiagram
   autonumber
   participant User
-  participant CLI as dsh / SDK / Web
-  participant Loop as core/agent-loop
-  participant Prompt as core/system-prompt
-  participant LLM as llm/llm
-  participant Tools as core/tools
-  participant Sess as core/session
+  participant CLI as dsh Web or SDK
+  participant Driver as core agent-loop
+  participant Prompt as core system-prompt
+  participant LLM as llm adapter
+  participant Tools as core tools
+  participant Sess as core session
   User->>CLI: 任务文本或 followup
-  CLI->>Loop: inbox 唤醒
-  Loop->>Sess: turn/start
-  Loop->>Loop: claim next-step + 一条排队消息
-  Loop->>Loop: agent/pre-step 瀑布
+  CLI->>Driver: inbox 唤醒
+  Driver->>Sess: turn start
+  Driver->>Driver: claim next-step 与一条排队消息
+  Driver->>Driver: agent pre-step 瀑布
   alt 拒绝或首轮 enter 为空
-    Loop->>Sess: turn/end（无 step，仍记一次尝试）
+    Driver->>Sess: turn end 无 step 仍记一次尝试
   else 进入 step
-    Loop->>Sess: step/start + user/message
-    Loop->>Prompt: 组装 prompt 段与 tool schema
-    Loop->>LLM: agent/request → llm/stream
-    LLM-->>Sess: assistant/chunk* → assistant/message
+    Driver->>Sess: step start 与 user message
+    Driver->>Prompt: 组装 prompt 段与 tool schema
+    Driver->>LLM: agent request 再 llm stream
+    LLM-->>Sess: assistant chunk 再 assistant message
     loop 工具屏障与有界并发池
-      Loop->>Tools: tools/pre-execute → execute → post-execute
-      Tools-->>Sess: tool/call + tool/result
+      Driver->>Tools: tools pre-execute 再 execute 再 post-execute
+      Tools-->>Sess: tool call 与 tool result
     end
-    Loop->>Sess: step/end
+    Driver->>Sess: step end
     opt 仍欠下一次模型请求
-      Loop->>Loop: 再 claim → 下一 step
+      Driver->>Driver: 再 claim 下一 step
     end
-    Loop->>Loop: agent/turn-stopping
-    Loop->>Sess: turn/end
+    Driver->>Driver: agent turn-stopping
+    Driver->>Sess: turn end
   end
 ```
 
-复现路径：先 `npx @deepseek-ai/dsh web` 配 API key 与 workspace；无头/评测走 Python `examples/jsonrpc-agent/minimal.py` 或 `pnpm dsh --profile headless`。
+`Driver` 对应仓内 `core/agent-loop`（避免 Mermaid 把参与者名 `Loop` 解析成保留字 `loop`）。复现路径：先 `npx @deepseek-ai/dsh web` 配 API key 与 workspace；无头/评测走 Python `examples/jsonrpc-agent/minimal.py` 或 `pnpm dsh --profile headless`。
 
 ## 工程实践
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 DeepSeek Harness 详情页源码运行时序图无法渲染：Mermaid `sequenceDiagram` 把参与者名 `Loop` 当成保留字 `loop`，解析报 `Expecting ACTOR, got 'loop'`。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `mermaid@10.parse`：时序图 `PARSE OK`
- [x] `make ci-preflight`（lint 0 问题，搜索回归 37/37）
- [x] 静态站详情页两张图均渲染出 SVG（flowchart + sequenceDiagram，无 Parse error）

## 相关 Issue

无

## 风险或回滚

仅改 wiki 图语法与一句说明；回滚该页即可。

## 验证截图

![DeepSeek Harness 源码运行时序图（已渲染）](https://cursor.com/artifacts/c/art-ae82f375-f7c4-49a6-9f65-032fb17b04a7)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e472751-2420-4e1e-9c10-25c30e4fbe52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e472751-2420-4e1e-9c10-25c30e4fbe52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

