### PR TITLE
fix(frontend): 居中只作用于首页榜单入口，hubs.html 恢复左对齐

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -791,8 +791,10 @@ a.hero-stat-num:focus-visible {
   white-space: nowrap;
   justify-self: end;
 }
-/* 居中：左对齐时会被左下角的 .home-nav-fab 浮动按钮压住（移动端尤其明显） */
-.home-hub-more { margin-top: 18px; font-size: .9rem; text-align: center; }
+.home-hub-more { margin-top: 18px; font-size: .9rem; }
+/* 仅首页这个入口居中：左对齐时会被左下角的 .home-nav-fab 浮动按钮压住（移动端尤其
+   明显）。hubs.html 复用了 .home-hub-more，但那页没有该浮动按钮，保持左对齐。 */
+#home-hub-section .home-hub-more { text-align: center; }
 /* 详情页关联区块：复用互链枢纽紧凑行（类型 / 标题+后缀 / 尾列元信息） */
 .detail-compact-list {
   list-style: none;


### PR DESCRIPTION
## 摘要

修 #1825 引入的回归：`.home-hub-more` 这个类被 `docs/index.html`（「查看完整榜单」）和 `docs/hubs.html`（「在知识图谱中查看全站结构 →」）共用，#1825 直接给类加了 `text-align: center`，把 hubs 页那条链接也一起居中了。本 PR 把居中限定到首页那一处，hubs 页恢复左对齐。

## 变更类型

- [ ] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [x] 前端（`docs/`）
- [ ] 其他：

具体改动（`docs/style.css` 一处）：

- `.home-hub-more` 去掉 `text-align: center`，恢复原样
- 新增 `#home-hub-section .home-hub-more { text-align: center; }`——`#home-hub-section` 只存在于 `docs/index.html`，所以不用改 HTML 就能把作用域收窄到首页

首页需要居中的原因不变：左对齐时该链接落进左下角浮动按钮 `.home-nav-fab` 的覆盖范围（移动端尤其明显）；hubs 页没有这个浮动按钮，无需让位。

## 验证

- [x] `make ci-preflight` —— 全部通过（`通过：12/12`）
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`（N/A：本 PR 不涉及 Python）
- [x] headless Chromium 实测两页渲染（起 `docs` 静态服务，滚到页面底部量 DOM 位置）

实测几何（链接横向区间 vs 两个底部浮动按钮）：

| 页面 / 视口 | 链接文案 | 链接横向区间 | 左下 `.home-nav-fab` | 右下 `.back-to-top` | 结论 |
|-------------|----------|--------------|----------------------|---------------------|------|
| `hubs.html` 390×844 | 在知识图谱中查看全站结构 → | 18–209 px | 该页无此按钮 | 322–370 px | 左对齐，不重叠 |
| `hubs.html` 1400×900 | 在知识图谱中查看全站结构 → | 237–428 px | 该页无此按钮 | 1332–1380 px | 左对齐，不重叠 |
| `index.html` 390×844 | 查看完整榜单 | 152–238 px | 20–68 px | 322–370 px | 仍居中，不重叠 |

## 验证截图

截图在运行容器内生成于 `.cursor-artifacts/screenshots/hubs-more-mobile.png`、`hubs-more-pc.png`、`hub-more-mobile.png`。该目录被 `.gitignore` 屏蔽、不入库，且本运行环境不会把绝对路径图片自动上传到 PR，因此以上表的实测 DOM 坐标作为等价证据。

## 相关 Issue

无

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPSPDSc72Wq1ARyvBgSdA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPSPDSc72Wq1ARyvBgSdA3)_