### PR TITLE
fix(wiki): 清零全量 lint 的 1 条信息型预警（缺页概念 Critic）

### DIFF
--- a/exports/lint-report.md
+++ b/exports/lint-report.md
@@ -2,7 +2,7 @@
 
 ## [2026-09-08] lint | health-check | 自动化 wiki 健康检查
 
-共发现 **0** 个问题（另含 **1** 条信息型预警）：
+共发现 **0** 个问题（另含 **0** 条信息型预警）：
 
 ### ⚠️ 孤儿页（无入链）（0 个）
 - 无
@@ -52,8 +52,8 @@
 ### 💡 频繁提及但缺少 wiki 页面的概念（0 个）
 - 无
 
-### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（1 个）
-- Critic（被 6 个页面以加粗/反引号引用，但无独立 concepts/methods/formalizations 页，建议评估新建）
+### 💡 多页以加粗/反引号高频引用但缺独立 concepts/methods/formalizations 页（信息型，不阻塞 CI）（0 个）
+- 无
 
 ### ⚠️ Frontmatter 缺少 type 字段（0 个）
 - 无

--- a/scripts/lint_wiki.py
+++ b/scripts/lint_wiki.py
@@ -376,6 +376,13 @@ MISSING_CONCEPT_COVERED_ELSEWHERE: set[str] = {
     "amp",
     "armature",
     "cartpole-v1",  # Gymnasium 环境注册 id，已由 concepts/cartpole.md 覆盖
+    # critic：Actor–Critic 的价值网络半边，不单独成页——机制已由
+    # methods/reinforcement-learning.md 的「Actor-Critic」专节（策略网络 + 价值网络
+    # 信息流）定义，非对称变体归 concepts/privileged-training.md 的「Asymmetric
+    # Actor-Critic」节，价值/优势估计的形式化归 formalizations/bellman-equation.md
+    # 与 gae.md；entities/litereality-agent.md 的 `critic` 则是 agent 自查循环里的
+    # 工具名，属另一义。与 rl / wbc 同类「已有归属、slug 与页面 stem 不同名」。
+    "critic",
     "damping",  # MuJoCo/Isaac Lab 关节属性，已由阻抗控制 + PD 增益 / 参数辨识页覆盖
     "ethercat",  # 已由 concepts/ethercat-protocol.md 覆盖（slug 与页面 stem 不同名）
     "g1",

--- a/tests/test_lint_wiki_missing_concept_pages.py
+++ b/tests/test_lint_wiki_missing_concept_pages.py
@@ -189,6 +189,18 @@ def test_covered_elsewhere_base_ignored(tmp_path, monkeypatch) -> None:
     assert results["missing_concept_pages"] == []
 
 
+def test_covered_elsewhere_critic_ignored(tmp_path, monkeypatch) -> None:
+    wiki = _setup_wiki(tmp_path, monkeypatch)
+    pages = [
+        _page(wiki, f"p{i}.md", "非对称 AC 里 **Critic** 读特权状态。")
+        for i in range(lw.MISSING_CONCEPT_PAGE_MIN_PAGES)
+    ]
+    results = _run(pages)
+    # Critic 是 Actor–Critic 的价值网络半边，已由 methods/reinforcement-learning.md、
+    # concepts/privileged-training.md 与 formalizations/gae.md 等页覆盖
+    assert results["missing_concept_pages"] == []
+
+
 def test_case_insensitive_merge(tmp_path, monkeypatch) -> None:
     wiki = _setup_wiki(tmp_path, monkeypatch)
     half = lw.MISSING_CONCEPT_PAGE_MIN_PAGES // 2 + 1


### PR DESCRIPTION
全量 `python3 scripts/lint_wiki.py` 基线为 0 阻塞 + 1 条信息型预警（缺页概念巡检
命中 `Critic`，被 6 个页面以加粗/反引号引用），本次收敛至 0：

- 逐页核对 6 处引用后判为「已有归属」入 MISSING_CONCEPT_COVERED_ELSEWHERE：
  Actor–Critic 的价值网络半边不单独成页，机制已由 methods/reinforcement-learning.md
  的「Actor-Critic」专节定义，非对称变体归 concepts/privileged-training.md 的
  「Asymmetric Actor-Critic」节，价值/优势估计的形式化归 formalizations/
  bellman-equation.md 与 gae.md；entities/litereality-agent.md 的 `critic` 是
  agent 自查循环里的工具名，属另一义。判据按既有注释体例写明，与 rl / wbc 同类。
- 按 COVERED_ELSEWHERE 既有体例补回归测试 test_covered_elsewhere_critic_ignored。

验证：`make ci-preflight` 全绿（lint 0 问题 0 预警、搜索回归 40/40、导出质量
12/12、图谱 0 孤儿），`ruff check/format scripts tests` 通过，`pytest` 444 passed
/ 694 subtests。派生产物仅 exports/lint-report.md 随预警清零更新；容器为浅克隆，
已先 `git fetch --unshallow` 再跑 graph，避免 recency 口径从 git 降级为 log.md。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FZdV2kpqc8kLwQc3B6Ksrt