### PR TITLE
ingest: Update π0-policy.md timestamp to 2026-08-27

### DIFF
--- a/wiki/methods/π0-policy.md
+++ b/wiki/methods/π0-policy.md
@@ -2,7 +2,7 @@
 type: method
 tags: [vla, foundation-policy, deepmind, flow-matching, manipulation]
 status: complete
-updated: 2026-08-09
+updated: 2026-08-27
 related:
   - ./vla.md
   - ./pi07-policy.md


### PR DESCRIPTION
## 摘要

更新 π0-policy 方法文档的 `updated` 字段，从 2026-08-09 改为 2026-08-27，反映最近的文档维护。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight`
- [ ] 其他：N/A（仅元数据更新）

## 相关 Issue

无

https://claude.ai/code/session_014VTWs611Wp1Jy4QywfP5dx