### PR TITLE
roadmap sync: 补齐 5 条纵深路线对近期知识节点的引用

### DIFF
--- a/roadmap/depth-contact-manipulation.md
+++ b/roadmap/depth-contact-manipulation.md
@@ -89,6 +89,7 @@ flowchart LR
 - [Query：操作任务里的模仿学习](../wiki/queries/il-for-manipulation.md)
 - [数据手套 vs 视觉遥操作](../wiki/comparisons/data-gloves-vs-vision-teleop.md) — 采集方案选型
 - [DexVerse](../wiki/entities/paper-dexverse.md) — 100 任务 × 3 臂 × 6 手灵巧操作 benchmark；π₀.₅ / DP3 均值成功率仅 34%，暴露跨技能泛化与亚厘米接触对齐瓶颈
+- [DexBench](../wiki/entities/dexbench.md)（本仓库）— RLWRLD × NVIDIA 工业灵巧操作开放规格：OSC 六轴诊断难度、五种 Dexterity Regime 规定能力包络，18 任务 / 55 用例 + 可采购实物；官方评测仓与 Isaac Lab-Arena 集成待发布
 - Zhao et al., *Learning Fine-Grained Bimanual Manipulation with Low-Cost Hardware* (ACT, 2023)
 
 ### 推荐做什么

