### PR TITLE
feat(ux): 全站回到顶部按钮（带阅读进度环）+ 首页章节跳转浮动按钮

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -7464,14 +7464,15 @@
     if (!document.getElementById('hero')) return;
     if (document.querySelector('.home-nav-fab')) return;
 
-    // 章节按 DOM 顺序收集；标题优先取 .section-title，其次取 section 自身的 aria-label
+    // 章节按 DOM 顺序收集，只收有 .section-title 的板块：没有可见标题的过渡区
+    // （如首页入口卡片区 #home-start）不进菜单
     var items = [{ id: 'hero', label: '顶部' }];
     var sections = document.querySelectorAll('main > section[id]');
     for (var i = 0; i < sections.length; i++) {
       var sec = sections[i];
       if (sec.id === 'hero') continue;
       var titleEl = sec.querySelector('.section-title');
-      var label = (titleEl && titleEl.textContent.trim()) || sec.getAttribute('aria-label') || '';
+      var label = titleEl ? titleEl.textContent.trim() : '';
       if (label) items.push({ id: sec.id, label: label });
     }
     if (items.length < 2) return;

--- a/docs/main.js
+++ b/docs/main.js
@@ -7437,3 +7437,147 @@
     init();
   }
 })();
+
+/* ── 首页章节跳转按钮 ──
+   参考 https://imchong.github.io/ 的 .home-nav-fab：左下角浮动按钮 + 上弹章节菜单。
+   与参考站的差异：那边只在 ≤720px 显示（PC 交给 .site-header 里的 .main-nav），本站
+   不改动 .site-header，所以不设断点，PC 端同样用这个按钮跳转。
+   只在首页注入：#hero 是 index.html 独有的锚点。 */
+(function () {
+  'use strict';
+
+  function fabIcon(kind) {
+    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.setAttribute('class', 'home-nav-fab__icon home-nav-fab__icon--' + kind);
+    var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    // open 复用站内 .sidebar-toggle 的同一条汉堡路径，两个浮动按钮观感一致
+    path.setAttribute('d', kind === 'close'
+      ? 'M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'
+      : 'M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z');
+    svg.appendChild(path);
+    return svg;
+  }
+
+  function init() {
+    if (!document.getElementById('hero')) return;
+    if (document.querySelector('.home-nav-fab')) return;
+
+    // 章节按 DOM 顺序收集；标题优先取 .section-title，其次取 section 自身的 aria-label
+    var items = [{ id: 'hero', label: '顶部' }];
+    var sections = document.querySelectorAll('main > section[id]');
+    for (var i = 0; i < sections.length; i++) {
+      var sec = sections[i];
+      if (sec.id === 'hero') continue;
+      var titleEl = sec.querySelector('.section-title');
+      var label = (titleEl && titleEl.textContent.trim()) || sec.getAttribute('aria-label') || '';
+      if (label) items.push({ id: sec.id, label: label });
+    }
+    if (items.length < 2) return;
+
+    var overlay = document.createElement('div');
+    overlay.className = 'home-nav-overlay';
+    overlay.setAttribute('aria-hidden', 'true');
+
+    var fab = document.createElement('div');
+    fab.className = 'home-nav-fab';
+
+    var toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.id = 'homeNavToggle';
+    toggle.className = 'home-nav-fab__toggle';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-controls', 'homeNavMenu');
+    toggle.setAttribute('aria-label', '打开或关闭章节导航');
+    toggle.setAttribute('title', '章节导航');
+    toggle.appendChild(fabIcon('open'));
+    toggle.appendChild(fabIcon('close'));
+
+    var menu = document.createElement('nav');
+    menu.id = 'homeNavMenu';
+    menu.className = 'home-nav-menu';
+    menu.setAttribute('aria-label', '章节导航');
+
+    var list = document.createElement('ul');
+    for (var j = 0; j < items.length; j++) {
+      var li = document.createElement('li');
+      var link = document.createElement('a');
+      link.href = '#' + items[j].id;
+      link.textContent = items[j].label;
+      li.appendChild(link);
+      list.appendChild(li);
+    }
+    menu.appendChild(list);
+
+    // 按钮先入 DOM，保证 Tab 顺序是「按钮 → 菜单项」
+    fab.appendChild(toggle);
+    fab.appendChild(menu);
+    document.body.appendChild(overlay);
+    document.body.appendChild(fab);
+
+    function closeMenu() {
+      if (!fab.classList.contains('is-open')) return;
+      fab.classList.remove('is-open');
+      overlay.classList.remove('is-open');
+      toggle.setAttribute('aria-expanded', 'false');
+      if (menu.contains(document.activeElement)) toggle.focus();
+    }
+
+    function openMenu() {
+      fab.classList.add('is-open');
+      overlay.classList.add('is-open');
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+
+    toggle.addEventListener('click', function (event) {
+      event.stopPropagation();
+      if (fab.classList.contains('is-open')) closeMenu();
+      else openMenu();
+    });
+    overlay.addEventListener('click', closeMenu);
+    menu.addEventListener('click', function (event) {
+      // 立刻关闭，别挡住 hash 跳转
+      if (event.target.closest('a')) closeMenu();
+    });
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') closeMenu();
+    });
+
+    // 滚动高亮当前章节：判定线取吸顶 header 下沿，与 html 的 scroll-padding-top 同口径
+    var links = menu.querySelectorAll('a');
+    var lastActive = -1;
+    function updateActive() {
+      var header = document.querySelector('.site-header');
+      var line = (header ? header.getBoundingClientRect().height : 0) + 24;
+      var current = 0;
+      for (var k = 0; k < items.length; k++) {
+        var target = document.getElementById(items[k].id);
+        if (target && target.getBoundingClientRect().top <= line) current = k;
+      }
+      if (current === lastActive) return;
+      lastActive = current;
+      for (var m = 0; m < links.length; m++) {
+        links[m].classList.toggle('active', m === current);
+      }
+    }
+
+    // 与页面其他滚动监听一致：rAF 节流
+    var ticking = false;
+    window.addEventListener('scroll', function () {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(function () {
+        updateActive();
+        ticking = false;
+      });
+    }, { passive: true });
+    updateActive();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/style.css
+++ b/docs/style.css
@@ -2526,6 +2526,129 @@ button.home-wiki-heatmap-cell.is-active {
   }
 }
 
+/* 首页章节跳转按钮（由 main.js 仅在首页注入）
+   参考 https://imchong.github.io/ 的 .home-nav-fab：左下角浮动按钮 + 上弹章节菜单。
+   与参考站的差异：那边只在 ≤720px 显示（PC 交给 header 里的 .main-nav），本站不改
+   .site-header，所以不设断点，PC 端同样用这个按钮跳转。
+   位置与 .back-to-top 关于窗口中轴镜像：bottom / 内缩量 / 尺寸三者一致；左侧没有
+   scrollbar-gutter 装订线，故直接写 left: 20px。首页没有 .sidebar-toggle，不会撞位。 */
+.home-nav-fab {
+  position: fixed;
+  bottom: 24px;
+  left: 20px;
+  z-index: 1350;
+  display: flex;
+  /* 按钮在 DOM 里排在菜单之前（Tab 顺序从按钮进菜单），column-reverse 把菜单画在上方 */
+  flex-direction: column-reverse;
+  align-items: flex-start;
+  gap: 12px;
+}
+.home-nav-fab__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+.home-nav-fab__toggle:active {
+  transform: scale(0.9);
+}
+.home-nav-fab.is-open .home-nav-fab__toggle {
+  background: var(--accent-hover);
+}
+.home-nav-fab__toggle svg {
+  width: 24px;
+  height: 24px;
+  fill: currentColor;
+}
+.home-nav-fab__icon--close {
+  display: none;
+}
+.home-nav-fab.is-open .home-nav-fab__icon--open {
+  display: none;
+}
+.home-nav-fab.is-open .home-nav-fab__icon--close {
+  display: block;
+}
+
+.home-nav-menu {
+  width: max-content;
+  min-width: 168px;
+  max-width: min(72vw, 280px);
+  max-height: calc(100vh - 150px);
+  overflow-y: auto;
+  padding: 8px;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px) scale(0.96);
+  transform-origin: bottom left;
+  transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.2s ease;
+}
+.home-nav-fab.is-open .home-nav-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0) scale(1);
+}
+.home-nav-menu ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.home-nav-menu a {
+  display: block;
+  padding: 9px 12px;
+  border-radius: 8px;
+  font-size: 0.92rem;
+  line-height: 1.3;
+  color: var(--text-muted);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background var(--transition), color var(--transition);
+}
+.home-nav-menu a:hover {
+  color: var(--text);
+  background: var(--bg-alt);
+}
+.home-nav-menu a.active {
+  color: var(--accent);
+  font-weight: 600;
+  background: var(--quote-bg);
+}
+
+.home-nav-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1250;
+  background: rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(2px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+}
+.home-nav-overlay.is-open {
+  opacity: 1;
+  visibility: visible;
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-nav-fab__toggle,
+  .home-nav-menu,
+  .home-nav-overlay {
+    transition: none;
+  }
+}
+
 @media (max-width: 1631px) {
   .detail-toc-panel {
     position: fixed;

--- a/docs/style.css
+++ b/docs/style.css
@@ -2469,8 +2469,13 @@ button.home-wiki-heatmap-cell.is-active {
   align-items: center;
   justify-content: center;
   position: fixed;
+  /* 与左下角 .sidebar-toggle 关于窗口中轴镜像：bottom / 内缩量 / 尺寸三者与它一致
+     （那边是 bottom:24px; left:20px; 48x48，且没有窄屏覆写），所以这里同样不加断点覆写。
+     右侧要额外减掉滚动条装订线：html 上的 scrollbar-gutter: stable 会把 fixed 元素的
+     包含块从右侧缩窄，而 .sidebar-toggle 的 left 仍贴窗口左边缘；(100vw - 100%) 即该
+     装订线宽度（无装订线时为 0，移动端 overlay 滚动条自动退化成 right: 20px）。 */
   bottom: 24px;
-  right: 20px;
+  right: calc(20px - (100vw - 100%));
   width: 48px;
   height: 48px;
   padding: 0;
@@ -2518,14 +2523,6 @@ button.home-wiki-heatmap-cell.is-active {
 @media (prefers-reduced-motion: reduce) {
   .back-to-top {
     transition: none;
-  }
-}
-@media (max-width: 768px) {
-  .back-to-top {
-    bottom: 20px;
-    right: 16px;
-    width: 44px;
-    height: 44px;
   }
 }
 


### PR DESCRIPTION
## 摘要

给站点补两个浮动导航控件，左右对称落在窗口两侧底角：

- **回到顶部按钮**（除图谱页外全站生效）：右下角浮动圆钮，外圈是阅读进度环，进度由滚动位置驱动。
- **首页章节跳转按钮**：左下角浮动按钮 + 上弹章节菜单，参考 [imchong.github.io](https://imchong.github.io/index.html) 的 `.home-nav-fab`。参考站只在 ≤720px 显示该按钮（PC 交给 header 里的 `.main-nav`），本站**不改动 `.site-header`**，因此不设断点，PC 端同样用这个按钮跳转。

两者关于窗口中轴严格镜像（`bottom` / 内缩量 / 尺寸一致）。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

仅改动 `docs/main.js` 与 `docs/style.css` 两个文件，未新增依赖、未改动任何页面的 HTML。

### 回到顶部按钮

- `docs/main.js` 追加独立模块，按「页面是否有站内 footer」判定注入 —— 与 `docs/style.css` 里 `body:has(> .footer)` 同一口径，因此 `graph.html`（全屏画布、无 footer）与 `references.html`（meta-refresh 跳转桩页）自动排除，其余 7 个页面统一生效：`index / detail / roadmap / module / tech-map / hubs / change-log`。
- 进度环用 CSS 变量 `--btt-progress` 驱动 `conic-gradient`，取色为主题变量 `--accent`（暗色 `#5b9cf6`、亮色 `#2d74da`），轨道为 `--text-muted` 32% 的中性灰。
- 滚动监听沿用站内既有的 `requestAnimationFrame` 节流写法，进度量化到 1% 再写样式，避免每帧重绘。
- 出现阈值取 `min(0.6 屏, 可滚距离 × 35%)`，可滚距离不足 240px 的页面不出现 —— 否则在 `hubs.html`（可滚约 570px）这类短页上按钮只会在最后几十像素闪现。
- `prefers-reduced-motion` 下关闭淡入过渡并改用即时滚动。

### 首页章节跳转按钮

- 仅在首页注入（`#hero` 是 `index.html` 独有的锚点）。
- 菜单条目按 DOM 顺序从 `main > section[id]` 自动收集，标题优先取 `.section-title`、其次取 `section` 的 `aria-label`，因此以后新增首页板块无需改 JS。当前解析出 6 项：顶部 / 入口 / 搜索知识库 / 最新知识节点 / 知识图谱预览 / 互链枢纽 · Top 10。
- 支持遮罩点击关闭、`Esc` 关闭、点条目后立即关闭以让 hash 跳转生效；滚动高亮当前章节，判定线取吸顶 header 下沿，与 `html` 的 `scroll-padding-top` 同口径。

### 镜像对称的两处修正

1. 删除回到顶部按钮的 `@media (max-width: 768px)` 覆写（原为 `bottom:20px / right:16px / 44×44`）—— `.sidebar-toggle` 没有窄屏覆写，这层覆写正是窄屏不对称的来源；改回 48×48 同时也更符合触控最小尺寸。
2. `right` 改为 `calc(20px - (100vw - 100%))`：`html` 上的 `scrollbar-gutter: stable` 会把 `position:fixed` 的包含块从右侧缩窄 15px（实测 1440 宽下包含块只有 1425px），而 `.sidebar-toggle` 的 `left` 仍贴窗口左边缘，导致同样写 20px 却差 15px。`(100vw - 100%)` 即装订线宽度，无装订线时为 0，移动端 overlay 滚动条下自动退化回 `right: 20px`。

## 验证

- [x] `make ci-preflight` 通过（12/12）
- [x] `make lint-js` 无 error 无 warning
- [ ] `make test`：N/A，本 PR 不涉及 Python

浏览器实测（Chromium headless，1440×900 与 390×844）：

| 项 | 结果 |
|---|---|
| 回到顶部按钮注入范围 | 7 个目标页均注入并在 60% 滚动处可见；`graph.html` 未注入 |
| 点击回顶 | `detail` / `index` / `change-log` 三页 `pageYOffset` 6458 / 1245 / 6438 → 0，按钮自动隐藏 |
| 章节按钮注入范围 | 仅 `index.html` 注入，其余 6 页均为 `false` |
| 章节跳转 | 点「知识图谱预览」→ `hash=#mini-graph-section`，章节顶端落在 76px（吸顶 header 高 58px，未被遮挡），菜单自动关闭 |
| 章节高亮 | 跳转后重开菜单，`.active` 命中「知识图谱预览」 |
| `Esc` / 遮罩关闭 | 均生效 |
| `.site-header` 未被改动 | `header-right` 仍是 `github-link` / `themeToggle` / `sponsorToggle` 三项，header 内无 `nav` 注入 |
| 左右镜像 | 320 / 390 / 430 / 768 / 820 / 1024 / 1440 / 1631 八档宽度下，两按钮中心 x 之和恒等于视口宽（dx = 0），`bottom` 与尺寸一致 |

## 验证截图

首页 PC 端（1440×900，暗色）—— 菜单展开，「搜索知识库」高亮，右下角为回到顶部按钮：

``&lt;img alt="首页 PC 端章节菜单展开" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/nav-pc-open-dark.png" /&gt;``

首页 PC 端收起态 —— 左下章节按钮与右下回到顶部按钮左右对称：

``&lt;img alt="首页 PC 端收起态" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/nav-pc-closed-dark.png" /&gt;``

首页移动端（390×844，暗色）—— 菜单展开：

``&lt;img alt="首页移动端章节菜单展开" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/nav-m-open-dark.png" /&gt;``

详情页回到顶部按钮（1440×900，暗色，进度 55%）：

``&lt;img alt="详情页回到顶部按钮" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/btt-detail-dark.png" /&gt;``

tech-map 亮色（进度 50%）：

``&lt;img alt="tech-map 亮色回到顶部按钮" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/btt-techmap-light.png" /&gt;``

移动端 roadmap（390×844）—— 与左下角目录抽屉按钮分居两侧，实测矩形不重叠：

``&lt;img alt="移动端 roadmap 两个浮动按钮" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/sym-m-roadmap.png" /&gt;``

进度环取色样张（直接加载仓库 `style.css` 渲染，15 / 40 / 75 / 100% 四档，暗色 + 亮色）：

``&lt;img alt="进度环暗色取色" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/btt-swatch-dark.png" /&gt;``
``&lt;img alt="进度环亮色取色" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/btt-swatch-light.png" /&gt;``

`graph.html` 确认未注入任何浮动按钮：

``&lt;img alt="graph.html 无浮动按钮" src="/home/user/Robotics_Notebooks/.cursor-artifacts/screenshots/btt-graph-none.png" /&gt;``

## 相关 Issue

无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wRo1SVASLYM8HHRD5j5B2

---
_Generated by [Claude Code](https://claude.ai/code/session_018wRo1SVASLYM8HHRD5j5B2)_