### PR TITLE
docs: 补充停用词与已覆盖术语，完善 SIL 与数据集页面链接

### DIFF
--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -196,6 +196,18 @@ MISSING_CONCEPT_STOPWORDS: set[str] = {
     # 导航评测的片段类别（Green for Go 的 stop 片段）。非单一可成页概念，
     # 与 clip（模型名 vs 限幅动词）同类语义噪声。
     "stop",
+    # eval：各页正文里的 `eval` / **Eval** 均为仓库入口脚本名或任务名后缀
+    # （「无可对齐的 `train` / `eval` 入口」「`lego run` / `eval` / `viewer`」、
+    # Isaac Lab 任务用途标签 `Eval`），与已作停用词的 `train` 成对出现，是
+    # 工具链/命令 token；评测作为机制已由 concepts/sim-vs-real-eval-gap.md、
+    # concepts/motion-control-policy-evaluation-metrics.md 等页覆盖，不应建独立页。
+    "eval",
+    # play：各页正文里的 `play` / **Play** 是运行时命令或脚本名——mjlab/Isaac Lab
+    # 的回放脚本与配置（`scripts/play.py`、`play_env_cfg`、「课内第一次 `play`」）、
+    # Omniverse timeline 的 **Play** 按钮（OmniGraph 的 On Playback Tick 触发条件）。
+    # 与 stop（BehaviorTree 命令名 / 动作枚举）同类运行时命令 token，非机器人
+    # 概念/方法/形式化，不应建独立页。
+    "play",
 }
 
 # 高频术语但「已在 entities/ 或非同名 stem 的 methods 页有恰当归属」，
@@ -362,6 +374,13 @@ MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "sim-to-real",  # 已由 concepts/sim2real.md 覆盖（全称写法与页面 stem 不同名）
     "ros2",  # 已由 concepts/ros2-basics.md 覆盖（slug 与页面 stem 不同名）
     "sonic",
+    # state：三义各有归属——决策过程里的状态量已由 formalizations/mdp.md /
+    # pomdp.md 定义（「**State** 是物理/机器人意义上的完整瞬时描述」即该形式化的
+    # 复述），可观状态的估计归 concepts/state-estimation.md，仿真真值与观测之分归
+    # concepts/humanoid-policy-observation-inputs.md；余下的 `State` 是代码 token
+    # （Newton 的 `Model` / `State` / `Control` 抽象、观测字典键 `state`），与 qpos /
+    # reset 同类，不单建概念页
+    "state",
     "wbc",  # 已由 concepts/whole-body-control.md 覆盖（slug 与页面 stem 不同名）
     "wam",  # 已由 concepts/world-action-models.md 覆盖（缩写 slug 与页面 stem 不同名）
     "zero-shot",  # 迁移/评测的条件状语，已由 concepts/sim2real.md 等页覆盖

--- a/wiki/concepts/software-in-the-loop.md
+++ b/wiki/concepts/software-in-the-loop.md
@@ -11,6 +11,7 @@ related:
   - ../concepts/simulation-evaluation-infrastructure.md
   - ../entities/nvidia-spatial-intelligence-lab.md
   - ../queries/robot-policy-debug-playbook.md
+  - ../queries/simulation-physics-fidelity.md
 sources:
   - ../../sources/sites/nvidia-isaac-sim-sil-tutorial.md
 summary: "Software-in-the-Loop（SIL）是在仿真虚拟机器人与环境上验证机器人软件、再接 ROS 2 等外部栈的工程方法；Isaac Sim 提供 ROS 2 bridge、OmniGraph 与 Python API，与 Hardware-in-the-Loop（HIL）及 Spatial Intelligence Lab 缩写消歧。"
@@ -89,7 +90,7 @@ flowchart LR
 ## 局限与风险
 
 - **不能替代全部硬件测试：** 课程明确 SIL **减少** 而非 **消除** 对物理样机的需求；接触、延迟、驱动 bug 仍要靠 HIL/真机。
-- **仿真保真度上限：** 传感器噪声、摩擦、通信抖动建模不足会导致「SIL 全绿、真机翻车」——见 [Sim2Real](../concepts/sim2real.md)。
+- **仿真保真度上限：** 传感器噪声、摩擦、通信抖动建模不足会导致「SIL 全绿、真机翻车」——见 [Sim2Real](../concepts/sim2real.md)；该往几何/动力学/接触/执行器哪一层加投，按 [仿真物理保真度链路选型指南](../queries/simulation-physics-fidelity.md) 逐层判。
 - **与 Spatial Intelligence Lab 混淆：** 同一缩写 **SIL** 在仓库中亦指 NVIDIA 研究组，上下文靠链接区分。
 
 ## 关联页面
@@ -100,6 +101,7 @@ flowchart LR
 - [Sim2Real](../concepts/sim2real.md)
 - [NVIDIA Spatial Intelligence Lab](../entities/nvidia-spatial-intelligence-lab.md) — **不同含义的 SIL**
 - [RL 策略真机调试 Playbook](../queries/robot-policy-debug-playbook.md)
+- [仿真物理保真度链路选型指南](../queries/simulation-physics-fidelity.md) — SIL 通过后仍要逐层核的保真度投资判据
 
 ## 参考来源
 

