### PR TITLE
feat(ux): 全站（图谱页除外）新增带阅读进度环的回到顶部按钮

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -7357,3 +7357,83 @@
     container.innerHTML = othersHtml;
   }
 })();
+
+/* ── 全站「回到顶部」按钮（带阅读进度环） ──
+   注入判据与 style.css 里 `body:has(> .footer)` 一致：graph.html / references.html
+   没有站内 footer，因此自动排除（图谱页全屏画布不加浮层，跳转桩页无需）。 */
+(function () {
+  'use strict';
+
+  function init() {
+    if (!document.querySelector('body > .footer')) return;
+    if (document.querySelector('.back-to-top')) return;
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.id = 'backToTop';
+    btn.className = 'back-to-top';
+    btn.setAttribute('aria-label', '回到顶部');
+    btn.setAttribute('title', '回到顶部');
+    btn.setAttribute('aria-hidden', 'true');
+    btn.tabIndex = -1;
+    btn.innerHTML = '<span class="back-to-top-arrow" aria-hidden="true">↑</span>';
+    document.body.appendChild(btn);
+
+    var visible = false;
+    var lastProgress = -1;
+
+    function update() {
+      var doc = document.documentElement;
+      var scrolled = window.pageYOffset || doc.scrollTop || 0;
+      var scrollable = doc.scrollHeight - window.innerHeight;
+      var progress = scrollable > 0 ? Math.min(1, Math.max(0, scrolled / scrollable)) : 0;
+      // 量化到 1% 再写回样式，避免每帧都触发进度环重绘
+      var rounded = Math.round(progress * 100) / 100;
+      if (rounded !== lastProgress) {
+        lastProgress = rounded;
+        btn.style.setProperty('--btt-progress', String(rounded));
+      }
+      // 出现阈值：默认 0.6 屏，但对本身就不长的页面（如 hubs.html 可滚约 570px）
+      // 按可滚距离的 35% 提前放出，否则按钮只会在最后几十像素里闪一下；
+      // 可滚距离不足 240px 的页面则完全不出现，避免为一点点滚动挂个浮层。
+      var shouldShow = scrollable >= 240 &&
+        scrolled > Math.min(window.innerHeight * 0.6, scrollable * 0.35);
+      if (shouldShow !== visible) {
+        visible = shouldShow;
+        btn.classList.toggle('is-visible', shouldShow);
+        btn.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+        btn.tabIndex = shouldShow ? 0 : -1;
+      }
+    }
+
+    // 与页面其他滚动监听一致：rAF 节流
+    var ticking = false;
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(function () {
+        update();
+        ticking = false;
+      });
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+
+    btn.addEventListener('click', function () {
+      var reduce = false;
+      try {
+        reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      } catch { /* 老浏览器无 matchMedia：按默认平滑滚动处理 */ }
+      window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+    });
+
+    update();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/style.css
+++ b/docs/style.css
@@ -2460,6 +2460,75 @@ button.home-wiki-heatmap-cell.is-active {
   opacity: 1;
 }
 
+/* Back to Top（进度环 FAB，main.js 注入；graph.html / references.html 无 footer 故不注入）
+   右下角落位：与左下角的 .sidebar-toggle 分居两侧，移动端抽屉目录展开时互不遮挡 */
+.back-to-top {
+  --btt-progress: 0;
+  --btt-track: color-mix(in srgb, var(--text-muted) 32%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  bottom: 24px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  /* 外圈 = 阅读进度环，由 JS 每帧更新 --btt-progress（0~1） */
+  background: conic-gradient(var(--accent) calc(var(--btt-progress) * 360deg), var(--btt-track) 0);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 1100;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+.back-to-top.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+/* 内圈实心底，把 conic-gradient 削成一条 3px 宽的环 */
+.back-to-top::before {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+}
+.back-to-top:hover::before {
+  background: var(--bg-alt);
+}
+.back-to-top:active {
+  transform: scale(0.9);
+}
+.back-to-top-arrow {
+  position: relative;
+  font-size: 1.05rem;
+  line-height: 1;
+  color: var(--text);
+}
+.back-to-top:hover .back-to-top-arrow {
+  color: var(--accent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top {
+    transition: none;
+  }
+}
+@media (max-width: 768px) {
+  .back-to-top {
+    bottom: 20px;
+    right: 16px;
+    width: 44px;
+    height: 44px;
+  }
+}
+
 @media (max-width: 1631px) {
   .detail-toc-panel {
     position: fixed;


### PR DESCRIPTION
- docs/main.js：追加独立模块，按「页面是否有站内 footer」判定注入
  （与 style.css 里 body:has(> .footer) 同一口径），因此 graph.html 与
  references.html 跳转桩页自动排除，其余 7 个页面统一生效。
- 阅读进度用 CSS 变量 --btt-progress 驱动 conic-gradient 外环；滚动监听
  沿用站内既有的 requestAnimationFrame 节流写法，进度量化到 1% 再写样式。
- 出现阈值取 min(0.6 屏, 可滚距离 35%)，可滚距离不足 240px 的页面不出现，
  避免 hubs.html 这类短页上按钮只在最后几十像素闪现。
- docs/style.css：按钮固定右下角，与左下角 .sidebar-toggle 分居两侧，
  1440×900 与 390×844 下实测矩形无重叠；暗/亮色均走既有主题变量。
- prefers-reduced-motion 下关闭淡入过渡并改用即时滚动。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018wRo1SVASLYM8HHRD5j5B2