### PR TITLE
fix: 豁免「英文缩写速查」区块与运行时命令词

### DIFF
--- a/catalog.md
+++ b/catalog.md
@@ -113,7 +113,7 @@
 - [Mapillary Vistas](wiki/entities/dataset-mapillary.md) — Mapillary Vistas**：街景大规模语义分割数据集，类别与地域覆盖广，常与 Cityscapes 对照做域泛化评测。 `📅unknown` `[entity_page]`
 - [MNIST](wiki/entities/dataset-mnist.md) — MNIST**：手写数字分类小规模基准：6 万训练/1 万测试灰度 28×28；教学与算法冒烟测试常用，非现代机器人感知主基准。 `📅unknown` `[entity_page]`
 - [Objects365](wiki/entities/dataset-objects365.md) — Objects365**：超大规模目标检测数据集（365 类、逾百万图像），常用作比 COCO 更强的检测预训练源，再向下游迁移。 `📅unknown` `[entity_page]`
-- [PASCAL VOC](wiki/entities/dataset-pascal-voc.md) — PASCAL VOC**：早期语义/目标检测标准集（20 类）；教学与历史对照常用，现代 SOTA 主战场已转向 COCO/ADE20K。 `📅unknown` `[entity_page]`
+- [PASCAL VOC](wiki/entities/dataset-pascal-voc.md) — PASCAL VOC**：早期语义/目标检测标准集（20 类）；教学与历史对照常用，检测/分割评测的主战场此后转向 COCO/ADE20K。 `📅unknown` `[entity_page]`
 - [VaTeX](wiki/entities/dataset-vatex.md) — VaTeX**：大规模多语言视频–文本数据集，用于视频描述与跨语言检索，服务多模态时序对齐研究。 `📅unknown` `[entity_page]`
 - [WIT](wiki/entities/dataset-wit.md) — WIT**：Wikipedia-based Image Text：维基图文对的超大规模多语言图文数据集，服务 CLIP 类对比学习与检索。 `📅unknown` `[entity_page]`
 - [DBHL窄地形全身运动](wiki/entities/dbhl-whole-body-loco.md) — DBHL窄地形全身运动](https://whole-body-loco.github.io/) 收录于具身智能研究室 [开源项目主表](https://github.com/RealXiaoze/ `📅unknown` `[entity_page]`

--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-08-14] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **16** 条信息型预警）：
+共发现 **0** 个问题（另含 **0** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -52,9 +52,8 @@
 ### 💡 频繁提及但缺少 wiki 页面的概念（0 个）
 - 无
 
-### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（2 个）
-- joint（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
-- STOP（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
+### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（0 个）
+- 无
 
 ### ⚠️ Frontmatter 缺少 type 字段（0 个）
 - 无
@@ -107,21 +106,8 @@
 ### 💡 dataset 实体正文缺「规模/模态/许可证/重定向就绪度」速查维度（信息型，不阻塞 CI）（0 个）
 - 无
 
-### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（14 个）
-- wiki/entities/dataset-ade20k.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-cifar.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-cityscapes.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-coco.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-flickr30k-entities.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-imagenet.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-jft-300m.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-mapillary.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-mnist.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-objects365.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-pascal-voc.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-vatex.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/dataset-wit.md（含绝对化措辞「SOTA」，updated=2026-08-12；同主题更新页 wiki/entities/paper-humanoidvln.md updated=2026-08-14）
-- wiki/entities/paper-occanyscene.md（含绝对化措辞「SOTA」，updated=2026-08-13；同主题更新页 wiki/entities/paper-da-nav.md updated=2026-08-14）
+### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（0 个）
+- 无
 
 ### 💡 动力学/仿真/物理概念页缺回链「仿真物理保真度」知识链枢纽（信息型，不阻塞 CI）（0 个）
 - 无

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -65,14 +65,17 @@ STALE_CLAIM_PATTERNS = [
     r"最新",
 ]
 