--- a/wiki/entities/nvidia-physical-ai-datasets.md
+++ b/wiki/entities/nvidia-physical-ai-datasets.md
@@ -104,6 +104,7 @@ flowchart TB
 - **集合 ≠ 完整 NVIDIA 数据宇宙：** 部分 checkpoint（如 Cosmos Policy-DROID）在独立 HF 仓，不在本 collection。
 - **门控与地域：** `gated: auto` 子集无法 CI 匿名拉取；企业合规需单独审数据卡。
 - **格式异构：** 有 parquet+video、USDZ、imagefolder、LeRobot v3 等；不要假设统一 schema。
+- **重定向就绪度：** 机器人子集按具体本体采集（`Teleop-G1` 为 Unitree G1、`Teleop-GR1`/`GR00T-GR1` 为 Fourier GR-1、`mindmap-Franka-*` 为 Franka），同形态可直接作策略输入；换目标形态须按目标骨架 **重定向 / retarget** 或重采。`X-Embodiment-Sim` 覆盖多本体但仍是各自动作空间，`LIBERO_LeRobot_v3` / `BridgeData2_LeRobot_v3` 统一的是 **schema 而非形态**。
 - **第三方条目：** 如 `bones-studio/seed`、`NianticSpatial/real2sim-sample-usdz-scenes` 许可与 NVIDIA 主集不同。
 
 ## 关联页面

--- a/wiki/entities/nvidia-spatial-intelligence-lab.md
+++ b/wiki/entities/nvidia-spatial-intelligence-lab.md
@@ -13,6 +13,7 @@ related:
   - ../methods/generative-world-models.md
   - ../concepts/simulation-evaluation-infrastructure.md
   - ../concepts/software-in-the-loop.md
+  - ../queries/robot-perception-stack-selection-loop.md
 sources:
   - ../../sources/sites/nvidia-spatial-intelligence-lab.md
   - ../../sources/repos/nv_tlabs.md
@@ -114,6 +115,7 @@ flowchart TB
 - [Software-in-the-Loop（概念）](../concepts/software-in-the-loop.md) — Isaac Sim 工程 SIL
 - [生成式世界模型](../methods/generative-world-models.md)
 - [仿真评测基础设施](../concepts/simulation-evaluation-infrastructure.md)
+- [机器人视觉感知栈选型闭环](../queries/robot-perception-stack-selection-loop.md) — SIL 的 3D/4D 感知与重建落到感知栈哪一层
 
 ## 参考来源
 


### PR DESCRIPTION
## 摘要

补充 `eval`、`play`、`state` 三个停用词与已覆盖术语的定义注释，澄清其作为工具链 token 或代码概念而非独立百科条目的原因；同时完善三个 wiki 页面的相关链接：
- Software-in-the-Loop 页补充仿真物理保真度链路选型指南链接
- NVIDIA Spatial Intelligence Lab 页补充机器人视觉感知栈选型闭环链接  
- NVIDIA Physical AI Datasets 页补充重定向就绪度说明

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [x] 维护脚本 / CI / 文档

## 详细说明

### 停用词补充（`scripts/lint_wiki.py`）

1. **`eval`**：各页正文中的 `eval` / **Eval** 均为仓库入口脚本名或任务名后缀（如 `lego run eval`、Isaac Lab 任务标签），与已有停用词 `train` 成对出现，属工具链 token；评测机制已由专题页（sim-vs-real-eval-gap.md、motion-control-policy-evaluation-metrics.md）覆盖。

2. **`play`**：各页正文中的 `play` / **Play** 是运行时命令或脚本名（mjlab/Isaac Lab 的 `scripts/play.py`、`play_env_cfg`、Omniverse timeline 的 **Play** 按钮），与 `stop` 同类运行时命令 token，非机器人概念/方法。

3. **`state`**：三义各有归属——决策过程的状态量由 formalizations/mdp.md / pomdp.md 定义，可观状态估计归 concepts/state-estimation.md，仿真真值与观测之分归 concepts/humanoid-policy-observation-inputs.md；余下的 `State` 是代码 token（Newton 的 `Model` / `State` / `Control` 抽象、观测字典键），与 qpos / reset 同类。

### Wiki 页面链接完善

1. **software-in-the-loop.md**：
   - 在「局限与风险」章节补充 [仿真物理保真度链路选型指南](../queries/simulation-physics-fidelity.md) 链接，指导 SIL 通过后的保真度投资判据
   - 在「关联页面」补充该指南链接

2. **nvidia-spatial-intelligence-lab.md**：
   - 在 `related` 字段补充 [机器人视觉感知栈选型闭环](../queries/robot-perception-stack-selection-loop.md)
   - 在「关联页面」补充该链接，说明 SIL 的 3D/4D 感知与重建落到感知栈哪一层

3. **nvidia-physical-ai-datasets.md**：
   - 在「局限」章节补充「重定向就绪度」条目，说明机器人子集按具体本体采集（Unitree G1、Fourier GR-1、Franka 等），同形态可直接作策略输入，换目标形态需重定向或重采；`X-Embodiment-Sim` 覆盖多本体但仍是各自动作空间，`LIBERO_LeRobot_v3` / `

https://claude.ai/code/session_016eGr4DH99ukYdRbjLYTrk6