### PR TITLE
fix(frontend): 底部浮动按钮不再压住站内页脚

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -7358,6 +7358,55 @@
   }
 })();
 
+/* ── 底部浮动按钮避让页脚 ──
+   .sidebar-toggle / .back-to-top / .home-nav-fab 都是 fixed 贴视口底部的浮层，滚到
+   页面末尾时会压住 .footer。这里按页脚探进视口的高度写 :root 上的 --fab-lift，
+   style.css 里三者的 bottom: calc(24px + var(--fab-lift, 0px)) 据此顶到页脚上沿之上。
+   无站内 footer 的页面（graph.html / references.html）直接跳过，变量保持缺省 0px。 */
+(function () {
+  'use strict';
+
+  function init() {
+    var footer = document.querySelector('body > .footer');
+    if (!footer) return;
+
+    var root = document.documentElement;
+    var last = -1;
+
+    function update() {
+      // 页脚顶边高于视口底边多少，就把按钮抬多少；页脚未露头时为 0
+      var lift = Math.round(Math.max(0, window.innerHeight - footer.getBoundingClientRect().top));
+      if (lift === last) return;
+      last = lift;
+      root.style.setProperty('--fab-lift', lift + 'px');
+    }
+
+    // 与页内其他滚动监听一致：rAF 节流
+    var ticking = false;
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(function () {
+        update();
+        ticking = false;
+      });
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    // 页脚自身高度会随字体加载 / 换行变化，跟着重算
+    if (window.ResizeObserver) new ResizeObserver(onScroll).observe(footer);
+
+    update();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+
 /* ── 全站「回到顶部」按钮（带阅读进度环） ──
    注入判据与 style.css 里 `body:has(> .footer)` 一致：graph.html / references.html
    没有站内 footer，因此自动排除（图谱页全屏画布不加浮层，跳转桩页无需）。 */

--- a/docs/style.css
+++ b/docs/style.css
@@ -2418,7 +2418,9 @@ button.home-wiki-heatmap-cell.is-active {
 .sidebar-toggle {
   display: none;
   position: fixed;
-  bottom: 24px;
+  /* 底部避让站内页脚：--fab-lift 由 main.js 按 .footer 探进视口的高度实时写入
+     （无页脚的页面 / JS 未跑时回退 0px，即原来的贴底 24px） */
+  bottom: calc(24px + var(--fab-lift, 0px));
   left: 20px;
   width: 48px;
   height: 48px;
@@ -2474,7 +2476,7 @@ button.home-wiki-heatmap-cell.is-active {
      右侧要额外减掉滚动条装订线：html 上的 scrollbar-gutter: stable 会把 fixed 元素的
      包含块从右侧缩窄，而 .sidebar-toggle 的 left 仍贴窗口左边缘；(100vw - 100%) 即该
      装订线宽度（无装订线时为 0，移动端 overlay 滚动条自动退化成 right: 20px）。 */
-  bottom: 24px;
+  bottom: calc(24px + var(--fab-lift, 0px));
   right: calc(20px - (100vw - 100%));
   width: 48px;
   height: 48px;
@@ -2534,7 +2536,7 @@ button.home-wiki-heatmap-cell.is-active {
    scrollbar-gutter 装订线，故直接写 left: 20px。首页没有 .sidebar-toggle，不会撞位。 */
 .home-nav-fab {
   position: fixed;
-  bottom: 24px;
+  bottom: calc(24px + var(--fab-lift, 0px));
   left: 20px;
   z-index: 1350;
   display: flex;


### PR DESCRIPTION
- main.js 新增 --fab-lift：按 .footer 探进视口的高度实时写到 :root（rAF 节流，
  scroll / resize / ResizeObserver 三处触发），无站内 footer 的页面直接跳过
- style.css 中 .sidebar-toggle / .back-to-top / .home-nav-fab 的 bottom 改为
  calc(24px + var(--fab-lift, 0px))，滚到底时停在页脚上沿之上 24px

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WPSPDSc72Wq1ARyvBgSdA3