### PR TITLE
[2026-08-25] ingest | FetchMan — 二次核查开源状态（GitHub 占位仓）

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,9 @@
+## [2026-08-25] ingest | sources/repos/fetchman.md — FetchMan 二次核查开源状态：项目页挂 GitHub 占位仓；更新实体页与 loco-manipulation 索引
+
+- **触发：** 用户指定 <https://orayyan.com/fetchman>、arXiv:2608.17027；要求自动合并 PR
+- **步骤 2.5：** **部分开源 / 待发布** — [omarrayyann/fetchman](https://github.com/omarrayyann/fetchman) 仅 README；README：**Code will be added by September 1**；FetchMan-Bench 仍无下载链
+- **增量：** 新建 `sources/repos/fetchman.md`；更新 `sources/sites/`、`sources/papers/`、`wiki/entities/paper-fetchman.md` 开源结论（2026-08-20「未开源」→ 占位仓待发布）
+
 ## [2026-08-25] ingest | sources/blogs/wechat_embodied_heart_robot_icl_gen15_survey_2026-08-25.md — 具身智能之心「机器人上下文学习」万字综述；新建概念页 robot-in-context-learning；交叉 GEN-1.5 / IL / foundation-policy / manipulation
 
 - **触发：** 用户指定公众号 <https://mp.weixin.qq.com/s/V_Dm8kHvB2YxtGY7qScjXA>

--- a/roadmap/depth-loco-manipulation.md
+++ b/roadmap/depth-loco-manipulation.md
@@ -145,7 +145,7 @@ flowchart LR
 - [SplitAdapter](../wiki/entities/paper-splitadapter-load-aware-loco-manipulation.md)（本仓库）
 - [Whole-Body Tracking Pipeline](../wiki/concepts/whole-body-tracking-pipeline.md)（本仓库）
 - [SMPC-to-RL](../wiki/entities/paper-smpc2rl-loco-manipulation.md)（本仓库）— 仿真 SMPC 当可交互专家数据机，稀疏奖励 offline-to-online FastTD3 接冻结低层；Spot 推箱/扶胎与 G1 推箱真机可部署，策略比教师更快
-- [FetchMan](../wiki/entities/paper-fetchman.md)（本仓库）— MolmoSpaces 15 万场景脚本演示 → BC → Flow-GRPO 突破 BC 天花板；G1 真机 loco-manip 零样本 73.3%；代码未开源
+- [FetchMan](../wiki/entities/paper-fetchman.md)（本仓库）— MolmoSpaces 15 万场景脚本演示 → BC → Flow-GRPO 突破 BC 天花板；G1 真机 loco-manip 零样本 73.3%；GitHub 占位仓（2026-09-01 前补代码）
 
 ### 学完输出什么
 - 一个能在仿真里完成"走近 + 全身接触搬运"的技能策略

--- a/sources/papers/fetchman_arxiv_2608_17027.md
+++ b/sources/papers/fetchman_arxiv_2608_17027.md
@@ -9,13 +9,16 @@
 - **作者：** Omar Rayyan、Zhi Li、Max Argus、Yuxin Jiang、Chang Yu、Chenfanfu Jiang、Yuchen Cui
 - **机构：** 加州大学洛杉矶分校（UCLA）；艾伦人工智能研究所（Allen Institute for AI）；华盛顿大学（University of Washington）
 - **入库日期：** 2026-08-20
+- **再核日期：** 2026-08-25
+- **代码：** <https://github.com/omarrayyann/fetchman>（占位仓；README：**Code will be added by September 1**）
 - **一句话说明：** 在 MolmoSpaces 上生成 15 万场景脚本演示 → DINOv3+DiT BC → Flow-GRPO 稀疏奖励 refinement → Unitree G1 零样本 loco-manip。
 
 ## 开源状态（步骤 2.5）
 
-- **项目页（2026-08-20）：** 含摘要、架构、消融视频与 BibTeX；**未列 GitHub / Hugging Face / 权重下载**。
-- **论文：** 宣称 release **FetchMan-Bench**（固定 held-out 场景与评分），但未给代码 URL。
-- **结论：** **确认未开源**（训练代码与 checkpoint 截至入库日不可获取）；基准「将发布」待跟进。
+- **项目页（2026-08-25 再核）：** 页头 **Data & Code** → [omarrayyann/fetchman](https://github.com/omarrayyann/fetchman)；含摘要、架构、消融视频与 BibTeX。
+- **GitHub（2026-08-25）：** 仓已公开，**仅 README.md**；无训练/推理脚本、无权重、无 Bench 下载。
+- **论文：** 宣称 release **FetchMan-Bench**（固定 held-out 场景与评分），截至再核日仍无公开下载链。
+- **结论：** **部分开源 / 待发布** — 官方占位仓与时间表已挂出；可运行复现入口待 **2026-09-01 前** 跟进。
 
 ## 摘录 1：问题与管线（§1、§4–5）
 
@@ -44,5 +47,6 @@
 
 ## 建议 wiki 动作
 
-- 新建 **`wiki/entities/paper-fetchman.md`**；`sources/sites/fetchman-orayyan.md`。
-- 更新 [loco-manipulation](../../wiki/tasks/loco-manipulation.md) 视觉 sim 路线索引。
+- 维护 **`wiki/entities/paper-fetchman.md`**、`sources/sites/fetchman-orayyan.md`、`sources/repos/fetchman.md`。
+- 更新 [loco-manipulation](../../wiki/tasks/loco-manipulation.md) 开源状态（占位仓 → 待发布）。
+- 代码释出后补实体页 **源码运行时序图** 与 repo 入口表。

--- a/sources/repos/fetchman.md
+++ b/sources/repos/fetchman.md
@@ -1,0 +1,41 @@
+# FetchMan（omarrayyann/fetchman）
+
+- **URL：** <https://github.com/omarrayyann/fetchman>
+- **Maintainer：** Omar Rayyan 等（UCLA / AI2 / UW，与 arXiv:2608.17027 作者团队一致）
+- **入库日期：** 2026-08-25
+- **关联论文：** [FetchMan](https://arxiv.org/abs/2608.17027)（arXiv:2608.17027）
+- **项目页：** <https://orayyan.com/fetchman>
+- **开源状态（截至 2026-08-25）：** **部分开源 / 待发布** — 仓库与项目页「Data & Code」已公开，当前仅 `README.md`；README 声明 **Code will be added by September 1**；FetchMan-Bench 尚无下载链。
+- **Tags：** #fetchman #humanoid #loco-manipulation #sim2real #flow-grpo #molmospaces #unitree-g1 #behavior-cloning
+
+## 一句话说明
+
+FetchMan 官方 GitHub 占位仓：项目页与 README 互链，承诺 **2026-09-01 前** 释出数据与训练/推理代码；入库日尚无可运行入口。
+
+## 仓库要点（2026-08-25 核查）
+
+| 字段 | 内容 |
+|------|------|
+| 创建时间 | 2026-08-16 |
+| 默认分支 | `main` |
+| 当前内容 | `README.md`（Website / Paper 链接 + 开源时间表） |
+| 许可证 | 待代码释出后确认（API `license: null`） |
+| Stars（约） | 43（2026-08-25） |
+
+## 入口速查
+
+| 路径 / 命令 | 作用 |
+|-------------|------|
+| README | 项目页、论文链接；**Code will be added by September 1** |
+| 训练 / 推理 / Bench | **未发布** |
+
+## 对 wiki 的映射
+
+- [FetchMan 论文实体](../../wiki/entities/paper-fetchman.md)
+- [Loco-Manipulation 任务](../../wiki/tasks/loco-manipulation.md)
+- [Unitree G1](../../wiki/entities/unitree-g1.md)
+
+## 维护备注
+
+- 项目页页头 **Data & Code** 按钮指向本仓（2026-08-20 入库时页上尚无 GitHub 链）。
+- 代码落地后应补：`sources/repos/fetchman.md` 训练/推理入口表、`wiki/entities/paper-fetchman.md` 源码运行时序图。

--- a/sources/sites/fetchman-orayyan.md
+++ b/sources/sites/fetchman-orayyan.md
@@ -7,17 +7,19 @@
 - **官方入口：** <https://orayyan.com/fetchman>
 - **论文：** <https://arxiv.org/abs/2608.17027>
 - **入库日期：** 2026-08-20
+- **再核日期：** 2026-08-25
 - **一句话说明：** UCLA 等人形 loco-manip 项目页：150k MolmoSpaces 场景合成数据、BC+Flow-GRPO 两阶段、G1 零样本视频与架构/消融表。
 
 ## 开源核查（步骤 2.5）
 
-| 资源 | 入库日状态 |
-|------|------------|
-| 项目首页 | 可访问；含 demo 视频、Table 1–2、Citation |
-| GitHub / HF / 权重 | **未列出** |
-| FetchMan-Bench | 论文与页面宣称发布；**无下载链** |
+| 资源 | 2026-08-20 | 2026-08-25 再核 |
+|------|------------|----------------|
+| 项目首页 | 可访问；含 demo 视频、Table 1–2、Citation | 同左；页头新增 **Data & Code** |
+| GitHub | **未列出** | [omarrayyann/fetchman](https://github.com/omarrayyann/fetchman) — **仅占位 README** |
+| HF / 权重 | **未列出** | 仍 **未列出** |
+| FetchMan-Bench | 论文与页面宣称发布；**无下载链** | 仍 **无下载链** |
 
-**结论：** **确认未开源**（代码与 checkpoint）；页面作方法与结果溯源。
+**结论：** **部分开源 / 待发布** — 官方仓与项目页互链；README 写 **Code will be added by September 1**；训练/推理/Bench 截至再核日不可运行。
 
 ## 页面公开信息摘录
 
@@ -30,3 +32,4 @@
 
 - [`wiki/entities/paper-fetchman.md`](../../wiki/entities/paper-fetchman.md)
 - [`sources/papers/fetchman_arxiv_2608_17027.md`](../papers/fetchman_arxiv_2608_17027.md)
+- [`sources/repos/fetchman.md`](../repos/fetchman.md)

--- a/wiki/entities/paper-fetchman.md
+++ b/wiki/entities/paper-fetchman.md
@@ -1,8 +1,8 @@
 ---
 type: entity
-tags: [paper, humanoid, loco-manipulation, sim2real, visual-rl, flow-matching, grpo, behavior-cloning, unitree-g1, molmospaces, ucla, ai2]
+tags: [paper, humanoid, loco-manipulation, sim2real, visual-rl, flow-matching, grpo, behavior-cloning, unitree-g1, molmospaces, ucla, ai2, uw]
 status: complete
-updated: 2026-08-20
+updated: 2026-08-25
 arxiv: "2608.17027"
 related:
   - ../tasks/loco-manipulation.md
@@ -15,7 +15,8 @@ related:
 sources:
   - ../../sources/papers/fetchman_arxiv_2608_17027.md
   - ../../sources/sites/fetchman-orayyan.md
-summary: "FetchMan（arXiv:2608.17027，UCLA×AI2）：MolmoSpaces 15 万场景脚本演示 → DINOv3+DiT BC → Flow-GRPO 破 BC 顶；G1 真机 loco-manip 零样本 73.3%；FetchMan-Bench 将发布；确认未开源代码。"
+  - ../../sources/repos/fetchman.md
+summary: "FetchMan（arXiv:2608.17027，UCLA×AI2×UW）：MolmoSpaces 15 万场景脚本演示 → DINOv3+DiT BC → Flow-GRPO 破 BC 顶；G1 真机 loco-manip 零样本 73.3%；官方 GitHub 占位仓（2026-09-01 前补代码）；FetchMan-Bench 待发布。"
 ---
 
 # FetchMan：仿真视觉人形 loco-manipulation
@@ -56,7 +57,7 @@ summary: "FetchMan（arXiv:2608.17027，UCLA×AI2）：MolmoSpaces 15 万场景�
 | **观测** | 头 fisheye + 腕 RGB + 本体；10 Hz 策略 |
 | **动作** | 15 维：base vel/height + 上身/夹爪目标 |
 | **数据** | ~150k 场景 bowl-pick；~650 h；单 L40S ~40 GPU-h 采集 |
-| **开源** | **确认未开源**（2026-08-20 项目页无 GitHub/权重）；Bench 宣称 release |
+| **开源** | **部分开源 / 待发布** — [omarrayyann/fetchman](https://github.com/omarrayyann/fetchman) 占位仓（2026-08-25 仅 README；**Code by 2026-09-01**）；Bench 仍无下载 |
 
 ## 核心原理
 
@@ -82,12 +83,13 @@ flowchart TB
 
 ## 源码运行时序图
 
-**不适用**（截至 **2026-08-20**）：[orayyan.com/fetchman](https://orayyan.com/fetchman) 无训练/推理仓库；FetchMan-Bench 尚无公开下载。代码发布后应补：MolmoSpaces rollout → BC 训练 → Flow-GRPO → Bench/真机部署。
+**不适用**（截至 **2026-08-25**）：[omarrayyann/fetchman](https://github.com/omarrayyann/fetchman) 与项目页 **Data & Code** 已互链，但仓内仅 README（声明 **2026-09-01 前** 补代码）；FetchMan-Bench 尚无公开下载。代码释出后应补：MolmoSpaces rollout → BC 训练 → Flow-GRPO → Bench/真机部署。
 
 ## 工程实践
 
 | 项 | 内容 |
 |----|------|
+| **开源跟进** | 2026-08-25 项目页已挂 GitHub 占位仓；训练/推理入口待 README 时间表落地后更新 repo 归档与时序图 |
 | **分层命令** | 固定 SONIC 低层；策略只出 15 维语义命令——与 VIRAL/DoorMan 同类 factorization |
 | **BC 上限诊断** | manip SR 高、loco-manip 低 → 优先 RL refinement 而非加演示 |
 | **Sim2Real** | 不要替换 DINOv3 或 delta 动作；二者是真机 transfer 必要条件 |
@@ -110,7 +112,7 @@ flowchart TB
 - **无历史：** 单帧策略难推断脚本 相位；加 history 增 token 成本未 ablate。
 - **固定 SONIC：** 不能 adapt  gait/stance；重物体或大扰动超出低层包络。
 - **任务：** 仅 fetch/reach-pick；未覆盖铰接/长程组合技能。
-- **未开源：** 截至入库日不可复现训练栈；Bench 发布前仅能引用论文数字。
+- **复现待落地：** 官方占位仓已挂出（2026-09-01 前补代码）；截至 2026-08-25 仍不可跑训练栈；Bench 发布前仅能引用论文数字。
 
 ## 实验与评测
 
@@ -129,7 +131,7 @@ Flow-GRPO 相对 BC：sim loco-manip **+16 pp**；真机 **+16.6 pp**。Architec
 2. **真影响：DINOv3 + delta** — sim2real 必要条件；缺一则真机 loco-manip 崩塌。
 3. **真影响：增益在 loco-manip 不在 manip** — 克隆已够好，RL 预算应瞄准行走/handoff。
 4. **次要代价：固定 SONIC** — 平衡/步态不可 adapt。
-5. **工程读法：未开源** — 方法坐标可用；复现需等 Bench/代码。
+5. **工程读法：占位仓已挂** — 方法坐标可用；复现跟 [GitHub](https://github.com/omarrayyann/fetchman) README 时间表与 Bench 发布。
 6. **多物体初步可行** — 62% sim loco-manip，仍低于单物体 83%。
 
 ## 关联页面
@@ -144,9 +146,11 @@ Flow-GRPO 相对 BC：sim loco-manip **+16 pp**；真机 **+16.6 pp**。Architec
 
 - [FetchMan 论文归档](../../sources/papers/fetchman_arxiv_2608_17027.md)
 - [FetchMan 项目页归档](../../sources/sites/fetchman-orayyan.md)
+- [FetchMan 官方仓库归档](../../sources/repos/fetchman.md)
 
 ## 推荐继续阅读
 
 - 项目页 — <https://orayyan.com/fetchman>
+- 官方 GitHub（占位）— <https://github.com/omarrayyann/fetchman>
 - Flow-GRPO — <https://arxiv.org/abs/2505.05470>
 - MolmoSpaces — <https://arxiv.org/abs/2602.11337>

--- a/wiki/entities/paper-viral-humanoid-visual-sim2real.md
+++ b/wiki/entities/paper-viral-humanoid-visual-sim2real.md
@@ -3,7 +3,7 @@
 type: entity
 tags: [paper, humanoid, sim2real, visual-rl, loco-manipulation, teacher-student, dagger, ppo, unitree-g1, isaac-lab, cvpr2026, nvidia, cmu, berkeley, cuhk, body-system-stack]
 status: complete
-updated: 2026-08-20
+updated: 2026-08-25
 arxiv: "2511.15200"
 venue: "CVPR 2026"
 code: https://github.com/NVlabs/GR00T-VisualSim2Real

--- a/wiki/tasks/loco-manipulation.md
+++ b/wiki/tasks/loco-manipulation.md
@@ -3,7 +3,7 @@ type: task
 tags: [loco-manipulation, humanoid, whole-body, manipulation, locomotion]
 status: complete
 summary: "Loco-Manipulation 关注机器人边移动边操作的全身协调问题。2025-2026 年的趋势正从分层控制扩展到生成模型、VLA 与触觉增强的统一全身感知控制。"
-updated: 2026-08-22
+updated: 2026-08-25
 sources:
   - ../../sources/papers/roboreact_arxiv_2608_03387.md
   - ../../sources/papers/smpc2rl_arxiv_2608_12063.md
@@ -274,7 +274,7 @@ flowchart TD
 - [Humanoid Transformer with Touch Dreaming](../methods/humanoid-transformer-touch-dreaming.md)
 - [ExoActor](../methods/exoactor.md) — 视频生成驱动的零样本人形交互行为生成
 - [VIRAL（论文实体）](../entities/paper-viral-humanoid-visual-sim2real.md) — 人形 loco-manipulation 视觉 Sim2Real 全栈（arXiv:2511.15200）
-- [FetchMan（论文实体）](../entities/paper-fetchman.md) — MolmoSpaces 15 万场景 BC+Flow-GRPO；G1 真机 loco-manip 73.3% zero-shot（arXiv:2608.17027；未开源）
+- [FetchMan（论文实体）](../entities/paper-fetchman.md) — MolmoSpaces 15 万场景 BC+Flow-GRPO；G1 真机 loco-manip 73.3% zero-shot（arXiv:2608.17027；GitHub 占位仓，2026-09-01 前补代码）
 - [DoorMan（论文实体）](../entities/paper-doorman-opening-sim2real-door.md) — 人形纯 RGB 开门铰接操作与 GRPO 自举（arXiv:2512.01061）
 - [REFINE-DP（论文实体）](../entities/paper-loco-manip-161-157-refine-dp.md) — DP 规划器 + RL 跟踪器联合微调的人形 loco-manip（arXiv:2603.13707，Booster T1）
 - [InterPrior（论文实体）](../entities/paper-interprior.md) — 物理 HOI 生成式先验：模仿专家 → 变分蒸馏 → RL 微调（arXiv:2602.06035）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

FetchMan（arXiv:2608.17027）已于 2026-08-20 入库；本次按用户指定项目页二次核查 **步骤 2.5**：项目页已挂 **Data & Code** → [omarrayyann/fetchman](https://github.com/omarrayyann/fetchman)，但仓内仅 README（**Code will be added by September 1**）。将开源结论从「确认未开源」更新为 **部分开源 / 待发布**，并新建 `sources/repos/fetchman.md` 归档。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）

## 验证

- [x] `make ci-preflight` — lint 0 阻塞项、搜索回归 40/40、导出检查 12/12
- [x] 静态站详情页 `wiki-entities-paper-fetchman` 渲染截图

## 验证截图

![FetchMan 详情页（开源状态更新后）](https://cursor.com/artifacts/c/art-74f8f83d-2ac0-4647-b353-9c6408d1e3f2)

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f904747c-a6bc-4e67-a2d4-dbf50a0fad3d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f904747c-a6bc-4e67-a2d4-dbf50a0fad3d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

