### PR TITLE
fix(wiki): 修复 LEGO 流程总览 mermaid 保留字 graph 导致渲染失败

### DIFF
--- a/wiki/entities/paper-lego-leveled-language-gaussian-splatting.md
+++ b/wiki/entities/paper-lego-leveled-language-gaussian-splatting.md
@@ -94,21 +94,21 @@ flowchart TB
   sam["SAM 多粒度掩码"]
   sfm["MASt3R-SfM / COLMAP"]
   lift["提升 + 共视尺度峰检测"]
-  ind["层级稠密指示器 I_k"]
+  ind["层级稠密指示器 I(k)"]
   rgbgs["RGB 3DGS 30k"]
   feat["冻几何 · 层级特征 10k"]
   tree["HDBSCAN 嵌套树"]
-  clip["OVS → CLIP"]
-  graph["层级 + 邻接场景图"]
+  clipFeat["OVS 到 CLIP"]
+  sceneGraph["层级 + 邻接场景图"]
   q1["单词/短语 · 前三层 CLIP"]
   q2["复合查询 · LLM CoR"]
   rgb --> sam --> lift
   rgb --> sfm --> lift
   sfm --> rgbgs --> feat
   lift --> ind --> feat
-  feat --> tree --> clip --> graph
-  graph --> q1
-  graph --> q2
+  feat --> tree --> clipFeat --> sceneGraph
+  sceneGraph --> q1
+  sceneGraph --> q2
 ```
 
 结构层级对视距和绝对尺寸不变：大车和小车可以同时落在同一「整车 / 部件」级，不必手调全局尺度。
@@ -137,12 +137,12 @@ sequenceDiagram
     SAM->>LVL: 共视 + 3D 尺度定级
     SFM->>LVL: 像素–点映射
     SFM->>RGB: 初始化高斯场
-    LVL->>FEAT: 层级指示器 I_k
+    LVL->>FEAT: 层级指示器 I(k)
     RGB->>FEAT: 冻几何后蒸馏 identity
     FEAT->>TREE: HDBSCAN 树 + 邻接图
     TREE->>CLIP: OVS 裁剪提 CLIP
-    CLIP->>EVAL: clustering/ 产物
-    U->>EVAL: eval 协议或 Viser / --scene-graph
+    CLIP->>EVAL: clustering 产物
+    U->>EVAL: eval 协议或 Viser scene-graph
 ```
 
 断点续跑用 `--from-stage train-rgb --to-stage build-tree`。上游阶段重跑会作废下游 manifest。CoR 查看器要 `LLM_API_KEY`，标注放在 `$LEGO_DATA_ROOT/cor`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

修复 LEGO 实体页「流程总览」mermaid 无法渲染的问题：节点 ID `graph` 是 mermaid 保留字，站点 mermaid@10 报 `Syntax error in text`。已改为 `sceneGraph`，并去掉时序图消息里易歧义的 `--`。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] 浏览器 mermaid.parse：流程图与时序图均 OK
- [x] 静态站详情页流程图 `aria-roledescription=flowchart-v2`（修复前为 `error`）
- [x] `make ci-preflight` 通过

## 验证截图

![修复后的 LEGO 流程总览 mermaid](https://cursor.com/artifacts/c/art-efa9deb6-341d-40c1-b5de-a2b4dc76849e)
![修复后的 LEGO 源码运行时序图](https://cursor.com/artifacts/c/art-ec8d33f4-d7f8-4ebf-b8f0-fb97439b0432)

## 相关 Issue

无（跟进已合并的 ingest PR #1592）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0573863e-63f9-4906-b3f1-4cc6689b821b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0573863e-63f9-4906-b3f1-4cc6689b821b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

