### PR TITLE
refactor: 扩展陈旧声明检测支持后置辟谣线索

### DIFF
--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-08-28] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **6** 条信息型预警）：
+共发现 **0** 个问题（另含 **0** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -52,12 +52,8 @@
 ### 💡 频繁提及但缺少 wiki 页面的概念（0 个）
 - 无
 
-### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（5 个）
-- base（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
-- CartPole-v1（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
-- Isaac-Cartpole-v0（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
-- LIBERO（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
-- OnPolicyRunner（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
+### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（0 个）
+- 无
 
 ### ⚠️ Frontmatter 缺少 type 字段（0 个）
 - 无
@@ -110,8 +106,8 @@
 ### 💡 dataset 实体正文缺「规模/模态/许可证/重定向就绪度」速查维度（信息型，不阻塞 CI）（0 个）
 - 无
 
-### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（1 个）
-- wiki/entities/paper-worldecho-worldsync.md（含绝对化措辞「SOTA」，updated=2026-08-27；同主题更新页 wiki/entities/cosmos-3.md updated=2026-08-28）
+### 💡 陈旧声明（含绝对化措辞但同主题有更晚更新页，建议复核；信息型，不阻塞 CI）（0 个）
+- 无
 
 ### 💡 动力学/仿真/物理概念页缺回链「仿真物理保真度」知识链枢纽（信息型，不阻塞 CI）（0 个）
 - 无

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -68,7 +68,9 @@ STALE_CLAIM_PATTERNS = [
 # 陈旧声明巡检的误报豁免：命中绝对化措辞不等于本页在下时效性断言。以下四类是
 # 结构性误报，按命中处的上下文豁免，避免为迁就正则去改写本就正确的正文：
 #   1) 否定语境：「这是部署证据，不是策略 SoTA」「不要把它读成又一个 SoTA」
-#      「这一行不可直接当 SOTA 通才」等辟谣式写法，本身就在否认该断言；
+#      「这一行不可直接当 SOTA 通才」等辟谣式写法，本身就在否认该断言；中文里
+#      辟谣也可后置（「0.066 vs 0.067，读『SOTA 碾压』会过读」），落笔顺序相反、
+#      语义同为否认，故前置线索回看、后置线索前看，都限制在命中词同句内；
 #   2) 库内页面名：「VLA SOTA Leaderboard」是 entities/vla-sota-leaderboard.md 的
 #      页面标题，正文引用它属导航，不是本页断言；
 #   3) 运行时对象：「服务端只保留最新 pending 帧」「取最新状态」描述系统行为，
@@ -92,6 +94,14 @@ STALE_CLAIM_NEGATION_CUES: tuple[str, ...] = (
 # 命中词前回看的字符数（并限制在同一句内：遇句末标点/换行即截断）
 STALE_CLAIM_NEGATION_WINDOW = 30
 STALE_CLAIM_SENTENCE_BREAKS = "。！？；\n"
+# 后置否定线索：把「读成 X」的读法判为过度解读，与前置的「不是 X」同为辟谣
+STALE_CLAIM_OVERREAD_CUES: tuple[str, ...] = (
+    "过读",
+    "过度解读",
+    "读过头",
+)
+# 命中词后前看的字符数（同样限制在同一句内）
+STALE_CLAIM_OVERREAD_WINDOW = 30
 # 「最新」后紧跟的运行时对象名词；中间允许夹一段英文/数字标识（如「最新 pending 帧」）
 STALE_CLAIM_RUNTIME_OBJECT_RE = re.compile(
     r"[\sA-Za-z0-9_./-]{0,16}(?:帧|状态|观测|位姿|数据|快照|消息|指令|读数)"
@@ -269,20 +279,49 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
 #                （泛化侧取舍）：迁移/评测的 **条件状语**（zero-shot 迁移、
 #                zero-shot 泛化、0% 任务数据），与 rgb-d / vlm 同为描述性标签
 #                而非独立可成页机制，另建概念页只会与 sim2real 重复同一来源
+#   base       → 三义各有归属：URDF/MuJoCo 的基座连杆（TITA `base` 接触即
+#                terminate、相机到 `base`/`head` 的 TF）归
+#                concepts/urdf-robot-description.md + concepts/floating-base-dynamics.md
+#                （固定基座 vs 浮动基座、\(q_b\) 位姿）；权重档名（EgoSteer
+#                「自有数据微调用 **Base**」）属外部模型型号；消融/基线条件名
+#                （HumanoidArena 的 **Base** 任务档、AMP survey 的 **Base** = 仅
+#                Stage 1）属单页实验设定。与 joint 同为多义 token，本库按本体/
+#                实验维度记述，不单建概念页
+#   cartpole-v1 → concepts/cartpole.md（canonical 概念页，注册名写法与页面 stem
+#                不同名）+ entities/gymnasium.md（注册表入口）：Gymnasium 的环境
+#                注册 id，与 sim-to-real / urdf 同属「id 写法 ≠ 页面 stem」，
+#                不应按裸 id 误报为缺页
+#   isaac-cartpole-v0 → concepts/cartpole.md（同一 cart-pole 概念的 GPU 并行版，
+#                该页「从 CPU 玩具跨到 GPU 训练栈」一节逐条记述）+
+#                entities/isaac-lab-default-environments.md（默认环境清单）：
+#                与 cartpole-v1 同为环境注册 id，不单建概念页
+#   libero     → entities/libero-benchmark.md（130 个机械臂任务的终身学习/迁移
+#                基准，slug 与页面 stem 不同名）：基准数据集归 entities，
+#                与 lerobot / mjlab 同类，不应按裸名误报为缺 concepts 页
+#   onpolicyrunner → concepts/rl-runner.md（Runner 层的 canonical 概念页，
+#                「rsl_rl 叫 `OnPolicyRunner`」即该页对号入座的锚点）+
+#                entities/rsl-rl.md（该类的实现库）：具体实现的类名，本体是已建
+#                页的 on-policy Runner 抽象，与 qpos / reset 同为代码 token 而非
+#                机制，不单建概念页
 MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "action",
+    "base",  # 基座连杆 / 权重档名 / 消融条件名三义，已由 URDF + 浮动基座等页覆盖
     "amp",
     "armature",
+    "cartpole-v1",  # Gymnasium 环境注册 id，已由 concepts/cartpole.md 覆盖
     "damping",  # MuJoCo/Isaac Lab 关节属性，已由阻抗控制 + PD 增益 / 参数辨识页覆盖
     "ethercat",  # 已由 concepts/ethercat-protocol.md 覆盖（slug 与页面 stem 不同名）
     "g1",
     "gmr",
     "heracles",
+    "isaac-cartpole-v0",  # Isaac Lab 环境注册 id，已由 concepts/cartpole.md 覆盖
     "joint",  # 关节属性 / WAM Joint 族 / 消融条件名三义，已由 URDF + WAM 等页覆盖
     "lerobot",  # 已由 entities/lerobot.md 覆盖（框架/工具，与 mjlab / mujoco 同类）
+    "libero",  # 已由 entities/libero-benchmark.md 覆盖（基准，slug 与页面 stem 不同名）
     "mit",  # 机构（schema/institutions.json），非概念，不应建 concepts/methods 页
     "mjlab",
     "mujoco",
+    "onpolicyrunner",  # rsl_rl 的 Runner 类名，已由 concepts/rl-runner.md 覆盖
     "qpos",  # MuJoCo 状态数组字段名，已由广义坐标 $q$ 的形式化/概念页覆盖
     "qwen3-vl",  # 外部 VLM 底座型号，已在 methods/vla.md 等按「底座」维度记述
     "reset",  # 环境/策略 API 方法名（episode 复位），已由 entities/gymnasium.md 释义
@@ -762,12 +801,20 @@ def _frontmatter_tags(fm_block: str) -> set[str]:
     return tags
 
 
-def _stale_claim_negated(body: str, start: int) -> bool:
-    """命中词前、同一句内出现否定线索 → 辟谣式写法，不是本页在下断言。"""
-    window = body[max(0, start - STALE_CLAIM_NEGATION_WINDOW) : start]
+def _stale_claim_negated(body: str, start: int, end: int) -> bool:
+    """命中词同句内出现否定线索 → 辟谣式写法，不是本页在下断言。
+
+    前置线索回看（「不是策略 SoTA」），后置线索前看（「读『SOTA 碾压』会过读」）。
+    """
+    before = body[max(0, start - STALE_CLAIM_NEGATION_WINDOW) : start]
     for brk in STALE_CLAIM_SENTENCE_BREAKS:
-        window = window.rsplit(brk, 1)[-1]
-    return any(cue in window for cue in STALE_CLAIM_NEGATION_CUES)
+        before = before.rsplit(brk, 1)[-1]
+    if any(cue in before for cue in STALE_CLAIM_NEGATION_CUES):
+        return True
+    after = body[end : end + STALE_CLAIM_OVERREAD_WINDOW]
+    for brk in STALE_CLAIM_SENTENCE_BREAKS:
+        after = after.split(brk, 1)[0]
+    return any(cue in after for cue in STALE_CLAIM_OVERREAD_CUES)
 
 
 def _stale_claim_span_slug(body: str, start: int, end: int) -> str:
@@ -783,7 +830,7 @@ def _stale_claim_hit(body: str, page_stems: set[str]) -> str | None:
     """返回正文里第一个「真·绝对化断言」，命中全属结构性误报时返回 ``None``。"""
     for pat in STALE_CLAIM_PATTERNS:
         for m in re.finditer(pat, body, re.IGNORECASE):
-            if _stale_claim_negated(body, m.start()):
+            if _stale_claim_negated(body, m.start(), m.end()):
                 continue
             if _stale_claim_span_slug(body, m.start(), m.end()) in page_stems:
                 continue

--- a/tests/test_lint_wiki_missing_concept_pages.py
+++ b/tests/test_lint_wiki_missing_concept_pages.py
@@ -134,6 +134,39 @@ def test_covered_elsewhere_rgbd_ignored(tmp_path, monkeypatch) -> None:
     assert results["missing_concept_pages"] == []
 
 
+def test_covered_elsewhere_env_ids_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "从 `CartPole-v1` 跨到 `Isaac-Cartpole-v0`。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # 两者都是环境注册 id，同一 cart-pole 概念已由 concepts/cartpole.md 覆盖
+    assert results["missing_concept_pages"] == []
+
+
+def test_covered_elsewhere_onpolicyrunner_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "rsl_rl 的循环入口叫 `OnPolicyRunner`。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # 具体实现的类名，本体是 concepts/rl-runner.md 的 on-policy Runner 抽象
+    assert results["missing_concept_pages"] == []
+
+
+def test_covered_elsewhere_base_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "TITA 对 `base` 接触直接 terminate。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # base 的基座连杆 / 权重档名 / 消融条件名三义已由 URDF、浮动基座等页覆盖
+    assert results["missing_concept_pages"] == []
+
+
 def test_case_insensitive_merge(tmp_path, monkeypatch) -> None:
     wiki = _setup_wiki(tmp_path, monkeypatch)
     half = lw.MISSING_CONCEPT_PAGE_MIN_PAGES // 2 + 1

--- a/tests/test_lint_wiki_stale_claims.py
+++ b/tests/test_lint_wiki_stale_claims.py
@@ -114,6 +114,36 @@ def test_cannot_be_read_as_claim_is_not_flagged(tmp_path, monkeypatch) -> None:
     assert _run([claim, newer])["stale_claims"] == []
 
 
+def test_postpositioned_overread_cue_is_not_flagged(tmp_path, monkeypatch) -> None:
+    # 「读『SOTA 碾压』会过读」是后置辟谣：落笔顺序与「不是 SoTA」相反，语义同为否认。
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    claim = _page(
+        wiki,
+        "a.md",
+        "2025-01-01",
+        ["world-model"],
+        "门控误差领先很窄：0.066 vs 0.067，读「SOTA 碾压」会过读。",
+    )
+    newer = _page(wiki, "b.md", "2026-01-01", ["world-model"], "更晚的同主题页。")
+    assert _run([claim, newer])["stale_claims"] == []
+
+
+def test_overread_cue_in_next_sentence_does_not_exempt(tmp_path, monkeypatch) -> None:
+    # 后置线索同样只在命中词同句内生效：下一句的「过读」不应放过本句的真实断言。
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    claim = _page(
+        wiki,
+        "a.md",
+        "2025-01-01",
+        ["world-model"],
+        "本方法仍是该任务的 SOTA。别的指标才容易过读。",
+    )
+    newer = _page(wiki, "b.md", "2026-01-01", ["world-model"], "更晚的同主题页。")
+    results = _run([claim, newer])
+    assert len(results["stale_claims"]) == 1
+    assert "SOTA" in results["stale_claims"][0]
+
+
 def test_negation_cue_in_previous_sentence_does_not_exempt(tmp_path, monkeypatch) -> None:
     # 否定线索只在命中词同句内生效：上一句的「不可」不应放过本句的真实断言。
     wiki = _setup_wiki(tmp_path, monkeypatch)


### PR DESCRIPTION
## 摘要

扩展陈旧声明（stale claims）检测逻辑，支持后置否定线索（如「过读」「过度解读」）。原有检测仅支持前置否定线索（「不是 X」），现在同时检查命中词后的否定线索，使「0.066 vs 0.067，读『SOTA 碾压』会过读」这类后置辟谣式写法也能被正确识别为非断言。同时补充 5 个多页高频引用但已由其他页覆盖的概念到豁免列表（`base`、`cartpole-v1`、`isaac-cartpole-v0`、`libero`、`onpolicyrunner`），减少误报。

## 变更类型

- [x] 维护脚本 / CI / 文档

## 详细说明

### 核心改动

1. **后置否定线索支持**（`scripts/lint_wiki.py`）
   - 新增 `STALE_CLAIM_OVERREAD_CUES` 常量，定义后置辟谣线索（「过读」「过度解读」「读过头」）
   - 新增 `STALE_CLAIM_OVERREAD_WINDOW` 参数，控制命中词后的前看窗口（30 字符）
   - 修改 `_stale_claim_negated()` 函数签名，接收 `end` 参数，同时检查前置和后置线索
   - 前置线索回看时截断到句末，后置线索前看时也截断到句末，确保同句内有效

2. **豁免列表扩展**（`scripts/lint_wiki.py`）
   - `base`：基座连杆/权重档名/消融条件名三义已由 URDF、浮动基座等页覆盖
   - `cartpole-v1`、`isaac-cartpole-v0`：Gymnasium/Isaac Lab 环境注册 id，同一概念已由 `concepts/cartpole.md` 覆盖
   - `libero`：基准数据集，已由 `entities/libero-benchmark.md` 覆盖（slug 与页面 stem 不同名）
   - `onpolicyrunner`：rsl_rl 的 Runner 类名，本体已由 `concepts/rl-runner.md` 覆盖

3. **测试覆盖**（`tests/test_lint_wiki_stale_claims.py`）
   - 新增 `test_postpositioned_overread_cue_is_not_flagged()`：验证后置辟谣线索生效
   - 新增 `test_overread_cue_in_next_sentence_does_not_exempt()`：验证后置线索仅在同句内生效

4. **豁免列表测试**（`tests/test_lint_wiki_missing_concept_pages.py`）
   - 新增 `test_covered_elsewhere_env_ids_ignored()`：验证环境 id 豁免
   - 新增 `test_covered_elsewhere_onpolicyrunner_ignored()`：验证类名豁免
   - 新增 `test_covered_elsewhere_base_ignored()`：验证 base 多义词豁免

### 行为变化

- 陈旧声明检测现在能正确识别后置辟谣式写法，减少信息型预警
- 5 个高频概念从「缺独立页」

https://claude.ai/code/session_01RcVMRMgGaJD5BiB6buUGPa