### PR TITLE
[ingest] REGRIND：复核灵巧重定向引导 RL 配方并补齐工程章节

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,5 @@
+## [2026-09-09] ingest | sources/papers/regrind_arxiv_2607_11874.md — 复核 REGRIND：补齐结论/源码运行时序图/工程实践，刷新 Isaac Lab 2.3 官方仓与项目页开源核查
+
 ## [2026-09-09] ingest | sources/papers/vgg_ttt_arxiv_2602_23361.md — VGG-T³（CVPR 2026）：TTT 线性化 VGGT 离线千图重建；推理/评测/HF 权重已开源（NVIDIA OneWay NC），训练数据集实现待发布
 
 ## [2026-09-09] ingest | sources/papers/soma_arxiv_2606_09246.md — SOMA/SKIM（ECCV 2026，MPI-INF）肌肉解剖反演；GitHub+数据集已开源

--- a/sources/papers/regrind_arxiv_2607_11874.md
+++ b/sources/papers/regrind_arxiv_2607_11874.md
@@ -1,41 +1,64 @@
-# regrind_arxiv_2607_11874
+# REGRIND: A Minimalist Retargeting-Guided Reinforcement Learning Recipe for Dexterous Manipulation
 
-> 来源归档（ingest）
+> 来源归档（ingest · 复核 2026-09-09）
 
 - **标题：** REGRIND: A Minimalist Retargeting-Guided Reinforcement Learning Recipe for Dexterous Manipulation
-- **类型：** paper
-- **来源：** arXiv abs / arXiv HTML / 项目页 / GitHub
-- **原始链接：**
-  - <https://arxiv.org/abs/2607.11874>
-  - <https://arxiv.org/html/2607.11874>
-  - <https://www.yunhaifeng.com/REGRIND/>
-  - <https://github.com/yunhaif/regrind>
-- **作者：** Yunhai Feng, Natalie Leung, Jiaxuan Wang（Cornell University）；Lujie Yang, Haozhi Qi（Amazon FAR）；Preston Culbertson（Cornell University）
-- **入库日期：** 2026-07-16
-- **一句话说明：** 从**单次光学动捕人手–物体演示**出发，用 **interaction mesh 交互保留重定向**（OmniRetarget 同族 Laplacian 形变能 + Drake/MOSEK SQP）生成机器人参考轨迹，再以 **残差 RL + 物体关键点跟踪奖励 + RSI 参考状态初始化 + 训练时 SE(3) 增广** 在仿真中闭环学习，经系统辨识后 **零样本** 部署到 **LEAP / WUJI** 灵巧手，完成剪刀、螺丝刀等 **contact-rich 工具操作**；系统实验对比 SPIDER、DexMachina、Mink IK+RL，并总结灵巧操作 sim2real 比 loco 更敏感。
+- **缩写：** **REGRIND** / REtargeting-Guided ReINforcement learning for Dexterous manipulation
+- **类型：** paper / dexterous-manipulation / motion-retargeting / reinforcement-learning / sim2real / contact-rich-manipulation
+- **arXiv：** <https://arxiv.org/abs/2607.11874>（PDF: <https://arxiv.org/pdf/2607.11874>；HTML: <https://arxiv.org/html/2607.11874>）
+- **项目页：** <https://www.yunhaifeng.com/REGRIND/>
+- **代码：** <https://github.com/yunhaif/regrind>
+- **机构：** 康奈尔大学（Cornell University）；亚马逊 FAR（Amazon FAR / Frontier AI & Robotics）
+- **作者：** Yunhai Feng, Natalie Leung, Jiaxuan Wang（Cornell）；Lujie Yang, Haozhi Qi（Amazon FAR）；Preston Culbertson（Cornell）
+- **状态：** arXiv 预印本（2026）；**已开源**（MIT 代码 + 预计算重定向轨迹）
+- **入库日期：** 2026-07-16（初入库）；**复核：** 2026-09-09
+- **一句话说明：** 单次光学 MoCap 人手–物体演示 → **interaction mesh 交互保留重定向**（OmniRetarget 同族）→ **残差 RL** 跟踪物体关键点 + RSI/SE(3) 增广 → 系统辨识后零样本部署 **LEAP/WUJI** 剪刀与螺丝刀；系统实验总结 contact-rich 灵巧 sim2real 关键因素。
 
