### PR TITLE
fix(ux): 修复首页左下角浮动导航吞掉「知识图谱」入口卡点击的问题

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2547,6 +2547,14 @@ button.home-wiki-heatmap-cell.is-active {
   flex-direction: column-reverse;
   align-items: flex-start;
   gap: 12px;
+  /* 菜单折叠用的是 visibility:hidden（保留过渡），仍然占布局位，
+     容器因此是一个 168x264 左右的透明 fixed 盒子。透明不等于不接收点击，
+     不放行就会吞掉左下角一片区域内卡片/链接的点击（首页「知识图谱」入口卡等）。 */
+  pointer-events: none;
+}
+.home-nav-fab__toggle,
+.home-nav-menu {
+  pointer-events: auto;
 }
 .home-nav-fab__toggle {
   display: inline-flex;


### PR DESCRIPTION
.home-nav-fab 是 fixed 容器，折叠态的 .home-nav-menu 用 visibility:hidden
隐藏（保留过渡动画），仍然参与布局，容器因此在左下角撑出约 168x264 的透明盒子。
透明不等于不接收指针事件，该区域会整块吞掉下层卡片/链接的点击。

给容器加 pointer-events:none 放行，再在 .home-nav-fab__toggle / .home-nav-menu
上恢复 auto，浮动按钮与展开后的菜单项照常可点。

验证（Playwright + document.elementFromPoint 命中测试）：
- 430x932 移动端：修复前「知识图谱」入口卡及其链接命中 .home-nav-fab，修复后命中自身
- 1024x700 桌面端：修复前「从零开始」「更多路线」两张卡同样被吞，修复后正常
- 1440x900 桌面端：卡片不在该区域，前后均正常
- 三个视口下浮动按钮本体可点、展开后菜单项可点均为 true

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DGaoBHk6KBUDAKqEuCgZ3D