### PR TITLE
[2026-09-09] ingest | Hand Visibility Detector — 复核四链并补 HF Papers

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,5 @@
+## [2026-09-09] ingest | sources/papers/hand_visibility_detector_arxiv_2608_11574.md — 复核 Hand Visibility Detector 四链（GitHub/arXiv v1/HF 模型/HF Papers），补 HF Papers 与 2026-09-09 开源核查
+
 ## [2026-09-09] ingest | sources/papers/ge_act_2_arxiv_2609_05588.md — GE-Act 2.0（AgiBot WAM 预训练缩放）；代码待发布；升格 wiki/entities/paper-ge-act-2.md
 
 ## [2026-09-09] ingest | sources/papers/eneas_arxiv_2609_03756.md — SperidLabs ENEAS 文本实例跟踪与语义发现；已开源，交叉 SAM3/ObjectNav

--- a/sources/papers/hand_visibility_detector_arxiv_2608_11574.md
+++ b/sources/papers/hand_visibility_detector_arxiv_2608_11574.md
@@ -5,9 +5,10 @@
 - **标题：** Hand Visibility Detector: Per-Keypoint Visibility Estimation for Hands
 - **短名：** Hand Visibility Detector / HVD
 - **类型：** paper / hand-pose / visibility / keypoint / perception / annotation
-- **arXiv：** <https://arxiv.org/abs/2608.11574>
+- **arXiv：** <https://arxiv.org/abs/2608.11574>（v1：<https://arxiv.org/abs/2608.11574v1>）
 - **PDF：** <https://arxiv.org/pdf/2608.11574>
 - **HTML：** <https://arxiv.org/html/2608.11574>
+- **Hugging Face Papers：** <https://huggingface.co/papers/2608.11574>
 - **代码：** <https://github.com/ryhara/hand_visibility_detector> — [`sources/repos/hand_visibility_detector.md`](../repos/hand_visibility_detector.md)
 - **权重 / Demo：** <https://huggingface.co/ryhara/hand-visibility-detector> · <https://huggingface.co/spaces/ryhara/hand-visibility-detector>
 - **作者：** Ryosei Hara（庆应 / AIST）、Masashi Hatano（东京大学）、Rintaro Yanagi（AIST）、Atsushi Hashimoto（欧姆龙 SINIC X）、Takuma Yagi（AIST）、Mariko Isogawa（庆应 / AIST）
@@ -23,7 +24,7 @@
 - **数据：** HInt（Pavlakos et al. 2024）人工逐关节可见标签；训练 25,273 / 评测 5,374。覆盖 web 与 egocentric。
 - **主结果：** HInt mAP **0.931** / F1 **0.896**，相对 Kim et al. 2021 与 Contact4D 的 ImageNet CNN 头约 **+3.4 mAP**。骨干消融：HaMeR / WiLoR 最好；DINOv3 0.897；微调 WiLoR 骨干反而掉到 **0.622**。
 - **下游：** 用 WiLoR 的 2D 关键点做 DLT 三角化；按本文逐关节可见性加权，相对无加权与「整手检测置信度加权」，DexYCB / HO3D / H2O 的重投影误差都下降，HO3D 均值最多 **−10.1%**。
-- **开源（截至 2026-08-15）：** 无独立 `*.github.io` 项目页；以用户给出的 GitHub 与 HF 为准。`demo.py` / `demo_video.py` / `demo_gradio.py` + `training.train` / `evaluate` + HF `best.pt` / `best_hamer.pt` → **已开源、可运行**。许可为研究/非商用，叠加 WiLoR / HaMeR / MANO 等上游条款。
+- **开源（截至 2026-09-09）：** 无独立 `*.github.io` 项目页；入口为 GitHub + HF 模型 / Space / Papers。`demo.py` / `demo_video.py` / `demo_gradio.py` + `training.train` / `evaluate` + HF `best.pt` / `best_hamer.pt` → **已开源、可运行**。许可为研究/非商用，叠加 WiLoR / HaMeR / MANO 等上游条款。
 
 ## 核心摘录（面向 wiki 编译）
 
@@ -46,9 +47,9 @@
 | 阈值 0.3–0.7 | F1 > 0.88 | 峰值约 0.5 |
 | 三角化重投影 | 三数据集中位/均值/IQR 都降 | HO3D 均值最多 **−10.1%**（视角少、物体遮挡重） |
 
-### 开源核查（步骤 2.5）
+### 开源核查（步骤 2.5，2026-09-09 复核）
 
