### PR TITLE
ingest: 复核加深 ParkourFormer（arXiv:2605.25782），开源结论改为 Coming Soon

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,11 @@
+## [2026-08-30] ingest | sources/papers/parkourformer_arxiv_2605_25782.md — 复核 ParkourFormer：加深既有实体，代码改为 Coming Soon
+
+- **触发：** 用户指定 [arXiv:2605.25782](https://arxiv.org/abs/2605.25782)（Mai et al.，HKUST-GZ / CLAI-LAB / SCAU / GDUT；G1 29 DoF 多地形跑酷）
+- **排重：** 已有 canonical [`wiki/entities/paper-parkourformer.md`](wiki/entities/paper-parkourformer.md)（2026-08-16 ingest）；**未新建**第二篇 `paper-*`。
+- **步骤 2.5：** 项目页现写「Code(Coming Soon)」，但 `MRonaldo-gif/parkourformer.github.io` 仍只有站点页；arXiv 仍为 **v3**；无训练仓 → **宣称将开源 / 待发布**。时序图继续不适用。
+- **加深：** 观测拆分、query \(\mathbb{R}^{2\times 128}\) / 记忆 \(8\times 128\) / AMP \(10\times 67\)、Conditional SwiGLU Eq. 5、地形三维加难；交叉页开源措辞同步。
+- **机构：** 既有 `hkust-gz` / `clai-lab` / `scau` / `gdut`，未改 `institutions.json`
+
 ## [2026-08-30] ingest | sources/repos/archify.md — Archify 可校验系统图 Skill；项目页已开源 MIT；wiki/entities/archify.md
 
 - **触发：** 用户指定 <https://github.com/tt-a1i/archify>

--- a/sources/papers/parkourformer_arxiv_2605_25782.md
+++ b/sources/papers/parkourformer_arxiv_2605_25782.md
@@ -5,22 +5,23 @@
 - **标题：** ParkourFormer: Integrating Predictive Supervision and Sequence Modeling into Parkour Locomotion
 - **缩写：** **ParkourFormer**
 - **类型：** paper / humanoid / parkour / sequence-modeling / future-prediction / amp / rgb-d
-- **来源：** [arXiv:2605.25782](https://arxiv.org/abs/2605.25782)（HTML：[ar5iv](https://ar5iv.labs.arxiv.org/html/2605.25782)）
+- **来源：** [arXiv:2605.25782](https://arxiv.org/abs/2605.25782)（官方 HTML：[v3](https://arxiv.org/html/2605.25782v3)；镜像：[ar5iv](https://ar5iv.labs.arxiv.org/html/2605.25782)）
 - **项目页：** <https://mronaldo-gif.github.io/parkourformer.github.io/> — 归档见 [`sources/sites/parkourformer-github-io.md`](../sites/parkourformer-github-io.md)
 - **PDF：** <https://arxiv.org/pdf/2605.25782>
 - **作者：** Yanheng Mai、Wenhao Xu、Zirui Huang、Yifei Fu、Shengwei Dong、Xinjue Wang、Kailun Huang、Yanzhe Xie、Renjing Xu†（† corresponding，`renjingxu@hkust-gz.edu.cn`）
 - **机构：** 香港科技大学广州校区（HKUST-GZ）；CLAI-LAB / CL-TECH；华南农业大学（SCAU）；广东工业大学（GDUT）
 - **发表：** arXiv preprint，2026（检索到 v3，2026-06-12）
 - **入库日期：** 2026-08-16
-- **最后更新：** 2026-08-16
+- **最后更新：** 2026-08-30
 - **一句话说明：** 把人形跑酷写成 **future-conditioned Seq2Seq**：当前状态用 cross-attention 查询历史，预测头监督未来两步本体/AMP 状态，再把预测未来拼进动作头与 AMP 判别器；G1 上九类地形统一策略平均穿越成功率 **93.85%**。
 
 ## 开源状态（步骤 2.5）
 
-- **核查日：** 2026-08-16。打开项目页、作者 GitHub [`MRonaldo-gif`](https://github.com/MRonaldo-gif) 与站点仓 [`parkourformer.github.io`](https://github.com/MRonaldo-gif/parkourformer.github.io)。
-- **已发布：** 项目页、arXiv PDF/HTML、真机与仿真演示视频（页内嵌入）。
-- **未发布：** 训练/推理代码、权重、数据集。站点仓仅为 github.io 主页；作者公开仓无训练入口；论文未承诺开源。
-- **结论：** **确认未开源**。wiki 实体页「源码运行时序图」写 **不适用**。
+- **复核日：** 2026-08-30。打开项目页、作者 GitHub [`MRonaldo-gif`](https://github.com/MRonaldo-gif)、站点仓 [`parkourformer.github.io`](https://github.com/MRonaldo-gif/parkourformer.github.io)、arXiv HTML v3，并检索 GitHub「ParkourFormer」。
+- **已发布：** 项目页、arXiv PDF/HTML（仍为 **v3**，2026-06-12）、真机与仿真演示视频（页内嵌入）。
+- **未发布：** 训练/推理代码、权重、数据集。站点仓仅为 github.io 主页（`index.html` + `static`）；作者公开仓无训练入口。`Pixel-114514/parkourformer.github.io` 为早期主页拷贝，同样无训练脚本。
+- **承诺：** 项目页按钮现为 **「Code(Coming Soon)」**（`href` 仍注释掉，未指向训练仓）。论文正文仍无 GitHub / HF 链接。
+- **结论：** **宣称将开源 / 待发布**（相对 2026-08-16「确认未开源」：页上已出现 Coming Soon，但仍无可运行实现）。wiki「源码运行时序图」继续写 **不适用**。
 
 ## 摘录 1：问题与三条贡献
 
@@ -44,7 +45,7 @@
 | 历史 | \(\mathbf{o}_t=\{o_{t-7},\ldots,o_t\}\)（8 帧） |
 | 动作 | \(\mathbf{a}_t\in\mathbb{R}^{29}\)，名义姿态上的 action delta，底层 PD |
 
-骨干：当前观测 + 深度 token 作 **query**，历史 token 作 **key/value**，多层 cross-attention + residual FFN。地形上下文 \(c_t\) 经 **Conditional SwiGLU** 乘性门控调制中间特征。非对称 critic 额外吃特权线速度 \(\mathbf{v}_l\)。
+骨干：当前观测 + 深度 token 作 **query** \(\mathbf{Q}_t^{(0)}\in\mathbb{R}^{2\times 128}\)，历史投成记忆 \(\mathbf{M}_t\in\mathbb{R}^{8\times 128}\) 作 **key/value**，多层 cross-attention + residual FFN。地形上下文 \(c_t\) 经 **Conditional SwiGLU**（Eq. 5，\(C_1,C_2\) 调制）乘性门控中间特征。非对称 critic 额外吃特权线速度 \(\mathbf{v}_l\)。判别器完整序列 \(\tilde{\mathbf{s}}_t\in\mathbb{R}^{10\times 67}\)。仿真与真机评测均用 **G1 29 DoF**。
 
 **未来预测头：** 从 Transformer 特征确定性预测未来 **两步** AMP 状态 \(\hat{\mathbf{s}}_{t+1:t+2}\)。监督：
 
@@ -66,7 +67,7 @@
 
 ## 摘录 3：九类地形与主结果（Table 1–3）
 
-训练地形（Fig. 5）：Boxes、Walk Over Obstacles、Climb Slope、Rough ground、Up Stairs、Climb Down、Down stairs、Climb Up、Gaps Crossing；每类 **L1–L9** 难度。
+训练地形（Fig. 5）：Boxes、Walk Over Obstacles、Climb Slope、Rough ground、Up Stairs、Climb Down、Down stairs、Climb Up、Gaps Crossing；每类 **L1–L9** 难度。复杂度沿三维：几何变化（阶高/坡角）、障碍密度与间距、不连续（缺口/突变高差）。
 
 **Table 1 平均穿越成功率（%）：**
 

--- a/sources/sites/parkourformer-github-io.md
+++ b/sources/sites/parkourformer-github-io.md
@@ -9,20 +9,21 @@
 - **平台：** Unitree G1（29 DoF）
 - **配套论文归档：** [`sources/papers/parkourformer_arxiv_2605_25782.md`](../papers/parkourformer_arxiv_2605_25782.md)
 - **入库日期：** 2026-08-16
+- **最后复核：** 2026-08-30
 
 ## 一句话摘要
 
 HKUST-GZ 等单位的人形跑酷项目页：用 **Transformer + 未来两步本体监督** 把策略从 reactive 映射改成 future-conditioned Seq2Seq，在九类地形上以**单一策略**跑仿真 L1–L9 与真机楼梯/平台/缺口。
 
-## 开源状态（步骤 2.5，截至 2026-08-16）
+## 开源状态（步骤 2.5，截至 2026-08-30）
 
 | 资源 | 状态 |
 |------|------|
 | 项目页 + 真机/仿真视频 + BibTeX | **已发布** |
-| arXiv PDF/HTML | **已发布**（2605.25782） |
-| 训练 / 推理代码 / 权重 | **未列出**（页上无 Code 按钮；GitHub 仅 `parkourformer.github.io` 站点仓） |
+| arXiv PDF/HTML | **已发布**（2605.25782 **v3**，2026-06-12） |
+| 训练 / 推理代码 / 权重 | **待发布**（页上按钮「Code(Coming Soon)」；`href` 仍注释，未指向训练仓；GitHub 仅 `MRonaldo-gif/parkourformer.github.io` 站点仓） |
 
-**结论：确认未开源（无可运行官方实现）。** wiki「源码运行时序图」标 **不适用**。
+**结论：宣称将开源 / 待发布（无可运行官方实现）。** wiki「源码运行时序图」标 **不适用**。勿把 `Pixel-114514/parkourformer.github.io` 当成训练仓。
 
 ## 公开信息要点
 

--- a/wiki/entities/paper-hiking-in-the-wild.md
+++ b/wiki/entities/paper-hiking-in-the-wild.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, rl, motion-control, perceptive-locomotion, depth, parkour, tsinghua, amp]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 arxiv: "2601.07718"
 venue: arXiv
 summary: "Hiking in the Wild（arXiv:2601.07718）单阶段 E2E 深度+本体 RL，用地形边缘与足端体积点软约束实现野外 2.5 m/s 感知跑酷，含 AMP-style 自然性项与开源栈。"
@@ -132,7 +132,7 @@ flowchart TB
 ## 与其他页面的关系
 
 - 姊妹感知跑酷：[MoRE #08](./paper-amp-survey-08-more.md)、[Deep Whole-body Parkour](./paper-deep-whole-body-parkour.md)
-- 同族 MuJoCo、改未来监督：[ParkourFormer](./paper-parkourformer.md) — Instinct 九类课 + query 历史 / 未来两步 AMP；代码未开源
+- 同族 MuJoCo、改未来监督：[ParkourFormer](./paper-parkourformer.md) — Instinct 九类课 + query 历史 / 未来两步 AMP；代码 Coming Soon
 - 无 AMP、无建图的单阶段 raw 深度：[CReF](./paper-cref.md) — 交叉注意 + 落脚奖励；X2 Ultra 实验室课
 - 任务：[stair-obstacle-perceptive-locomotion.md](../tasks/stair-obstacle-perceptive-locomotion.md)
 - RL 栈：[humanoid-rl-motion-control-body-system-stack.md](../overview/humanoid-rl-motion-control-body-system-stack.md)

--- a/wiki/entities/paper-hrl-stack-22-perceptive_humanoid_parkour.md
+++ b/wiki/entities/paper-hrl-stack-22-perceptive_humanoid_parkour.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, rl, locomotion, parkour, motion-matching, depth, teacher-student, dagger, ppo, unitree-g1, perception, skill-chaining, amazon-far, body-system-stack]
 status: complete
-updated: 2026-08-22
+updated: 2026-08-30
 arxiv: "2602.15827"
 venue: "RSS 2026"
 related:

--- a/wiki/entities/paper-light-loco-parkour.md
+++ b/wiki/entities/paper-light-loco-parkour.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, parkour, perceptive-locomotion, distillation, real2sim2real, dagger, light-origins, whole-body]
 status: complete
-updated: 2026-08-16
+updated: 2026-08-30
 venue: "Light Origins 项目页（暂无 arXiv）"
 related:
   - ./paper-hrl-stack-22-perceptive_humanoid_parkour.md

--- a/wiki/entities/paper-notebook-humanoid-locomotion-as-next-token-prediction.md
+++ b/wiki/entities/paper-notebook-humanoid-locomotion-as-next-token-prediction.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid-paper-notebooks, paper-notebook-stub]
 status: stub
-updated: 2026-08-16
+updated: 2026-08-30
 arxiv: "2402.19469"
 related:
   - ../overview/paper-notebook-category-03-high-impact-selection.md

--- a/wiki/entities/paper-parkourformer.md
+++ b/wiki/entities/paper-parkourformer.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, parkour, locomotion, transformer, sequence-modeling, future-prediction, amp, rgb-d, perceptive-locomotion, unitree-g1, hkust-gz, scau, gdut, clai-lab]
 status: complete
-updated: 2026-08-16
+updated: 2026-08-30
 arxiv: "2605.25782"
 venue: arXiv
 related:
@@ -22,7 +22,7 @@ related:
 sources:
   - ../../sources/papers/parkourformer_arxiv_2605_25782.md
   - ../../sources/sites/parkourformer-github-io.md
-summary: "ParkourFormer（HKUST-GZ 等，arXiv:2605.25782）：Transformer 用当前状态 cross-attention 查询历史，监督未来两步 AMP 状态并条件化动作与判别器；G1 九类地形单策略平均穿越 93.85%；代码未开源。"
+summary: "ParkourFormer（HKUST-GZ 等，arXiv:2605.25782）：Transformer 用当前状态 cross-attention 查询历史，监督未来两步 AMP 状态并条件化动作与判别器；G1 九类地形单策略平均穿越 93.85%；代码 Coming Soon。"
 ---
 
 # ParkourFormer（预测监督 + 序列建模人形跑酷）
@@ -61,10 +61,11 @@ summary: "ParkourFormer（HKUST-GZ 等，arXiv:2605.25782）：Transformer 用�
 | **机构** | 香港科技大学广州校区（HKUST-GZ）；创联人工智能实验室（CLAI-LAB / CL-TECH）；华南农业大学（SCAU）；广东工业大学（GDUT） |
 | **平台** | Unitree G1，29 DoF；真机 + 仿真 |
 | **仿真** | Project Instinct MuJoCo；4096 并行；200 Hz 仿真 / 50 Hz 控制；≤30k iter；RTX 4090D |
-| **输入（策略）** | 8 帧本体 \(o_t\in\mathbb{R}^{96}\) + 当前 RGB-D token \(\mathbf{z}_t\in\mathbb{R}^{128}\) |
-| **AMP 状态** | \(s_t\in\mathbb{R}^{67}\)（含特权线速度 \(\mathbf{v}_l\)） |
+| **输入（策略）** | 8 帧本体 \(o_t\in\mathbb{R}^{96}=[\boldsymbol{\omega}_a,\mathbf{g}_p,\mathbf{v}_c,\mathbf{q}_p,\mathbf{q}_v,\mathbf{a}_{t-1}]\) + 当前 RGB-D token \(\mathbf{z}_t\in\mathbb{R}^{128}\) |
+| **Query / 记忆** | \(\mathbf{Q}_t^{(0)}\in\mathbb{R}^{2\times 128}\)（当前观测 ⊕ 深度）；记忆 \(\mathbf{M}_t\in\mathbb{R}^{8\times 128}\) |
+| **AMP 状态** | \(s_t\in\mathbb{R}^{67}\)（含特权线速度 \(\mathbf{v}_l\)）；判别序列 \(\tilde{\mathbf{s}}_t\in\mathbb{R}^{10\times 67}\)（8 真实 + 2 预测） |
 | **动作** | \(\mathbf{a}_t\in\mathbb{R}^{29}\) 名义姿态 delta，底层 PD |
-| **开源（截至 2026-08-16）** | **未开源**（仅项目页/视频/arXiv；无训练仓） |
+| **开源（截至 2026-08-30）** | **待发布**（项目页按钮「Code(Coming Soon)」；作者仓仅站点页，无训练/推理入口） |
 
 ## 核心原理（方法）
 
@@ -72,9 +73,9 @@ summary: "ParkourFormer（HKUST-GZ 等，arXiv:2605.25782）：Transformer 用�
 
 | 模块 | 作用 |
 |------|------|
-| 位置编码历史 | 把 \(\{o_{t-7},\ldots,o_t\}\) 投成有序 token 记忆 |
-| Cross-attention | 当前观测 ⊕ 深度 token 作 query，历史作 KV（「now → past」） |
-| Conditional SwiGLU | RGB-D 地形上下文 \(c_t\) 乘性门控中间 FFN |
+| 位置编码历史 | 把 \(\{o_{t-7},\ldots,o_t\}\) 投成 \(\mathbf{X}_t\in\mathbb{R}^{8\times 128}\) 有序记忆 |
+| Cross-attention | 当前观测 ⊕ 深度 token 作 \(\mathbf{Q}\in\mathbb{R}^{2\times 128}\)，历史作 KV（「now → past」） |
+| Conditional SwiGLU | RGB-D 地形上下文 \(c_t\) 经 \(C_1,C_2\) 乘性门控中间 FFN（论文 Eq. 5） |
 | 未来预测头 | 确定性预报 \(\hat{\mathbf{s}}_{t+1:t+2}\)；rollout MSE + 无效步 mask |
 | 未来条件动作头 | \(\hat{\mathbf{a}}_t\sim\pi'(\mathbf{a}_t\mid\mathbf{Q}_t^{(L)},\hat{\mathbf{s}}_{t+1:t+2})\) |
 | AMP 判别器 | 输入改为 \([\mathbf{s}_{t-7:t};\hat{\mathbf{s}}_{t+1:t+2}]\)，把预期运动钉在参考流形上 |
@@ -113,23 +114,25 @@ flowchart TB
 \mathcal{L}_{\mathrm{pred}}=\frac{1}{|\mathcal{M}_{\mathrm{pred}}|}\sum_i\sum_{k=1}^{2}m_{i,k}\,\|\hat{s}_{i,k}-s_{i,k}\|_2^2
 \]
 
-动作在名义姿态附近输出 delta；总奖励 \(R_{\mathrm{task}}+R_{\mathrm{AMP}}\)。
+Conditional SwiGLU（论文 Eq. 5）：\(\mathrm{FFN}(x,c_t)=\mathbf{W}_5\bigl(\mathrm{SiLU}(\mathbf{W}_3 x+C_1 c_t)\odot(\mathbf{W}_4 x+C_2 c_t)\bigr)\)。动作在名义姿态附近输出 delta；总奖励 \(R_{\mathrm{task}}+R_{\mathrm{AMP}}\)。
+
+地形课沿三维加难：几何变化（阶高/坡角）、障碍密度与间距、不连续（缺口/突变高差）。仿真与真机评测均用 **G1 29 DoF**。
 
 ## 源码运行时序图
 
-**不适用**（截至 2026-08-16：项目页与作者 GitHub 仅有 [`parkourformer.github.io`](https://github.com/MRonaldo-gif/parkourformer.github.io) 站点仓，无训练/推理入口）。待代码发布后按 README 补 `sequenceDiagram`。
+**不适用**（截至 2026-08-30：项目页写「Code(Coming Soon)」；作者 GitHub 仅有 [`parkourformer.github.io`](https://github.com/MRonaldo-gif/parkourformer.github.io) 站点仓，无训练/推理入口）。待代码发布后按 README 补 `sequenceDiagram`。
 
 ## 工程实践
 
 | 项 | 建议 |
 |----|------|
-| 复现入口 | arXiv HTML/PDF + 项目页视频；**代码未发布** |
+| 复现入口 | arXiv HTML/PDF + 项目页视频；**代码 Coming Soon，尚未可跑** |
 | 仿真对齐 | 先对齐 Project Instinct / [Hiking](./paper-hiking-in-the-wild.md) 的 MuJoCo 地形课，再谈 Transformer |
 | 预测步长 | 论文钉死 **2 步**；更长视野未报，勿默认可外推 |
 | 监督权重 | \(c_2\) 对失败/负 advantage 加大——下楼消融说明这不是装饰项 |
 | AMP 拼接 | 判别器必须看到「历史+预测」连续序列，而不是只加 MSE |
 | 感知 | 缺口/攀升依赖 RGB-D query；盲走或深度失效会整体掉功能 |
-| 源码运行时序图 | **不适用**（未开源） |
+| 源码运行时序图 | **不适用**（待发布，无可运行实现） |
 
 ## 实验与评测
 
@@ -162,7 +165,7 @@ flowchart TB
 3. **AMP 要吃预测未来** — 只加 \(\mathcal{L}_{\mathrm{pred}}\) 不够，判别序列必须接上 \(\hat{\mathbf{s}}_{t+1:t+2}\)。
 4. **单策略换技能链** — 适合「九类程序地形课」；不覆盖 PHP 式 1.25 m 攀墙技能库或 LightLP 的 0.83H 承重攀爬。
 5. **负 advantage 加权监督** — 失败轨迹更需要学「下一步身体会怎样」，而不是只在成功轨迹上拟合。
-6. **代码未开源** — 选型先看表与视频；仿真数字绑定 Instinct MuJoCo + 自建九类课，勿直接对标 IsaacLab 论文。
+6. **代码仍不可复现** — 2026-08-30 项目页改为「Code(Coming Soon)」，但仓库仍只有站点页；选型先看表与视频。仿真数字绑定 Instinct MuJoCo + 自建九类课，勿直接对标 IsaacLab 论文。
 
 ## 与其他工作对比
 
@@ -177,7 +180,7 @@ flowchart TB
 
 ## 局限与风险
 
-- **未开源：** 无法核对网络宽度、\(c_{1\ldots4}\) 或地形生成器；数字以 arXiv v3 / 项目页为准。
+- **代码待发布：** 无法核对网络宽度、\(c_{1\ldots4}\) 或地形生成器；数字以 arXiv v3 / 项目页为准。`Pixel-114514/parkourformer.github.io` 亦为早期主页拷贝，不是训练仓。
 - **AMP reset 无地形：** 作者自承参考被随机切段，动态跑酷缺地形条件化运动检索。
 - **RGB-D 单点故障：** 深度损坏则策略整体失效，没有盲走回退。
 - **奖励稀疏：** 大缺口/不规则障碍上优化仍弱。

--- a/wiki/entities/paper-ssr-humanoid-open-world-traversal.md
+++ b/wiki/entities/paper-ssr-humanoid-open-world-traversal.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, locomotion, perception, depth, foothold-guidance, symmetry, amp, open-world, stairs, parkour, sim2real, agibot, zju]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 arxiv: "2605.30770"
 related:
   - ./paper-cref.md

--- a/wiki/methods/amp-reward.md
+++ b/wiki/methods/amp-reward.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, imitation-learning, gan, motion-prior, humanoid]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 related:
   - ../overview/jason-peng-flexible-motion-skill-learning.md
   - ../entities/mimickit.md

--- a/wiki/methods/reinforcement-learning.md
+++ b/wiki/methods/reinforcement-learning.md
@@ -2,7 +2,7 @@
 type: method
 tags: [rl, locomotion, policy-optimization, model-free]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 related:
   - ../concepts/rl-runner.md
   - ../entities/embodied-interview-qa.md

--- a/wiki/tasks/humanoid-locomotion.md
+++ b/wiki/tasks/humanoid-locomotion.md
@@ -2,7 +2,7 @@
 type: task
 tags: [humanoid, locomotion, whole-body-control]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 related:
   - ./locomotion.md
   - ./stair-obstacle-perceptive-locomotion.md
@@ -123,7 +123,7 @@ summary: "人形机器人在复杂地形下的平衡与移动任务，强调高�
 - [HIL](../methods/hil-hybrid-imitation-learning.md) — 物理角色跑酷：tracking + AMP 混合模仿（仿真）
 - [HIL vs MTRG vs ZEST 跑酷路线对比](../comparisons/hil-vs-mtrg-vs-zest-parkour-imitation.md) — 跑酷模仿三条路线选型
 - [Light-Loco-Parkour（LightLP）](../entities/paper-light-loco-parkour.md) — Light Origins / Lightbot 0；稀疏种子 Real2Sim2Real + 多专家蒸馏，无技能标签机载深度跑酷（代码未开源）
-- [ParkourFormer](../entities/paper-parkourformer.md) — HKUST-GZ 等；Transformer 查询历史 + 未来两步 AMP 监督；G1 九类地形单策略平均穿越 93.85%（代码未开源）
+- [ParkourFormer](../entities/paper-parkourformer.md) — HKUST-GZ 等；Transformer 查询历史 + 未来两步 AMP 监督；G1 九类地形单策略平均穿越 93.85%（代码 Coming Soon）
 - [TRAMP（IEEE RA-L 2026）](../entities/paper-tramp-vision-assisted-bipedal-locomotion.md) — SJTU；单阶段低成本深度 + MoE + 平地/楼梯地形相关 AMP；真机坡/楼梯/高台/宽沟与户外（代码未开源）
 - [Diffusion-based Motion Generation](../methods/diffusion-motion-generation.md)
 - [PPO](../methods/policy-optimization.md)

--- a/wiki/tasks/locomotion.md
+++ b/wiki/tasks/locomotion.md
@@ -2,7 +2,7 @@
 type: task
 tags: [locomotion, bipedal, humanoid, rl, control]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 related:
   - ../concepts/whole-body-control.md
   - ../concepts/sim2real.md
@@ -332,7 +332,7 @@ flowchart TD
 - [DPL（单深度感知人形行走）](../entities/paper-notebook-dpl-depth-only-perceptive-humanoid-locomotion-vi.md) — arXiv:2510.07152（IEEE RA-L；深度合成 + 交叉注意力高程重建 + 盲骨干多教师；TienKung Ultra；代码未开源）
 - [SOLO（长程感知人形运动）](../entities/paper-solo.md) — arXiv:2608.26583（QR + TA-MSE；天工 Omni 零样本 1.5 km；截至入库日未开源）
 - [Light-Loco-Parkour（LightLP）](../entities/paper-light-loco-parkour.md) — Light Origins 2026-08-03（稀疏种子 Real2Sim2Real + 转移组 RL；Lightbot 0 无技能标签深度跑酷；代码未开源）
-- [ParkourFormer](../entities/paper-parkourformer.md) — arXiv:2605.25782（query 历史 + 未来两步本体监督；G1 九类地形单策略 93.85%；代码未开源）
+- [ParkourFormer](../entities/paper-parkourformer.md) — arXiv:2605.25782（query 历史 + 未来两步本体监督；G1 九类地形单策略 93.85%；代码 Coming Soon）
 - [SMPLOlympics](../entities/smplolympics.md) — arXiv:2407.00187（SMPL 仿真人形 10 项奥运运动 benchmark；PPO/AMP/PULSE 基线）
 - [Table Tennis Strategy & Skill（PhysicsPingPong）](../methods/table-tennis-strategy-skill-learning.md) — arXiv:2407.16210（SIGGRAPH 2024 分层乒乓球 + VR 人–机）
 - [乒乓球分层技能选型指南](../queries/table-tennis-hierarchical-skill-learning-guide.md) — ASE 专家 + mixer + 策略层选型

--- a/wiki/tasks/stair-obstacle-perceptive-locomotion.md
+++ b/wiki/tasks/stair-obstacle-perceptive-locomotion.md
@@ -2,7 +2,7 @@
 type: task
 tags: [locomotion, stairs, obstacle, perception, blind-locomotion, parkour, humanoid, quadruped, hub]
 status: complete
-updated: 2026-08-29
+updated: 2026-08-30
 related:
   - ../entities/paper-cref.md
   - ../entities/paper-ame-attention-based-map-encoding.md
@@ -161,7 +161,7 @@ flowchart TB
 |------|------|------|------|
 | 人形 G1 | **深度** | [PHP（Perceptive Humanoid Parkour）](../entities/paper-hrl-stack-22-perceptive_humanoid_parkour.md) | motion matching 合成长程参考 + DAgger+PPO 单策略 |
 | 人形 Lightbot 0 | **深度** | [Light-Loco-Parkour（LightLP）](../entities/paper-light-loco-parkour.md) | 稀疏种子 Real2Sim2Real + 多专家/转移组蒸馏；**无技能标签**；代码未开源 |
-| 人形 G1 | **RGB-D** | [ParkourFormer](../entities/paper-parkourformer.md) | Transformer 查询历史 + 未来两步 AMP 监督；九类地形单策略 **93.85%**；代码未开源 |
+| 人形 G1 | **RGB-D** | [ParkourFormer](../entities/paper-parkourformer.md) | Transformer 查询历史 + 未来两步 AMP 监督；九类地形单策略 **93.85%**；代码 Coming Soon |
 | 人形 | **深度**（策展） | [Deep Whole-body Parkour](../entities/paper-deep-whole-body-parkour.md) | 全身跑酷，与 PHP 同簇 |
 | 四足 Go1 | **单目深度** | [Extreme Parkour](../entities/extreme-parkour.md) | 端到端跑酷；两阶段特权 scandots → 深度蒸馏 |
 | 四足 Apollo | **深度 + RSSM WM** | [SWAP](../entities/paper-swap-parkour.md) | 对称等变潜变量世界模型 + 等变 Actor-Critic；2.13 m 远跳 / 1.63 m 攀台 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 用户指定 ingest *ParkourFormer*（[arXiv:2605.25782](https://arxiv.org/abs/2605.25782)；HKUST-GZ / CLAI-LAB / SCAU / GDUT；Unitree G1 29 DoF 多地形人形跑酷）。
- **排重：** 仓库已有 canonical 实体 `wiki/entities/paper-parkourformer.md`（2026-08-16 ingest，同一 arXiv）。**未新建**第二篇 `paper-*`，只加深既有节点。
- **步骤 2.5（2026-08-30）：** 项目页按钮现为「Code(Coming Soon)」；作者仓仍只有 `MRonaldo-gif/parkourformer.github.io` 站点页；arXiv 仍为 **v3**。开源结论从「确认未开源」改为 **宣称将开源 / 待发布**。源码运行时序图继续「不适用」。
- **加深：** 观测拆分、query 2×128 / 记忆 8×128 / AMP 10×67、Conditional SwiGLU Eq. 5、地形三维加难；交叉页开源措辞同步。机构已注册，未改 `institutions.json`。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight` 通过（lint 0 issues；搜索 40/40；导出 12/12）
- [x] GitHub Actions 全绿（smoke / pytest / lint / quality-check）后已合并
- [x] 未新增 wiki 页，未改 `institutions.json`，无需额外 `make test`
- [x] 静态站详情页 `docs/detail.html?id=wiki-entities-paper-parkourformer` 渲染正常

## 相关 Issue

无。

## 验证截图

![ParkourFormer 详情页：Coming Soon 摘要与 2026-08-30 更新](https://cursor.com/artifacts/c/art-473fb3bc-29c3-4561-9542-f563360870d7)
![ParkourFormer 详情页来源链接](https://cursor.com/artifacts/c/art-a84a3adf-f54b-42d2-a719-0045fa30353f)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e45e5e6f-5168-4611-97ce-b8968fee30d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e45e5e6f-5168-4611-97ce-b8968fee30d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

