### PR TITLE
fix(ux): 修复 All Hands Up 详情页美元价被 KaTeX 吞掉

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -1683,6 +1683,18 @@
       .replace(/\*([^*]+)\*/g, '<em>$1</em>');
   }
 
+  /**
+   * `$50k ... $7.5k` / `$30,000–$90,000` are currency, not `$...$` math.
+   * Keep `$0.99$`, `$O(n)$`, `$1/(1-\gamma)$` as KaTeX.
+   */
+  function isCurrencyDollarPair(expr) {
+    var s = String(expr || '').trim();
+    if (!s) return false;
+    if (/[\u3400-\u9fff]/.test(s)) return true;
+    if (/\*\*/.test(s)) return true;
+    return /^\d[\d,]*(?:\.\d+)?(?:[kKmMbB])?\s*(?:[–\-—/]|…|\.{2,3})\s*$/.test(s);
+  }
+
   function renderInlineMarkdown(text, markdownContext) {
     markdownContext = markdownContext || {};
     const source = String(text || '');
@@ -1709,6 +1721,7 @@
       .replace(/\$\s*([^$]+?)\s*\$/g, function (match, expr) {
         const trimmed = String(expr || '').trim();
         if (!trimmed) return match;
+        if (isCurrencyDollarPair(trimmed)) return match;
         const token = mathPrefix + mathTokens.length + '@@';
         // Normalize $...$ to \(...\) so downstream renderMathBlocks can catch it
         mathTokens.push({ token: token, html: '\\(' + trimmed + '\\)' });

--- a/log.md
+++ b/log.md
@@ -1,3 +1,8 @@
+## [2026-08-17] fix(ux): 美元价不被 KaTeX 成对 `$...$` 吞掉（entity-all-hands-up）
+
+- **现象：** [`wiki/entities/all-hands-up.md`](wiki/entities/all-hands-up.md) 工程实践段「约 $50k … 约 $7.5k」被 `docs/main.js` 行内公式正则配对，详情页把中间加粗与中文吞成公式
+- **修复：** `renderInlineMarkdown` 跳过货币配对（CJK / `**` / `$30,000–$90,000` 价带）；`$O(n)$`、`$0.99$` 仍走 KaTeX
+
 ## [2026-08-17] ingest | sources/blogs/current_robotics_currentworld.md — 接入 CurrentWorld-0 跨本体交互世界模拟器；确认未开源
 
 - **触发：** 用户指定 ingest <https://current-robotics.com/blog/currentworld>，并要求自动合并 PR

--- a/tests/test_content_sync.py
+++ b/tests/test_content_sync.py
@@ -455,6 +455,44 @@ console.log('ok');
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
         self.assertIn("ok", result.stdout)
 
+    def test_currency_dollar_pairs_are_not_treated_as_inline_math(self):
+        """Prose prices like $50k ... $7.5k must not become KaTeX (entity-all-hands-up)."""
+        node = r"""
+const fs = require('fs');
+const content = fs.readFileSync(process.argv[2], 'utf8');
+const start = content.indexOf('const matchHtmlRegExp');
+const endNorm = content.indexOf('function normalizeMathExpr(expr)', start);
+const endMath = content.indexOf('function applyMathBlocksInHtmlFragment', endNorm);
+eval(content.slice(start, endNorm));
+eval(content.slice(endNorm, endMath));
+const sample = '§2 点名的「高分叙事」是 **SharpaWave**（力任务强、约 $50k）、**DG-5F-S**（DexBench 接近 Sharpa、约 $7.5k，金属指面摩擦偏低）';
+const out = renderMathBlocks(renderInlineMarkdown(sample, {}));
+if (out.includes('class="math-inline"')) throw new Error('currency eaten as math: ' + out);
+if (!out.includes('$50k') || !out.includes('$7.5k')) throw new Error('currency dollars lost: ' + out);
+if (!out.includes('<strong>SharpaWave</strong>') || !out.includes('<strong>DG-5F-S</strong>')) {
+  throw new Error('bold lost: ' + out);
+}
+const math = renderMathBlocks(renderInlineMarkdown('经典 $O(n)$ 与 $\\gamma=0.99$', {}));
+if ((math.match(/class="math-inline"/g) || []).length !== 2) throw new Error('real math broken: ' + math);
+const range = renderInlineMarkdown('约 **$30,000–$90,000**', {});
+if (range.includes('\\(')) throw new Error('price range eaten: ' + range);
+if (!range.includes('$30,000') || !range.includes('$90,000')) throw new Error('price range lost: ' + range);
+console.log('ok');
+"""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as tmp:
+            tmp.write(node)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["node", tmp_path, str(MAIN_JS)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        self.assertIn("ok", result.stdout)
+
     def test_inline_math_with_padding_spaces_in_table_cells(self):
         """$ ... $ with spaces inside delimiters (abbrev glossary tables) should render."""
         node = r"""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

`detail.html?id=entity-all-hands-up` 工程实践段「约 $50k … 约 $7.5k」被 `docs/main.js` 的行内 `$...$` 正则配对成公式，中间加粗与中文被 KaTeX 吞掉。本次让 `renderInlineMarkdown` 跳过货币配对，真实公式（`$O(n)$`、`$0.99$`）仍走 KaTeX。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [x] 其他：回归测试 + `log.md`

## 验证

- [x] `make ci-preflight` 通过
- [x] `PYTHONPATH=scripts python3 -m pytest tests/test_content_sync.py::DetailContentSyncTests::test_currency_dollar_pairs_are_not_treated_as_inline_math --no-cov` 通过
- [x] 本地 `docs/detail.html?id=entity-all-hands-up`：`$50k` / `$7.5k` 为普通货币文本，无 `.math-inline` / `.katex`

## 验证截图

线上现状（修复前）：`$50k … $7.5k` 被当成行内公式，`**DG-5F-S**` 泄漏为数学斜体。

![修复前：All Hands Up 价格句被 KaTeX 吞掉](https://cursor.com/artifacts/c/art-8f6a8758-4c60-421f-aa38-c610a561437f)

本地修复后：美元价按正文显示，加粗名称正常。

![修复后：约 $50k 与约 $7.5k 按货币文本渲染](https://cursor.com/artifacts/c/art-02508758-2e8b-42c1-bd08-de0d13bc106b)

![修复后：工程实践段上下文，$50k / $7.5k 可见](https://cursor.com/artifacts/c/art-fb98e594-fd2d-4a4d-9c95-536a143db770)

<a href="https://cursor.com/agents/bc-be45ce59-a4da-4529-b003-85920e4f1b3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fall_hands_up_price_line_renders_as_currency.mp4"><img src="https://cursor.com/artifacts/c/art-e7712d06-e7e5-40d2-abc3-6fe4a9a81383" alt="all_hands_up_price_line_renders_as_currency.mp4" /></a>

## 相关 Issue

无

## 风险或回滚注意

仅影响 `$...$` 行内公式识别：含 CJK / Markdown `**` 的跨美元配对、以及 `$30,000–$90,000` 这类价带不再当公式。若误伤，回滚 `docs/main.js` 中 `isCurrencyDollarPair` 即可。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be45ce59-a4da-4529-b003-85920e4f1b3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be45ce59-a4da-4529-b003-85920e4f1b3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