--- a/roadmap/depth-rl-locomotion.md
+++ b/roadmap/depth-rl-locomotion.md
@@ -53,6 +53,7 @@ flowchart LR
 - [动手学强化学习（蘑菇书）](../wiki/entities/hands-on-rl-book.md) — 中文：MDP → PPO/SAC 章节 + [hrl.boyuai.com](https://hrl.boyuai.com/chapter) 在线 notebook；配套 [伯禹免费视频课](https://www.boyuai.com/elites/course/xVqhU42F5IDky94x)
 - Spinning Up (OpenAI) — Part 1: Key Concepts
 - [Reinforcement Learning](../wiki/methods/reinforcement-learning.md)（本仓库）
+- [强化学习史（试错学习 / 最优控制 / 时序差分三脉汇合）](../wiki/concepts/reinforcement-learning-history.md)（本仓库）— Sutton & Barto §1.6；读懂谱系有助于区分 RL 与监督学习及 model-based 控制
 - [PPO](../wiki/methods/ppo.md) · [SAC](../wiki/methods/sac.md)（本仓库）
 - [Query：机器人任务里 PPO 与 SAC 怎么选](../wiki/queries/ppo-vs-sac-for-robots.md)
 

--- a/roadmap/depth-sim2real.md
+++ b/roadmap/depth-sim2real.md
@@ -178,6 +178,8 @@ flowchart LR
 - [Query：RL 策略真机调试 Playbook](../wiki/queries/robot-policy-debug-playbook.md)（本仓库）
 - [ONNX](../wiki/entities/onnx.md) · [ONNX Runtime vs MNN vs TensorRT](../wiki/comparisons/onnxruntime-vs-mnn-vs-tensorrt.md)（本仓库）
 - [Open Duck Mini](../wiki/entities/open-duck-mini.md)（本仓库）— 低成本平台全链路 sim2real 公开参考
+- [NVIDIA Isaac Lab · Spot Locomotion Sim2Real](../wiki/entities/nvidia-isaac-lab-spot-locomotion-sim2real.md)（本仓库）— 官方教程：Isaac-Velocity-Flat-Spot-v0 训平地速度跟踪，Jetson Orin 上 ONNX 推理 + Spot SDK 零样本部署
+- [NVIDIA Isaac Lab · UR10e Industrial Assembly Sim2Real](../wiki/entities/nvidia-isaac-lab-ur10e-industrial-assembly-sim2real.md)（本仓库）— 官方案例：RL 出 motion/insertion、Isaac ROS 做 6D 感知、UR Direct Torque 阻抗环 500 Hz 真机执行的零样本装配
 
 ### 学完输出什么
 - 一份本平台的部署 SOP 文档与 sim2sim 回归报告

--- a/roadmap/depth-vla.md
+++ b/roadmap/depth-vla.md
@@ -121,6 +121,7 @@ flowchart LR
 - [BridgeVLA++](../wiki/entities/paper-bridgevla-plusplus.md)（本仓库）— 多视图 heatmap 对齐 3D VLA 加统一时空记忆（粗阶段关键帧检索 + 细阶段初始几何），RMBench 记忆依赖任务 18.9%→96.0%，RLBench 93.7%；代码与权重已开源
 - [Galaxea G0.5](../wiki/entities/paper-galaxea-g05.md)（本仓库）— VLM-as-Actor + 学出来的 ActionCodec 27 维去掉自回归 token 税，原生 CoT 直接 attend；真机六设定 76.7% vs π0.5 53.3%，LIBERO 98.9% / RoboTwin 93.3%；GalaxeaVLA + HF 权重已开源（G0.5 Community License，非商用）
 - [GSR / ParaVLA](../wiki/entities/paper-gsr-paravla.md)（本仓库）— 指出 VLA 指令改写崩溃来自联合 V-L 路由而非不懂语义，冻结 T5 重绑原生视觉并重训动作专家；LIBERO-Para 上 SmolVLA +44.6 pp；训练与 HF 权重已开源
+- [Indi](../wiki/entities/paper-indi.md)（本仓库）— 冻结教师 VLM 把示范片段的局部行为意图蒸馏进动作解码器，部署时无需教师；GR00T-N1.7 在 SimplerEnv-Bridge 64.3%→84.7%，真机 62.0%→68.7%
 
 ### 学完输出什么
 - 能画出典型 VLA 的三段式结构（视觉编码 → 语义 backbone → 动作专家）并说清各家差异
@@ -270,3 +271,4 @@ flowchart LR
 - "RT-2: Vision-Language-Action Models" (Brohan et al., 2023) — VLA 概念确立
 - "π0: A Vision-Language-Action Flow Model" (Black et al., 2024) — flow matching 动作专家代表
 - "OpenVLA: An Open-Source Vision-Language-Action Model" (Kim et al., 2024) — 开源 VLA 与 OXE 跨本体路线
+- [GlanceWAM / VLA Crew 10 篇技术地图（2026-08-30 策展）](../wiki/overview/glancewam-vla-crew-10-papers-technology-map.md)

--- a/roadmap/depth-wam.md
+++ b/roadmap/depth-wam.md
@@ -159,6 +159,7 @@ flowchart LR
 - [FACT](../wiki/entities/paper-fact.md)（本仓库）— 用失败演示的后果监督打破 Joint WAM 的 success bias（只在成功轨迹上训未来，测试时错误动作仍配上"成功未来"）；进度头可选做部署前打分，真机消融显示无失败共训时打分能力显著下降（79%），证明价值头确实吃后果监督；RoboTwin 管线 + HF checkpoint 已开源
 - [Motubrain](../wiki/entities/paper-motubrain.md)（本仓库）— UniDiffuser 式 Joint WAM，三流 MoT + H-bridge，50–100 条同本体轨迹即可适配；RoboTwin 2.0 95.8/96.1；官方仓仅 PDF，训练/推理待发布
 - [Flex-π](../wiki/entities/paper-flex-pi.md)（本仓库）— 6B 多流 Joint WAM，共享冻结 Wan VAE 联合编码 RGB+pointmap+DINOv3，流 dropout + CMF 让单 checkpoint 覆盖 56 种流组合；真机双臂 YAM 最高约 2–7× 基线；代码待发布
+- [GlanceWAM](../wiki/entities/paper-glancewam.md)（本仓库）— 单视频 DiT 内异步稀疏前瞻，想象离关键路径、动作头潜空间 48 ms 解码；RoboCasa 72.2%、LIBERO 99.0%；代码与权重已开源
 
 ### 学完输出什么
 - 能比较至少两种 Joint 实现（扩散双塔 vs 潜自回归闭环）的延迟与闭环形态
@@ -264,4 +265,5 @@ flowchart LR
 - [sources/papers/world_action_models_survey_2605.md](../sources/papers/world_action_models_survey_2605.md) — Wang et al., arXiv:2605.12090
 - [动作后果技术地图](../wiki/overview/robot-world-models-action-consequence-technology-map.md) 与 2026-07 策展 12 篇实体页
 - [机器人世界模型训练闭环 taxonomy](../wiki/overview/robot-world-models-training-loop-taxonomy.md)
+- [GlanceWAM / VLA Crew 10 篇技术地图（2026-08-30 策展）](../wiki/overview/glancewam-vla-crew-10-papers-technology-map.md)
 - OpenMOSS [Awesome-WAM](https://github.com/OpenMOSS/Awesome-WAM)


### PR DESCRIPTION
## 摘要

审计发现 8/27–8/30 期间入库的多个 wiki 知识节点未被任何 `roadmap/depth-*.md` 纵深路线引用；本 PR 做最小引用补齐：

- `depth-wam.md` / `depth-vla.md`：接入 [GlanceWAM / VLA Crew 10 篇技术地图](wiki/overview/glancewam-vla-crew-10-papers-technology-map.md)（2026-08-30 策展），并各补一条代表论文（GlanceWAM → Stage 3 Joint WAM；Indi → Stage 2 VLA 主线）
- `depth-rl-locomotion.md`：Stage 0 补 [强化学习史（Sutton & Barto §1.6）](wiki/concepts/reinforcement-learning-history.md)
- `depth-contact-manipulation.md`：补 [DexBench](wiki/entities/dexbench.md) 工业灵巧操作基准（与既有 DexVerse 并列）
- `depth-sim2real.md`：Stage 4 补 NVIDIA Isaac Lab 官方 [UR10e 工业装配](wiki/entities/nvidia-isaac-lab-ur10e-industrial-assembly-sim2real.md) / [Spot locomotion](wiki/entities/nvidia-isaac-lab-spot-locomotion-sim2real.md) sim2real 案例

**未处理项（留待人工决策）**：轮腿方向（`wheel-legged-biped`/`wheel-legged-quadruped` 等概念、tita_rl、wheel_legged_genesis 等，8/28 入库）目前没有对应纵深路线，是否新增第 22 条路线（并更新 `roadmap/README.md`）超出本次"最小引用补齐"范围，未在本 PR 处理。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）— roadmap 引用补齐，未新增/改写 wiki 正文
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make export graph` 后全量 `PYTHONPATH=scripts python3 -m pytest tests/`：415 passed
- [x] 本地静态站点 `docs/roadmap.html?id=roadmap-depth-wam` 已渲染确认：Stage 3 正确显示新增的 GlanceWAM 条目（Playwright headless 截图核对，未在本 PR 附图 — 本会话环境未提供可自动转存为稳定 URL 的截图上传通道，附本地绝对路径会在 PR 正文中原样失效，故以文字说明代替）
- 说明：`make export graph` 同时会重生成 `exports/home-stats.json` 等派生统计，但本沙箱为浅克隆（shallow clone），会导致 `latest_wiki_nodes` 的 `source` 字段从 `git` 回退成 `log.md`，属沙箱环境限制而非真实内容变化，故未随本 PR 提交这些派生文件的重新生成结果，避免引入无关噪声。

## 相关 Issue

无