-# 陈旧声明巡检的误报豁免：命中绝对化措辞不等于本页在下时效性断言。以下三类是
+# 陈旧声明巡检的误报豁免：命中绝对化措辞不等于本页在下时效性断言。以下四类是
 # 结构性误报，按命中处的上下文豁免，避免为迁就正则去改写本就正确的正文：
 #   1) 否定语境：「这是部署证据，不是策略 SoTA」「不要把它读成又一个 SoTA」等
 #      辟谣式写法，本身就在否认该断言；
 #   2) 库内页面名：「VLA SOTA Leaderboard」是 entities/vla-sota-leaderboard.md 的
 #      页面标题，正文引用它属导航，不是本页断言；
 #   3) 运行时对象：「服务端只保留最新 pending 帧」「取最新状态」描述系统行为，
-#      不会随领域进展过时。
+#      不会随领域进展过时；
+#   4) 英文缩写速查区块：`| SOTA | State of the Art | 排行榜对照参考 |` 是词条
+#      释义表（写作规范要求的固定区块），在给缩写下定义而非给结论下断言，
+#      与「常见误区」区块同属结构性区块，扫描前整段剥离。
 STALE_CLAIM_NEGATION_CUES: tuple[str, ...] = (
     "不是",
     "并非",
@@ -149,6 +152,13 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
     # 循环延迟累计等），是语言/工具链 token，非机器人概念/方法/形式化，
     # 不应建独立页；与 uv/md 同类基础设施停用词。
     "printf",
+    # stop：各页正文里的 `STOP` / `stop` 是运行时命令名或枚举值，三义被小写
+    # slug 合并——BehaviorTree/Groot 控制命令（`STOP`→复位→`RESUME`，其语义已在
+    # concepts/behavior-tree-vla-orchestration.md 的命令表逐条释义）、agent 自
+    # 校正循环的动作枚举（img2threejs 的 `continue`/`refine-code`/`stop`）、
+    # 导航评测的片段类别（Green for Go 的 stop 片段）。非单一可成页概念，
+    # 与 clip（模型名 vs 限幅动词）同类语义噪声。
+    "stop",
 }
 
 # 高频术语但「已在 entities/ 或非同名 stem 的 methods 页有恰当归属」，
@@ -165,6 +175,13 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
 #   g1         → entities/unitree-g1.md（硬件，归 entities）
 #   gmr        → methods/motion-retargeting-gmr.md（General Motion Retargeting，方法页）
 #   heracles   → entities/paper-heracles-humanoid-diffusion.md（具体系统）
+#   joint      → 三义各有归属，均非同名 stem：URDF/MuJoCo 的关节元素归
+#                concepts/urdf-robot-description.md + concepts/armature-modeling.md
+#                （`joint` 上的 armature/反射惯量）；WAM 分类学的 **Joint** 族
+#                （联合预测未来与动作，对 **Cascaded**）归
+#                concepts/world-action-models.md；论文消融条件名「joint」
+#                （Green for Go）属单页实验设定。与 damping 同为 MuJoCo 关节属性
+#                token，本库按参数/分类维度记述，不单建概念页
 #   mjlab      → entities/mjlab.md（库/工具）
 #   mujoco     → entities/mujoco.md（仿真器/工具）
 #   sonic      → methods/sonic-motion-tracking.md（具体方法）
@@ -196,6 +213,7 @@ MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "g1",
     "gmr",
     "heracles",
+    "joint",  # 关节属性 / WAM Joint 族 / 消融条件名三义，已由 URDF + WAM 等页覆盖
     "mit",  # 机构（schema/institutions.json），非概念，不应建 concepts/methods 页
     "mjlab",
     "mujoco",
@@ -711,13 +729,16 @@ def _check_stale_claims(pages: list[Path], results: dict[str, Any]) -> None:
     建议复核。属信息型预警，不计入 lint 失败总数。
 
     命中判定见 :func:`_stale_claim_hit`：否定语境 / 库内页面名引用 / 运行时对象
