### PR TITLE
fix(ux): 修复首页因未解决 Git 合并冲突导致的渲染异常

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,13 @@
 
 机器人技术栈知识库 / Robotics research and engineering wiki.
 
-<<<<<<< HEAD
 <!-- Last updated: 2026-08-25 (V31 自动更新：图谱 3286 节点 29095 边) -->
-=======
-<!-- Last updated: 2026-08-25 (V31 自动更新：图谱 3286 节点 29095 边) -->
->>>>>>> origin/main
 
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Live-brightgreen?logo=github)](https://imchong.github.io/Robotics_Notebooks/)
 [![Deploy GitHub Pages](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/pages.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/pages.yml)
 [![Wiki Lint](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml/badge.svg)](https://github.com/ImChong/Robotics_Notebooks/actions/workflows/lint.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-<<<<<<< HEAD
 [![Knowledge Graph](https://img.shields.io/badge/知识图谱-3286节点_29095边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
-=======
-[![Knowledge Graph](https://img.shields.io/badge/知识图谱-3286节点_29095边-blue?logo=d3.js)](https://imchong.github.io/Robotics_Notebooks/graph.html)
->>>>>>> origin/main
 [![Sources Coverage](https://img.shields.io/badge/sources覆盖率-100%25-green)](docs/checklists/tech-stack-next-phase-checklist-v31.md)
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,19 +43,11 @@
 
         <ul class="hero-stats" aria-label="知识库当前规模">
           <li class="hero-stat">
-<<<<<<< HEAD
             <a class="hero-stat-num" id="heroNodeCount" href="graph.html" aria-label="查看知识图谱（知识节点）">3286</a>
             <span class="hero-stat-label">知识节点</span>
           </li>
           <li class="hero-stat">
             <a class="hero-stat-num" id="heroEdgeCount" href="graph.html" aria-label="查看知识图谱（互链关系）">29095</a>
-=======
-            <a class="hero-stat-num" id="heroNodeCount" href="graph.html" aria-label="查看知识图谱（知识节点）">3280</a>
-            <span class="hero-stat-label">知识节点</span>
-          </li>
-          <li class="hero-stat">
-            <a class="hero-stat-num" id="heroEdgeCount" href="graph.html" aria-label="查看知识图谱（互链关系）">29050</a>
->>>>>>> origin/main
             <span class="hero-stat-label">互链关系</span>
           </li>
           <li class="hero-stat">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
- `docs/index.html` Hero 统计区残留 `<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main` 合并冲突标记，导致首页直接渲染出冲突文本并破坏 DOM 结构
- 同步清理 `README.md` 中两处相同冲突标记（内容一致，无功能差异）
- 保留与 `exports/home-stats.json` 一致的统计值：3286 节点 / 29095 边

## 根因
某次合并未正确解决冲突，冲突标记被提交进 `main`，首页 Hero 区 HTML 被破坏。

## 验证
- `curl` 检查 served HTML：无冲突标记
- 本地 `make export graph` + `python3 -m http.server 8765` 预览首页
- Puppeteer 截图确认 Hero 区正常显示 `3286` / `29095`

## 验证截图
![首页 Hero 区修复后渲染正常](https://cursor.com/artifacts/c/art-dd7158b2-c8de-4d60-ba66-a7e1a9f02c6a)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d066d19d-5628-45ac-901b-89040bfc18a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d066d19d-5628-45ac-901b-89040bfc18a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

