### PR TITLE
fix(ux): 详情页简介渲染行内公式

### DIFF
--- a/docs/checklists/frontend-optimization-v1.md
+++ b/docs/checklists/frontend-optimization-v1.md
@@ -111,6 +111,7 @@
 - [x] 首页 Hero 规模数字（知识节点 / 互链关系 / 主路线 / 纵深路线）每次进入/刷新 count-up 翻滚；内联脚本首屏前归零避免终值闪跳；立刻用 `data-fallback` 开播（不等 fetch、不重播）；翻滚中保持终值文字色（不变强调色）；去掉位移动画；重 DOM 延后以减轻卡顿；`prefers-reduced-motion` 时直接显示终值。验证脚本 `scripts/verify_hero_stats_countup.cjs`。
 - [x] 首页 Hero 徽章「持续更新…」前蓝点改为慢呼吸灯（`hero-badge-dot-breathe`，3.6s 正弦感曲线，透明度 0.68↔1 + 峰谷短暂停留 + 外环微强弱，避免闪烁）；`prefers-reduced-motion` 下保持静态圆点。
 - [x] 详情/模块/路线「未找到」与长正文切换抖动：根因是经典滚动条有无导致居中主栏横移（宽仍同为 912px），以及空态 `.section` 在 JS 隐藏前吃掉 88px 顶底留白；修复为 `html { scrollbar-gutter: stable }`、空态 section 默认 `hidden` + `padding: 0`，并把空态卡片放进与正文相同的 `detail-content-layout` / `detail-content-main`。验证脚本 `scripts/verify_detail_empty_column_stable.cjs`。
+- [x] 详情页英雄区简介：`#detailSummary` 走与正文相同的 `renderMathBlocks` + `renderDetailMath`，避免 `$O(n)$` 泄漏为 `\(...\)`；`.detail-summary .math-inline` 沿用正文公式高亮。
 ---
 
 ### Phase 4: 信息架构优化 (Information Architecture) - [x] *已完成*