-    三类结构性误报不算断言。
+    三类结构性误报不算断言；「英文缩写速查」区块是词条释义表，扫描前整段剥离。
     """
+    from wiki_abbrev_section import extract_abbrev_section
+
     page_stems = {p.stem.lower() for p in pages}
     meta: list[tuple[Path, date | None, set[str], str]] = []
     for page in pages:
         content = page.read_text(encoding="utf-8")
         body = re.sub(r"^---\n.*?\n---", "", content, flags=re.DOTALL)
+        body = extract_abbrev_section(body)[1]
         body = strip_misconception_sections(strip_code_blocks(body))
         meta.append(
             (

--- a/tests/test_lint_wiki_missing_concept_pages.py
+++ b/tests/test_lint_wiki_missing_concept_pages.py
@@ -79,6 +79,28 @@ def test_toolchain_stopword_printf_ignored(tmp_path, monkeypatch) -> None:
     assert results["missing_concept_pages"] == []
 
 
+def test_runtime_command_stopword_stop_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "行为树里 `STOP` 后插入复位动作。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # STOP 是运行时命令名 / 动作枚举值，非单一可成页概念
+    assert results["missing_concept_pages"] == []
+
+
+def test_covered_elsewhere_joint_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "MuJoCo 在 **joint** 上提供 `armature` 属性。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # joint 的关节属性 / WAM Joint 族两义已由 URDF、world-action-models 等页覆盖
+    assert results["missing_concept_pages"] == []
+
+
 def test_case_insensitive_merge(tmp_path, monkeypatch) -> None:
     wiki = _setup_wiki(tmp_path, monkeypatch)
     half = lw.MISSING_CONCEPT_PAGE_MIN_PAGES // 2 + 1

--- a/tests/test_lint_wiki_stale_claims.py
+++ b/tests/test_lint_wiki_stale_claims.py
@@ -123,6 +123,42 @@ def test_runtime_object_latest_is_not_flagged(tmp_path, monkeypatch) -> None:
     assert _run([claim, newer])["stale_claims"] == []
 
 
+def test_abbrev_glossary_entry_is_not_flagged(tmp_path, monkeypatch) -> None:
+    # 「英文缩写速查」区块是词条释义表（写作规范固定区块），不是本页断言。
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    claim = _page(
+        wiki,
+        "a.md",
+        "2025-01-01",
+        ["vision"],
+        "## 一句话定义\n\n常规语义分割基准。\n\n"
+        "## 英文缩写速查\n\n"
+        "| 缩写 | 英文全称 | 简要说明 |\n"
+        "|------|----------|----------|\n"
+        "| SOTA | State of the Art | 排行榜对照参考 |\n\n"
+        "## 为什么重要\n\n教学与历史对照常用。",
+    )
+    newer = _page(wiki, "b.md", "2026-01-01", ["vision"], "更晚的同主题页。")
+    assert _run([claim, newer])["stale_claims"] == []
+
+
+def test_claim_outside_abbrev_glossary_is_still_flagged(tmp_path, monkeypatch) -> None:
+    # 豁免只剥离速查区块本身：区块外的正文断言仍须命中。
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    claim = _page(
+        wiki,
+        "a.md",
+        "2025-01-01",
+        ["vision"],
+        "## 英文缩写速查\n\n| SOTA | State of the Art | 排行榜对照参考 |\n\n"
+        "## 为什么重要\n\n本方法仍是该任务的 SOTA。",
+    )
+    newer = _page(wiki, "b.md", "2026-01-01", ["vision"], "更晚的同主题页。")
+    results = _run([claim, newer])
+    assert len(results["stale_claims"]) == 1
+    assert "SOTA" in results["stale_claims"][0]
+
+
 def test_plain_latest_claim_is_still_flagged(tmp_path, monkeypatch) -> None:
     # 豁免只针对结构性误报：无否定/无页面名/非运行时对象的断言仍须命中。
     wiki = _setup_wiki(tmp_path, monkeypatch)

--- a/wiki/entities/dataset-pascal-voc.md
+++ b/wiki/entities/dataset-pascal-voc.md
@@ -5,8 +5,8 @@ tags:
   - computer-vision
   - benchmark
 status: complete
-updated: 2026-08-12
-summary: "早期语义/目标检测标准集（20 类）；教学与历史对照常用，现代 SOTA 主战场已转向 COCO/ADE20K。"
+updated: 2026-08-14
+summary: "早期语义/目标检测标准集（20 类）；教学与历史对照常用，检测/分割评测的主战场此后转向 COCO/ADE20K。"
 related:
   - ../entities/transformer-cv-curriculum.md
   - ../concepts/vision-backbones.md
@@ -20,7 +20,7 @@ sources:
 
 ## 一句话定义
 
-**PASCAL VOC**：早期语义/目标检测标准集（20 类）；教学与历史对照常用，现代 SOTA 主战场已转向 COCO/ADE20K。
+**PASCAL VOC**：早期语义/目标检测标准集（20 类）；教学与历史对照常用，检测/分割评测的主战场此后转向 COCO/ADE20K。
 
 ## 英文缩写速查
 

--- a/wiki/entities/paper-occanyscene.md
+++ b/wiki/entities/paper-occanyscene.md
@@ -15,7 +15,7 @@ tags:
   - hitsz
   - peng-cheng-lab
 status: complete
-updated: 2026-08-13
+updated: 2026-08-14
 arxiv: "2608.08696"
 related:
   - ../concepts/embodied-perception-six-spatial-representations.md
@@ -108,7 +108,7 @@ flowchart TB
 | 项 | 建议 / 论文设定 |
 |----|----------------|
 | **何时用** | 需要 **同一套视觉占据** 覆盖房间级细网格与街道级粗网格，且相机内外参已知 |
-| **何时不用** | 只要单域 SOTA、或必须在线可跑：今日无官方实现；单域也可直接上 EmbodiedOcc / SplatSSC / 驾驶侧 GaussianFormer 系 |
+| **何时不用** | 只需单域最优指标、或必须在线可跑：截至 2026-08-13 无官方实现；单域也可直接上 EmbodiedOcc / SplatSSC / 驾驶侧 GaussianFormer 系 |
 | **几何参照** | 不要回归跨场景绝对高斯尺度；用 **视锥截面 \(d/f\)** 当尺度单位 |
 | **遮挡** | \(K=1\) 已接近 \(K=3\)；补全靠 **邻像素交替 \(\Delta d\)**，不是同一射线多层分离 |
 | **效率参考** | DAv2：98.2 M / 86.4 ms / **670 MiB**（Occ-ScanNet，RTX 4090）；DAv3 时延约 88.4 ms |


### PR DESCRIPTION
## 摘要

修复陈旧声明检查的两处误报：
1. **英文缩写速查区块豁免**：`| SOTA | State of the Art | ...` 这类词条释义表是写作规范的固定结构区块，不是本页时效性断言，扫描前整段剥离
2. **运行时命令词补充**：`stop` 和 `joint` 是运行时命令名/枚举值/属性名，非单一可成页概念，加入停用词表

这两处改动消除了 14 条虚假的陈旧声明预警，同时新增 2 条高频词覆盖测试。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### 1. 英文缩写速查区块豁免（`scripts/lint_wiki.py`）

**问题**：数据集页面（如 `dataset-pascal-voc.md`）的「英文缩写速查」区块包含 `| SOTA | State of the Art | ...` 这样的表格行，被误识别为陈旧声明。

**根本原因**：这类区块是词条释义表（写作规范要求的固定结构），在给缩写下定义而非给结论下断言，属结构性误报。

**解决方案**：
- 新增 `wiki_abbrev_section` 模块的 `extract_abbrev_section()` 函数，识别并剥离「英文缩写速查」区块
- 在 `_check_stale_claims()` 中调用该函数，扫描前移除整个区块
- 更新注释说明，将豁免类别从 3 类扩展为 4 类

### 2. 运行时命令词补充（`scripts/lint_wiki.py`）

**新增停用词**：
- `stop`：BehaviorTree/Groot 控制命令、agent 自校正循环的动作枚举、导航评测片段类别，非单一可成页概念
- `joint`：URDF/MuJoCo 关节元素、WAM 分类学的 Joint 族、论文消融条件名，三义各有归属，已由 `concepts/urdf-robot-description.md` + `concepts/world-action-models.md` 等页覆盖

### 3. 页面内容更新

- `wiki/entities/dataset-pascal-voc.md`：将 summary 和正文中的「现代 SOTA 主战场已转向」改为「检测/分割评测的主战场此后转向」，避免绝对化措辞
- `wiki/entities/paper-occanyscene.md`：将「只要单域 SOTA」改为「只需单域最优指标」，并补充时间戳「截至 2026-08-13」

## 验证

- [x] `make ci-preflight`：陈旧声明预警从 14 条降至 0 条；高频词缺页预警从 2 条降至 0 条
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_lint_wiki_stale_claims.py::test_abbrev_glossary_entry_is_not_flagged` — 新增测试通过
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_lint_wiki_stale_claims.py::test_claim_outside_abbrev_glossary_is_still_

https://claude.ai/code/session_01LPPtod1Fcx3HkUUBSi6f38