### PR TITLE
fix(graph): 路线视图 chip 改由 DEPTH_ORDER 渲染，补回缺失的 ICL / 具身测评 / 具身数据

### DIFF
--- a/docs/graph.html
+++ b/docs/graph.html
@@ -2019,30 +2019,10 @@
             <span class="filter-depth-summary-label">路线视图</span>
             <span class="filter-depth-summary-current" id="filter-depth-current"><span>🌐</span><span>全量</span></span>
           </summary>
+          <!-- 路线 chip 由 depth-filters.js 的 DEPTH_ORDER / DEPTH_META 渲染（见 renderDepthChips），
+               静态只留「全量」，避免此处列表与单一事实源脱节 -->
           <div class="filter-depth-chips" id="filter-depth-chips">
             <button class="filter-depth-chip is-active" type="button" data-depth="all" title="全量"><span>🌐</span><span>全量</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="motion-control" title="主路线-运动控制"><span>🧭</span><span>主路线-运动控制</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="teleoperation" title="遥操作"><span>🎮</span><span>遥操作</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="torque-motor-design" title="力矩电机设计"><span>⚙️</span><span>力矩电机设计</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="classical-control" title="传统控制"><span>📐</span><span>传统控制</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="humanoid-hardware-design" title="整机硬件"><span>🛠️</span><span>整机硬件</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="safe-control" title="安全控制"><span>🛡️</span><span>安全控制</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="contact-manipulation" title="接触操作"><span>🤏</span><span>接触操作</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="navigation" title="导航"><span>🗺️</span><span>导航</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="imitation-learning" title="模仿学习"><span>🎓</span><span>模仿学习</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="rl-locomotion" title="RL 运动控制"><span>🚶</span><span>RL 运动控制</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="loco-manipulation" title="Loco-Manip"><span>🤖</span><span>Loco-Manip</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="humanoid-soccer" title="人形足球"><span>⚽</span><span>人形足球</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="motion-retargeting" title="动作重定向"><span>🤸</span><span>动作重定向</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="humanoid-swarm-performance" title="人形群控展演"><span>🕺</span><span>人形群控展演</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="sim2real" title="Sim2Real"><span>🔁</span><span>Sim2Real</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="humanoid-boxing" title="人形拳击"><span>🥊</span><span>人形拳击</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="bfm" title="BFM"><span>🧠</span><span>BFM</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="perceptive-locomotion" title="感知越障"><span>👁️</span><span>感知越障</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="motion-generation" title="动作生成"><span>✨</span><span>动作生成</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="vla" title="VLA"><span>👀</span><span>VLA</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="real2sim" title="Real2Sim"><span>🌍</span><span>Real2Sim</span></button>
-            <button class="filter-depth-chip" type="button" data-depth="wam" title="WAM"><span>🔮</span><span>WAM</span></button>
           </div>
         </details>
         <details class="filter-depth-section" id="filter-institution-section">
@@ -4873,6 +4853,18 @@
     /* ── 路线视图切换（已合入筛选面板内 <details> 区块）── */
     const topicChipsEl = document.getElementById('filter-depth-chips');
     const topicCurrentEl = document.getElementById('filter-depth-current');
+    /* chip 列表按 DEPTH_ORDER 渲染（含主路线与全部纵深），与 depth-filters.js 单一事实源同步 */
+    function renderDepthChips() {
+      if (!topicChipsEl) return;
+      topicChipsEl.insertAdjacentHTML('beforeend', window.RNDepthFilters.DEPTH_ORDER.map(key => {
+        const meta = DEPTH_META[key] || {};
+        const label = escapeHtml(meta.label || key);
+        return '<button class="filter-depth-chip" type="button" data-depth="' + escapeHtml(key)
+          + '" title="' + label + '"><span>' + (meta.emoji || '🏷️') + '</span><span>'
+          + label + '</span></button>';
+      }).join(''));
+    }
+    renderDepthChips();
     function setActiveTopic(topic) {
       currentDepth = topic || 'all';
       let activeBtn = null;

--- a/tests/test_depth_filters.py
+++ b/tests/test_depth_filters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import unittest
 from pathlib import Path
@@ -178,6 +179,41 @@ console.log(JSON.stringify({ football, ball, multi, singleExact }));
         data = json.loads(out.strip())
         self.assertTrue(data["multi"])
         self.assertTrue(data["singleExact"])
+
+
+class GraphDepthChipsTests(unittest.TestCase):
+    """docs/graph.html 的路线视图 chip 必须由 DEPTH_ORDER 渲染，不能再写死列表。"""
+
+    GRAPH_HTML = ROOT / "docs" / "graph.html"
+
+    def test_static_markup_only_keeps_the_all_chip(self):
+        html = self.GRAPH_HTML.read_text(encoding="utf-8")
+        hardcoded = re.findall(
+            r'<button class="filter-depth-chip[^"]*"[^>]*data-depth="([a-z0-9-]+)"', html
+        )
+        self.assertEqual(hardcoded, ["all"])
+
+    def test_rendered_chips_cover_every_route(self):
+        html = self.GRAPH_HTML.read_text(encoding="utf-8")
+        start = html.index("    function renderDepthChips() {")
+        end = html.index("    renderDepthChips();", start)
+        out = _run_depth_filters_node(
+            """
+const chunks = [];
+const window = { RNDepthFilters: DF };
+const DEPTH_META = DF.DEPTH_META;
+const topicChipsEl = { insertAdjacentHTML: (_pos, html) => chunks.push(html) };
+function escapeHtml(s) { return String(s); }
+"""
+            + html[start:end]
+            + """
+renderDepthChips();
+const keys = [...chunks.join('').matchAll(/data-depth="([a-z0-9-]+)"/g)].map(m => m[1]);
+console.log(JSON.stringify({ keys, order: DF.DEPTH_ORDER }));
+"""
+        )
+        data = json.loads(out.strip())
+        self.assertEqual(data["keys"], data["order"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
图谱筛选面板的「路线视图」写死了一份静态 chip 列表，新增纵深路线时漏改（ICL、
具身测评、具身数据三条自加入 depth-filters.js 起就没进过图谱），导致图谱里只有
22 条路线，而 depth-filters.js / 首页 / roadmap 都是主路线 + 24 条纵深。

- docs/graph.html：静态标记只保留「全量」chip，其余按 window.RNDepthFilters.DEPTH_ORDER
  与 DEPTH_META（emoji / label）渲染，图谱与单一事实源不再有第二份列表
- tests/test_depth_filters.py：新增 GraphDepthChipsTests，断言静态标记只剩 all，
  并把 renderDepthChips 拉进 Node 执行，校验渲染出的 data-depth 序列与 DEPTH_ORDER 一致

验证：make ci-preflight 全绿；node --test tests/*.test.cjs 58/58；unittest 219 通过
（4 个 error 均为本机缺 pytest 模块的收集失败，与本改动无关）；本地静态站 graph.html
实测 chip 26 个（全量 + 主路线 + 24 纵深），ICL 33 / 3947 节点、具身数据 81 / 3947 节点，
路线导读条与「打开路线页」均正常。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SFnkSKukKGHzBGDwbpDB45