--- a/docs/main.js
+++ b/docs/main.js
@@ -5224,10 +5224,11 @@
       const summaryText = detailPage.summary || '';
       if (summaryText && !isMetadataOnlySummary(summaryText)) {
         summaryEl.hidden = false;
-        summaryEl.innerHTML = renderInlineMarkdown(summaryText, {
+        summaryEl.innerHTML = renderMathBlocks(renderInlineMarkdown(summaryText, {
           currentPath: detailPage.path || '',
           routeIndex: markdownRouteIndex
-        });
+        }));
+        renderDetailMath(summaryEl);
       } else {
         summaryEl.hidden = true;
         summaryEl.textContent = '';

--- a/docs/style.css
+++ b/docs/style.css
@@ -2291,7 +2291,8 @@ button.home-wiki-heatmap-cell.is-active {
   border-radius: 0 8px 8px 0;
   color: var(--text-muted);
 }
-.detail-markdown-body .math-inline {
+.detail-markdown-body .math-inline,
+.detail-summary .math-inline {
   display: inline-block;
   vertical-align: middle;
   padding: .05em .35em;
@@ -2299,11 +2300,14 @@ button.home-wiki-heatmap-cell.is-active {
   background: rgba(45,116,218,.08);
   border: 1px solid rgba(45,116,218,.18);
 }
-.detail-markdown-body .math-inline .katex {
+.detail-markdown-body .math-inline .katex,
+.detail-summary .math-inline .katex {
   display: inline-block;
 }
 .detail-markdown-body .math-inline .katex,
-.detail-markdown-body .math-inline .katex * {
+.detail-markdown-body .math-inline .katex *,
+.detail-summary .math-inline .katex,
+.detail-summary .math-inline .katex * {
   color: var(--accent);
 }
 .detail-markdown-body .math-block {
@@ -2329,7 +2333,8 @@ button.home-wiki-heatmap-cell.is-active {
 .detail-markdown-body .math-block .katex * {
   color: var(--text);
 }
-:root:not([data-theme="light"]) .detail-markdown-body .math-inline {
+:root:not([data-theme="light"]) .detail-markdown-body .math-inline,
+:root:not([data-theme="light"]) .detail-summary .math-inline {
   background: rgba(105,163,255,.12);
   border-color: rgba(105,163,255,.28);
 }

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -385,9 +385,39 @@ console.log('ok');
             "left: '\\\\[', right: '\\\\]', display: true",
             "left: '\\\\(', right: '\\\\)', display: false",
             "renderDetailMath(contentEl);",
+            "renderDetailMath(summaryEl);",
         ]
         for snippet in expected_snippets:
             self.assertIn(snippet, content)
+
+    def test_detail_summary_inline_math_gets_math_inline_wrapper(self):
+        """Hero summary $O(n)$ must wrap math-inline so KaTeX can typeset it."""
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('const matchHtmlRegExp');
+const end = content.indexOf('function applyMathBlocksInHtmlFragment', start);
+eval(content.slice(start, end));
+const sample = '经典 $O(n)$ 算法；计算 $M(q)$、$g(q)$ 与仿真积分。';
+const out = renderMathBlocks(renderInlineMarkdown(sample, {}));
+if ((out.match(/class="math-inline"/g) || []).length !== 3) throw new Error('expected 3 math-inline: ' + out);
+if (out.includes('$')) throw new Error('raw dollar delimiters remain: ' + out);
+if (!out.includes('O(n)') || !out.includes('M(q)') || !out.includes('g(q)')) throw new Error('math content lost: ' + out);
+console.log('ok');
+"""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
 
     def test_bracket_display_math_gets_block_wrapper(self):
         """\\[...\\] display math (common in formalization pages) should wrap math-block for KaTeX."""

--- a/wiki/formalizations/articulated-body-algorithms.md
+++ b/wiki/formalizations/articulated-body-algorithms.md
@@ -2,7 +2,7 @@
 type: formalization
 tags: [dynamics, robotics, aba, rnea, inverse-dynamics, forward-dynamics]
 status: complete
-updated: 2026-08-13
+updated: 2026-08-14
 related:
   - ./lie-group-rigid-body-motions.md
   - ../concepts/floating-base-dynamics.md
@@ -15,7 +15,7 @@ related:
 sources:
   - ../../sources/courses/quadruped_control_simulation_rl_curriculum.md
   - ../../sources/repos/dynibo.md
-summary: "ABA 与 RNEA 是求解树状刚体系统正向/逆向动力学的经典 $O(n)$ 算法；四足浮动基扩展下用于计算 M(q)、g(q) 与仿真积分。"
+summary: "ABA 与 RNEA 是求解树状刚体系统正向/逆向动力学的经典 $O(n)$ 算法；四足浮动基扩展下用于计算 $M(q)$、$g(q)$ 与仿真积分。"
 ---
 
 # Articulated Body Algorithms（ABA / RNEA）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

详情页英雄区简介（`#detailSummary`）把 `$O(n)$` 转成 `\(...\)` 后没有走 KaTeX，[Articulated Body Algorithms](https://imchong.github.io/Robotics_Notebooks/detail.html?id=wiki-formalizations-articulated-body-algorithms) 的简介会露出 `\(O(n)\)`。现与正文共用 `renderMathBlocks` + `renderDetailMath`，并补齐该页摘要里的 `$M(q)$` / `$g(q)$`。

## 变更类型

- [x] 前端（`docs/`）
- [x] 知识入库（ingest / wiki 内容）— 仅 ABA 页 `summary` 公式定界

## 验证

- [x] `make ci-preflight` 通过
- [x] `make test`：398 passed
- [x] `npm run lint:js`：0 errors（既有 unused `err` warning，未改）
- [x] 本地 `detail.html?id=wiki-formalizations-articulated-body-algorithms`：简介内 `$O(n)$` / `$M(q)$` / `$g(q)$` 已由 KaTeX 渲染（`#detailSummary .katex`）

## 相关 Issue

无

## 验证截图

修复前（线上 Pages，简介泄漏 `\(O(n)\)`）：

![ABA 详情页简介修复前：O(n) 显示为反斜杠定界符](https://cursor.com/artifacts/c/art-ac33faf1-3d58-4264-930b-bc2d08350dac)

修复后（本地静态站，行内公式已渲染）：

![ABA 详情页简介修复后：O(n)、M(q)、g(q) 由 KaTeX 渲染](https://cursor.com/artifacts/c/art-0cfd0634-6432-415d-b2a0-4ddda2483d67)

详情页全页（本地，含正文与图谱）：

![ABA 详情页本地全页渲染](https://cursor.com/artifacts/c/art-03102737-edcf-419d-8459-046f4b7694df)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e28d7da2-0524-477f-b9be-901fa5373da2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e28d7da2-0524-477f-b9be-901fa5373da2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