-无独立项目页。论文 Code 链与用户给出的 GitHub 一致。仓库核查见 [`sources/repos/hand_visibility_detector.md`](../repos/hand_visibility_detector.md)：推理包 + 训练/评测脚本 + HF 权重 + Gradio Space → **已开源、可运行**。许可 **非 OSI 宽松许可**（研究/非商用 + 上游叠加）。
+无独立项目页。论文 Code 链、HF Papers 与 GitHub 一致。仓库核查见 [`sources/repos/hand_visibility_detector.md`](../repos/hand_visibility_detector.md)：推理包 + 训练/评测脚本 + HF 权重 + Gradio Space → **已开源、可运行**（GitHub 约 94★）。许可 **非 OSI 宽松许可**（研究/非商用 + 上游叠加）。
 
 ## 对 wiki 的映射
 

--- a/sources/repos/hand_visibility_detector.md
+++ b/sources/repos/hand_visibility_detector.md
@@ -9,15 +9,16 @@
 - **默认分支：** `main`
 - **权重：** <https://huggingface.co/ryhara/hand-visibility-detector>（`best.pt` / `best_hamer.pt`）
 - **Demo Space：** <https://huggingface.co/spaces/ryhara/hand-visibility-detector>
+- **Hugging Face Papers：** <https://huggingface.co/papers/2608.11574>
 - **论文：** arXiv:2608.11574 — [`sources/papers/hand_visibility_detector_arxiv_2608_11574.md`](../papers/hand_visibility_detector_arxiv_2608_11574.md)
-- **入库日期：** 2026-08-15
+- **入库日期：** 2026-08-15（2026-09-09 复核）
 - **一句话说明：** 冻结 WiLoR / HaMeR 骨干 + 轻量 visibility head；`HandVisibilityPipeline` 可 `pip`/`uv` 安装。**已开源、可运行**（研究/非商用）。
 
-## 开源核查（2026-08-15）
+## 开源核查（2026-09-09）
 
 | 项 | 状态 |
 |----|------|
-| 仓库可见 | 是（公开；默认 `main`；约 52★） |
+| 仓库可见 | 是（公开；默认 `main`；约 94★） |
 | 项目页 | **无**独立 `*.github.io`；入口即 GitHub + HF |
 | License | GitHub `license` 字段为空。README 写 **research and non-commercial use only**，须同时遵守 WiLoR / WiLoR-mini / HaMeR / MANO / HInt / COCO-WholeBody / Ultralytics 上游条款 |
 | 可运行入口 | **有** — `HandVisibilityPipeline.predict`；`demo.py` / `demo_video.py` / `demo_gradio.py`；`python -m training.train` / `training.evaluate` |

--- a/wiki/entities/mediapipe.md
+++ b/wiki/entities/mediapipe.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [perception, computer-vision, hand-tracking, pose-estimation, open-source, google, on-device-ml]
 status: complete
-updated: 2026-09-05
+updated: 2026-09-09
 related:
   - ../queries/robot-perception-stack-selection-loop.md
   - ../queries/dexterous-data-collection-guide.md

--- a/wiki/entities/paper-hand-visibility-detector.md
+++ b/wiki/entities/paper-hand-visibility-detector.md
@@ -15,7 +15,7 @@ tags:
   - omron-sinic-x
   - u-tokyo
 status: complete
-updated: 2026-08-19
+updated: 2026-09-09
 arxiv: "2608.11574"
 code: https://github.com/ryhara/hand_visibility_detector
 related:
