### PR TITLE
fix(frontend): 首页「查看完整榜单」入口居中并去掉箭头

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -213,7 +213,7 @@
           <p class="data-meta">正在加载互链统计…</p>
         </div>
         <div id="homeHubPanelPaper" class="home-hub-panel" aria-live="polite" hidden></div>
-        <p class="home-hub-more"><a href="hubs.html">查看完整榜单 →</a></p>
+        <p class="home-hub-more"><a href="hubs.html">查看完整榜单</a></p>
       </div>
     </section>
   </main>

--- a/docs/style.css
+++ b/docs/style.css
@@ -791,7 +791,8 @@ a.hero-stat-num:focus-visible {
   white-space: nowrap;
   justify-self: end;
 }
-.home-hub-more { margin-top: 18px; font-size: .9rem; }
+/* 居中：左对齐时会被左下角的 .home-nav-fab 浮动按钮压住（移动端尤其明显） */
+.home-hub-more { margin-top: 18px; font-size: .9rem; text-align: center; }
 /* 详情页关联区块：复用互链枢纽紧凑行（类型 / 标题+后缀 / 尾列元信息） */
 .detail-compact-list {
   list-style: none;


### PR DESCRIPTION
## 摘要

首页「互链枢纽 · Top 10」底部的「查看完整榜单」入口原本左对齐（`docs/style.css` 的 `.home-hub-more` 只有 `margin-top` / `font-size`），在移动端正好落进左下角浮动按钮 `.home-nav-fab` 的覆盖范围，链接被挡住点不到。本 PR 把该入口在 PC / 移动端统一居中，并按需求去掉文案尾部的「→」。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

具体改动（共 2 处，2 行）：

- `docs/style.css`：`.home-hub-more` 增加 `text-align: center`
- `docs/index.html`：`查看完整榜单 →` → `查看完整榜单`

## 验证

- [x] `make ci-preflight` —— 全部通过（`通过：12/12`，另含 5 条信息型预警，不阻塞 CI）
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`（N/A：本 PR 不涉及 Python）
- [x] headless Chromium 实测首页渲染（`make export graph` 后起 `docs` 静态服务，滚到页面底部量 DOM 位置）

实测几何（滚到底、`.home-hub-more a` 与两个底部浮动按钮的横向区间）：

| 视口 | 「查看完整榜单」横向区间 | 左下 `.home-nav-fab` | 右下 `.back-to-top` | 结论 |
|------|--------------------------|----------------------|---------------------|------|
| 390×844（移动端） | 152–238 px | 20–68 px | 322–370 px | 两侧均不重叠，链接可点 |
| 1400×900（PC） | 649–736 px | 20–68 px | 1332–1380 px | 居中，不重叠 |

（PC 上链接中心为 692.5 而非视口中点 700，是 `html` 上 `scrollbar-gutter: stable` 的滚动条装订线所致；相对 `.container` 是正的居中。）

## 验证截图

截图已在 CI 容器内生成于 `.cursor-artifacts/screenshots/hub-more-mobile.png` / `hub-more-pc.png`。该目录被 `.gitignore` 屏蔽、不入库，且本次运行环境没有把绝对路径图片自动上传到 PR 的能力，因此这里以上表的实测 DOM 坐标作为等价证据；需要图片的话我可以另行附上。

## 相关 Issue

无

---

注：本分支上一版的「底部浮动按钮不再压住站内页脚」（`1ca73e9`）已随 #1821 合入 `main`，本分支已 rebase 到最新 `main`，本 PR 只含上述一个新 commit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPSPDSc72Wq1ARyvBgSdA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPSPDSc72Wq1ARyvBgSdA3)_