### PR TITLE
[2026-09-12] ingest | EgoHTR — 数据集已上 HF，CoRL 2026，代码仍待发布

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,3 +1,5 @@
+## [2026-09-12] ingest | sources/sites/egohtr-github-io.md — EgoHTR 数据集已上 HF leggedrobotics/egohtr（~719 GB）；CoRL 2026；代码仍 coming soon；刷新 wiki/entities/paper-egohtr.md 与选型对照页
+
 ## [2026-09-12] ingest | sources/papers/designing_physics_experiments_with_ai_nature_s41586_026_10898_6.md — Nature Review「AI 物理实验设计」+ Learn2Design-2026 / Differometor；竞赛栈 MIT 已开源
 
 - **意图：** 入库 Nature 2026 Review 四问框架，并以 NeurIPS 2026 Learn2Design 引力波探测器设计赛为旗舰案例

--- a/sources/papers/egohtr_arxiv_2607_13472.md
+++ b/sources/papers/egohtr_arxiv_2607_13472.md
@@ -10,9 +10,9 @@
 - **项目页：** <https://egohtr.github.io>
 - **机构：** 苏黎世联邦理工（ETH Zürich）；斯坦福大学（Stanford）；加州大学伯克利分校（UC Berkeley）；慕尼黑工业大学（TU Munich）
 - **作者：** Alex Brandes、Haig Conti Georges Sajelian、Manthan Patel、Dominik Hollidt、Chenhao Li、Matthias Heyrman、Oliver Hausdörfer、Manuel Kaufmann、Xi Wang、Jonas Frey、Angela P. Schoellig、Christian Holz、Marc Pollefeys、Marco Hutter 等
-- **状态：** arXiv 预印本（约 2026-07-15）；**数据与代码计划开放**（项目页 Dataset / Code 均标 *coming soon*）
+- **状态：** arXiv 预印本（约 2026-07-15）；**CoRL 2026 accepted**（项目页 / HF README）
 - **入库日期：** 2026-07-21
-- **开源再核查：** 2026-07-27 — 项目页仍为 Dataset / Code *coming soon*；GitHub org `egohtr` 仅 `egohtr.github.io` 站点仓
+- **开源再核查：** 2026-09-12 — **数据集已发布** <https://huggingface.co/datasets/leggedrobotics/egohtr>（~719 GB）；项目页 **Code (coming soon)**；GitHub org `egohtr` 仍仅 `egohtr.github.io` 站点仓
 - **一句话说明：** 用 Aria 眼镜 + Rokoko IMU 服 + Leica BLK2GO 扫描，在 rough terrain 上采集 **55** 条场景对齐的 4D 人体运动（约 **1.37 h / 150k** 帧），并以此训练 Unitree G1 感知 locomotion。
 
 ## 摘录 1：问题与贡献
@@ -60,12 +60,12 @@
 
 - **基准（Table 4 节选）：** 外视 JOSH SR **57.2%** / Human3R SR **80.5%**（遮挡、运动模糊下失败）；EgoAllo 虽 SR 100% 但局部 MPJPE **161.1 mm**、PA-MPJPE **111.5 mm**（偏平地先验）；IMU poser 易时序漂移致不可物理交互。数据集可作 fine-tune 资源。
 - **局限：** 规模尚不足以大规模预训练；仅静态环境、无关节物体；手部未并入身体模型；无事后联合人–场景优化；无特征环境 / 高加速机动可能失败。
