### PR TITLE
fix: remove progress bar transition to sync with percentage display

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -705,7 +705,9 @@
       height: 100%;
       border-radius: 999px;
       background: linear-gradient(90deg, #5b9cf6, #7ab3ff);
-      transition: width .3s ease;
+      /* 不要给 width 加过渡：下载阶段每个分片都会重设 width，过渡会被反复打断，
+         进度条稳态落后百分比数字约 v×时长（实测 .3s 过渡 ≈ 落后 2 个百分点）。
+         分片更新本身足够密集，直接写宽度即可保证「进度条 === 数字」。 */
     }
     .graph-loading-pct {
       font-size: .8rem;
@@ -3027,6 +3029,7 @@
     const loadingTitle = document.getElementById('graph-loading-title');
     let loadingValue = 0;
     let loadingDone  = false;
+    const LOADING_HOLD_MS = 140;   // 淡出前让 100% 的满条真正被绘制出来的停留时长
 
     function setLoadingProgress(pct) {
       if (loadingDone) return;
@@ -3039,12 +3042,17 @@
     function finishLoading() {
       if (loadingDone) return;
       loadingDone = true;
+      loadingValue = 100;
       if (loadingFill) loadingFill.style.width = '100%';
       if (loadingPct)  loadingPct.textContent = '100%';
-      if (loadingEl) {
+      if (!loadingEl) return;
+      /* 先让走满的进度条绘制出来再淡出：构图阶段主线程被占满，80/88/96 这几档都没机会绘制，
+         finishLoading 时进度条还停在下载结束的 78% 左右。若在同一帧就开始淡出，
+         用户看到的就是「100% 的数字 + 走了四分之三的进度条」一闪而过。 */
+      setTimeout(() => {
         loadingEl.classList.add('is-hidden');
         setTimeout(() => { loadingEl.hidden = true; }, 500);
-      }
+      }, LOADING_HOLD_MS);
     }
 
     function failLoading(msg) {


### PR DESCRIPTION
## 摘要

修正知识图谱加载页「进度条」与「百分比数字」对不上的问题。两者来自同一个 `pct` 值，但数字是同步写入 DOM 的，进度条要经过 `transition: width .3s ease` 才绘制，因此始终脱节。

## 变更类型

- [x] 前端（`docs/`）

## 详细说明

### 问题（均为实测，非推断）

1. **下载阶段持续落后约 2.2 个百分点**：`fetchJsonWithProgress` 每收到一个分片就重设一次 `width`，过渡被反复打断。稳态落后量 ≈ 进度速度 × 过渡时长，**与缓动曲线无关** —— 中途试过把 `.3s ease` 换成 `.18s linear`，落后量纹丝不动，正好印证了这一点。

2. **收尾差 23.9 个百分点（主要症状）**：`finishLoading()` 在同一帧里写入 `100%` 并立刻 `addClass('is-hidden')`。而构图阶段主线程被占满约 3 秒，`setLoadingProgress(80/88/96)` 这几档**根本没机会绘制**，进度条还停在下载结束的 78%。于是数字直接跳到 100%、进度条却只有 76.1%，随即跟着淡出一起消失。

### 解决方案

1. 去掉 fill 的 `width` 过渡 —— 分片更新本身足够密集，直接写宽度即可保证「进度条 === 数字」。
2. `finishLoading()` 留 140ms 让走满的进度条真正绘制出来，再开始淡出（原有 500ms 淡出逻辑不变）。

## 验证

用 Playwright + CDP 限速 6Mbps 逐帧采样，对比显示的数字与**实际绘制宽度**（`getBoundingClientRect`，而非 `style.width` —— 后者读不出过渡造成的落后）：

| | 稳态落后 | 收尾最大差 |
|---|---|---|
| 修复前 | 2.2 点 | **23.9 点**（数字 `100%` / 进度条 `76.1%`） |
| 修复后 | **0.0** | **0.0** |

- [x] 修复后 530 帧采样 gap 全部为 `0.0`，且满条绘制出来后才淡出（`LAST FRAME BEFORE FADE: text=100%, bar painted 100%`）
- [x] 不限速全量加载：3113 节点 / 27341 边正常渲染，加载页正常隐藏，最终 `100%/100%`，无 pageerror
- [x] `make ci-preflight` 通过（12/12 导出质量检查）

修复前采样节选：

```
  t(ms)    text   target  painted     gap
   9291     78%      78%     75.8    +2.2
  11780    100%     100%     76.1   +23.9    ← 数字已 100%，进度条仍停在 76.1%
```

修复后同一路径：

```
  t(ms)    text   target  painted     gap
   9301     78%      78%       78    +0.0
  11856    100%     100%      100    +0.0
```

> 验证截图（数字 50% 时进度条正好走到一半）已在会话中提供；因 `.cursor-artifacts/` 被 `.gitignore` 屏蔽且本环境不会自动上传本地绝对路径图片，此处不放会渲染失败的图片引用，改以上述逐帧实测数据作为证据。

## 相关 Issue

无

## 备注（本 PR 未处理）

`setLoadingProgress(80/88/96)` 三档在实际加载中永远绘制不出来（构图期间主线程阻塞约 3 秒，无帧渲染），进度条会在 78% 上冻结约 3 秒再跳到 100%。修复后数字与进度条是**一起**冻结、一起跳的，不违反本 PR 要修的「对应上」；若要让这段也走得动，需在挂载 DOM 时主动让出主线程，属于另一处改动，建议单开。