### PR TITLE
lint: 补充陈旧声明与缺页豁免规则

### DIFF
--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-08-16] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **4** 条信息型预警）：
+共发现 **0** 个问题（另含 **0** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -52,9 +52,8 @@
 ### 💡 频繁提及但缺少 wiki 页面的概念（0 个）
 - 无
 
-### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（2 个）
-- reset（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
-- RGB-D（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
+### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（0 个）
+- 无
 
 ### ⚠️ Frontmatter 缺少 type 字段（0 个）
 - 无
@@ -107,9 +106,8 @@
 ### 💡 dataset 实体正文缺「规模/模态/许可证/重定向就绪度」速查维度（信息型，不阻塞 CI）（0 个）
 - 无
 
-### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（2 个）
-- wiki/entities/paper-gentrack.md（含绝对化措辞「SOTA」，updated=2026-08-15；同主题更新页 wiki/entities/paper-arcadia.md updated=2026-08-16）
-- wiki/entities/paper-seeker.md（含绝对化措辞「SOTA」，updated=2026-08-15；同主题更新页 wiki/entities/paper-arcadia.md updated=2026-08-16）
+### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（0 个）
+- 无
 
 ### 💡 动力学/仿真/物理概念页缺回链「仿真物理保真度」知识链枢纽（信息型，不阻塞 CI）（0 个）
 - 无

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -67,8 +67,8 @@ STALE_CLAIM_PATTERNS = [
 
 # 陈旧声明巡检的误报豁免：命中绝对化措辞不等于本页在下时效性断言。以下四类是
 # 结构性误报，按命中处的上下文豁免，避免为迁就正则去改写本就正确的正文：
-#   1) 否定语境：「这是部署证据，不是策略 SoTA」「不要把它读成又一个 SoTA」等
-#      辟谣式写法，本身就在否认该断言；
+#   1) 否定语境：「这是部署证据，不是策略 SoTA」「不要把它读成又一个 SoTA」
+#      「这一行不可直接当 SOTA 通才」等辟谣式写法，本身就在否认该断言；
 #   2) 库内页面名：「VLA SOTA Leaderboard」是 entities/vla-sota-leaderboard.md 的
 #      页面标题，正文引用它属导航，不是本页断言；
 #   3) 运行时对象：「服务端只保留最新 pending 帧」「取最新状态」描述系统行为，
@@ -84,6 +84,7 @@ STALE_CLAIM_NEGATION_CUES: tuple[str, ...] = (
     "不要",
     "而非",
     "不应",
+    "不可",
     "未必",
     "勿",
 )
@@ -220,6 +221,18 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
 #                comparisons/rl-vs-il.md / mpc-vs-rl.md / wbc-vs-rl.md（选型对照）：
 #                与 wbc / wam / urdf 同属「缩写 slug ≠ 页面 stem」，不应按裸缩写
 #                误报为缺页
+#   reset      → entities/gymnasium.md（`reset` / `step` 标准方法集合、四入口节点图、
+#                「先 step 再 reset 会被 OrderEnforcing 拦下」误区条）+
+#                entities/paper-xpolicylab.md（策略侧 `reset` 清 episode 状态）：
+#                环境/策略 API 的方法名（episode 复位），与 stop（运行时命令名）
+#                同类 token，语义已在 API 表逐条释义，不单建概念页
+#   rgb-d      → concepts/embodied-perception-six-spatial-representations.md
+#                （缩写速查 + 「深度」层的 RGB-D SLAM / 尺度对齐口径）+
+#                formalizations/3d-coordinate-transforms-vision-robotics.md
+#                （深度获取路径表：结构光 / ToF 直接测距，及反投影链路）+
+#                concepts/2d-to-3d-semantic-lifting-gap.md（RGB-D 补尺度路线）：
+#                传感模态标签而非独立可成页机制，与 vlm 同类，另建概念页只会与
+#                上述表征/几何页重复同一来源
 MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "amp",
     "armature",
@@ -234,6 +247,8 @@ MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "mujoco",
     "qpos",  # MuJoCo 状态数组字段名，已由广义坐标 $q$ 的形式化/概念页覆盖
     "qwen3-vl",  # 外部 VLM 底座型号，已在 methods/vla.md 等按「底座」维度记述
+    "reset",  # 环境/策略 API 方法名（episode 复位），已由 entities/gymnasium.md 释义
+    "rgb-d",  # 传感模态标签，已由六种空间表征 / 三维坐标变换等页覆盖
     "rl",  # 已由 methods/reinforcement-learning.md 覆盖（缩写 slug 与页面 stem 不同名）
     "sonic",
     "wbc",  # 已由 concepts/whole-body-control.md 覆盖（slug 与页面 stem 不同名）

--- a/tests/test_lint_wiki_missing_concept_pages.py
+++ b/tests/test_lint_wiki_missing_concept_pages.py
@@ -101,6 +101,28 @@ def test_covered_elsewhere_joint_ignored(tmp_path, monkeypatch) -> None:
     assert results["missing_concept_pages"] == []
 
 
+def test_covered_elsewhere_reset_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "Gym 风格 `reset` / `step` 接口。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # reset 是环境/策略 API 的方法名（episode 复位），已由 entities/gymnasium.md 释义
+    assert results["missing_concept_pages"] == []
+
+
+def test_covered_elsewhere_rgbd_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "输入为 **RGB-D** 观测。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # RGB-D 是传感模态标签，已由六种空间表征 / 三维坐标变换等页覆盖
+    assert results["missing_concept_pages"] == []
+
+
 def test_case_insensitive_merge(tmp_path, monkeypatch) -> None:
     wiki = _setup_wiki(tmp_path, monkeypatch)
     half = lw.MISSING_CONCEPT_PAGE_MIN_PAGES // 2 + 1

--- a/tests/test_lint_wiki_stale_claims.py
+++ b/tests/test_lint_wiki_stale_claims.py
@@ -100,6 +100,36 @@ def test_negated_claim_is_not_flagged(tmp_path, monkeypatch) -> None:
     assert _run([claim, newer])["stale_claims"] == []
 
 
+def test_cannot_be_read_as_claim_is_not_flagged(tmp_path, monkeypatch) -> None:
+    # 「不可直接当 SOTA 通才」与「不是 SoTA」同属辟谣式写法，在否认该断言。
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    claim = _page(
+        wiki,
+        "a.md",
+        "2025-01-01",
+        ["humanoid"],
+        "BeyondMimic 行不可直接当 SOTA 通才。论文自己把它标成 specialist。",
+    )
+    newer = _page(wiki, "b.md", "2026-01-01", ["humanoid"], "更晚的同主题页。")
+    assert _run([claim, newer])["stale_claims"] == []
+
+
+def test_negation_cue_in_previous_sentence_does_not_exempt(tmp_path, monkeypatch) -> None:
+    # 否定线索只在命中词同句内生效：上一句的「不可」不应放过本句的真实断言。
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    claim = _page(
+        wiki,
+        "a.md",
+        "2025-01-01",
+        ["humanoid"],
+        "该权重不可商用。本方法仍是该任务的 SOTA。",
+    )
+    newer = _page(wiki, "b.md", "2026-01-01", ["humanoid"], "更晚的同主题页。")
+    results = _run([claim, newer])
+    assert len(results["stale_claims"]) == 1
+    assert "SOTA" in results["stale_claims"][0]
+
+
 def test_library_page_title_reference_is_not_flagged(tmp_path, monkeypatch) -> None:
     # 「VLA SOTA Leaderboard」是库内页面标题，引用它属导航而非本页断言。
     wiki = _setup_wiki(tmp_path, monkeypatch)

--- a/wiki/entities/paper-seeker.md
+++ b/wiki/entities/paper-seeker.md
@@ -13,7 +13,7 @@ tags:
   - uni-freiburg
   - uni-hamburg
 status: complete
-updated: 2026-08-15
+updated: 2026-08-16
 arxiv: "2608.13422"
 code: https://github.com/zheyu-zhuang/seeker
 related:
@@ -163,7 +163,7 @@ sequenceDiagram
 | MirrorAug | 37.2 | 对称增强、仍看全图 |
 | RVT2-Crop | 42.6 | 最强输入级基线；夹爪/低速关键帧会鬼影或错过连续运动 |
 | **Seeker** | **62.6** | 相对 RVT2 +20.0 点；3-P Assembly / Threading 相对增益最大 |
-| RAVEN | 52.1 | 外部等变策略 SOTA，不在同栈 |
+| RAVEN | 52.1 | 外部等变策略的已发表最优对照（论文口径），不在同栈 |
 | Oracle ROI | 64.2 | 特权阶段 affordance 框；Seeker 差 1.6 点 |
 
 **背景：** 原背景训出的 mask 做 Guided Overlay，在打乱桌面纹理上仍最强；只加纹理多样性不够，细交互会被盖住。


### PR DESCRIPTION
## 摘要

补充 wiki 巡检规则中的两类豁免：
1. 陈旧声明巡检：新增「不可」作为否定线索，并补充「不可直接当 SOTA 通才」等辟谣式写法的示例；强化「否定线索仅在同句内生效」的约束。
2. 缺页巡检：将 `reset` 和 `rgb-d` 加入「已在他处覆盖」豁免集合，避免误报为缺页。

同步更新测试用例和巡检报告。

## 变更类型

- [x] 维护脚本 / CI / 文档
- [x] 知识入库（wiki 内容更新）

## 详细说明

### 脚本改动（`scripts/lint_wiki.py`）

**陈旧声明巡检（第 67-90 行）：**
- 在 `NEGATION_CUES` 元组中新增 `"不可"` 作为否定线索
- 更新注释示例，补充「不可直接当 SOTA 通才」等辟谣式写法
- 澄清否定线索的作用域：仅在命中词同句内生效

**缺页巡检（第 220-247 行）：**
- 在 `MISSING_CONCEPT_COVERED_ELSEWHERE` 集合中新增 `"reset"` 和 `"rgb-d"`
- 补充详细注释说明两个概念的覆盖来源：
  - `reset`：由 `entities/gymnasium.md`（标准方法集合、四入口节点图）和 `entities/paper-xpolicylab.md`（策略侧状态清理）覆盖
  - `rgb-d`：由 `concepts/embodied-perception-six-spatial-representations.md`（缩写速查）、`formalizations/3d-coordinate-transforms-vision-robotics.md`（深度获取路径）和 `concepts/2d-to-3d-semantic-lifting-gap.md`（RGB-D 补尺度路线）覆盖

### 测试用例（`tests/test_lint_wiki_stale_claims.py`）

新增两个测试：
- `test_cannot_be_read_as_claim_is_not_flagged`：验证「不可直接当 SOTA 通才」等辟谣式写法不被误报
- `test_negation_cue_in_previous_sentence_does_not_exempt`：验证否定线索仅在同句内生效，上一句的「不可」不应放过本句的真实断言

### 测试用例（`tests/test_lint_wiki_missing_concept_pages.py`）

新增两个测试：
- `test_covered_elsewhere_reset_ignored`：验证 `reset` 不被误报为缺页
- `test_covered_elsewhere_rgbd_ignored`：验证 `rgb-d` 不被误报为缺页

### 内容更新（`wiki/entities/paper-seeker.md`）

- 更新 `updated` 字段从 `2026-08-15` 到 `2026-08-16`
- 修改表格中 RAVEN 行的描述，从「外部等变策略 SOTA」改为「外部等变策略的已发表最优对照（论文口径）」，避免绝对化措辞

### 巡检报告（`exports/lint-report.md`）

- 缺页预警从

https://claude.ai/code/session_012AX85NF9ggsPCR5oAsHGq9