@@ -73,7 +73,7 @@ summary: "Hand Visibility Detector（庆应/AIST/欧姆龙 SINIC X/东大，arXi
 | 骨干 | 冻结 [HaMeR](https://geopavlakos.github.io/hamer/) 或 [WiLoR](../methods/wilor.md) 的 ViT（631M）；发布默认走 WiLoR-mini |
 | 输出 | \(V\in[0,1]^{21}\)：每关节「可见」概率（未见 = 遮挡或出画） |
 | 训练数据 | HInt：25,273 / 5,374 |
-| 开源（截至 2026-08-15） | **已开源、可运行**：[`ryhara/hand_visibility_detector`](https://github.com/ryhara/hand_visibility_detector) + HF 权重 / Space。许可为 **研究/非商用**，叠加上游 |
+| 开源（截至 2026-09-09） | **已开源、可运行**：[`ryhara/hand_visibility_detector`](https://github.com/ryhara/hand_visibility_detector) + [HF 权重](https://huggingface.co/ryhara/hand-visibility-detector) / [Space](https://huggingface.co/spaces/ryhara/hand-visibility-detector) / [HF Papers](https://huggingface.co/papers/2608.11574)。许可为 **研究/非商用**，叠加上游 |
 
 ## 方法与核心结构
 
@@ -208,12 +208,13 @@ sequenceDiagram
 - [hand_visibility_detector_arxiv_2608_11574.md](../../sources/papers/hand_visibility_detector_arxiv_2608_11574.md)
 - [hand_visibility_detector 仓库归档](../../sources/repos/hand_visibility_detector.md)
 - [具身智能小站 10 篇盘点（2026-08-19）](../../sources/blogs/wechat_embodied_station_world_model_exec_10_papers_2026-08-19.md)
-- Hara et al. — <https://arxiv.org/abs/2608.11574>
+- Hara et al. — <https://arxiv.org/abs/2608.11574>（v1：<https://arxiv.org/abs/2608.11574v1>）
 - 代码 — <https://github.com/ryhara/hand_visibility_detector>
+- Hugging Face Papers — <https://huggingface.co/papers/2608.11574>
 
 ## 推荐继续阅读
 
-- 官方仓 README 与 HF 模型卡 — <https://github.com/ryhara/hand_visibility_detector>
+- 官方仓 README 与 [HF 模型卡](https://huggingface.co/ryhara/hand-visibility-detector) — <https://github.com/ryhara/hand_visibility_detector>
 - HInt 数据集 — <https://github.com/ddshan/hint>
 - HaMeR — <https://arxiv.org/abs/2312.05251>
 - WiLoR — <https://arxiv.org/abs/2409.12259>

--- a/wiki/methods/auto-labeling-pipelines.md
+++ b/wiki/methods/auto-labeling-pipelines.md
@@ -2,7 +2,7 @@
 type: method
 tags: [data-engine, vlm, labeling, data-collection, machine-learning]
 status: complete
-updated: 2026-09-07
+updated: 2026-09-09
 related:
   - ../concepts/embodied-scaling-laws.md
   - ../methods/vla.md

--- a/wiki/methods/wilor.md
+++ b/wiki/methods/wilor.md
@@ -2,7 +2,7 @@
 type: method
 tags: [hand-pose, 3d-vision, manipulation, perception, video-to-control]
 status: complete
-updated: 2026-08-19
+updated: 2026-09-09
 related:
   - ../queries/robot-perception-stack-selection-loop.md
   - ./exoactor.md

--- a/wiki/queries/dexterous-data-collection-guide.md
+++ b/wiki/queries/dexterous-data-collection-guide.md
@@ -2,7 +2,7 @@
 type: query
 tags: [dexterity, data-collection, teleoperation, simulation, robot-hand]
 status: complete
-updated: 2026-09-05
+updated: 2026-09-09
 related:
   - ../entities/allegro-hand.md
   - ../entities/ruka-v2-hand.md

--- a/wiki/queries/dexterous-manipulation-data-pipeline.md
+++ b/wiki/queries/dexterous-manipulation-data-pipeline.md
@@ -3,7 +3,7 @@ title: 灵巧操作数据管线与 RL 训练基建指南
 type: query
 status: complete
 created: 2026-05-21
-updated: 2026-08-15
+updated: 2026-09-09
 related:
   - ../methods/auto-labeling-pipelines.md
   - ../methods/wilor.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 复核用户指定的 Hand Visibility Detector 四链：GitHub、arXiv v1、Hugging Face 模型卡、Hugging Face Papers。
- 在 `sources/papers/`、`sources/repos/` 与 [`wiki/entities/paper-hand-visibility-detector.md`](wiki/entities/paper-hand-visibility-detector.md) 补全 **HF Papers** 链接与 **2026-09-09** 开源核查（GitHub 约 94★，推理/训练/权重仍可运行）。
- 该论文实体已于 2026-08-15 首次入库；本次为链接补全与开源状态复核，非新建页面。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）
- [ ] 维护脚本 / CI / 文档
- [ ] 前端（`docs/`）
- [ ] 其他：

## 验证

- [x] `make ci-preflight` 通过（0 阻塞项）
- [ ] `make test` 或 `PYTHONPATH=scripts python3 -m pytest`（未改 institutions/schema/脚本）
- [x] 静态站详情页渲染正常

## 验证截图

![Hand Visibility Detector 详情页](https://cursor.com/artifacts/c/art-20b64d93-624d-48d7-ba4a-b9b95e87a289)

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31d37f1b-120b-4799-9119-ce68536a6d61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31d37f1b-120b-4799-9119-ce68536a6d61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