-- **开放边界（项目页核查，截至 2026-07-27 再确认）：** 页头 **Dataset (coming soon)**、**Code (coming soon)**；GitHub org `egohtr` 仅公开项目站仓 `egohtr/egohtr.github.io`，**无可运行重建/训练仓与数据下载 URL** → 归类 **宣称将开源 / 待发布**。
+- **开放边界（项目页核查，截至 2026-09-12 再确认）：** **Dataset** 已指向 HF [`leggedrobotics/egohtr`](https://huggingface.co/datasets/leggedrobotics/egohtr)；**Code (coming soon)**；GitHub org `egohtr` 仍仅站点仓 → 归类 **部分开源**（数据已发布，重建/训练管线待发布）。HF 归档见 [`sources/sites/egohtr-dataset-huggingface.md`](../sites/egohtr-dataset-huggingface.md)。
 
 **对 wiki 的映射：** sites 归档与实体页「开源状态 / 源码运行时序图：不适用」。
 
 ## 当前提炼状态
 
 - [x] arXiv HTML / 项目页 / GitHub org 已对齐摘录
-- [x] wiki 映射：`wiki/entities/paper-egohtr.md`（2026-07-21 新建；2026-07-27 加深评测数字与开源再核查）
-- [x] 开源边界写入 sites / wiki 局限（无 repos：尚无代码 URL）
+- [x] wiki 映射：`wiki/entities/paper-egohtr.md`（2026-07-21 新建；2026-07-27 加深评测数字；2026-09-12 HF 数据集发布再核查）
+- [x] 开源边界写入 sites / wiki 局限（HF 数据集已发布；repos 仍无训练/重建代码 URL）

--- a/sources/sites/egohtr-dataset-huggingface.md
+++ b/sources/sites/egohtr-dataset-huggingface.md
@@ -1,0 +1,55 @@
+# EgoHTR 数据集（Hugging Face）
+
+- **标题:** EgoHTR — Egocentric Human-Terrain Reconstruction Dataset
+- **类型:** dataset / huggingface
+- **链接:** <https://huggingface.co/datasets/leggedrobotics/egohtr>
+- **论文:** [EgoHTR（arXiv:2607.13472）](https://arxiv.org/abs/2607.13472)
+- **项目页:** <https://egohtr.github.io>
+- **机构:** 苏黎世联邦理工（ETH Zürich）× 斯坦福大学（Stanford）× 加州大学伯克利分校（UC Berkeley）× 慕尼黑工业大学（TU Munich）
+- **收录日期:** 2026-09-12
+
+## 一句话摘要
+
+ETH RSL 在 Hugging Face 发布的 **rough-terrain 人–场景 4D** 多模态数据集（**55** 序列 / ~**1.37 h** / ~**150k** 帧 @ 30 fps）；含 Aria ego/exo、IMU MoCap、3D 场景扫描、SMPL-X 与可选机器人 retarget；总体量约 **719 GB**；**重建/训练代码仍待发布**。
+
+## 开放状态（截至 2026-09-12）
+
+| 项 | 状态 |
+|----|------|
+| **数据集** | **已发布** — <https://huggingface.co/datasets/leggedrobotics/egohtr>（项目页 Dataset 按钮已指向 HF；访问可能需 HF 登录/授权） |
+| **重建管线代码** | **待发布** — 项目页 **Code (coming soon)**；HF README 写「Generation pipeline (code): Github」但尚无公开复现仓 |
+| **GitHub org** | <https://github.com/egohtr> 仍仅 [`egohtr/egohtr.github.io`](https://github.com/egohtr/egohtr.github.io) 站点仓 |
+
+## 模态与目录结构（HF README 摘要）
+
+每条序列文件夹含压缩处理后输出：
+
+| 文件 | 说明 |
+|------|------|
+| `full_sequence.npz` | 完整同步数据 |
+| `full_opt_sequence.npz` | 优化后序列 |
+| `full_retarget_sequence.npz` | 可选：重定向到机器人 embodiment |
+
+原始传感与管线输出子目录：
+
+| 目录 | 内容 |
+|------|------|
+| `aria/` | Project Aria egocentric RGB + SLAM 轨迹 + 手部跟踪 |
+| `egomc/` | Rokoko IMU 服 MoCap（BVH + raw） |
+| `exomc/` | 可选 marker MoCap（评测 GT） |
+| `scene/` | BLK2GO 点云与纹理 mesh |
+| `retarget/` | 重定向到机器人（URDF/XML） |
+
+字段级 schema 以未来发布的 **EgoHTR pipeline 仓库** README 为准。
+
+## 直接用途（官方）
+
+- 4D 人–场景重建 / HMR 基准（相对 MoCap GT）
+- 感知、地形感知全身控制 / 人形 locomotion 策略训练与评测（论文演示 Unitree G1）
+- 经配套管线将人体运动 retarget 到机器人 embodiment
+
+## 对 Wiki 的映射
+
+- [`wiki/entities/paper-egohtr.md`](../../wiki/entities/paper-egohtr.md) — 论文与数据集实体页
+- [`sources/sites/egohtr-github-io.md`](egohtr-github-io.md) — 项目页开源核查主入口
+- [`sources/papers/egohtr_arxiv_2607_13472.md`](../papers/egohtr_arxiv_2607_13472.md) — 论文摘录

--- a/sources/sites/egohtr-github-io.md
+++ b/sources/sites/egohtr-github-io.md
@@ -6,20 +6,22 @@
 - **类型：** site / project-page
 - **URL：** <https://egohtr.github.io>
 - **论文：** <https://arxiv.org/abs/2607.13472> — 归档见 [`sources/papers/egohtr_arxiv_2607_13472.md`](../papers/egohtr_arxiv_2607_13472.md)
+- **会议：** CoRL 2026（项目页与 HF README 均标注 accepted）
 - **机构：** 苏黎世联邦理工（ETH Zürich）× 斯坦福大学（Stanford）× 加州大学伯克利分校（UC Berkeley）× 慕尼黑工业大学（TU Munich）
 - **入库日期：** 2026-07-21
-- **开源再核查：** 2026-07-27（状态未变）
+- **开源再核查：** 2026-09-12（数据集已上 HF；代码仍 coming soon）
 - **一句话说明：** EgoHTR 官方项目页：数据集统计/场景浏览、采集传感器表、Human2Robot 重定向说明，以及 G1 感知全身控制与 HMR 基准应用叙事。
 
-## 公开信息要点（截至 2026-07-27 再核查）
+## 公开信息要点（截至 2026-09-12 再核查）
 
 | 项 | 状态 |
 |----|------|
 | **arXiv / PDF** | 已挂：<https://arxiv.org/abs/2607.13472> |
-| **Dataset** | 页头按钮文案 **Dataset (coming soon)**；**无** Hugging Face / Zenodo / 下载 URL |
-| **Code** | 页头按钮文案 **Code (coming soon)**；**无** 可点击训练/重建仓库 URL |
-| **GitHub org** | <https://github.com/egohtr> 目前仅 [`egohtr/egohtr.github.io`](https://github.com/egohtr/egohtr.github.io)（项目站源码，`updated_at`≈2026-07-16），**非** 复现仓 |
-| **开源结论** | **宣称将开源 / 待发布**（论文写 open-source pipeline，项目页尚未列有效数据/代码链接；2026-07-27 再确认无变） |
+| **Video** | <https://www.youtube.com/watch?v=9K8voGp2Xw0> |
+| **Dataset** | **已发布** — 页头按钮指向 <https://huggingface.co/datasets/leggedrobotics/egohtr>（约 **719 GB**；HF 侧可能需登录授权） |
+| **Code** | 页头按钮文案 **Code (coming soon)**；`href` 仍为空；**无** 可点击训练/重建仓库 URL |
+| **GitHub org** | <https://github.com/egohtr> 目前仅 [`egohtr/egohtr.github.io`](https://github.com/egohtr/egohtr.github.io)（项目站源码，`updated_at`≈2026-09-11），**非** 复现仓 |
+| **开源结论** | **部分开源**：**数据集已发布**（HF）；**重建/训练管线代码待发布** |
 
 ### 页面内容摘要
 
@@ -31,11 +33,12 @@
 
 ## 为何值得保留
 
-- 步骤 2.5 项目页核查主入口：用「coming soon」文案锁定开放边界，避免 wiki 误写「已可下载」。
+- 步骤 2.5 项目页核查主入口：锁定「数据已上 HF、代码仍 coming soon」边界，避免 wiki 误写「全无」或「全已开源」。
 - 提供比 PDF 更易浏览的序列/模态表，便于与 AMASS / SLOPER4D 等选型对照。
-- 后续数据/代码一旦放出，可在此页与 `sources/repos/` 增量更新。
+- 数据集归档见 [`egohtr-dataset-huggingface.md`](egohtr-dataset-huggingface.md)。
 
 ## 关联资料
 
 - 论文摘录：[`sources/papers/egohtr_arxiv_2607_13472.md`](../papers/egohtr_arxiv_2607_13472.md)
+- HF 数据集：[`sources/sites/egohtr-dataset-huggingface.md`](egohtr-dataset-huggingface.md)
 - Wiki 实体：[`wiki/entities/paper-egohtr.md`](../../wiki/entities/paper-egohtr.md)

--- a/wiki/comparisons/humanoid-reference-motion-datasets.md
+++ b/wiki/comparisons/humanoid-reference-motion-datasets.md
@@ -3,7 +3,7 @@ type: comparison
 title: 人形参考运动与操作数据集选型（AMASS / LAFAN1 / OMOMO / PHUMA / Humanoid Everyday / KungFuAthlete）
 tags: [dataset, comparison, motion-retargeting, humanoid, mocap, unitree-g1, martial-arts]
 summary: "常用人形数据源的表示、任务域、是否预重定向与典型下游对照；含 KungFuAthlete 高动态与 EgoHTR rough-terrain 人–场景扩展。"
-updated: 2026-08-15
+updated: 2026-09-12
 status: complete
 related:
   - ../concepts/motion-retargeting.md
@@ -26,6 +26,7 @@ sources:
   - ../../sources/sites/humanoideveryday.md
   - ../../sources/papers/kung_fu_athlete_bot.md
   - ../../sources/papers/egohtr_arxiv_2607_13472.md
+  - ../../sources/sites/egohtr-dataset-huggingface.md
   - ../../sources/repos/exercises-dataset.md
   - ../../sources/papers/humantracker_arxiv_2608_13555.md
   - ../../sources/papers/humaps4d_cvpr_2026.md
@@ -56,7 +57,7 @@ sources:
 | [PHUMA](../entities/dataset-bfm-phuma.md) | **已 PhySINK 重定向到 G1/H1-2** 的 73 h locomotion；宇树友好 |
 | [Humanoid Everyday](../entities/humanoid-everyday-dataset.md) | **真机人形操作** 多模态集；非 MoCap 参考库 |
 | [KungFuAthlete](../entities/paper-kungfuathlete-humanoid-martial-arts-tracking.md) | **武术高动态** 视频→GVHMR→GMR；Jump 子集动力学上界；Ground ready |
-| [EgoHTR](../entities/paper-egohtr.md) | **rough-terrain 人–场景 4D**（Aria+IMU 服+扫描）；感知 locomotion 参考；数据/代码待发布 |
+| [EgoHTR](../entities/paper-egohtr.md) | **rough-terrain 人–场景 4D**（Aria+IMU 服+扫描）；感知 locomotion 参考；**HF 数据已发布**（~719 GB），代码待发布 |
 | [HumanTracker](../entities/paper-humantracker.md) | **153 h / 25K 四族光学评测集 + HumanScore**；GMR→29-DoF；**数据待发布**，评测代码已开 |
 | [HUMAPS-4D](../entities/paper-humaps4d.md) | **可穿戴生物力学 4D**（MoCap+RGB+sEMG+足底）；隐私友好姿态/动作识别；**DUA 数据、无代码** |
 
@@ -113,7 +114,7 @@ flowchart TD
   start --> q5{要武术 / 空翻<br/>极高动态上界?}
   q5 -->|是| kfa[KungFuAthlete Jump/Ground]
   start --> q6{要 rough-terrain<br/>人–场景对齐演示?}
-  q6 -->|是| egohtr[EgoHTR 待开放]
+  q6 -->|是| egohtr[EgoHTR HF 已发布]
   start --> q7{要按失败机制分族<br/>评已有 tracker?}
   q7 -->|是| ht[HumanTracker 数据待发布]
 ```
@@ -125,7 +126,7 @@ flowchart TD
 3. **轻量 recovery 原型**：LaFAN1 子集 → 重定向 → 单策略走/跑/起身（见 [SD-AMP](../entities/paper-unified-walk-run-recovery-sdamp.md)）。
 4. **操作策略（非参考轨迹）**：Humanoid Everyday 真机轨迹 → 模仿 / VLA；与 MoCap 库 **互补而非替代**。
 5. **全合成 G1 loco-manip 参考**：[GRAIL Dataset](../entities/grail-locomanipulation-dataset.md) 直接提供 post-SONIC 物理可行 `robot/` + `objects/` 轨迹，适合 tracker / IL / 视觉策略数据混合。
-6. **粗糙地形场景对齐人演示**：[EgoHTR](../entities/paper-egohtr.md)（待开放）→ OmniRetarget/GMR → 高度图条件 mimic；适合 foothold-critical 踏石/梁/废墟，**非** AMASS 规模替代。
+6. **粗糙地形场景对齐人演示**：[EgoHTR](../entities/paper-egohtr.md)（[HF 数据已发布](https://huggingface.co/datasets/leggedrobotics/egohtr)）→ OmniRetarget/GMR → 高度图条件 mimic；适合 foothold-critical 踏石/梁/废墟，**非** AMASS 规模替代。
 
 ## 四段衔接：数据来源 → 质量评估 → 重定向 → 策略输入
 
@@ -158,6 +159,7 @@ flowchart TD
 - [GRAIL 数据集 Hugging Face 归档](../../sources/sites/grail-locomanipulation-huggingface.md)
 - [KungFuAthleteBot 论文 ingest](../../sources/papers/kung_fu_athlete_bot.md)
 - [EgoHTR 论文 ingest](../../sources/papers/egohtr_arxiv_2607_13472.md)
+- [EgoHTR 数据集 HF 归档](../../sources/sites/egohtr-dataset-huggingface.md)
 - [Exercises Dataset 仓库归档](../../sources/repos/exercises-dataset.md) — 健身动作目录（非 MoCap）对照
 - [HumanTracker 论文摘录](../../sources/papers/humantracker_arxiv_2608_13555.md) — 153 h 四族评测集（数据待发布）
 
@@ -170,7 +172,7 @@ flowchart TD
 - [OmniRetarget 数据集](../entities/omniretarget-dataset.md)
 - [GRAIL Loco-Manipulation Dataset](../entities/grail-locomanipulation-dataset.md)
 - [KungFuAthleteBot](../entities/paper-kungfuathlete-humanoid-martial-arts-tracking.md) — 武术高动态 + tracking∪recovery
-- [EgoHTR](../entities/paper-egohtr.md) — rough-terrain 人–场景 4D；数据/代码待发布
+- [EgoHTR](../entities/paper-egohtr.md) — rough-terrain 人–场景 4D；HF 数据已发布，代码待发布
 - [KungfuBot / PBHC](../entities/paper-notebook-kungfubot-physics-based-humanoid-whole-body-cont.md) — LAFAN/AMASS/视频 → SMPL 训练输入（[repo](../../sources/repos/pbhc.md)）
 - [Unitree G1](../entities/unitree-g1.md)
 - [Exercises Dataset](../entities/exercises-dataset.md) — 健身目录/GIF；勿与本表 MoCap 源混用

--- a/wiki/concepts/motion-retargeting.md
+++ b/wiki/concepts/motion-retargeting.md
@@ -3,7 +3,7 @@ title: Motion Retargeting（动作重定向）
 type: concept
 status: complete
 created: 2026-04-14
-updated: 2026-09-10
+updated: 2026-09-12
 summary: 将人类或动物参考动作映射到异构机器人骨架上，在保留运动风格和语义的同时满足机器人的关节限制和动力学约束。
 ---
 

--- a/wiki/concepts/terrain-adaptation.md
+++ b/wiki/concepts/terrain-adaptation.md
@@ -2,7 +2,7 @@
 type: concept
 tags: [locomotion, terrain, perception, footstep-planning, sim2real]
 status: complete
-updated: 2026-09-02
+updated: 2026-09-12
 summary: "Terrain Adaptation 指机器人根据地形感知结果调整步位、身体姿态和接触策略，以在不平整环境中保持稳定移动。"
 related:
   - ../queries/robot-perception-stack-selection-loop.md

--- a/wiki/entities/amass.md
+++ b/wiki/entities/amass.md
@@ -4,7 +4,7 @@ type: entity
 title: AMASS（统一 SMPL 表示的大规模人体动捕档案）
 tags: [dataset, mocap, smpl, human-motion, deep-learning, animation, mpi-tuebingen, max-planck]
 summary: "AMASS 将多份光学标记动捕数据通过 MoSh++ 拟合到 SMPL 参数序列，形成可合并训练的人体运动档案；站点提供注册下载与教程代码，是机器人学习里常见的人体参考运动来源之一。"
-updated: 2026-08-20
+updated: 2026-09-12
 status: complete
 related:
   - ../concepts/motion-retargeting.md
@@ -95,7 +95,7 @@ flowchart LR
 - [PHUMA](./dataset-bfm-phuma.md) — PhySINK 重定向后的 G1 locomotion 对照
 - [OMOMO](./omomo-dataset.md) — 人–物交互 MoCap 源
 - [五集选型对比](../comparisons/humanoid-reference-motion-datasets.md)
-- [EgoHTR](./paper-egohtr.md) — 有场景 mesh 的 rough-terrain 4D 对照（规模远小于 AMASS；待开放）
+- [EgoHTR](./paper-egohtr.md) — 有场景 mesh 的 rough-terrain 4D 对照（规模远小于 AMASS；[HF 数据已发布](https://huggingface.co/datasets/leggedrobotics/egohtr)）
 - [Exercises Dataset](./exercises-dataset.md) — 健身动作目录/GIF；**不是** MoCap 参考库
 - [HumanTracker](./paper-humantracker.md) — 四族光学评测集；批评 AMASS-140 测试协议
 

--- a/wiki/entities/paper-egohtr.md
+++ b/wiki/entities/paper-egohtr.md
@@ -2,9 +2,9 @@
 type: entity
 tags: [paper, dataset, eth, stanford, berkeley, tum, humanoid, egocentric, 4d-reconstruction, human-motion, perceptive-locomotion, terrain, motion-retargeting, unitree-g1, smpl-x]
 status: complete
-updated: 2026-07-27
+updated: 2026-09-12
 arxiv: "2607.13472"
-venue: "arXiv 2026"
+venue: "CoRL 2026"
 related:
   - ../comparisons/humanoid-reference-motion-datasets.md
   - ./amass.md
@@ -21,7 +21,8 @@ related:
 sources:
   - ../../sources/papers/egohtr_arxiv_2607_13472.md
   - ../../sources/sites/egohtr-github-io.md
-summary: "EgoHTR（ETH×Stanford×Berkeley×TUM，arXiv:2607.13472）：Aria+Rokoko+BLK2GO 采集 55 条 rough-terrain 场景对齐 4D 人体运动（~1.37 h / 150k 帧）；局部 MPJPE 73.2 mm、全局 W-MPJPE 151.3 mm；支撑 HMR 基准与 G1 感知 locomotion；数据与代码项目页仍标 coming soon（2026-07-27 再核查）。"
+  - ../../sources/sites/egohtr-dataset-huggingface.md
+summary: "EgoHTR（ETH×Stanford×Berkeley×TUM，CoRL 2026 / arXiv:2607.13472）：Aria+Rokoko+BLK2GO 采集 55 条 rough-terrain 场景对齐 4D 人体运动（~1.37 h / 150k 帧）；局部 MPJPE 73.2 mm、全局 W-MPJPE 151.3 mm；数据集已上 HF leggedrobotics/egohtr（~719 GB）；重建/训练代码仍 coming soon（2026-09-12 再核查）。"
 ---
 
 # EgoHTR：第一视角粗糙地形人–场景 4D 演示
@@ -50,11 +51,11 @@ summary: "EgoHTR（ETH×Stanford×Berkeley×TUM，arXiv:2607.13472）：Aria+Rok
 | 字段 | 内容 |
 |------|------|
 | **机构** | 苏黎世联邦理工（ETH Zürich）；斯坦福大学（Stanford）；加州大学伯克利分校（UC Berkeley）；慕尼黑工业大学（TU Munich） |
-| **arXiv** | [2607.13472](https://arxiv.org/abs/2607.13472)（约 2026-07-15 预印本） |
+| **会议 / arXiv** | **CoRL 2026** accepted；[2607.13472](https://arxiv.org/abs/2607.13472)（约 2026-07-15 预印本） |
 | **规模** | **7** 场景 / **8** 被试 / **55** 序列 / **1.37 h** / ~**150k** 帧 @ 30 fps |
 | **传感** | Aria Gen.1 + Rokoko Pro II + Leica BLK2GO（可选第二 Aria / 固定相机） |
 | **下游** | HMR / 4D human-scene 基准；Unitree G1 感知全身跟踪 |
-| **开源（截至 2026-07-27 再核查）** | **宣称将开源 / 待发布**：项目页 Dataset / Code 均为 *coming soon*；无公开下载或可运行仓 |
+| **开源（截至 2026-09-12 再核查）** | **部分开源**：数据集 [HF `leggedrobotics/egohtr`](https://huggingface.co/datasets/leggedrobotics/egohtr)（~**719 GB**）；项目页 **Code (coming soon)**；无可运行重建/训练仓 |
 
 ## 为什么重要
 
@@ -71,8 +72,8 @@ summary: "EgoHTR（ETH×Stanford×Berkeley×TUM，arXiv:2607.13472）：Aria+Rok
 | **表示** | 参数化身体 + ego/exo 视频/SLAM + 场景几何 + 可选 mocap GT |
 | **任务侧重** | **粗糙地形穿越**、场景感知 mimic、4D 重建评测 |
 | **预重定向** | 否（人体参考）；G1 侧另走 OmniRetarget/GMR 管线 |
-| **许可 / 获取** | 以项目页为准；**截至入库日尚未开放下载** |
-| **选型提示** | 要 **场景对齐 + rough terrain** 人演示 → 优先跟进 EgoHTR；要最大人体分布仍选 [AMASS](./amass.md)；要已重定向 G1 locomotion 选 PHUMA |
+| **许可 / 获取** | HF 数据集已发布（访问可能需登录授权）；以项目页 / HF 卡片为准 |
+| **选型提示** | 要 **场景对齐 + rough terrain** 人演示 → 可下载 HF 数据；要最大人体分布仍选 [AMASS](./amass.md)；要已重定向 G1 locomotion 选 PHUMA |
 
 ## 核心原理
 
@@ -133,7 +134,7 @@ flowchart TB
 3. **重建三阶段** — MoCap→SMPL-X、拍手同步（<60 ms）、Aria 锚定 + ICP 到 BLK2GO 场景。
 4. **局部/全局 HPS** — mocap GT 子集 MPJPE **73.2** / PA **54.3** mm；全局 W-MPJPE **151.3** / WA **66.7** mm、RTE **0.09%**。
 5. **下游 mimic** — 高度图条件 PPO + 时间脚接触奖励（踏石 SR +5 pp、收敛更快）；G1 有 beam/box-up 等演示。
-6. **开源按待发布管** — Dataset/Code 项目页 *coming soon*（2026-07-27 再确认）；规模适合基准/fine-tune，不宜单独撑 foundation 预训练。
+6. **部分开源** — 数据集已上 [HF](https://huggingface.co/datasets/leggedrobotics/egohtr)（~719 GB）；重建/训练代码仍 *coming soon*（2026-09-12 再确认）；规模适合基准/fine-tune，不宜单独撑 foundation 预训练。
 
 ## 对比定位
 
@@ -147,7 +148,7 @@ flowchart TB
 
 ## 源码运行时序图
 
-**不适用**（截至 2026-07-27 再核查）：[项目页](https://egohtr.github.io) Dataset / Code 均标 *coming soon*；GitHub org 仅有站点仓 [`egohtr/egohtr.github.io`](https://github.com/egohtr/egohtr.github.io)，无可辨识的训练/重建入口，无法绘制可复现运行时序。开放后应在 `sources/repos/` 补档并补本图。
+**不适用**（截至 2026-09-12 再核查）：[项目页](https://egohtr.github.io) **Code (coming soon)**；GitHub org 仅有站点仓 [`egohtr/egohtr.github.io`](https://github.com/egohtr/egohtr.github.io)，无可辨识的训练/重建入口，无法绘制可复现运行时序。数据集已发布于 [HF](https://huggingface.co/datasets/leggedrobotics/egohtr)；管线代码开放后应在 `sources/repos/` 补档并补本图。
 
 ## 工程实践
 
@@ -155,8 +156,8 @@ flowchart TB
 |----|------|
 | **选型** | 需要 **人–地形耦合参考**（踏石/梁/废墟）时纳入候选；勿与纯人体 AMASS 混为一谈 |
 | **精度预期** | 局部 MPJPE ~73 / PA ~54 mm；全局 W-MPJPE ~151 / WA ~67 mm、RTE ~0.09%（mocap GT 子集） |
-| **上机路径** | 等数据放出 → OmniRetarget/GMR 重定向到 G1 → 加接触奖励的 mimic PPO → 高度图条件策略 |
-| **开源跟进** | 定期复查项目页按钮是否变为有效 URL；勿假设「论文写 open-source」即可复现（2026-07-27 仍未放出） |
+| **上机路径** | 从 [HF 数据集](https://huggingface.co/datasets/leggedrobotics/egohtr) 取 `retarget/` 或自跑 OmniRetarget/GMR → 加接触奖励的 mimic PPO → 高度图条件策略 |
+| **开源跟进** | 数据集已可下载；仍须跟进项目页 **Code** 是否放出重建/训练仓（2026-09-12 仍 coming soon） |
 | **源码运行时序图** | **不适用**（原因见上节） |
 
 ## 局限与风险
@@ -164,7 +165,7 @@ flowchart TB
 - **规模：** 1.37 h 适合基准与 fine-tune，不足以单独撑大规模 foundation 预训练。
 - **场景假设：** 静态环境、无关节物体；手部跟踪未并入身体模型；无事后联合人–场景优化。
 - **硬件失败模式：** 无特征环境、高加速机动可能击穿定位。
-- **开放风险：** **数据与代码尚未公开**；选型与复现计划须按「待发布」管理，避免阻塞工程排期。
+- **开放风险：** **重建/训练代码仍未公开**；HF 数据约 **719 GB** 且可能需授权；复现管线须等官方代码或自研对齐 schema。
 
 ## 关联页面
 
@@ -183,11 +184,13 @@ flowchart TB
 
 - [EgoHTR 论文摘录](../../sources/papers/egohtr_arxiv_2607_13472.md)
 - [EgoHTR 项目页归档](../../sources/sites/egohtr-github-io.md)
+- [EgoHTR 数据集 Hugging Face 归档](../../sources/sites/egohtr-dataset-huggingface.md)
 - Brandes et al., *EgoHTR: Egocentric 4D Demonstrations of Human Terrain Traversal* — <https://arxiv.org/abs/2607.13472>
 - 项目页：<https://egohtr.github.io>
 
 ## 推荐继续阅读
 
 - 项目页方法与数据集浏览器：<https://egohtr.github.io>
+- Hugging Face 数据集：<https://huggingface.co/datasets/leggedrobotics/egohtr>
 - OmniRetarget（交互保留重定向）：<https://arxiv.org/abs/2509.26633>
 - RPL（鲁棒人形感知 locomotion）：<https://arxiv.org/abs/2602.03002>

--- a/wiki/entities/paper-hrl-stack-03-omniretarget.md
+++ b/wiki/entities/paper-hrl-stack-03-omniretarget.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid, rl, motion-retargeting, motion-control, interaction-mesh, loco-manipulation, data-generation, amazon-far, body-system-stack, icra-2026]
 status: complete
-updated: 2026-09-07
+updated: 2026-09-12
 arxiv: "2509.26633"
 venue: ICRA 2026
 summary: "OmniRetarget 用 interaction mesh + Sequential SOCP 硬约束生成交互保留的人形运动学参考，支持单演示增广与 holosoma 开源管线；下游 5 reward + 4 DR 无 curriculum 即可 G1 零样本实机 30 s parkour/loco-manipulation；PHP 等论文的原子技能重定向上游。"

--- a/wiki/entities/paper-notebook-meshmimic.md
+++ b/wiki/entities/paper-notebook-meshmimic.md
@@ -2,7 +2,7 @@
 type: entity
 tags: [paper, humanoid-paper-notebooks, paper-notebook-stub]
 status: stub
-updated: 2026-07-27
+updated: 2026-09-12
 arxiv: "2602.15733"
 related:
   - ../overview/paper-notebook-category-04-loco-manipulation-and-wbc.md
@@ -71,4 +71,4 @@ MeshMimic 把普通单目 RGB 视频变成可训练人形机器人的“运动-�
 ## 推荐继续阅读
 
 - [机器人论文阅读笔记：MeshMimic](https://imchong.github.io/Robot_Learning_Paper_Notebooks/papers/04_Loco-Manipulation_and_WBC/MeshMimic__Geometry-Aware_Humanoid_Motion_Learning_through_3D_Scene_Reconstructi/MeshMimic__Geometry-Aware_Humanoid_Motion_Learning_through_3D_Scene_Reconstructi.html)
-- [EgoHTR](./paper-egohtr.md) — rough-terrain 可穿戴+扫描 4D 对照（数据/代码待发布）
+- [EgoHTR](./paper-egohtr.md) — rough-terrain 可穿戴+扫描 4D 对照（HF 数据已发布，代码待发布）

--- a/wiki/entities/paper-notebook-visualmimic.md
+++ b/wiki/entities/paper-notebook-visualmimic.md
@@ -3,7 +3,7 @@
 type: entity
 tags: [paper, humanoid, loco-manipulation, visual-rl, sim2real, hierarchical-control, teacher-student, dagger, ppo, keypoint-tracking, depth, humanoid-paper-notebooks, stanford]
 status: complete
-updated: 2026-08-26
+updated: 2026-09-12
 arxiv: "2509.20322"
 venue: "2025 · arXiv"
 code: https://github.com/visualmimic/VisualMimic

--- a/wiki/entities/paper-rpl-robust-humanoid-perceptive-locomotion.md
+++ b/wiki/entities/paper-rpl-robust-humanoid-perceptive-locomotion.md
@@ -18,7 +18,7 @@ tags:
   - stanford
   - berkeley
 status: complete
-updated: 2026-09-04
+updated: 2026-09-12
 arxiv: "2602.03002"
 related:
   - ../tasks/stair-obstacle-perceptive-locomotion.md

--- a/wiki/methods/motion-retargeting-gmr.md
+++ b/wiki/methods/motion-retargeting-gmr.md
@@ -2,7 +2,7 @@
 type: method
 tags: [robotics, kinematics, retargeting, humanoid]
 status: complete
-updated: 2026-09-10
+updated: 2026-09-12
 related:
   - ../concepts/motion-retargeting.md
   - ./neural-motion-retargeting-nmr.md

--- a/wiki/tasks/locomotion.md
+++ b/wiki/tasks/locomotion.md
@@ -2,7 +2,7 @@
 type: task
 tags: [locomotion, bipedal, humanoid, rl, control]
 status: complete
-updated: 2026-09-10
+updated: 2026-09-12
 related:
   - ../concepts/whole-body-control.md
   - ../concepts/sim2real.md
@@ -373,7 +373,7 @@ flowchart TD
 - [磁驱动双稳态软跳跃机器人](../entities/paper-bistable-soft-jumper-magnetic.md)
 - [统一流体-机器人多物理游泳仿真](../entities/paper-unified-fluid-robot-multiphysics-swimming.md)
 - [ergoCub Shared Embodied Intelligence](../entities/paper-ergocub-shared-embodied-intelligence.md) — 硬件优化抬高 CoM + 分层 WBC 行走，相对 iCub3 更大步长/更短步周期
-- [EgoHTR](../entities/paper-egohtr.md) — rough-terrain 人–场景 4D 演示 → G1 感知 mimic（数据/代码待发布）
+- [EgoHTR](../entities/paper-egohtr.md) — rough-terrain 人–场景 4D 演示 → G1 感知 mimic（[HF 数据已发布](https://huggingface.co/datasets/leggedrobotics/egohtr)，代码待发布）
 - [ADP](../entities/paper-adp.md) — 对抗动力学先验（SRBD-TO + 动力学窗），抗扰相对 AMP 提升；代码待发布
 - [SD-AMP](../entities/paper-unified-walk-run-recovery-sdamp.md) — 重力门控双 AMP，走跑起身统一策略
 - [PRISM](../entities/paper-prism.md) — 多项式本体交互；Humanoid-Gym 生存率大幅高于同容量更大 MLP（arXiv:2607.23473）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

- 再核查 https://egohtr.github.io/：**数据集**已发布至 [HF `leggedrobotics/egohtr`](https://huggingface.co/datasets/leggedrobotics/egohtr)（~719 GB）；**Code** 仍为 *coming soon*
- 新增 `sources/sites/egohtr-dataset-huggingface.md`；刷新项目页/论文摘录与 `wiki/entities/paper-egohtr.md`（venue → **CoRL 2026**，开源状态 → **部分开源**）
- 交叉更新人形参考运动数据集选型、locomotion、AMASS、VisualMimic/MeshMimic 等回链

## 验证

- `make ci-preflight` 通过（lint 0 阻塞项；search 39/40）

## 验证截图

![EgoHTR 详情页渲染](https://cursor.com/artifacts/c/art-804cd0fa-fa5f-4477-8b32-6ef06c65355a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a8b29b4-2ded-4084-8531-79a4db28a055?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a8b29b4-2ded-4084-8531-79a4db28a055&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