-## 核心摘录
+## 摘录 1：问题与核心主张
 
-### 1) REGRIND（Feng 等，arXiv:2607.11874，2026）
-- **链接：** <https://arxiv.org/abs/2607.11874>；HTML：<https://arxiv.org/html/2607.11874>；项目页：<https://www.yunhaifeng.com/REGRIND/>；代码：<https://github.com/yunhaif/regrind>
-- **问题：** 人形 WBT 已验证「重定向参考 + RL 跟踪」简洁配方，但灵巧 **contact-rich manipulation** 涉及接触模式/力精细调节，纯运动学重定向常产生 **穿透、接触结构丢失**，下游 RL 难学或 sim2real 失败。
-- **核心管线（real-to-sim-to-real）：**
-  1. **3D 人类演示：** MANO 手部关键点 + 物体 6D 位姿（铰接物体含关节角）；剪刀来自 ARCTIC，螺丝刀为自采光学 mocap。
-  2. **交互保留重定向：** 物体 + 人手语义关键点 Delaunay 四面体建 **interaction mesh**；最小化源/机器人 mesh 的 **Laplacian 坐标差** + 时序平滑；逐帧 SQP（Drake + MOSEK）；保留 hand–object 空间与接触关系（ formulation 继承 [OmniRetarget](https://arxiv.org/abs/2606.16272)）。
-  3. **参考引导 RL：** **残差动作** 叠在名义参考关节上 → PD；**物体-centric 关键点距离** 指数跟踪奖励（无需显式接触先验）；**RSI** 从重定向轨迹采样重启 + 小扰动；**训练时增广**：初始物体位姿 ±5 cm / ±30°，对整条参考做时间插值 SE(3) 变换（不重跑重定向优化）。
-  4. **Sim2Real：** 域随机化（摩擦、电机增益、时延等）、观测噪声、推力/重力课程；部署时 **MoCap 直接提供物体位姿**（隔离感知误差）；需 **系统辨识**。
-- **平台与任务：** UR5e + **16-DoF LEAP** / **20-DoF WUJI**；四组 **剪刀 / 螺丝刀 × LEAP / WUJI**；LEAP 因尺寸使用 3D 打印放大工具。
-- **仿真结果（Table 1，1024 rollout 级）：** REGRIND 四任务 SR **98.7–99.8%**，关键点误差 **5.3–6.5 mm**；DexMachina 剪刀任务 SR **0–22%**；Mink IK+RL 多数 **0–3%**；SPIDER 作为开环/MPC 轨迹跟踪演示，四任务 SR **0%**（轨迹偏离演示、不适合 residual RL 初始化）。
-- **真机结果（Table 2–3）：** LEAP-Scissors **9/10**、LEAP-Screwdriver **10/10**、WUJI-Screwdriver **9/10**；**WUJI-Scissors 0/10**（非反驱电机 + 剪刀 mesh 误差）；随机初态泛化与演示初态接近（Table 3）。
-- **相对基线洞见：** interaction-preserving 重定向显著改善 RL 初始化与正则；DexMachina 无交互语义时易 ** exploit 仿真 artifact**，真机 screwdriver 亦不稳定。
-- **局限：** 部署依赖 **MoCap 物体状态**；仍需仔细系统辨识；单演示 + 增广覆盖有限。
-- **代码：** MIT；仓库含预计算重定向轨迹，重定向模块依赖 **Drake/MOSEK**（可选安装）。
-- **对 wiki 的映射：**
-  - [REGRIND（重定向引导灵巧操作 RL）](../../wiki/methods/regrind-retargeting-guided-rl.md)（方法页兼论文索引）
-  - 在 [TopoRetarget](../../wiki/methods/toporetarget-interaction-preserving-dexterous-retargeting.md)、[SPIDER](../../wiki/methods/spider-physics-informed-dexterous-retargeting.md)、[Motion Retargeting Pipeline](../../wiki/concepts/motion-retargeting-pipeline.md)、[Manipulation](../../wiki/tasks/manipulation.md) 中补充交叉引用
+- **动机：** 人形 WBT 已验证「重定向参考 + RL 跟踪」极简配方；灵巧 **contact-rich manipulation** 需精细调节接触模式与力，纯运动学重定向易 **穿透、丢失接触结构**，下游 RL 与 sim2real 难。
+- **REGRIND 管线：** 单次人类演示 → **保留 hand–object 空间/接触关系** 的机器人参考 → 仿真 **残差 RL** 跟踪 **物体-centric 关键点** → **系统辨识** 后 **零样本** 真机。
+- **真机展示：** LEAP / WUJI 双手 × 剪刀 / 螺丝刀；流体、类人行为；项目页含 sim vs real 1× 与初态泛化 2× 视频。
 
-## 当前提炼状态
+**对 wiki 的映射：** [`wiki/methods/regrind-retargeting-guided-rl.md`](../../wiki/methods/regrind-retargeting-guided-rl.md)
 
-- [x] 摘要 + 方法主线（重定向 / RL / 增广 / sim2real）已摘录
-- [x] 四任务仿真与真机数字已摘录
-- [x] wiki 方法页（兼论文索引）与流程图已落盘
+## 摘录 2：交互保留重定向
+
+- **输入：** MANO 手部关键点 + 物体 6D（铰接含关节角）；剪刀来自 ARCTIC，螺丝刀自采光学 mocap。
+- **优化：** 物体 + 人手语义关键点 Delaunay **interaction mesh**；最小化源/机器人 mesh **Laplacian 坐标差** + 时序平滑；逐帧 SQP（**Drake + MOSEK**，可换 Clarabel）。
+- **继承：** [OmniRetarget](https://arxiv.org/abs/2606.16272) formulation；相对 DexMachina functional retargeting **显式保留交互语义**。
+
+**对 wiki 的映射：** 方法页「主要技术路线 / 流程总览」；对照 [TopoRetarget](../../wiki/methods/toporetarget-interaction-preserving-dexterous-retargeting.md)。
+
+## 摘录 3：残差 RL + 增广 + Sim2Real
+
+- **控制：** 残差叠在名义参考关节 $\bar{q}_t$ 上 → PD；$q^{\text{target}}=\bar{q}_t+\alpha\odot\pi_\theta$。
+- **奖励：** **物体-centric 关键点** 指数距离跟踪（无需显式接触先验）。
+- **探索：** **RSI** 从重定向轨迹采样 episode 初态；训练时 **SE(3) 增广**（物体初态 ±5 cm / ±30° 时对整条参考插值 warp，**不重解**重定向）。
+- **Sim2Real：** DR（摩擦、增益、时延）、观测噪声、推力/重力课程；部署 **MoCap 馈物体位姿**（隔离感知）；**系统辨识** 不可省略。
+
+**对 wiki 的映射：** 方法页「实验要点 / 工程实践 / 结论」。
+
+## 摘录 4：实验数字（Table 1–3）
+
+| 设置 | REGRIND | 对照印象 |
+|------|---------|----------|
+| 仿真四任务 SR（1024 rollout） | **98.7–99.8%**；关键点误差 **5.3–6.5 mm** | DexMachina scissors **0–22%**；Mink IK+RL **0–3%** |
+| SPIDER 轨迹 + residual RL | SR **0%** | MPC 轨迹偏离演示，不适合 residual 初始化 |
+| 真机（演示初态） | LEAP 剪刀 **9/10**、螺丝刀 **10/10**；WUJI 螺丝刀 **9/10** | WUJI-Scissors **0/10** |
+| 初态泛化 ±5 cm / ±30° | 与演示初态性能接近（Table 3） | 增广在 RL 训练时动态生成 |
+
+**对 wiki 的映射：** 方法页实验表与结论。
+
+## 摘录 5：开源边界（步骤 2.5 · 2026-09-09）
+
+| 项 | 结论 |
+|----|------|
+| **代码** | **已开源** — [yunhaif/regrind](https://github.com/yunhaif/regrind)（MIT，~100★） |
+| **预计算轨迹** | 仓内已附带 retargeted `.h5`，可 **跳过重定向** 直接 RL |
+| **重定向依赖** | 可选：`pydrake` + **MOSEK** license（或 `solver=clarabel`） |
+| **仿真栈** | **Isaac Sim 5.1.0** + **Isaac Lab 2.3.0** + `rsl_rl` |
+| **训练/评测脚本** | `scripts/rsl_rl/train.py`、`play.py`；任务 `Regrind-{LeapHand,WujiHand}-{Scissors,Screwdriver}-v0` |
+| **未开源** | 无；论文下一步为 **vision-based** 蒸馏（部署仍依赖 MoCap 物体状态） |
+
+**对 wiki 的映射：** [`sources/repos/regrind.md`](../repos/regrind.md)、[`sources/sites/regrind-project-yunhaifeng.md`](../sites/regrind-project-yunhaifeng.md)

--- a/sources/repos/regrind.md
+++ b/sources/repos/regrind.md
@@ -1,17 +1,58 @@
-# regrind
+# yunhaif/regrind
 
-> 来源归档（ingest）
+> 来源归档（复核 2026-09-09）
 
-- **标题：** yunhaif/regrind
+- **标题：** REGRIND — Official Implementation
 - **类型：** repo
-- **原始链接：** <https://github.com/yunhaif/regrind>
+- **组织：** yunhaif（Cornell / Amazon FAR 作者）
+- **代码：** <https://github.com/yunhaif/regrind>
+- **论文：** <https://arxiv.org/abs/2607.11874>
+- **项目页：** <https://www.yunhaifeng.com/REGRIND/>
 - **许可证：** MIT
-- **入库日期：** 2026-07-16
-- **一句话说明：** REGRIND 官方实现：含预计算重定向轨迹、Drake 重定向脚本、RL 训练与部署；`pydrake`/MOSEK 为可选重定向依赖。
+- **Stars：** ~100（2026-09-09）
+- **入库日期：** 2026-07-16；**复核：** 2026-09-09
+- **一句话说明：** Isaac Lab 2.3.0 / Isaac Sim 5.1.0 官方实现：预计算 interaction mesh 重定向轨迹、Drake 重定向脚本、RSL-RL 残差策略训练与 Play 评测；`import regrind` 不强制 Drake。
+- **沉淀到 wiki：** [`wiki/methods/regrind-retargeting-guided-rl.md`](../../wiki/methods/regrind-retargeting-guided-rl.md)
 
-## 核心摘录
+## 开源边界（步骤 2.5）
 
-- **重定向入口：** `python scripts/retarget_hand_object.py --robot {leaphand,wujihand} --object {scissors,screwdriver}`；需 `source scripts/set_path.sh`。
-- **可跳过重定向：** 仓库内已附带 retargeted trajectories，可直接 RL training。
-- **依赖：** 核心 `import regrind` 不强制 Drake；重定向需单独安装 Drake + MOSEK license。
-- **对 wiki 的映射：** 见 [REGRIND（重定向引导灵巧操作 RL）](../../wiki/methods/regrind-retargeting-guided-rl.md)
+| 项 | 结论 |
+|----|------|
+| **状态** | **已开源**（MIT） |
+| **推理/训练** | `scripts/rsl_rl/train.py` / `play.py`；四任务环境 + `-Play-v0` 评测环境 |
+| **重定向** | `scripts/retarget_hand_object.py`；**可跳过**（仓内已有 `.h5`） |
+| **重定向依赖** | 可选 `pip install -e "source/regrind[retargeting]"`（Drake）；默认 MOSEK，可 `solver=clarabel` |
+| **硬件** | README 面向 LEAP / WUJI + UR5e 真机部署文档在论文；仓以仿真训练为主 |
+
+## README 要点（2026-09-09）
+
+### 环境
+
+- Python **3.11**；**Isaac Sim 5.1.0** + **Isaac Lab 2.3.0**（按官方 binary 安装）
+- `cd IsaacLab && ./isaaclab.sh --conda regrind`
+- `cd regrind && conda activate regrind && isaaclab -i rsl_rl && pip install -e source/regrind && source scripts/set_path.sh`
+
+### 重定向
+
+```bash
+python scripts/retarget_hand_object.py --robot {leaphand,wujihand} --object {scissors,screwdriver}
+python scripts/replay_retargeted_traj.py --task Regrind-LeapHand-Scissors-Play-v0 \
+  --headless --video --num_envs 1 --retargeted_traj_path /path/to/out.h5
+```
+
+输出 `.h5` 键：`robot_pos/quat/joints`、`object_pos/quat/joint`、`robot_keypoints`、`mano_joint_coords`。
+
+### RL 训练与评测
+
+| 脚本 | 用途 |
+|------|------|
+| `scripts/list_envs.py` | 列出 `Regrind-{LeapHand,WujiHand}-{Scissors,Screwdriver}-v0` |
+| `scripts/rsl_rl/train.py` | PPO 训练（例：`--task Regrind-LeapHand-Scissors-v0 --headless --num_envs 4096`） |
+| `scripts/rsl_rl/play.py` | 评测/录视频（用 `-Play-v0` 环境；`--auto_gravity_from_ckpt` 配合重力课程） |
+| `scripts/zero_agent.py` / `random_agent.py` | 环境冒烟 |
+
+## 对 wiki 的映射
+
+- 方法页（兼论文索引）：[`wiki/methods/regrind-retargeting-guided-rl.md`](../../wiki/methods/regrind-retargeting-guided-rl.md)
+- 论文摘录：[`sources/papers/regrind_arxiv_2607_11874.md`](../papers/regrind_arxiv_2607_11874.md)
+- 项目页：[`sources/sites/regrind-project-yunhaifeng.md`](../sites/regrind-project-yunhaifeng.md)

--- a/sources/sites/regrind-project-yunhaifeng.md
+++ b/sources/sites/regrind-project-yunhaifeng.md
@@ -1,15 +1,46 @@
-# regrind_project_yunhaifeng
+# REGRIND — 官方项目页
 
-> 来源归档（ingest）
+> 来源归档（ingest · 步骤 2.5 · 复核 2026-09-09）
 
 - **标题：** REGRIND Project Page
-- **类型：** site
+- **类型：** site（作者托管项目页）
+- **发布方：** Yunhai Feng 等（Cornell + Amazon FAR）
 - **原始链接：** <https://www.yunhaifeng.com/REGRIND/>
-- **入库日期：** 2026-07-16
-- **一句话说明：** REGRIND 官方项目页：交互保留重定向 + 残差 RL 学习剪刀/螺丝刀等 contact-rich 灵巧工具操作；含方法概览视频、LEAP/WUJI 四任务 sim vs real 对比、初态泛化演示。
+- **论文：** <https://arxiv.org/abs/2607.11874>
+- **代码：** <https://github.com/yunhaif/regrind>
+- **入库日期：** 2026-07-16；**复核：** 2026-09-09
+- **一句话说明：** 官方项目页：方法动画、LEAP/WUJI 四任务 sim vs real 1× 视频、初态扰动（±5 cm / ±30°）10 组泛化 2× 演示；页眉链 arXiv 与 GitHub。
 
-## 核心摘录
+## 步骤 2.5 开源核查（2026-09-09）
 
-- **方法一句话：** Retarget human hand-object motion → preserve spatial/contact relationships → train residual RL to track object-centric keypoints → zero-shot hardware with system identification.
-- **展示任务：** LEAP/WUJI × Scissors/Screwdriver；仿真与真机 1× 速度 rollout；初态扰动（±5 cm / ±30°）10 组泛化（2× 速）。
-- **对 wiki 的映射：** 见 [REGRIND（重定向引导灵巧操作 RL）](../../wiki/methods/regrind-retargeting-guided-rl.md)
+| 项 | 项目页 / 关联链接 |
+|----|-------------------|
+| **代码** | **已开源** — 页内链 [github.com/yunhaif/regrind](https://github.com/yunhaif/regrind) |
+| **论文** | arXiv [2607.11874](https://arxiv.org/abs/2607.11874) |
+| **权重/数据** | 预计算重定向轨迹随 GitHub 仓发布（非独立 HF） |
+| **视频** | 方法旁白视频 + 四任务 sim/real 对比 + 初态泛化 |
+
+## 主页摘录
+
+### Abstract（与 arXiv 一致）
+
+- 人形 WBT「重定向 + RL 跟踪」能否迁移到 **contact-rich 灵巧操作** 不显然。
+- REGRIND：单次人类演示 → **保留 hand–object 空间与接触关系** 的机器人参考 → 仿真 **残差 RL** 跟踪 **物体-centric 关键点** → **系统辨识** 后零样本硬件。
+- 系统硬件实验分析灵巧 sim2real **关键因素**，为 retargeting-based contact-rich 学习提供实践指南。
+
+### Method Overview
+
+Retarget human hand-object motion → preserve spatial/contact relationships → residual RL tracks object-centric keypoints → zero-shot hardware with system identification.
+
+### 展示内容
+
+| 区块 | 内容 |
+|------|------|
+| **General recipe** | LEAP / WUJI × Scissors / Screwdriver；左 sim、右 real，**1×** 速 |
+| **Initial config generalization** | ±5 cm 位置、±30° 朝向；同任务 **10** 组初态；**2×** 速 |
+
+## 对 wiki 的映射
+
+- 方法页：[`wiki/methods/regrind-retargeting-guided-rl.md`](../../wiki/methods/regrind-retargeting-guided-rl.md)
+- 论文摘录：[`sources/papers/regrind_arxiv_2607_11874.md`](../papers/regrind_arxiv_2607_11874.md)
+- 代码归档：[`sources/repos/regrind.md`](../repos/regrind.md)

--- a/wiki/methods/regrind-retargeting-guided-rl.md
+++ b/wiki/methods/regrind-retargeting-guided-rl.md
@@ -1,10 +1,11 @@
 ---
 type: method
-tags: [robotics, motion-retargeting, dexterous-manipulation, reinforcement-learning, contact-rich-manipulation, sim2real, mocap, cornell, amazon-far]
+tags: [robotics, motion-retargeting, dexterous-manipulation, reinforcement-learning, contact-rich-manipulation, sim2real, mocap, cornell, amazon, residual-policy, isaac-lab]
 status: complete
 date: 2026-07-16
-updated: 2026-07-16
+updated: 2026-09-09
 arxiv: "2607.11874"
+code: https://github.com/yunhaif/regrind
 related:
   - ../concepts/motion-retargeting.md
   - ../concepts/motion-retargeting-pipeline.md
@@ -100,6 +101,58 @@ flowchart LR
 | DexMachina | functional IK + 仿真投影 | RL | scissors 真机 **0/10** |
 | SPIDER | 物理采样 MPC | 开环/MPC | SR **0%**（论文设置） |
 | **REGRIND** | **interaction mesh** | **残差 RL + 增广** | **9–10/10**（除 WUJI-Scissors） |
+
+## 源码运行时序图
+
+官方实现为 [yunhaif/regrind](https://github.com/yunhaif/regrind)（MIT）。主线：**MoCap 演示 →（可选）Drake 重定向 → Isaac Lab 残差 PPO → Play 评测 → 真机 MoCap 闭环**；仓内已附带预计算 `.h5`，可跳过重定向直接训练。
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as 用户
+  participant M as MoCap 演示<br/>MANO + 物体 6D
+  participant RT as scripts/retarget_hand_object.py<br/>Drake SQP + MOSEK
+  participant H5 as retargeted .h5
+  participant IL as Isaac Lab 环境<br/>Regrind-*-v0
+  participant TR as scripts/rsl_rl/train.py<br/>残差 PPO + RSI/增广
+  participant PL as scripts/rsl_rl/play.py<br/>-Play-v0
+  participant HW as LEAP/WUJI + UR5e<br/>MoCap 物体反馈
+
+  U->>M: 单次人手–物体演示
+  opt 可选重定向
+    M->>RT: interaction mesh Laplacian
+    RT->>H5: robot/object 轨迹 + keypoints
+  end
+  H5->>IL: load_retargeted_traj
+  IL->>TR: 物体关键点跟踪奖励 + DR/课程
+  TR->>PL: checkpoint
+  PL->>HW: 系统辨识后零样本部署
+```
+
+**复现捷径：** 直接使用仓内预计算轨迹 → `python scripts/rsl_rl/train.py --task Regrind-LeapHand-Scissors-v0 --headless --num_envs 4096`；评测用 `Regrind-*-Play-v0` 与 `--auto_gravity_from_ckpt`（重力课程对齐）。
+
+## 工程实践
+
+| 项 | 建议 |
+|----|------|
+| **环境** | Isaac Sim **5.1.0** + Isaac Lab **2.3.0**；conda 环境 `regrind`；`pip install -e source/regrind` |
+| **跳过重定向** | 仓内已有四任务 retargeted `.h5` → 直接 RL；自采演示再跑 `retarget_hand_object.py` |
+| **重定向依赖** | `pip install -e "source/regrind[retargeting]"`；MOSEK 学术 license 或 `solver=clarabel` |
+| **训练** | `Regrind-{LeapHand,WujiHand}-{Scissors,Screwdriver}-v0`；4096 envs；可选 `--logger wandb` |
+| **评测** | 必须用 `-Play-v0`；`play.py --headless --video` |
+| **Sim2Real** | 摩擦/增益 **系统辨识** 优先；部署期 **MoCap 物体位姿** 闭环（论文隔离感知误差） |
+| **初态鲁棒** | 训练时 SE(3) 增广 ±5 cm / ±30°；勿指望无增广单演示泛化 |
+| **失败模式** | WUJI-Scissors **0/10**：非反驱 + 剪刀 mesh 误差；DexMachina 类无 mesh 易 exploit 仿真 |
+
+## 结论
+
+**REGRIND 证明「人形 WBT 的重定向 + 残差 RL」配方可以落到 contact-rich 灵巧工具操作，但成败关键在 interaction-preserving 参考与 manipulation 级 sim2real 细节，而非更复杂的端到端架构。**
+
+- **真影响指标的是交互保留重定向**：相对 DexMachina / Mink IK / SPIDER，interaction mesh 参考让残差 RL 初始化从 scissors **0–22%** 拉到仿真 **~99%**、真机 **9–10/10**（WUJI-Scissors 除外）。
+- **物体关键点奖励比显式接触先验更稳**：任务进度写在 **物体-centric 关键点** 上，配合 RSI + SE(3) 增广，无需手工接触模式表即可学到剪刀/螺丝刀节律。
+- **SPIDER 轨迹不适合 residual 初始化**：论文四任务 SPIDER→RL **SR 0%**——动力学 MPC 轨迹偏离演示时，**闭环 RL + 运动学交互参考** 是更匹配的下游。
+- **Sim2Real 比 loco 更苛刻**：系统辨识、DR、重力/推力课程与观测设计 **不可省略**；部署仍依赖 **MoCap 物体状态**（vision 蒸馏是明确下一步）。
+- **工程读法**：官方仓可 **跳过重定向直接训**；真机排期应按「参考质量 → RL → 辨识 → MoCap 闭环」顺序验收，WUJI-Scissors 作 **embodiment/资产** 反例保留。
 
 ## 核心信息
 

--- a/wiki/methods/toporetarget-interaction-preserving-dexterous-retargeting.md
+++ b/wiki/methods/toporetarget-interaction-preserving-dexterous-retargeting.md
@@ -3,7 +3,7 @@ type: method
 tags: [robotics, motion-retargeting, dexterous-manipulation, reinforcement-learning, contact-rich-manipulation, sim2real]
 status: complete
 date: 2026-06-17
-updated: 2026-07-16
+updated: 2026-09-09
 related:
   - ../concepts/motion-retargeting.md
   - ../concepts/motion-retargeting-pipeline.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

复核 **REGRIND**（arXiv:2607.11874，Cornell + Amazon FAR）：单次 MoCap 演示 → interaction mesh 重定向 → 残差 RL 跟踪物体关键点 → 系统辨识后零样本部署 LEAP/WUJI 剪刀/螺丝刀。本次在既有 2026-07-16 入库基础上，按当前 schema 补齐 **结论 / 源码运行时序图 / 工程实践**，并刷新官方来源与 Isaac Lab 2.3 仓信息。

## 变更类型

- [x] 知识入库（ingest / wiki 内容）

## 更新内容

- `sources/papers|repos|sites/regrind_*` — 步骤 2.5 开源复核（MIT 已开源；预计算轨迹可跳过重定向）
- `wiki/methods/regrind-retargeting-guided-rl.md` — 新增结论、Mermaid 运行时序图、工程实践表；frontmatter 补 `code`

## 开源结论

| 项 | 状态 |
|----|------|
| 代码 | **已开源** — [yunhaif/regrind](https://github.com/yunhaif/regrind)（MIT） |
| 预计算轨迹 | 仓内附带，可直接 RL |
| 重定向 | 可选 Drake + MOSEK（或 Clarabel） |

## 验证

- [x] `make ci-preflight` — 全绿
- [x] 静态站方法页渲染正常

## 验证截图

![REGRIND 方法页详情](https://cursor.com/artifacts/c/art-e390d5b6-20d2-4de6-8dd7-5ead240e98be)

## 相关 Issue

无
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef0587b4-c99b-4f47-a354-f99bbd36e8c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef0587b4-c99b-4f47-a354-f99bbd36e8c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

